### PR TITLE
[WIP] feat(auth): Addition of 'userPasswordAuth' authentication flow type

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignInOptions.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignInOptions.swift
@@ -26,6 +26,8 @@ public struct AWSAuthSignInOptions {
 
 public enum AuthFlowType {
 
+    case userPasswordAuth
+   
     case userSRP
 
     case custom

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthSignInOperation.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Operations/AWSAuthSignInOperation.swift
@@ -110,6 +110,7 @@ public class AWSAuthSignInOperation: AmplifyOperation<
         switch authTypeString {
         case "CUSTOM_AUTH": return .custom
         case "USER_SRP_AUTH": return .userSRP
+        case "USER_PASSWORD_AUTH": return .userPasswordAuth
         default:
             return nil
         }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-ios/issues/2002
https://github.com/aws-amplify/amplify-ios/issues/1110

*Description of changes:*
This PR aims to add a new functionality for changing the authentication flow type dynamically in the Amplify IOS SDK. This will allow users to switch between user migration mode and custom authentication mode as and when needed.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
