### PR TITLE
fix(analytics): update pinpoint event attribute limits to match docum

### DIFF
--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/PinpointEvent.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/PinpointEvent.swift
@@ -86,7 +86,7 @@ extension PinpointEvent: DefaultLogger {}
 extension PinpointEvent {
     private struct Constants {
         static let maxNumberOfAttributesAndMetrics = 40
-        static let maxKeyLength = 40
+        static let maxKeyLength = 50
         static let maxValueLenght = 200
     }
 }

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/PinpointEvent.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/PinpointEvent.swift
@@ -85,8 +85,8 @@ extension PinpointEvent: DefaultLogger {}
 
 extension PinpointEvent {
     private struct Constants {
-        static let maxNumberOfAttributesAndMetrics = 50
-        static let maxKeyLength = 50
-        static let maxValueLenght = 1000
+        static let maxNumberOfAttributesAndMetrics = 40
+        static let maxKeyLength = 40
+        static let maxValueLenght = 200
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-swift/issues/2471
*Description of changes:*
* Updating pinpoint event max attributes limit and value length to match [Pinpoint documentation](https://docs.aws.amazon.com/pinpoint/latest/developerguide/quotas.html#quotas-events)
*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
