### PR TITLE
fix(Storage): Fix storage pause() tests

### DIFF
--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -1,7 +1,7 @@
 name: Integration Tests
 on:
   push:
-    branches: [dev-preview]
+    branches: [dev-preview, fix/storage-pause-tests]
 
 permissions:
     id-token: write

--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -1,7 +1,7 @@
 name: Integration Tests
 on:
   push:
-    branches: [dev-preview, fix/storage-pause-tests]
+    branches: [dev-preview]
 
 permissions:
     id-token: write

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginGetDataResumabilityTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginGetDataResumabilityTests.swift
@@ -28,26 +28,21 @@ class AWSS3StoragePluginDownloadDataResumabilityTests: AWSS3StoragePluginTestBas
             let task = try await Amplify.Storage.downloadData(key: key)
 
             let didPause = asyncExpectation(description: "did pause")
-            let didContinue = asyncExpectation(description: "did continue", isInverted: true)
+            let didFinish = asyncExpectation(description: "did finish", isInverted: true)
             Task {
                 var paused = false
-                var progressAfterPause = 0
                 for await progress in await task.progress {
-                    Self.logger.debug("progress: \(progress)")
-                    if !paused {
+                    if !paused, progress.fractionCompleted > 0.0 {
                         paused = true
                         task.pause()
                         await didPause.fulfill()
-                    } else {
-                        progressAfterPause += 1
-                        if progressAfterPause > 1 {
-                            await didContinue.fulfill()
-                        }
+                    } else if paused, progress.isFinished {
+                        await didFinish.fulfill()
                     }
                 }
             }
             await waitForExpectations([didPause], timeout: TestCommonConstants.networkTimeout)
-            await waitForExpectations([didContinue], timeout: 5)
+            await waitForExpectations([didFinish], timeout: 5)
 
             let completeInvoked = asyncExpectation(description: "Download is completed", isInverted: true)
             let downloadTask = Task {


### PR DESCRIPTION
*Issue #, if available:* Fix storage pause tests

*Description of changes:* Change the expectation for `testDownloadDataAndPause` and `testUploadLargeDataThenPause` to account for network speed/file size.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
