### PR TITLE
chore: Add buildtool plugin for SPM swiftlint support

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
@@ -328,6 +328,20 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SwiftLintPlugin"
+               BuildableName = "SwiftLintPlugin"
+               BlueprintName = "SwiftLintPlugin"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Amplify/Categories/Auth/AuthCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategory+ClientBehavior.swift
@@ -63,7 +63,7 @@ extension AuthCategory: AuthCategoryBehavior {
     }
 
     public func resetPassword(for username: String, options: AuthResetPasswordRequest.Options? = nil) async throws -> AuthResetPasswordResult {
-        return try await plugin.resetPassword(for: username,options: options)
+        return try await plugin.resetPassword(for: username,options: options) // swiftlint:disable:this comma
     }
 
     public func confirmResetPassword(

--- a/Amplify/Core/Support/Amplify+Publisher.swift
+++ b/Amplify/Core/Support/Amplify+Publisher.swift
@@ -47,7 +47,7 @@ public extension Amplify {
                     }
                 }
             }
-            .handleEvents(receiveCancel: { task.cancel() } )
+            .handleEvents(receiveCancel: { task.cancel() } ) // swiftlint:disable:this closing_brace
             .eraseToAnyPublisher()
         }
         

--- a/Amplify/Core/Support/AmplifyTask.swift
+++ b/Amplify/Core/Support/AmplifyTask.swift
@@ -37,7 +37,7 @@ public protocol AmplifyInProcessReportingTask {
 }
 
 public extension AmplifyInProcessReportingTask where InProcess == Progress {
-    var progress : AmplifyAsyncSequence<InProcess> {
+    var progress : AmplifyAsyncSequence<InProcess> { // swiftlint:disable:this colon
         get async {
             await inProcess
         }

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/EventRecorder.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/EventRecorder.swift
@@ -81,7 +81,7 @@ class EventRecorder: AnalyticsEventRecording {
     func submitAllEvents() async throws -> [PinpointEvent] {
         submittedEvents = []
         let eventsBatch = try getBatchRecords()
-        if eventsBatch.count > 0 {
+        if eventsBatch.count > 0 { // swiftlint:disable:this empty_count
             let endpointProfile = await endpointClient.currentEndpointProfile()
             try await processBatch(eventsBatch, endpointProfile: endpointProfile)
         }
@@ -96,7 +96,7 @@ class EventRecorder: AnalyticsEventRecording {
         try await submit(pinpointEvents: eventBatch, endpointProfile: endpointProfile)
         try storage.removeFailedEvents()
         let nextEventsBatch = try getBatchRecords()
-        if nextEventsBatch.count > 0 {
+        if nextEventsBatch.count > 0 { // swiftlint:disable:this empty_count
             try await processBatch(nextEventsBatch, endpointProfile: endpointProfile)
         }
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/Configuration/InitializeAuthConfiguration.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/Configuration/InitializeAuthConfiguration.swift
@@ -30,10 +30,10 @@ struct InitializeAuthConfiguration: Action {
             if case .amplifyCredentials(let fetchedCredentials) = data {
                 credentials = fetchedCredentials
             }
-        }
+        } // swiftlint:disable:this statement_position
         catch KeychainStoreError.itemNotFound {
             logVerbose("No existing session found.", environment: environment)
-        }
+        } // swiftlint:disable:this statement_position
         catch {
             logError("Error when loading amplify credentials: \(error)", environment: environment)
         }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/CredentialStore/MigrateLegacyCredentialStore.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/CredentialStore/MigrateLegacyCredentialStore.swift
@@ -22,8 +22,8 @@ struct MigrateLegacyCredentialStore: Action {
     private let AWSCredentialsProviderKeychainExpiration = "expiration"
     private let AWSCredentialsProviderKeychainIdentityId = "identityId"
 
-    private let FederationProviderKey = "federationProvider"
-    private let LoginsMapKey = "loginsMap"
+    private let FederationProviderKey = "federationProvider" // swiftlint:disable:this identifier_name
+    private let LoginsMapKey = "loginsMap" // swiftlint:disable:this identifier_name
 
     private let AWSCognitoAuthUserPoolCurrentUser = "currentUser"
     private let AWSCognitoAuthUserAccessToken = "accessToken"

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/CredentialStore/MigrateLegacyCredentialStore.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/CredentialStore/MigrateLegacyCredentialStore.swift
@@ -15,7 +15,7 @@ struct MigrateLegacyCredentialStore: Action {
 
     /// Legacy Keys
     private let AWSCredentialsProviderClassKey = "AWSCognitoCredentialsProvider"
-    private let UserPoolClassKey = "AWSCognitoIdentityUserPool"
+    private let UserPoolClassKey = "AWSCognitoIdentityUserPool" // swiftlint:disable:this identifier_name
     private let AWSCredentialsProviderKeychainAccessKeyId = "accessKey"
     private let AWSCredentialsProviderKeychainSecretAccessKey = "secretKey"
     private let AWSCredentialsProviderKeychainSessionToken = "sessionKey"

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/VerifyDevicePasswordSRP+Calculations.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/VerifyDevicePasswordSRP+Calculations.swift
@@ -28,7 +28,7 @@ extension VerifyDevicePasswordSRP {
         do {
             let dateStr = stateData.clientTimestamp.utcString
             let clientClass = type(of: srpClient)
-            let u = try clientClass.calculateUHexValue(
+            let u = try clientClass.calculateUHexValue( // swiftlint:disable:this identifier_name
                 clientPublicKeyHexValue: stateData.srpKeyPair.publicKeyHexValue,
                 serverPublicKeyHexValue: serverPublicBHexString)
             // HKDF

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/VerifyPasswordSRP+Calculations.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/VerifyPasswordSRP+Calculations.swift
@@ -28,7 +28,7 @@ extension VerifyPasswordSRP {
             let strippedPoolId =  strippedPoolId(poolId)
             let dateStr = stateData.clientTimestamp.utcString
             let clientClass = type(of: srpClient)
-            let u = try clientClass.calculateUHexValue(
+            let u = try clientClass.calculateUHexValue( // swiftlint:disable:this identifier_name
                 clientPublicKeyHexValue: stateData.srpKeyPair.publicKeyHexValue,
                 serverPublicKeyHexValue: serverPublicBHexString)
             // HKDF

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/SRP/AmplifySRPClient.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/SRP/AmplifySRPClient.swift
@@ -15,8 +15,8 @@ struct AmplifySRPClient: SRPClientBehavior {
     let client: SRPClientState
 
     init(NHexValue: String, gHexValue: String) throws {
-        guard let N = BigInt(NHexValue, radix: 16),
-              let g = BigInt(gHexValue, radix: 16)
+        guard let N = BigInt(NHexValue, radix: 16), // swiftlint:disable:this identifier_name
+              let g = BigInt(gHexValue, radix: 16) // swiftlint:disable:this identifier_name
         else {
                   throw SRPError.numberConversion
               }
@@ -36,7 +36,7 @@ struct AmplifySRPClient: SRPClientBehavior {
         return srpKeys
     }
 
-    func calculateSharedSecret(username: String,
+    func calculateSharedSecret(username: String, 
                                password: String,
                                saltHexValue: String,
                                clientPrivateKeyHexValue: String,
@@ -78,7 +78,7 @@ struct AmplifySRPClient: SRPClientBehavior {
         let signedClientPublicKey = AmplifyBigIntHelper.getSignedData(num: clientPublicNum)
         let signedServerPublicKey = AmplifyBigIntHelper.getSignedData(num: serverPublicNum)
 
-        let u = SRPClientState.calculcateU(publicClientKey: signedClientPublicKey,
+        let u = SRPClientState.calculcateU(publicClientKey: signedClientPublicKey, // swiftlint:disable:this identifier_name
                                            publicServerKey: signedServerPublicKey)
 
         return u.asString(radix: 16)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/ErrorMapping/SignInError+Helper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/ErrorMapping/SignInError+Helper.swift
@@ -57,7 +57,7 @@ extension SignInError {
                case .service(let serviceError, _) = cognitoError,
                case .passwordResetRequiredException = serviceError {
                 return true
-            }  else if let cognitoError = serviceError as? SdkError<InitiateAuthOutputError>,
+            }  else if let cognitoError = serviceError as? SdkError<InitiateAuthOutputError>, // swiftlint:disable:this statement_position
                        case .client(let clientError, _) = cognitoError,
                        case .retryError(let retryError) = clientError,
                        let cognitoServiceError = retryError as? SdkError<InitiateAuthOutputError>,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/Authentication/AuthenticationState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/Authentication/AuthenticationState+Resolver.swift
@@ -13,7 +13,7 @@ extension AuthenticationState {
 
         init() { }
 
-        func resolve(
+        func resolve( // swiftlint:disable:this cyclomatic_complexity
             oldState: StateType,
             byApplying event: StateMachineEvent
         ) -> StateResolution<StateType> {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/Authorization/AuthorizationState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/Authorization/AuthorizationState+Resolver.swift
@@ -15,7 +15,7 @@ extension AuthorizationState {
 
         init() { }
 
-        func resolve(
+        func resolve( // swiftlint:disable:this function_body_length cyclomatic_complexity
             oldState: StateType,
             byApplying event: StateMachineEvent
         ) -> StateResolution<StateType> {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/RefreshSession/RefreshSessionState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/RefreshSession/RefreshSessionState+Resolver.swift
@@ -14,7 +14,7 @@ extension RefreshSessionState {
 
         var defaultState: RefreshSessionState = .notStarted
 
-        func resolve(oldState: RefreshSessionState,
+        func resolve(oldState: RefreshSessionState, // swiftlint:disable:this cyclomatic_complexity
                      byApplying event: StateMachineEvent) -> StateResolution<RefreshSessionState> {
 
             switch oldState {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SignIn/SignInState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SignIn/SignInState+Resolver.swift
@@ -13,7 +13,7 @@ extension SignInState {
         typealias StateType = SignInState
         let defaultState = SignInState.notStarted
 
-        func resolve( // swiftlint:disable:this cyclomatic_complexity
+        func resolve( // swiftlint:disable:this cyclomatic_complexity function_body_length
             oldState: SignInState,
             byApplying event: StateMachineEvent)
         -> StateResolution<SignInState> {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SignIn/SignInState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SignIn/SignInState+Resolver.swift
@@ -13,7 +13,7 @@ extension SignInState {
         typealias StateType = SignInState
         let defaultState = SignInState.notStarted
 
-        func resolve(
+        func resolve( // swiftlint:disable:this cyclomatic_complexity
             oldState: SignInState,
             byApplying event: StateMachineEvent)
         -> StateResolution<SignInState> {

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/CascadeDeleteOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/CascadeDeleteOperation.swift
@@ -178,7 +178,7 @@ public class CascadeDeleteOperation<M: Model>: AsynchronousOperation {
                 
             let associatedModelIds = queriedModels.map { $0.1.identifier(schema: modelSchema).stringValue }
             associatedModels.append(contentsOf: queriedModels)
-            associatedModels.append(contentsOf: await recurseQueryAssociatedModels(modelSchema: associatedModelSchema,                                           ids: associatedModelIds))
+            associatedModels.append(contentsOf: await recurseQueryAssociatedModels(modelSchema: associatedModelSchema,                                           ids: associatedModelIds)) // swiftlint:disable:this comma
         }
         return associatedModels
     }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
@@ -13,7 +13,7 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
 
     /// Accepts a mutation event without a version, applies the latest version from the MutationSyncMetadata table,
     /// writes the updated mutation event to the local database, then submits it to `mutationEventSubject`
-    func submit(mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>)->Void) {
+    func submit(mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>)->Void) { // swiftlint:disable:this return_arrow_whitespace
         Task {
             log.verbose("\(#function): \(mutationEvent)")
             
@@ -32,7 +32,7 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
     /// rejects the event with an error
     func resolveConflictsThenSave(mutationEvent: MutationEvent,
                                   storageAdapter: StorageEngineAdapter,
-                                  completion: @escaping (Result<MutationEvent, DataStoreError>)->Void) {
+                                  completion: @escaping (Result<MutationEvent, DataStoreError>)->Void) { // swiftlint:disable:this return_arrow_whitespace
 
         // We don't want to query MutationSync<AnyModel> because a) we already have the model, and b) delete mutations
         // are submitted *after* the delete has already been applied to the local data store, meaning there is no model

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/MutationEvent/MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/MutationEvent/MutationEventIngester.swift
@@ -10,5 +10,5 @@ import Combine
 
 /// Ingests MutationEvents from and writes them to the MutationEvent persistent store
 protocol MutationEventIngester: AnyObject {
-    func submit(mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>)->Void)
+    func submit(mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>)->Void) // swiftlint:disable:this return_arrow_whitespace
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
@@ -238,7 +238,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         }
     }
 
-    func submit(_ mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>)->Void) {
+    func submit(_ mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>)->Void) { // swiftlint:disable:this return_arrow_whitespace
         mutationEventIngester.submit(mutationEvent: mutationEvent, completion: completion)
     }
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngineBehavior.swift
@@ -47,7 +47,7 @@ protocol RemoteSyncEngineBehavior: AnyObject {
 
     /// Submits a new mutation for synchronization to the remote API. The response will be handled by the appropriate
     /// reconciliation queue
-    func submit(_ mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>)->Void)
+    func submit(_ mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>)->Void) // swiftlint:disable:this return_arrow_whitespace
 
     var publisher: AnyPublisher<RemoteSyncEngineEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
@@ -56,7 +56,7 @@ class AWSS3StorageService: AWSS3StorageServiceBehaviour, StorageServiceProxy {
         let awsS3 = AWSS3Adapter(s3Client, config: clientConfig)
         let preSignedURLBuilder = AWSS3PreSignedURLBuilderAdapter(config: clientConfig, bucket: bucket)
 
-        var _sessionConfiguration: URLSessionConfiguration
+        var _sessionConfiguration: URLSessionConfiguration // swiftlint:disable:this identifier_name
         if let sessionConfiguration = sessionConfiguration {
             _sessionConfiguration = sessionConfiguration
         } else {

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,7 @@ let swiftSettings: [SwiftSetting]? = [.define("DEV_PREVIEW_BUILD")]
 let amplifyTargets: [Target] = [
     .target(
         name: "Amplify",
+        dependencies: ["SwiftLintPlugin"],
         path: "Amplify",
         exclude: [
             "Info.plist",
@@ -86,6 +87,16 @@ let amplifyTargets: [Target] = [
         exclude: [
             "Info.plist"
         ]
+    ),
+    .binaryTarget(
+        name: "SwiftLintBinary",
+        url: "https://github.com/realm/SwiftLint/releases/download/0.48.0/SwiftLintBinary-macos.artifactbundle.zip",
+        checksum: "9c255e797260054296f9e4e4cd7e1339a15093d75f7c4227b9568d63edddba50"
+    ),
+    .plugin(
+        name: "SwiftLintPlugin",
+        capability: .buildTool(),
+        dependencies: ["SwiftLintBinary"]
     )
 ]
 
@@ -95,7 +106,9 @@ let apiTargets: [Target] = [
         dependencies: [
             .target(name: "Amplify"),
             .target(name: "AWSPluginsCore"),
-            .product(name: "AppSyncRealTimeClient", package: "aws-appsync-realtime-client-ios")],
+            .product(name: "AppSyncRealTimeClient", package: "aws-appsync-realtime-client-ios"),
+            .swiftLint
+        ],
         path: "AmplifyPlugins/API/Sources/AWSAPIPlugin",
         exclude: [
             "Info.plist",
@@ -139,7 +152,8 @@ let authTargets: [Target] = [
             .target(name: "AWSPluginsCore"),
             .product(name: "AWSClientRuntime", package: "aws-sdk-swift"),
             .product(name: "AWSCognitoIdentityProvider", package: "aws-sdk-swift"),
-            .product(name: "AWSCognitoIdentity", package: "aws-sdk-swift")
+            .product(name: "AWSCognitoIdentity", package: "aws-sdk-swift"),
+            .swiftLint
         ],
         path: "AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin",
         swiftSettings: swiftSettings
@@ -181,7 +195,9 @@ let dataStoreTargets: [Target] = [
         dependencies: [
             .target(name: "Amplify"),
             .target(name: "AWSPluginsCore"),
-            .product(name: "SQLite", package: "SQLite.swift")],
+            .product(name: "SQLite", package: "SQLite.swift"),
+            .swiftLint
+        ],
         path: "AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin",
         exclude: [
             "Info.plist",
@@ -208,7 +224,9 @@ let storageTargets: [Target] = [
         dependencies: [
             .target(name: "Amplify"),
             .target(name: "AWSPluginsCore"),
-            .product(name: "AWSS3", package: "aws-sdk-swift")],
+            .product(name: "AWSS3", package: "aws-sdk-swift"),
+            .swiftLint
+        ],
         path: "AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin",
         exclude: [
             "Resources/Info.plist"
@@ -235,7 +253,9 @@ let geoTargets: [Target] = [
         dependencies: [
             .target(name: "Amplify"),
             .target(name: "AWSPluginsCore"),
-            .product(name: "AWSLocation", package: "aws-sdk-swift")],
+            .product(name: "AWSLocation", package: "aws-sdk-swift"),
+            .swiftLint
+        ],
         path: "AmplifyPlugins/Geo/AWSLocationGeoPlugin",
         exclude: [
             "Resources/Info.plist"
@@ -264,7 +284,9 @@ let analyticsTargets: [Target] = [
             .target(name: "AWSCognitoAuthPlugin"),
             .target(name: "AWSPluginsCore"),
             .product(name: "SQLite", package: "SQLite.swift"),
-            .product(name: "AWSPinpoint", package: "aws-sdk-swift")],
+            .product(name: "AWSPinpoint", package: "aws-sdk-swift"),
+            .swiftLint
+        ],
         path: "AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin"
     ),
     .testTarget(
@@ -334,3 +356,7 @@ let package = Package(
     dependencies: dependencies,
     targets: targets
 )
+
+extension Target.Dependency {
+    static let swiftLint: Self = "SwiftLintPlugin"
+}

--- a/Plugins/SwiftLintPlugin/plugin.swift
+++ b/Plugins/SwiftLintPlugin/plugin.swift
@@ -1,0 +1,33 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import PackagePlugin
+
+@main
+struct SwiftLintPlugin: BuildToolPlugin {
+    func createBuildCommands(
+        context: PluginContext,
+        target: Target
+    ) async throws -> [Command] {
+        dump(target)
+        return [
+            .buildCommand(
+                displayName: "Linting \(target.name)",
+                executable: try context.tool(named: "swiftlint").path,
+                arguments: [
+                    "lint",
+                    "--in-process-sourcekit",
+                    "--path",
+                    target.directory.string,
+                    "--config",
+                    "\(context.package.directory.string)/Plugins/SwiftLintPlugin/swiftlint.yml",
+                ],
+                environment: [:]
+            )
+        ]
+    }
+}

--- a/Plugins/SwiftLintPlugin/plugin.swift
+++ b/Plugins/SwiftLintPlugin/plugin.swift
@@ -13,7 +13,7 @@ struct SwiftLintPlugin: BuildToolPlugin {
         context: PluginContext,
         target: Target
     ) async throws -> [Command] {
-        dump(target)
+        print(context.pluginWorkDirectory)
         return [
             .buildCommand(
                 displayName: "Linting \(target.name)",
@@ -21,10 +21,13 @@ struct SwiftLintPlugin: BuildToolPlugin {
                 arguments: [
                     "lint",
                     "--in-process-sourcekit",
-                    "--path",
-                    target.directory.string,
+                    "--cache-path",
+                    "\(context.pluginWorkDirectory)",
                     "--config",
                     "\(context.package.directory.string)/Plugins/SwiftLintPlugin/swiftlint.yml",
+//                    "--path",
+                    target.directory.string
+
                 ],
                 environment: [:]
             )

--- a/Plugins/SwiftLintPlugin/swiftlint.yml
+++ b/Plugins/SwiftLintPlugin/swiftlint.yml
@@ -1,0 +1,39 @@
+# Do not specify an `included` section at this top-level file. Specify the
+# `--config` option pointing to this file, and the `--path` option to the files
+# you wish to lint
+
+excluded:
+  - Pods
+  - .build
+
+analyzer_rules:
+  - unused_import
+  - unused_declaration
+
+opt_in_rules:
+  - empty_count
+
+# configurable rules can be customized from this configuration file
+closing_brace: error
+colon:
+  severity: error
+comma: error
+empty_count: warning
+empty_enum_arguments: error
+function_body_length:
+  warning: 100
+  error: 150
+identifier_name:
+  excluded:
+    - id
+    - of
+    - or
+line_length:
+  warning: 120
+  error: 300 # 160
+opening_brace: error
+return_arrow_whitespace: error
+statement_position:
+  severity: error
+todo: warning
+trailing_semicolon: error


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adds a `buildtool()` swiftlint plugin, adds that plugin as a dependency for `Amplify` and each plugin. 
Adds `// swiftlint:disable: ...` in a few places in `AWSCognitoAuthPlugin` that were errors.

Implementation based on various points of information and examples in https://github.com/realm/SwiftLint/issues/3840
This targets a specific version of swiftlint w/ checksum.

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
