### PR TITLE
chore(datastore): update PR template with checkpoints

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,8 @@
 
 *DataStore checkpoints (check when completed)*
 
+- PR title should reflect V2, ie. `fix(datastore-v2)`.
+- If applicable, apply the change in V1 and reference the PR here: 
 - [ ] Ran AWSDataStorePluginIntegrationTests
 - [ ] Ran AWSDataStorePluginV2Tests
 - [ ] Ran AWSDataStorePluginMultiAuthTests

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,8 +15,6 @@
 
 *DataStore checkpoints (check when completed)*
 
-- PR title should reflect V2, ie. `fix(datastore-v2)`.
-- If applicable, apply the change in V1 and reference the PR here: 
 - [ ] Ran AWSDataStorePluginIntegrationTests
 - [ ] Ran AWSDataStorePluginV2Tests
 - [ ] Ran AWSDataStorePluginMultiAuthTests

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,13 @@
 - [ ] PR title conforms to conventional commit style
 - [ ] If breaking change, documentation/changelog update with migration instructions
 
+*DataStore checkpoints (check when completed)*
+
+- [ ] Ran AWSDataStorePluginIntegrationTests
+- [ ] Ran AWSDataStorePluginV2Tests
+- [ ] Ran AWSDataStorePluginMultiAuthTests
+- [ ] Ran AWSDataStorePluginCPKTests
+- [ ] Ran AWSDataStorePluginAuthCognitoTests
+- [ ] Ran AWSDataStorePluginAuthIAMTests
+
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Until the integration tests are running consistently successfully in github actions, add a PR template reminder to run the integration tests manually.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
