### PR TITLE
fix(Auth): Making improvements to federation flow

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/Federation/ClearFederationToIdentityPool.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/Federation/ClearFederationToIdentityPool.swift
@@ -18,8 +18,18 @@ struct ClearFederationToIdentityPool: Action {
 
         let event: StateMachineEvent
         do {
-            try await credentialStoreClient?.deleteData(type: .amplifyCredentials)
-            event = AuthenticationEvent.init(eventType: .clearedFederationToIdentityPool)
+            // Check if we have credentials are of type federation, otherwise throw an error
+            if case .amplifyCredentials(let credentials) = try await credentialStoreClient?.fetchData(
+                type: .amplifyCredentials),
+               case .identityPoolWithFederation = credentials {
+
+                try await credentialStoreClient?.deleteData(type: .amplifyCredentials)
+                event = AuthenticationEvent.init(eventType: .clearedFederationToIdentityPool)
+            } else {
+                let error = AuthenticationError.service(message: "Unable to find credentials to clear for federation.")
+                event = AuthenticationEvent.init(eventType: .error(error))
+                logError("\(#fileID) Sending event \(event.type) with error \(error)", environment: environment)
+            }
 
         } catch {
             let error = AuthenticationError.unknown(message: "Unable to clear credential store: \(error)")

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AmplifyCredentials+CognitoSession.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AmplifyCredentials+CognitoSession.swift
@@ -31,8 +31,13 @@ extension AmplifyCredentials {
                 identityIdResult: .success(identityId),
                 awsCredentialsResult: .success(awsCredentials),
                 cognitoTokensResult: .failure(
-                    .signedOut("Cognito tokens unavailable when federated to identity pool",
-                               "Clear federation and sign to get user pool tokens.", nil)))
+                    .invalidState(
+                        "Users Federated to Identity Pool do not have User Pool access.",
+                        "To access User Pool data, you must use a Sign In method.",
+                        nil
+                    )
+                )
+            )
         case .userPoolAndIdentityPool(let signedInData, let identityID, let credentials):
             return AWSAuthCognitoSession(
                 isSignedIn: true,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Errors/FetchSessionError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Errors/FetchSessionError.swift
@@ -77,7 +77,7 @@ extension FetchSessionError: AuthErrorConvertible {
                 AmplifyErrorMessages.reportBugToAWS())
         case .federationNotSupportedDuringRefresh:
             return .unknown(
-                "Federation triggered during refresh session that is not supported. \(AmplifyErrorMessages.reportBugToAWS())")
+                "Refreshing credentials from federationToIdentityPool is not supported \(AmplifyErrorMessages.reportBugToAWS())")
         case .service(let error):
             return .service(
                 "Service error occurred",

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/AuthorizationState.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/AuthorizationState.swift
@@ -19,8 +19,10 @@ enum AuthorizationState: State {
 
     case clearingFederation
 
-    case federatingToIdentityPool(FetchAuthSessionState,
-                                  FederatedToken)
+    case federatingToIdentityPool(
+        FetchAuthSessionState,
+        FederatedToken,
+        existingCredentials: AmplifyCredentials)
 
     case fetchingUnAuthSession(FetchAuthSessionState)
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/DebugInfo/AuthorizationState+Debug.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/DebugInfo/AuthorizationState+Debug.swift
@@ -24,7 +24,7 @@ extension AuthorizationState: CustomDebugDictionaryConvertible {
                                             "refreshState": state.debugDictionary]
         case .fetchingUnAuthSession(let state),
                 .fetchingAuthSessionWithUserPool(let state, _),
-                .federatingToIdentityPool(let state, _):
+                .federatingToIdentityPool(let state, _, _):
             additionalMetadataDictionary = state.debugDictionary
 
         case .error(let error):

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/Authentication/AuthenticationState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/Authentication/AuthenticationState+Resolver.swift
@@ -122,6 +122,13 @@ extension AuthenticationState {
                 } else if let authZEvent = event.isAuthorizationEvent,
                          case .startFederationToIdentityPool = authZEvent {
                     return .init(newState: .federatingToIdentityPool)
+                } else if let authEvent = event as? AuthenticationEvent,
+                   case .clearFederationToIdentityPool = authEvent.eventType {
+                    return .init(
+                        newState: .clearingFederation,
+                        actions: [
+                            ClearFederationToIdentityPool()
+                        ])
                 } else {
                     return .from(oldState)
                 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/HubEventTests/AuthHubEventHandlerTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/HubEventTests/AuthHubEventHandlerTests.swift
@@ -278,6 +278,7 @@ class AuthHubEventHandlerTests: XCTestCase {
             }
         }
 
+        _ = try await plugin.federateToIdentityPool(withProviderToken: "something", for: .facebook)
         try await plugin.clearFederationToIdentityPool()
 
         await waitForExpectations(timeout: networkTimeout)

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFederationToIdentityPoolTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFederationToIdentityPoolTests.swift
@@ -247,6 +247,64 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
 
     /// Test clear federation to identity pool
     ///
+    /// - Given: Given an auth plugin with an intial error state
+    /// - When:
+    ///    - I invoke clearFederationToIdentityPool
+    /// - Then:
+    ///    - I should get success result
+    ///
+    func testClearFederationToIdentityPoolWithInitialErrorState() async throws {
+
+        var shouldThrowError = false
+        let credentials = CognitoIdentityClientTypes.Credentials(
+            accessKeyId: "accessKey",
+            expiration: Date(),
+            secretKey: "secret",
+            sessionToken: "session")
+
+        let getId: MockIdentity.MockGetIdResponse = { _ in
+            if shouldThrowError {
+                throw GetIdOutputError.internalErrorException(.init())
+            } else {
+                return .init(identityId: "mockIdentityId")
+            }
+        }
+
+        let getCredentials: MockIdentity.MockGetCredentialsResponse = { _ in
+            return .init(credentials: credentials, identityId: "mockIdentityId")
+        }
+
+        let plugin = configurePluginWith(
+            identityPool: {
+                MockIdentity(
+                    mockGetIdResponse: getId,
+                    mockGetCredentialsResponse: getCredentials)
+            },
+            initialState: AuthState.configured(
+                AuthenticationState.error(.testData),
+                AuthorizationState.error(.invalidState(message: ""))))
+        do {
+            // Should setup the plugin with a token
+            shouldThrowError = false
+            _ = try await plugin.federateToIdentityPool(
+                withProviderToken: "someToken",
+                for: .facebook)
+
+            // Push the AuthState to an error state
+            shouldThrowError = true
+            _ = try? await plugin.federateToIdentityPool(
+                withProviderToken: "someToken",
+                for: .facebook)
+
+            // Should still be able to clear credentials
+            try await plugin.clearFederationToIdentityPool()
+        } catch {
+            XCTFail("Received failure with error \(error)")
+        }
+    }
+
+    /// Test clear federation to identity pool
+    ///
     /// - Given: Given an auth plugin with federated state
     /// - When:
     ///    - I invoke clearFederationToIdentityPool
@@ -255,14 +313,18 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
     ///
     func testClearFederationToIdentityPool() async throws {
 
+        let credentials = CognitoIdentityClientTypes.Credentials(
+            accessKeyId: "accessKey",
+            expiration: Date(),
+            secretKey: "secret",
+            sessionToken: "session")
+
         let getId: MockIdentity.MockGetIdResponse = { _ in
-            XCTFail("Get ID should not get called")
             return .init(identityId: "mockIdentityId")
         }
 
         let getCredentials: MockIdentity.MockGetCredentialsResponse = { _ in
-            XCTFail("Get AWS Credentials should not get called")
-            return .init(credentials: .none, identityId: "mockIdentityId")
+            return .init(credentials: credentials, identityId: "mockIdentityId")
         }
 
         let statesToTest = [
@@ -271,7 +333,10 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
                 AuthorizationState.sessionEstablished(.identityPoolWithFederation(
                     federatedToken: .testData,
                     identityID: "identityId",
-                    credentials: .testData)))
+                    credentials: .testData))),
+            AuthState.configured(
+                AuthenticationState.error(.testData),
+                AuthorizationState.error(.invalidState(message: "")))
         ]
 
         for initialState in statesToTest {
@@ -283,6 +348,9 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
                 },
                 initialState: initialState)
             do {
+                _ = try await plugin.federateToIdentityPool(
+                    withProviderToken: "someToken",
+                    for: .facebook)
                 try await plugin.clearFederationToIdentityPool()
             } catch {
                 XCTFail("Received failure with error \(error)")
@@ -418,8 +486,18 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
             XCTAssertNotNil(identityId)
             XCTAssertEqual(identityId, mockIdentityId)
 
-            let tokens = try? (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
-            XCTAssertNil(tokens)
+            do {
+                _ = try (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
+            }
+            catch let error as AuthError {
+                guard case .invalidState = error else {
+                    XCTFail("Should throw Auth Error with invalid state \(error)")
+                    return
+                }
+            } catch {
+                XCTFail("Should throw Auth Error \(error)")
+            }
+
         } catch {
             XCTFail("Received failure with error \(error)")
         }
@@ -487,8 +565,17 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
             XCTAssertNotNil(identityId)
             XCTAssertEqual(identityId, mockIdentityId)
 
-            let tokens = try? (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
-            XCTAssertNil(tokens)
+            do {
+                _ = try (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
+            }
+            catch let error as AuthError {
+                guard case .invalidState = error else {
+                    XCTFail("Should throw Auth Error with invalid state \(error)")
+                    return
+                }
+            } catch {
+                XCTFail("Should throw Auth Error \(error)")
+            }
         } catch {
             XCTFail("Received failure with error \(error)")
         }
@@ -570,8 +657,17 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
             XCTAssertNotNil(identityId)
             XCTAssertEqual(identityId, mockIdentityId)
 
-            let tokens = try? (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
-            XCTAssertNil(tokens)
+            do {
+                _ = try (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
+            }
+            catch let error as AuthError {
+                guard case .invalidState = error else {
+                    XCTFail("Should throw Auth Error with invalid state \(error)")
+                    return
+                }
+            } catch {
+                XCTFail("Should throw Auth Error \(error)")
+            }
         } catch {
             XCTFail("Received failure with error \(error)")
         }
@@ -659,5 +755,175 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
             }
         }
     }
+
+    /// Test federated to identity pool after an initial error
+    ///
+    /// - Given: Given an auth plugin with different valid states
+    /// - When:
+    ///    - I invoke first federateToIdentityPool, should throw an error
+    ///    - I invoke second federateToIdentityPool,
+    /// - Then:
+    ///    - I should get a valid FederatedToken result with the following details:
+    ///         - valid aws credentials
+    ///         - valid identity id
+    ///
+    func testFederateToIdentityPoolWhenGetIdErrorsOut() async throws {
+
+        var shouldThrowError: Bool = false
+
+        let provider = AuthProvider.facebook
+        let authenticationToken = "authenticationToken"
+        let mockIdentityId = "identityId"
+
+        let credentials = CognitoIdentityClientTypes.Credentials(
+            accessKeyId: "accessKey",
+            expiration: Date(),
+            secretKey: "secretAccessKey",
+            sessionToken: "sessionKey")
+
+        let getId: MockIdentity.MockGetIdResponse = { input in
+            return .init(identityId: mockIdentityId)
+        }
+
+        let getCredentials: MockIdentity.MockGetCredentialsResponse = { input in
+            if shouldThrowError {
+                throw GetCredentialsForIdentityOutputError.internalErrorException(.init())
+            } else {
+                return .init(credentials: credentials, identityId: mockIdentityId)
+            }
+        }
+
+        let initialState = AuthState.configured(
+            AuthenticationState.signedOut(.testData),
+            AuthorizationState.sessionEstablished(
+                AmplifyCredentials.testDataIdentityPoolWithExpiredTokens))
+
+        let plugin = configurePluginWith(
+            identityPool: {
+                MockIdentity(
+                    mockGetIdResponse: getId,
+                    mockGetCredentialsResponse: getCredentials)
+            },
+            initialState: initialState)
+
+        shouldThrowError = true
+        do {
+            _ = try await plugin.federateToIdentityPool(withProviderToken: authenticationToken, for: provider)
+        } catch let error as AuthError {
+            guard case .service = error else {
+                XCTFail("Should receive service error \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Test should throw Auth Error")
+        }
+
+        shouldThrowError = false
+        do {
+            let federatedResult = try await plugin.federateToIdentityPool(withProviderToken: authenticationToken, for: provider)
+            XCTAssertNotNil(federatedResult)
+            XCTAssertEqual(federatedResult.credentials.sessionToken, credentials.sessionToken)
+            XCTAssertEqual(federatedResult.credentials.accessKeyId, credentials.accessKeyId)
+            XCTAssertEqual(federatedResult.credentials.secretAccessKey, credentials.secretKey)
+            XCTAssertEqual(federatedResult.identityId, mockIdentityId)
+        } catch {
+            XCTFail("Received failure with error \(error)")
+        }
+    }
+
+    /// Test success fetchAuthSession after an error when federated to identity pool with valid credentials
+    ///
+    /// - Given: Given an auth plugin with a federated state
+    /// - When:
+    ///    - I invoke fetchAuthSession, throws error internal error exception
+    ///    - I invoke fetchAuthSession, should return valid credentials
+    /// - Then:
+    ///    - I should get a valid Cognito result with the following details:
+    ///         - isSignedIn as true
+    ///         - valid aws credentials
+    ///         - valid identity id
+    ///         - invalid user pool tokens error
+    ///
+    func testFetchAuthSessionFederatedToIdentityPoolWhenGetIdError() async throws {
+
+        let mockIdentityId = "mockIdentityId"
+
+        var shouldThrowError: Bool = false
+
+        let federatedToken: FederatedToken = .testData
+        let credentials = CognitoIdentityClientTypes.Credentials(
+            accessKeyId: "accessKey",
+            expiration: Date(),
+            secretKey: "secretAccessKey",
+            sessionToken: "sessionKey")
+
+        let getId: MockIdentity.MockGetIdResponse = { _ in
+            XCTFail("GetId should not be called")
+            throw GetIdOutputError.internalErrorException(.init())
+        }
+
+        let getCredentials: MockIdentity.MockGetCredentialsResponse = { _ in
+            if shouldThrowError {
+                throw GetCredentialsForIdentityOutputError.internalErrorException(.init())
+            } else {
+                return .init(credentials: credentials, identityId: mockIdentityId)
+            }
+        }
+
+        let initialState = AuthState.configured(
+            AuthenticationState.signedOut(.testData),
+            AuthorizationState.sessionEstablished(
+                .identityPoolWithFederation(
+                    federatedToken: federatedToken,
+                    identityID: mockIdentityId,
+                    credentials: .expiredTestData)))
+
+        let plugin = configurePluginWith(
+            identityPool: {
+                MockIdentity(
+                    mockGetIdResponse: getId,
+                    mockGetCredentialsResponse: getCredentials)
+            },
+            initialState: initialState)
+
+
+        shouldThrowError = true
+        do {
+            let session = try await plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options())
+            XCTAssertFalse(session.isSignedIn)
+            let creds = try? (session as? AuthAWSCredentialsProvider)?.getAWSCredentials().get()
+            XCTAssertNil(creds?.accessKeyId)
+            XCTAssertNil(creds?.secretAccessKey)
+
+            let identityId = try? (session as? AuthCognitoIdentityProvider)?.getIdentityId().get()
+            XCTAssertNil(identityId)
+
+            let tokens = try? (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
+            XCTAssertNil(tokens)
+        } catch {
+            XCTFail("Received failure with error \(error)")
+        }
+
+        shouldThrowError = false
+        do {
+            let session = try await plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options())
+            XCTAssertTrue(session.isSignedIn)
+            let creds = try? (session as? AuthAWSCredentialsProvider)?.getAWSCredentials().get()
+            XCTAssertNotNil(creds?.accessKeyId)
+            XCTAssertNotNil(creds?.secretAccessKey)
+            XCTAssertEqual(creds?.secretAccessKey, credentials.secretKey)
+            XCTAssertEqual(creds?.accessKeyId, credentials.accessKeyId)
+
+            let identityId = try? (session as? AuthCognitoIdentityProvider)?.getIdentityId().get()
+            XCTAssertNotNil(identityId)
+            XCTAssertEqual(identityId, mockIdentityId)
+
+            let tokens = try? (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
+            XCTAssertNil(tokens)
+        } catch {
+            XCTFail("Received failure with error \(error)")
+        }
+    }
+    
 
 }


### PR DESCRIPTION
*Issue #, if available:*
* Adding the ability to clear credentials when in an error state
* Fixing fetchAuthSession and federation workflows when in an error state

*Description of changes:*

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
