### PR TITLE
chore(api): fix remaining GraphQlConnection(1,2) to async api

### DIFF
--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario1Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario1Tests.swift
@@ -136,34 +136,23 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
             XCTFail("Failed with: \(response)")
         }
     }
-
-    func testPaginatedListProjects() {
-        guard let team = createTeam(name: "name"),
-              let projecta = createProject(team: team),
-              let projectb = createProject(team: team) else {
-            XCTFail("Could not create team and two projects")
-            return
-        }
-
-        let listProjectByTeamIDCompleted = expectation(description: "list projects completed")
+    
+    func testPaginatedListProjects() async throws {
+        let team = Team1(name: "name")
+        _ = try await Amplify.API.mutate(request: .create(team))
+        let projecta = Project1(team: team)
+        _ = try await Amplify.API.mutate(request: .create(projecta))
+        let projectb = Project1(team: team)
+        _ = try await Amplify.API.mutate(request: .create(projectb))
         var results: List<Project1>?
         let predicate = Project1.keys.id == projecta.id || Project1.keys.id == projectb.id
         let request: GraphQLRequest<List<Project1>> = GraphQLRequest<Project1>.list(Project1.self, where: predicate)
-        Amplify.API.query(request: request) { result in
-            switch result {
-            case .success(let result):
-                switch result {
-                case .success(let projects):
-                    results = projects
-                    listProjectByTeamIDCompleted.fulfill()
-                case .failure(let response):
-                    XCTFail("Failed with: \(response)")
-                }
-            case .failure(let error):
-                XCTFail("\(error)")
-            }
+        let result = try await Amplify.API.query(request: request)
+        guard case .success(let projects) = result else {
+            XCTFail("Missing Successful response")
+            return
         }
-        wait(for: [listProjectByTeamIDCompleted], timeout: TestCommonConstants.networkTimeout)
+        results = projects
         guard var subsequentResults = results else {
             XCTFail("Could not get first results")
             return
@@ -188,52 +177,6 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
             semaphore.wait()
         }
         XCTAssertEqual(resultsArray.count, 2)
-    }
-
-    func createTeam(id: String = UUID().uuidString, name: String) -> Team1? {
-        let team = Team1(id: id, name: name)
-        var result: Team1?
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-        Amplify.API.mutate(request: .create(team)) { event in
-            switch event {
-            case .success(let data):
-                switch data {
-                case .success(let team):
-                    result = team
-                default:
-                    XCTFail("Could not get data back")
-                }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("Failed \(error)")
-            }
-        }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
-        return result
-    }
-
-    func createProject(id: String = UUID().uuidString,
-                       name: String? = nil,
-                       team: Team1? = nil) -> Project1? {
-        let project = Project1(id: id, name: name, team: team)
-        var result: Project1?
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-        Amplify.API.mutate(request: .create(project)) { event in
-            switch event {
-            case .success(let data):
-                switch data {
-                case .success(let project):
-                    result = project
-                default:
-                    XCTFail("Could not get data back")
-                }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("Failed \(error)")
-            }
-        }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
-        return result
     }
 }
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario1Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario1Tests.swift
@@ -136,23 +136,34 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
             XCTFail("Failed with: \(response)")
         }
     }
