### PR TITLE
Make fields in SelectionSetField public to be able to filter out some…

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
@@ -18,8 +18,8 @@ public enum SelectionSetFieldType {
 }
 
 public class SelectionSetField {
-    var name: String?
-    var fieldType: SelectionSetFieldType
+    public var name: String?
+    public var fieldType: SelectionSetFieldType
     public init(name: String? = nil, fieldType: SelectionSetFieldType) {
         self.name = name
         self.fieldType = fieldType


### PR DESCRIPTION
… fields in a custom model decorator for  graphql doc generation

*Issue #, if available:*

*Description of changes:*

I need this change to be able write the following code:

```swift
/// Excludes from the GraphQL document "selectionSet" fields from fieldsToExclude set.
public struct ExcludeFieldsFromSelectionSetDecorator: ModelBasedGraphQLDocumentDecorator {

    private let excludeFields: Set<String>

    public init(excludeFields: Set<String>) {
        self.excludeFields = excludeFields
    }

    public func decorate(_ document: SingleDirectiveGraphQLDocument,
                         modelType: Model.Type) -> SingleDirectiveGraphQLDocument {
        guard var selectionSet = document.selectionSet else {
            fatalError("Document should contain selectionSet here.")
        }

        selectionSet = filter(selectionSet: selectionSet)

        return document.copy(selectionSet: selectionSet)
    }

    func filter(selectionSet: SelectionSet) -> SelectionSet {
        let result = SelectionSet(value: selectionSet.value)

        for child in selectionSet.children {
            if let name = child.value.name {
                if !excludeFields.contains(name) {
                    result.addChild(settingParentOf: child)
                }
            }
        }

        return result
    }
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
