### PR TITLE
fix: Make AWSPluginsCore public

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -295,6 +295,10 @@ let package = Package(
             targets: ["Amplify"]
         ),
         .library(
+            name: "AWSPluginsCore",
+            targets: ["AWSPluginsCore"]
+        ),
+        .library(
             name: "AWSAPIPlugin",
             targets: ["AWSAPIPlugin"]
         ),


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Re-enables `AWSPluginsCore` as a public product of amplify-swift

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] ~Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