-    
-    func testPaginatedListProjects() async throws {
-        let team = Team1(name: "name")
-        _ = try await Amplify.API.mutate(request: .create(team))
-        let projecta = Project1(team: team)
-        _ = try await Amplify.API.mutate(request: .create(projecta))
-        let projectb = Project1(team: team)
-        _ = try await Amplify.API.mutate(request: .create(projectb))
+
+    func testPaginatedListProjects() {
+        guard let team = createTeam(name: "name"),
+              let projecta = createProject(team: team),
+              let projectb = createProject(team: team) else {
+            XCTFail("Could not create team and two projects")
+            return
+        }
+
+        let listProjectByTeamIDCompleted = expectation(description: "list projects completed")
         var results: List<Project1>?
         let predicate = Project1.keys.id == projecta.id || Project1.keys.id == projectb.id
         let request: GraphQLRequest<List<Project1>> = GraphQLRequest<Project1>.list(Project1.self, where: predicate)
-        let result = try await Amplify.API.query(request: request)
-        guard case .success(let projects) = result else {
-            XCTFail("Missing Successful response")
-            return
+        Amplify.API.query(request: request) { result in
+            switch result {
+            case .success(let result):
+                switch result {
+                case .success(let projects):
+                    results = projects
+                    listProjectByTeamIDCompleted.fulfill()
+                case .failure(let response):
+                    XCTFail("Failed with: \(response)")
+                }
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
         }
-        results = projects
+        wait(for: [listProjectByTeamIDCompleted], timeout: TestCommonConstants.networkTimeout)
         guard var subsequentResults = results else {
             XCTFail("Could not get first results")
             return
@@ -177,6 +188,52 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
             semaphore.wait()
         }
         XCTAssertEqual(resultsArray.count, 2)
+    }
+
+    func createTeam(id: String = UUID().uuidString, name: String) -> Team1? {
+        let team = Team1(id: id, name: name)
+        var result: Team1?
+        let requestInvokedSuccessfully = expectation(description: "request completed")
+        Amplify.API.mutate(request: .create(team)) { event in
+            switch event {
+            case .success(let data):
+                switch data {
+                case .success(let team):
+                    result = team
+                default:
+                    XCTFail("Could not get data back")
+                }
+                requestInvokedSuccessfully.fulfill()
+            case .failure(let error):
+                XCTFail("Failed \(error)")
+            }
+        }
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
+        return result
+    }
+
+    func createProject(id: String = UUID().uuidString,
+                       name: String? = nil,
+                       team: Team1? = nil) -> Project1? {
+        let project = Project1(id: id, name: name, team: team)
+        var result: Project1?
+        let requestInvokedSuccessfully = expectation(description: "request completed")
+        Amplify.API.mutate(request: .create(project)) { event in
+            switch event {
+            case .success(let data):
+                switch data {
+                case .success(let project):
+                    result = project
+                default:
+                    XCTFail("Could not get data back")
+                }
+                requestInvokedSuccessfully.fulfill()
+            case .failure(let error):
+                XCTFail("Failed \(error)")
+            }
+        }
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
+        return result
     }
 }
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario2Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario2Tests.swift
@@ -140,39 +140,61 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
         }
     }
 
