### PR TITLE
fix(Analytics): Fixing Analytics issues

### DIFF
--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+ClientBehavior.swift
@@ -100,7 +100,7 @@ extension AWSPinpointAnalyticsPlugin {
         }
 
         // Do not attempt to submit events if we detect the device is offline, as it's gonna fail anyway
-        guard networkMonitor.currentPath.status == .satisfied else {
+        guard networkMonitor.isOnline else {
             let errorMessage = "Cannot flushEvents. \(AnalyticsPluginErrorConstant.deviceOffline.errorDescription)"
             log.error(errorMessage)
             Amplify.Hub.dispatchFlushEvents(.unknown(errorMessage))

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Configure.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Configure.swift
@@ -9,6 +9,7 @@ import Amplify
 import AWSPinpoint
 import AWSPluginsCore
 import Foundation
+import Network
 
 extension AWSPinpointAnalyticsPlugin {
     /// Configures AWSPinpointAnalyticsPlugin with the specified configuration.
@@ -83,5 +84,11 @@ extension AWSPinpointAnalyticsPlugin {
         isEnabled = true
         self.autoFlushEventsTimer = autoFlushEventsTimer
         self.autoFlushEventsTimer?.resume()
+        networkMonitor.start(
+            queue: DispatchQueue(
+                label: "com.amazonaws.Amplify.AWSPinpointAnalyticsPlugin.NetworkMonitor",
+                qos: .background
+            )
+        )
     }
 }

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Configure.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Configure.swift
@@ -69,7 +69,8 @@ extension AWSPinpointAnalyticsPlugin {
 
         configure(pinpoint: pinpoint,
                   authService: authService,
-                  autoFlushEventsTimer: autoFlushEventsTimer)
+                  autoFlushEventsTimer: autoFlushEventsTimer,
+                  networkMonitor: NWPathMonitor())
     }
 
     // MARK: Internal
@@ -77,17 +78,18 @@ extension AWSPinpointAnalyticsPlugin {
     /// Internal configure method to set the properties of the plugin
     func configure(pinpoint: AWSPinpointBehavior,
                    authService: AWSAuthServiceBehavior,
-                   autoFlushEventsTimer: DispatchSourceTimer?) {
+                   autoFlushEventsTimer: DispatchSourceTimer?,
+                   networkMonitor: NetworkMonitor) {
         self.pinpoint = pinpoint
         self.authService = authService
         globalProperties = [:]
         isEnabled = true
         self.autoFlushEventsTimer = autoFlushEventsTimer
         self.autoFlushEventsTimer?.resume()
-        networkMonitor.start(
-            queue: DispatchQueue(
-                label: "com.amazonaws.Amplify.AWSPinpointAnalyticsPlugin.NetworkMonitor",
-                qos: .background
+        self.networkMonitor = networkMonitor
+        self.networkMonitor.startMonitoring(
+            using: DispatchQueue(
+                label: "com.amazonaws.Amplify.AWSPinpointAnalyticsPlugin.NetworkMonitor"
             )
         )
     }

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Reset.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+Reset.swift
@@ -31,5 +31,10 @@ extension AWSPinpointAnalyticsPlugin {
         if isEnabled != nil {
             isEnabled = nil
         }
+        
+        if networkMonitor != nil {
+            networkMonitor.stopMonitoring()
+            networkMonitor = nil
+        }
     }
 }

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin.swift
@@ -9,6 +9,7 @@ import Amplify
 import AWSPinpoint
 import AWSPluginsCore
 import Foundation
+import Network
 
 /// The AWSPinpointAnalyticsPlugin implements the Analytics APIs for Pinpoint
 public final class AWSPinpointAnalyticsPlugin: AnalyticsCategoryPlugin {
@@ -27,6 +28,9 @@ public final class AWSPinpointAnalyticsPlugin: AnalyticsCategoryPlugin {
     /// Optional timer is nil when auto flush is disabled
     /// Otherwise automatically flushes the events that have been recorded on an interval
     var autoFlushEventsTimer: DispatchSourceTimer?
+    
+    /// An observer to monitor connectivity changes
+    let networkMonitor = NWPathMonitor()
 
     /// The unique key of the plugin within the analytics category
     public var key: PluginKey {

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin.swift
@@ -30,7 +30,7 @@ public final class AWSPinpointAnalyticsPlugin: AnalyticsCategoryPlugin {
     var autoFlushEventsTimer: DispatchSourceTimer?
     
     /// An observer to monitor connectivity changes
-    let networkMonitor = NWPathMonitor()
+    var networkMonitor: NetworkMonitor!
 
     /// The unique key of the plugin within the analytics category
     public var key: PluginKey {

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/LocalStorage/AnalyticsEventSQLStorage.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/LocalStorage/AnalyticsEventSQLStorage.swift
@@ -121,7 +121,7 @@ class AnalyticsEventSQLStorage: AnalyticsEventStorage {
     /// - Returns: A collection of PinpointEvent
     func getEventsWith(limit: Int) throws -> [PinpointEvent] {
         let queryStatement = """
-        SELECT id, attributes, eventType, metrics, eventTimestamp, sessionId, sessionStartTime, sessionStopTime, timestamp, retryCount
+        SELECT id, attributes, eventType, metrics, eventTimestamp, sessionId, sessionStartTime, sessionStopTime, timestamp, dirty, retryCount
         FROM Event
         ORDER BY timestamp ASC
         LIMIT ?
@@ -141,7 +141,7 @@ class AnalyticsEventSQLStorage: AnalyticsEventStorage {
     /// - Returns: A collection of PinpointEvent
     func getDirtyEventsWith(limit: Int) throws -> [PinpointEvent] {
         let queryStatement = """
-        SELECT id, attributes, eventType, metrics, eventTimestamp, sessionId, sessionStartTime, sessionStopTime, timestamp, retryCount
+        SELECT id, attributes, eventType, metrics, eventTimestamp, sessionId, sessionStartTime, sessionStopTime, timestamp, dirty, retryCount
         FROM DirtyEvent
         ORDER BY timestamp ASC
         LIMIT ?

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/LocalStorage/PinpointEvent+Bindings.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/LocalStorage/PinpointEvent+Bindings.swift
@@ -34,7 +34,7 @@ extension PinpointEvent {
             session.stopTime?.asISO8601String ?? "",
             Date().timeIntervalSince1970, // timestamp
             0, // isDirty
-            0 // RetryCount
+            retryCount // RetryCount
         ]
     }
 
@@ -75,8 +75,13 @@ extension PinpointEvent {
         guard let eventId = element[EventPropertyIndex.id] as? String else {
             return nil
         }
+       
+        var retryCount = 0
+        if let retryCountInt = element[EventPropertyIndex.retryCount] as? Int64 {
+            retryCount = Int(retryCountInt)
+        }
 
-        let pinpointEvent = PinpointEvent(id: eventId, eventType: eventType, eventDate: timestamp, session: session)
+        let pinpointEvent = PinpointEvent(id: eventId, eventType: eventType, eventDate: timestamp, session: session, retryCount: retryCount)
 
         if let attributes = element[EventPropertyIndex.attributes] as? Blob,
            let decodedAttributes = try? archiver.decode(AnalyticsClient.PinpointEventAttributes.self, from: Data(attributes.bytes)) {

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Constants/AWSPinpointAnalyticsConstants.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Constants/AWSPinpointAnalyticsConstants.swift
@@ -1,0 +1,19 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public struct AWSPinpointAnalytics {
+    public struct Constants {
+        public struct Event {
+            public static let maximumNumberOfAttributes = 40
+            public static let maximumNumberOfMetrics = 40
+            public static let maximumKeyLength = 50
+            public static let maximumValueLength = 200
+        }
+    }
+}

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Constants/AnalyticsErrorConstants.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Constants/AnalyticsErrorConstants.swift
@@ -92,4 +92,9 @@ struct AnalyticsPluginErrorConstant {
         "Could not instantiate service configuration from pinpoint targeting region",
         "Make sure the pinpoint targeting region and cognito credentials provider are correct"
     )
+    
+    static let deviceOffline: AnalyticsPluginErrorString = (
+        "The device does not have internet access. Please ensure the device is online and try again.",
+        ""
+    )
 }

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Extensions/AWSPinpointAnalyticsPlugin+HubCategory.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Extensions/AWSPinpointAnalyticsPlugin+HubCategory.swift
@@ -31,8 +31,8 @@ extension HubCategory {
         dispatch(to: .analytics, payload: payload)
     }
 
-    func dispatchFlushEvents(_ pinpointEventss: [AnalyticsEvent]) {
-        let payload = HubPayload(eventName: HubPayload.EventName.Analytics.flushEvents, data: pinpointEventss)
+    func dispatchFlushEvents(_ pinpointEvents: [AnalyticsEvent]) {
+        let payload = HubPayload(eventName: HubPayload.EventName.Analytics.flushEvents, data: pinpointEvents)
         dispatch(to: .analytics, payload: payload)
     }
 

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Extensions/SDKModels+AmplifyStringConvertible.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Extensions/SDKModels+AmplifyStringConvertible.swift
@@ -1,0 +1,24 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import AWSPinpoint
+import Foundation
+
+extension PutEventsInput: AmplifyStringConvertible {}
+
+extension PutEventsOutputResponse: AmplifyStringConvertible {
+    enum CodingKeys: Swift.String, Swift.CodingKey {
+        case eventsResponse = "EventsResponse"
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var encodeContainer = encoder.container(keyedBy: CodingKeys.self)
+        if let eventsResponse = self.eventsResponse {
+            try encodeContainer.encode(eventsResponse, forKey: .eventsResponse)
+        }
+    }
+}

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Utils/AmplifyStringConvertible.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Utils/AmplifyStringConvertible.swift
@@ -1,0 +1,28 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+protocol AmplifyStringConvertible: CustomStringConvertible, Encodable {}
+
+extension AmplifyStringConvertible {
+    private static var jsonEncoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+    
+    public var description: String {
+        if let data = try? Self.jsonEncoder.encode(self),
+           let result = String(data: data, encoding: .utf8) {
+            return result
+        }
+
+        return String(describing: self)
+    }
+}

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Utils/AnalyticsErrorHelper.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Utils/AnalyticsErrorHelper.swift
@@ -6,10 +6,20 @@
 //
 
 import Amplify
+import AWSPinpoint
+import ClientRuntime
 import Foundation
 
 class AnalyticsErrorHelper {
     static func getDefaultError(_ error: Error) -> AnalyticsError {
+        if let sdkError = error as? SdkError<PutEventsOutputError>{
+            return sdkError.analyticsError
+        }
+
+        if let analyticsError = error as? AnalyticsError {
+            return analyticsError
+        }
+
         return getDefaultError(error as NSError)
     }
 
@@ -22,6 +32,6 @@ class AnalyticsErrorHelper {
         LocalizedRecoverySuggestion: [\(error.localizedRecoverySuggestion ?? "")
         """
 
-        return AnalyticsError.unknown(errorMessage)
+        return AnalyticsError.unknown(errorMessage, error)
     }
 }

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Utils/NetworkMonitor.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Utils/NetworkMonitor.swift
@@ -1,0 +1,29 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Network
+
+protocol NetworkMonitor: AnyObject {
+    var isOnline: Bool { get }
+    func startMonitoring(using queue: DispatchQueue)
+    func stopMonitoring()
+}
+
+extension NWPathMonitor: NetworkMonitor {
+    var isOnline: Bool {
+        currentPath.status == .satisfied
+    }
+    
+    func startMonitoring(using queue: DispatchQueue) {
+        start(queue: queue)
+    }
+    
+    func stopMonitoring() {
+        cancel()
+    }
+}

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Utils/SdkError+Analytics.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Utils/SdkError+Analytics.swift
@@ -1,0 +1,130 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import AwsCIo
+import AwsCHttp
+import AwsCommonRuntimeKit
+import AWSPinpoint
+import ClientRuntime
+import Foundation
+
+extension SdkError {
+    private var clientError: ClientError? {
+        guard case .client(let clientError, _) = self else {
+            return nil
+        }
+
+        return clientError
+    }
+    
+    private var crtError: CRTError? {
+        if case .retryError(let crtError as CRTError) = clientError {
+            return crtError
+        }
+        
+        if case .crtError(let crtError) = clientError {
+            return crtError
+        }
+        
+        return nil
+    }
+
+    private var putEventsOutputError: PutEventsOutputError? {
+        guard case .retryError(let sdkError as SdkError) = clientError,
+              case .service(let putEventsError as PutEventsOutputError, _) = sdkError else {
+            return nil
+        }
+
+        return putEventsError
+    }
+
+    private var awsError: AWSError? {
+        guard case .crtError(let awsError) = crtError else {
+            return nil
+        }
+
+        return awsError
+    }
+
+    var errorDescription: String {
+        guard let putEventsOutputError = putEventsOutputError else {
+            return awsError?.errorMessage ?? localizedDescription
+        }
+
+        switch putEventsOutputError {
+        case .badRequestException(let exception as ServiceError),
+             .forbiddenException(let exception as ServiceError),
+             .internalServerErrorException(let exception as ServiceError),
+             .methodNotAllowedException(let exception as ServiceError),
+             .notFoundException(let exception as ServiceError),
+             .payloadTooLargeException(let exception as ServiceError),
+             .tooManyRequestsException(let exception as ServiceError),
+             .unknown(let exception as ServiceError):
+            return exception._message ?? localizedDescription
+        }
+    }
+    
+    private var rootError: Error? {
+        if putEventsOutputError != nil {
+            return putEventsOutputError
+        }
+        
+        if crtError != nil {
+            return crtError
+        }
+        
+        guard let clientError = clientError else {
+            return nil
+        }
+        
+        switch clientError {
+        case .networkError(let error),
+             .deserializationFailed(let error),
+             .retryError(let error):
+            return error
+        default:
+            return nil
+        }
+    }
+
+    var isConnectivityError: Bool {
+        if case .networkError(_) = clientError {
+            return true
+        }
+
+        guard let awsError = awsError else {
+            return false
+        }
+
+        let connectivityErrorCodes: [UInt32] = [
+            AWS_ERROR_HTTP_CONNECTION_CLOSED.rawValue,
+            AWS_ERROR_HTTP_SERVER_CLOSED.rawValue,
+            AWS_IO_DNS_INVALID_NAME.rawValue,
+            AWS_IO_DNS_NO_ADDRESS_FOR_HOST.rawValue,
+            AWS_IO_DNS_QUERY_FAILED.rawValue,
+            AWS_IO_SOCKET_CONNECT_ABORTED.rawValue,
+            AWS_IO_SOCKET_CONNECTION_REFUSED.rawValue,
+            AWS_IO_SOCKET_CLOSED.rawValue,
+            AWS_IO_SOCKET_NETWORK_DOWN.rawValue,
+            AWS_IO_SOCKET_NO_ROUTE_TO_HOST.rawValue,
+            AWS_IO_SOCKET_NOT_CONNECTED.rawValue,
+            AWS_IO_SOCKET_TIMEOUT.rawValue,
+            AWS_IO_TLS_NEGOTIATION_TIMEOUT.rawValue,
+            UInt32(AWS_HTTP_STATUS_CODE_408_REQUEST_TIMEOUT.rawValue)
+        ]
+
+        return connectivityErrorCodes.contains(where: { $0 == awsError.errorCode })
+    }
+
+    var analyticsError: AnalyticsError {
+        return .unknown(
+            isConnectivityError ? AnalyticsPluginErrorConstant.deviceOffline.errorDescription : errorDescription,
+            rootError ?? self
+        )
+    }
+}

--- a/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginTestBase.swift
+++ b/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginTestBase.swift
@@ -14,6 +14,7 @@ class AWSPinpointAnalyticsPluginTestBase: XCTestCase {
     var analyticsPlugin: AWSPinpointAnalyticsPlugin!
     var mockPinpoint: MockAWSPinpoint!
     var authService: MockAWSAuthService!
+    var mockNetworkMonitor: MockNetworkMonitor!
 
     let testAppId = "56e6f06fd4f244c6b202bc1234567890"
     let testRegion = "us-east-1"
@@ -34,10 +35,12 @@ class AWSPinpointAnalyticsPluginTestBase: XCTestCase {
 
         mockPinpoint = MockAWSPinpoint()
         authService = MockAWSAuthService()
+        mockNetworkMonitor = MockNetworkMonitor()
 
         analyticsPlugin.configure(pinpoint: mockPinpoint,
                                   authService: authService,
-                                  autoFlushEventsTimer: nil)
+                                  autoFlushEventsTimer: nil,
+                                  networkMonitor: mockNetworkMonitor)
 
         await Amplify.reset()
         let config = AmplifyConfiguration()

--- a/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/Mocks/MockNetworkMonitor.swift
+++ b/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/Mocks/MockNetworkMonitor.swift
@@ -1,0 +1,15 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AWSPinpointAnalyticsPlugin
+import Foundation
+
+class MockNetworkMonitor: NetworkMonitor {
+    var isOnline = true
+    func startMonitoring(using queue: DispatchQueue) {}
+    func stopMonitoring() {}
+}


### PR DESCRIPTION
*Description of changes:*

This PR addresses four issues with the current Analytics implementation:

----

#### If the `PutEvents` operation fails, the events in the database are updated but never deleted.

If the `pinpoint.putEvents(input:)` call inside the [`submit(pinpointEvents:endpointProfile)` method](https://github.com/aws-amplify/amplify-swift/blob/main/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/EventRecorder.swift#L104-L105) throws an error, we handle it [inside a `catch` block](https://github.com/aws-amplify/amplify-swift/blob/main/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/EventRecorder.swift#L155) that updates the events accordingly (i.e. either increases the counter or marks it as dirty, depending on the type of error thrown) and we [rethrow the error](https://github.com/aws-amplify/amplify-swift/blob/main/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/EventRecorder.swift#L166).

But because the enclosing [`processBatch(_:endpointProfile)` method](https://github.com/aws-amplify/amplify-swift/blob/main/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/EventRecorder.swift#L95) also throws, the [`try storage.removeFailedEvents()` statement](https://github.com/aws-amplify/amplify-swift/blob/main/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/EventRecorder.swift#L97) is never executed, as the error gets propagated.

This causes each failed event to get property updated, but since we fail to act on it we will keep trying to submit dirty events and/or events that exceeded their retry count until we get a successful response from Pinpoint.

So i've added a new `catch` block to attempt to clean up the events in the case we get an error, and then rethrow it.

#### If the `PutEvents` operation succeeds but **all** events are rejected, we don't recognize it as a failure.

When Pinpoint rejects an event, it does not cause the `pinpointClient.putEvents(input:)` to throw an error, but to state which event was rejected and its reason inside a `EventItemResponse` object that is part of the response.

I'd argue that if _all_ events in a batch are rejected, then it's likely there's an issue going on and we should consider the attempt a failure, instead of carrying on with the next batch. 
So I've added a small validation that will throw an error if 0 events were successful, which should interrupt the submission and allow the consumer to act.

####  [If the device lacks internet, all events that are submitted fail and are discarded](https://github.com/aws-amplify/amplify-swift/issues/2401)
If we attempt to call `pinpointClient.putEvents(input:)` and the device does not have internet, the request fails and it's considered a retryable error and the events retry counter is updated.

If the device stays offline during the next 3 attempts, the events will be discarded since they will exceed their retry-limit. This is not desired, as connectivity-related errors should be retryable indefinitely (and Android already does this).
So I've implemented a new check that first validates if the error was caused due to connectivity issues, and it so just immediately rethrow the error without doing updates to the database.

#### [Pinpoint event quota limits are incorrect](https://github.com/aws-amplify/amplify-swift/issues/2471)
We're currently validating that an event cannot exceed 50 metrics and attributes combined, and that each attribute value can be up to 1000 in length. These values are not aligned with [the Pinpoint documentation](https://docs.aws.amazon.com/pinpoint/latest/developerguide/quotas.html#quotas-events), which states that each event can have up to 40 metrics and 40 attributes, and that the maximum value length is 200.

I'm also exposing these values in a `AWSPinpointAnalytics.Constants.Event` struct, so that consumers can use them in their own validations if they want to.

----
#### Additional misc changes

I added extra `log.verbose` logs to match what we had on V1/legacy SDK, which provides additional debugging information, as well as other relevant information (e.g. if an event has exceeded its retry count)

I also created a `AmplifyStringConvertible` protocol to easily "prettify" the SDK objects when they are printed, and defined a custom `description` for the `PinpointEvent`s as well. 

----

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