-    func testListProjectsByTeamID() async throws {
-        let team2 = Team2(name: "name")
-        _ = try await Amplify.API.mutate(request: .create(team2))
-        let project2 = Project2(teamID: team2.id, team: team2)
-        _ = try await Amplify.API.mutate(request: .create(project2))
-        let predicate = Project2.keys.teamID.eq(team2.id)
-        let event = try await Amplify.API.query(request: .list(Project2.self, where: predicate))
-        switch event {
-        case .success(let projects):
-            print(projects)
-            XCTAssertEqual(projects[0].id, project2.id)
-        case .failure(let response):
-            XCTFail("Failed with: \(response)")
+    func testListProjectsByTeamID() {
+        guard let team = createTeam2(name: "name") else {
+            XCTFail("Could not create team")
+            return
         }
+        guard createProject2(teamID: team.id, team: team) != nil else {
+            XCTFail("Could not create project")
+            return
+        }
+        let listProjectByTeamIDCompleted = expectation(description: "list projects completed")
+        let predicate = Project2.keys.teamID.eq(team.id)
+        Amplify.API.query(request: .list(Project2.self, where: predicate)) { result in
+            switch result {
+            case .success(let result):
+                switch result {
+                case .success(let projects):
+                    print(projects)
+                    listProjectByTeamIDCompleted.fulfill()
+                case .failure(let response):
+                    XCTFail("Failed with: \(response)")
+                }
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [listProjectByTeamIDCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     // Create two projects for the same team, then list the projects by teamID, and expect two projects
     // after exhausting the paginated list via `hasNextPage` and `getNextPage`
-    func testPaginatedListProjectsByTeamID() async throws {
-        let team2 = Team2(name: "name")
-        _ = try await Amplify.API.mutate(request: .create(team2))
-        let project2a = Project2(teamID: team2.id, team: team2)
-        _ = try await Amplify.API.mutate(request: .create(project2a))
-        let project2b = Project2(teamID: team2.id, team: team2)
-        _ = try await Amplify.API.mutate(request: .create(project2b))
-        var results: List<Project2>?
-        let predicate = Project2.keys.teamID.eq(team2.id)
-        let result = try await Amplify.API.query(request: .list(Project2.self, where: predicate, limit: 1))
-        guard case .success(let projects) = result else {
-            XCTFail("Missing Successful response")
+    func testPaginatedListProjectsByTeamID() {
+        guard let team = createTeam2(name: "name"),
+              createProject2(teamID: team.id, team: team) != nil,
+              createProject2(teamID: team.id, team: team) != nil else {
+            XCTFail("Could not create team and two projects")
             return
         }
-        results = projects
+        let listProjectByTeamIDCompleted = expectation(description: "list projects completed")
+        var results: List<Project2>?
+        let predicate = Project2.keys.teamID.eq(team.id)
+        Amplify.API.query(request: .list(Project2.self, where: predicate, limit: 1)) { result in
+            switch result {
+            case .success(let result):
+                switch result {
+                case .success(let projects):
+                    results = projects
+                    listProjectByTeamIDCompleted.fulfill()
+                case .failure(let response):
+                    XCTFail("Failed with: \(response)")
+                }
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [listProjectByTeamIDCompleted], timeout: TestCommonConstants.networkTimeout)
         guard var subsequentResults = results else {
             XCTFail("Could not get first results")
             return
@@ -197,6 +219,53 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
             semaphore.wait()
         }
         XCTAssertEqual(resultsArray.count, 2)
+    }
+
+    func createTeam2(id: String = UUID().uuidString, name: String) -> Team2? {
+        let team = Team2(id: id, name: name)
+        var result: Team2?
+        let requestInvokedSuccessfully = expectation(description: "request completed")
+        Amplify.API.mutate(request: .create(team)) { event in
+            switch event {
+            case .success(let data):
+                switch data {
+                case .success(let team):
+                    result = team
+                default:
+                    XCTFail("Could not get data back")
+                }
+                requestInvokedSuccessfully.fulfill()
+            case .failure(let error):
+                XCTFail("Failed \(error)")
+            }
+        }
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
+        return result
+    }
+
+    func createProject2(id: String = UUID().uuidString,
+                        name: String? = nil,
+                        teamID: String,
+                        team: Team2? = nil) -> Project2? {
+        let project = Project2(id: id, name: name, teamID: teamID, team: team)
+        var result: Project2?
+        let requestInvokedSuccessfully = expectation(description: "request completed")
+        Amplify.API.mutate(request: .create(project)) { event in
+            switch event {
+            case .success(let data):
+                switch data {
+                case .success(let project):
+                    result = project
+                default:
+                    XCTFail("Could not get data back")
+                }
+                requestInvokedSuccessfully.fulfill()
+            case .failure(let error):
+                XCTFail("Failed \(error)")
+            }
+        }
+        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
+        return result
     }
 }
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario2Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario2Tests.swift
@@ -140,61 +140,39 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
         }
     }
 
-    func testListProjectsByTeamID() {
-        guard let team = createTeam2(name: "name") else {
-            XCTFail("Could not create team")
-            return
+    func testListProjectsByTeamID() async throws {
+        let team2 = Team2(name: "name")
+        _ = try await Amplify.API.mutate(request: .create(team2))
+        let project2 = Project2(teamID: team2.id, team: team2)
+        _ = try await Amplify.API.mutate(request: .create(project2))
+        let predicate = Project2.keys.teamID.eq(team2.id)
+        let event = try await Amplify.API.query(request: .list(Project2.self, where: predicate))
+        switch event {
+        case .success(let projects):
+            print(projects)
+            XCTAssertEqual(projects[0].id, project2.id)
+        case .failure(let response):
+            XCTFail("Failed with: \(response)")
         }
-        guard createProject2(teamID: team.id, team: team) != nil else {
-            XCTFail("Could not create project")
-            return
-        }
-        let listProjectByTeamIDCompleted = expectation(description: "list projects completed")
-        let predicate = Project2.keys.teamID.eq(team.id)
-        Amplify.API.query(request: .list(Project2.self, where: predicate)) { result in
-            switch result {
-            case .success(let result):
-                switch result {
-                case .success(let projects):
-                    print(projects)
-                    listProjectByTeamIDCompleted.fulfill()
-                case .failure(let response):
-                    XCTFail("Failed with: \(response)")
-                }
-            case .failure(let error):
-                XCTFail("\(error)")
-            }
-        }
-        wait(for: [listProjectByTeamIDCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     // Create two projects for the same team, then list the projects by teamID, and expect two projects
     // after exhausting the paginated list via `hasNextPage` and `getNextPage`
-    func testPaginatedListProjectsByTeamID() {
-        guard let team = createTeam2(name: "name"),
-              createProject2(teamID: team.id, team: team) != nil,
-              createProject2(teamID: team.id, team: team) != nil else {
-            XCTFail("Could not create team and two projects")
+    func testPaginatedListProjectsByTeamID() async throws {
+        let team2 = Team2(name: "name")
+        _ = try await Amplify.API.mutate(request: .create(team2))
+        let project2a = Project2(teamID: team2.id, team: team2)
+        _ = try await Amplify.API.mutate(request: .create(project2a))
+        let project2b = Project2(teamID: team2.id, team: team2)
+        _ = try await Amplify.API.mutate(request: .create(project2b))
+        var results: List<Project2>?
+        let predicate = Project2.keys.teamID.eq(team2.id)
+        let result = try await Amplify.API.query(request: .list(Project2.self, where: predicate, limit: 1))
+        guard case .success(let projects) = result else {
+            XCTFail("Missing Successful response")
             return
         }
-        let listProjectByTeamIDCompleted = expectation(description: "list projects completed")
-        var results: List<Project2>?
-        let predicate = Project2.keys.teamID.eq(team.id)
-        Amplify.API.query(request: .list(Project2.self, where: predicate, limit: 1)) { result in
-            switch result {
-            case .success(let result):
-                switch result {
-                case .success(let projects):
-                    results = projects
-                    listProjectByTeamIDCompleted.fulfill()
-                case .failure(let response):
-                    XCTFail("Failed with: \(response)")
-                }
-            case .failure(let error):
-                XCTFail("\(error)")
-            }
-        }
-        wait(for: [listProjectByTeamIDCompleted], timeout: TestCommonConstants.networkTimeout)
+        results = projects
         guard var subsequentResults = results else {
             XCTFail("Could not get first results")
             return
@@ -219,53 +197,6 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
             semaphore.wait()
         }
         XCTAssertEqual(resultsArray.count, 2)
-    }
-
-    func createTeam2(id: String = UUID().uuidString, name: String) -> Team2? {
-        let team = Team2(id: id, name: name)
-        var result: Team2?
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-        Amplify.API.mutate(request: .create(team)) { event in
-            switch event {
-            case .success(let data):
-                switch data {
-                case .success(let team):
-                    result = team
-                default:
-                    XCTFail("Could not get data back")
-                }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("Failed \(error)")
-            }
-        }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
-        return result
-    }
-
-    func createProject2(id: String = UUID().uuidString,
-                        name: String? = nil,
-                        teamID: String,
-                        team: Team2? = nil) -> Project2? {
-        let project = Project2(id: id, name: name, teamID: teamID, team: team)
-        var result: Project2?
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-        Amplify.API.mutate(request: .create(project)) { event in
-            switch event {
-            case .success(let data):
-                switch data {
-                case .success(let project):
-                    result = project
-                default:
-                    XCTFail("Could not get data back")
-                }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("Failed \(error)")
-            }
-        }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
-        return result
     }
 }
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario2Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario2Tests.swift
@@ -140,61 +140,42 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
         }
     }
 
-    func testListProjectsByTeamID() {
-        guard let team = createTeam2(name: "name") else {
+    func testListProjectsByTeamID() async throws {
+        guard let team = try await createTeam2(name: "name") else {
             XCTFail("Could not create team")
             return
         }
-        guard createProject2(teamID: team.id, team: team) != nil else {
+        guard try await createProject2(teamID: team.id, team: team) != nil else {
             XCTFail("Could not create project")
             return
         }
-        let listProjectByTeamIDCompleted = expectation(description: "list projects completed")
         let predicate = Project2.keys.teamID.eq(team.id)
-        Amplify.API.query(request: .list(Project2.self, where: predicate)) { result in
+        let result = try await Amplify.API.query(request: .list(Project2.self, where: predicate))
             switch result {
-            case .success(let result):
-                switch result {
                 case .success(let projects):
                     print(projects)
-                    listProjectByTeamIDCompleted.fulfill()
-                case .failure(let response):
-                    XCTFail("Failed with: \(response)")
-                }
-            case .failure(let error):
-                XCTFail("\(error)")
+                case .failure(let graphQLResponse):
+                    XCTFail("Failed with: \(graphQLResponse)")
             }
-        }
-        wait(for: [listProjectByTeamIDCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     // Create two projects for the same team, then list the projects by teamID, and expect two projects
     // after exhausting the paginated list via `hasNextPage` and `getNextPage`
-    func testPaginatedListProjectsByTeamID() {
-        guard let team = createTeam2(name: "name"),
-              createProject2(teamID: team.id, team: team) != nil,
-              createProject2(teamID: team.id, team: team) != nil else {
+    func testPaginatedListProjectsByTeamID() async throws {
+        guard let team = try await createTeam2(name: "name"),
+              try await createProject2(teamID: team.id, team: team) != nil,
+              try await createProject2(teamID: team.id, team: team) != nil else {
             XCTFail("Could not create team and two projects")
             return
         }
-        let listProjectByTeamIDCompleted = expectation(description: "list projects completed")
         var results: List<Project2>?
         let predicate = Project2.keys.teamID.eq(team.id)
-        Amplify.API.query(request: .list(Project2.self, where: predicate, limit: 1)) { result in
-            switch result {
-            case .success(let result):
-                switch result {
-                case .success(let projects):
-                    results = projects
-                    listProjectByTeamIDCompleted.fulfill()
-                case .failure(let response):
-                    XCTFail("Failed with: \(response)")
-                }
-            case .failure(let error):
-                XCTFail("\(error)")
-            }
+        let result = try await Amplify.API.query(request: .list(Project2.self, where: predicate, limit: 1))
+        guard case .success(let projects) = result else {
+            XCTFail("Missing Successful response")
+            return
         }
-        wait(for: [listProjectByTeamIDCompleted], timeout: TestCommonConstants.networkTimeout)
+        results = projects
         guard var subsequentResults = results else {
             XCTFail("Could not get first results")
             return
@@ -220,51 +201,33 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
         }
         XCTAssertEqual(resultsArray.count, 2)
     }
-
-    func createTeam2(id: String = UUID().uuidString, name: String) -> Team2? {
+    
+    func createTeam2(id: String = UUID().uuidString, name: String) async throws ->  Team2? {
         let team = Team2(id: id, name: name)
         var result: Team2?
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-        Amplify.API.mutate(request: .create(team)) { event in
+        let event = try await Amplify.API.mutate(request: .create(team))
             switch event {
-            case .success(let data):
-                switch data {
                 case .success(let team):
                     result = team
                 default:
                     XCTFail("Could not get data back")
                 }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("Failed \(error)")
-            }
-        }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
     func createProject2(id: String = UUID().uuidString,
                         name: String? = nil,
                         teamID: String,
-                        team: Team2? = nil) -> Project2? {
+                        team: Team2? = nil) async throws -> Project2? {
         let project = Project2(id: id, name: name, teamID: teamID, team: team)
         var result: Project2?
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-        Amplify.API.mutate(request: .create(project)) { event in
+        let event = try await Amplify.API.mutate(request: .create(project))
             switch event {
-            case .success(let data):
-                switch data {
-                case .success(let project):
+            case .success(let project):
                     result = project
-                default:
-                    XCTFail("Could not get data back")
+            case .failure(let graphQLResponseError):
+                    XCTFail("Failed with error: \(graphQLResponseError)")
                 }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("Failed \(error)")
-            }
-        }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+Helpers.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+Helpers.swift
@@ -11,90 +11,54 @@ import XCTest
 @testable import APIHostApp
 
 extension GraphQLConnectionScenario3Tests {
-
-    func createPost(id: String = UUID().uuidString, title: String) -> Post3? {
+    
+    func createPost(id: String = UUID().uuidString, title: String) async throws -> Post3? {
         let post = Post3(id: id, title: title)
         var result: Post3?
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-        Amplify.API.mutate(request: .create(post)) { event in
+        let event = try await Amplify.API.mutate(request: .create(post))
             switch event {
-            case .success(let data):
-                switch data {
                 case .success(let post):
                     result = post
-                default:
-                    XCTFail("Could not get data back")
+                case .failure(let graphQLResponseError):
+                    XCTFail("Failed with error: \(graphQLResponseError)")
                 }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("Failed \(error)")
-            }
-        }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
-    func createComment(id: String = UUID().uuidString, postID: String, content: String) -> Comment3? {
+    func createComment(id: String = UUID().uuidString, postID: String, content: String) async throws -> Comment3? {
         let comment = Comment3(id: id, postID: postID, content: content)
         var result: Comment3?
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-        Amplify.API.mutate(request: .create(comment)) { event in
+        let event = try await Amplify.API.mutate(request: .create(comment))
             switch event {
-            case .success(let data):
-                switch data {
                 case .success(let comment):
                     result = comment
-                default:
-                    XCTFail("Could not get data back")
+                case .failure(let graphQLResponseError):
+                XCTFail("Failed with error: \(graphQLResponseError)")
                 }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("Failed \(error)")
-            }
-        }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
-    func mutatePost(post: Post3) -> Post3? {
+    func mutatePost(post: Post3) async throws -> Post3? {
         var result: Post3?
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-        _ = Amplify.API.mutate(request: .update(post)) { event in
+        let event = try await Amplify.API.mutate(request: .update(post))
             switch event {
-            case .success(let data):
-                switch data {
-                case .success(let post):
-                    result = post
-                default:
-                    XCTFail("Could not get data back")
-                }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("Failed \(error)")
+            case .success(let post):
+                result = post
+            case .failure(let graphQLResponseError):
+                XCTFail("Failed with error: \(graphQLResponseError)")
             }
-        }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
-    func deletePost(post: Post3) -> Post3? {
+    func deletePost(post: Post3) async throws -> Post3? {
         var result: Post3?
-        let requestInvokedSuccessfully = expectation(description: "request completed")
-        _ = Amplify.API.mutate(request: .delete(post)) { event in
+        let event = try await Amplify.API.mutate(request: .delete(post))
             switch event {
-            case .success(let data):
-                switch data {
-                case .success(let post):
-                    result = post
-                default:
-                    XCTFail("Could not get data back")
-                }
-                requestInvokedSuccessfully.fulfill()
-            case .failure(let error):
-                XCTFail("Failed \(error)")
+            case .success(let post):
+                result = post
+            case .failure(let graphQLResponseError):
+                XCTFail("Failed with error: \(graphQLResponseError)")
             }
-        }
-        wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+List.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+List.swift
@@ -30,10 +30,10 @@ import XCTest
  */
 extension GraphQLConnectionScenario3Tests {
 
-    func testGetPostThenIterateComments() {
-        guard let post = createPost(title: "title"),
-              createComment(postID: post.id, content: "content") != nil,
-              createComment(postID: post.id, content: "content") != nil else {
+    func testGetPostThenIterateComments() async throws {
+        guard let post = try await createPost(title: "title"),
+             try await createComment(postID: post.id, content: "content") != nil,
+             try await createComment(postID: post.id, content: "content") != nil else {
             XCTFail("Could not create post and two comments")
             return
         }
@@ -98,10 +98,10 @@ extension GraphQLConnectionScenario3Tests {
         XCTAssertEqual(resultsArray.count, 2)
     }
 
-    func testGetPostThenFetchComments() {
-        guard let post = createPost(title: "title"),
-              createComment(postID: post.id, content: "content") != nil,
-              createComment(postID: post.id, content: "content") != nil else {
+    func testGetPostThenFetchComments() async throws {
+        guard let post = try await createPost(title: "title"),
+              try await createComment(postID: post.id, content: "content") != nil,
+              try await createComment(postID: post.id, content: "content") != nil else {
             XCTFail("Could not create post and two comments")
             return
         }
@@ -165,8 +165,8 @@ extension GraphQLConnectionScenario3Tests {
     }
 
     // Create a post and list the posts
-    func testListPost() {
-        guard createPost(title: "title") != nil else {
+    func testListPost() async throws {
+        guard try await createPost(title: "title") != nil else {
             XCTFail("Failed to ensure at least one Post to be retrieved on the listQuery")
             return
         }
@@ -191,11 +191,11 @@ extension GraphQLConnectionScenario3Tests {
         wait(for: [requestInvokedSuccessfully], timeout: TestCommonConstants.networkTimeout)
     }
 
-    func testListPostWithPredicate() {
+    func testListPostWithPredicate() async throws {
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let uniqueTitle = testMethodName + uuid + "Title"
-        guard let createdPost = createPost(id: uuid, title: uniqueTitle) else {
+        guard let createdPost = try await createPost(id: uuid, title: uniqueTitle) else {
             XCTFail("Failed to ensure at least one Post to be retrieved on the listQuery")
             return
         }
@@ -228,12 +228,12 @@ extension GraphQLConnectionScenario3Tests {
 
     // Create a post and a comment with that post
     // list the comments by postId
-    func testListCommentsByPostID() {
-        guard let post = createPost(title: "title") else {
+    func testListCommentsByPostID() async throws {
+        guard let post = try await createPost(title: "title") else {
             XCTFail("Could not create post")
             return
         }
-        guard createComment(postID: post.id, content: "content") != nil else {
+        guard try await createComment(postID: post.id, content: "content") != nil else {
             XCTFail("Could not create comment")
             return
         }
@@ -265,16 +265,16 @@ extension GraphQLConnectionScenario3Tests {
     ///    - subsequent queries exhaust the results from the API to retrieve the remaining results
     /// - Then:
     ///    - the in-memory Array is a populated with exactly two comments.
-    func testPaginatedListCommentsByPostID() {
-        guard let post = createPost(title: "title") else {
+    func testPaginatedListCommentsByPostID() async throws {
+        guard let post = try await createPost(title: "title") else {
             XCTFail("Could not create post")
             return
         }
-        guard createComment(postID: post.id, content: "content") != nil else {
+        guard try await createComment(postID: post.id, content: "content") != nil else {
             XCTFail("Could not create comment")
             return
         }
-        guard createComment(postID: post.id, content: "content") != nil else {
+        guard try await createComment(postID: post.id, content: "content") != nil else {
             XCTFail("Could not create comment")
             return
         }
@@ -330,9 +330,9 @@ extension GraphQLConnectionScenario3Tests {
     ///    - A `fetch` is made when `hasNextPage` returns false.
     /// - Then:
     ///    - A validation error is returned
-    func testPaginatedListFetchValidationError() throws {
+    func testPaginatedListFetchValidationError() async throws {
         let uuid1 = UUID().uuidString
-        guard createPost(id: uuid1, title: "title") != nil else {
+        guard try await createPost(id: uuid1, title: "title") != nil else {
             XCTFail("Failed to create post")
             return
         }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+Subscribe.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+Subscribe.swift
@@ -96,110 +96,91 @@ extension GraphQLConnectionScenario3Tests {
 
         await task.cancel()
     }
-
-    func testOnDeletePostSubscriptionWithModel() {
-        let connectedInvoked = expectation(description: "Connection established")
-        let disconnectedInvoked = expectation(description: "Connection disconnected")
-        let completedInvoked = expectation(description: "Completed invoked")
-        let progressInvoked = expectation(description: "progress invoked")
-
-        let operation = Amplify.API.subscribe(
-            request: .subscription(of: Post3.self, type: .onDelete),
-            valueListener: { event in
-                switch event {
+    
+    func testOnDeletePostSubscriptionWithModel() async throws {
+        let connectingInvoked = AsyncExpectation(description: "Connection connecting")
+        let connectedInvoked = AsyncExpectation(description: "Connection established")
+        let progressInvoked = AsyncExpectation(description: "progress invoked")
+        
+        let task = try await Amplify.API.subscribe(request: .subscription(of: Post3.self, type: .onDelete))
+        let subscription = await task.subscription
+        Task {
+            for await subscriptionEvent in subscription {
+                switch subscriptionEvent {
                 case .connection(let state):
                     switch state {
                     case .connecting:
-                        break
+                        await connectingInvoked.fulfill()
                     case .connected:
-                        connectedInvoked.fulfill()
+                        await connectedInvoked.fulfill()
                     case .disconnected:
-                        disconnectedInvoked.fulfill()
+                        break
                     }
                 case .data:
-                    progressInvoked.fulfill()
+                    await progressInvoked.fulfill()
                 }
-        },
-            completionListener: { event in
-                switch event {
-                case .failure(let error):
-                    XCTFail("Unexpected .failed event: \(error)")
-                case .success:
-                    completedInvoked.fulfill()
-                }
-        })
-        XCTAssertNotNil(operation)
-        wait(for: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+            }
+        }
+        try await AsyncExpectation.waitForExpectations([connectingInvoked, connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
 
-        guard let post = createPost(id: uuid, title: title) else {
+        guard let post = try await createPost(id: uuid, title: title) else {
             XCTFail("Failed to create post")
             return
         }
 
-        guard deletePost(post: post) != nil else {
+        guard try await deletePost(post: post) != nil else {
             XCTFail("Failed to update post")
             return
         }
 
-        wait(for: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
-        operation.cancel()
-        wait(for: [disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
-        XCTAssertTrue(operation.isFinished)
+        try await AsyncExpectation.waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await task.cancel()
     }
 
-    func testOnCreateCommentSubscriptionWithModel() {
-        let connectedInvoked = expectation(description: "Connection established")
-        let disconnectedInvoked = expectation(description: "Connection disconnected")
-        let completedInvoked = expectation(description: "Completed invoked")
-        let progressInvoked = expectation(description: "progress invoked")
-
-        let operation = Amplify.API.subscribe(
-            request: .subscription(of: Comment3.self, type: .onCreate),
-            valueListener: { event in
-                switch event {
+    func testOnCreateCommentSubscriptionWithModel() async throws {
+        let connectingInvoked = AsyncExpectation(description: "Connection connecting")
+        let connectedInvoked = AsyncExpectation(description: "Connection established")
+        let progressInvoked = AsyncExpectation(description: "progress invoked")
+        let task = try await Amplify.API.subscribe(request: .subscription(of: Comment3.self, type: .onCreate))
+        let subscription = await task.subscription
+        Task {
+            for await subscriptionEvent in subscription {
+                switch subscriptionEvent {
                 case .connection(let state):
                     switch state {
                     case .connecting:
-                        break
+                        await connectingInvoked.fulfill()
                     case .connected:
-                        connectedInvoked.fulfill()
+                        await connectedInvoked.fulfill()
                     case .disconnected:
-                        disconnectedInvoked.fulfill()
+                        break
                     }
                 case .data:
-                    progressInvoked.fulfill()
+                    await progressInvoked.fulfill()
                 }
-        },
-            completionListener: { event in
-                switch event {
-                case .failure(let error):
-                    XCTFail("Unexpected .failed event: \(error)")
-                case .success:
-                    completedInvoked.fulfill()
-                }
-        })
-        XCTAssertNotNil(operation)
-        wait(for: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+            }
+        }
+        XCTAssertNotNil(task)
+        try await AsyncExpectation.waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let title = testMethodName + "Title"
 
-        guard let createdPost = createPost(id: uuid, title: title) else {
+        guard let createdPost = try await createPost(id: uuid, title: title) else {
             XCTFail("Failed to create post")
             return
         }
 
-        guard createComment(postID: createdPost.id, content: "content") != nil else {
+        guard try await createComment(postID: createdPost.id, content: "content") != nil else {
             XCTFail("Failed to create comment with post")
             return
         }
 
-        wait(for: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
-        operation.cancel()
-        wait(for: [disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
-        XCTAssertTrue(operation.isFinished)
+        try await AsyncExpectation.waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await task.cancel()
+
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
fixed remaining tests of the GraphQLConnectionScrenario1Tests and GraphQLConnectionScrenario2Tests, in continuation with [https://github.com/aws-amplify/amplify-ios/pull/2178](url)
<img width="378" alt="Screen Shot 2022-08-29 at 1 06 26 PM" src="https://user-images.githubusercontent.com/107574718/187288723-8290296e-cea1-4233-8824-1e51bcf19596.png">


*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
