### PR TITLE
test: Update the canaries script to use the right devices

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,8 +257,6 @@ deploy_requires: &deploy_requires
     - macos_unit_test_datastore
     - macos_unit_test_geo
     - macos_unit_test_storage
-    - smoke-test-latest-supported-version
-    - smoke-test-minimum-supported-version
 
 workflows:
   build_test_deploy:
@@ -388,16 +386,6 @@ workflows:
           destination: << pipeline.parameters.macos-destination >>
           requires:
             - build_amplify_macos_spm
-      - getting-started-smoke-test/ios:
-          name: smoke-test-latest-supported-version
-          xcode-version: "14.1.0"
-          simulator-os-version: "16.1"
-          simulator-device: "iPhone 14 Pro"
-      - getting-started-smoke-test/ios:
-          name: smoke-test-minimum-supported-version
-          xcode-version: "13.4.1"
-          simulator-os-version: "15.5"
-          simulator-device: "iPhone 13 Pro"
       - deploy:
           name: deploy unstable
           <<: *deploy_requires
@@ -425,6 +413,10 @@ workflows:
   # Scheduled smoke test workflow
   # Jobs are pulled from the getting-started-smoke-test inline orb defined above
   canaries:
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "Canaries", << pipeline.schedule.name >> ]
     jobs:
       - getting-started-smoke-test/ios:
           xcode-version: "14.1.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,8 +257,8 @@ deploy_requires: &deploy_requires
     - macos_unit_test_datastore
     - macos_unit_test_geo
     - macos_unit_test_storage
-    - getting-started-smoke-test/latest-supported-version
-    - getting-started-smoke-test/minimum-supported-version
+    - smoke-test-latest-supported-version
+    - smoke-test-minimum-supported-version
 
 workflows:
   build_test_deploy:
@@ -389,10 +389,12 @@ workflows:
           requires:
             - build_amplify_macos_spm
       - getting-started-smoke-test/ios:
+          name: smoke-test-latest-supported-version
           xcode-version: "14.1.0"
           simulator-os-version: "16.1"
           simulator-device: "iPhone 14 Pro"
       - getting-started-smoke-test/ios:
+          name: smoke-test-minimum-supported-version
           xcode-version: "13.4.1"
           simulator-os-version: "15.5"
           simulator-device: "iPhone 13 Pro"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,13 +64,13 @@ orbs:
         parameters:
           xcode-version:
             type: string
-            default: 13.3.0
+            default: 13.4.1
           simulator-device:
             type: string
             default: iPhone 13
           simulator-os-version:
             type: string
-            default: "15.4"
+            default: "15.5"
         working_directory: ~/ios-canaries/canaries/example
         macos:
           xcode: <<parameters.xcode-version>>
@@ -90,7 +90,7 @@ orbs:
           - ruby/install-deps
           - run-with-retry:
               label: Run tests
-              command: bundle exec fastlane scan
+              command: bundle exec fastlane scan --device "<<parameters.simulator-device>>" --deployment_target_version "<<parameters.simulator-os-version>>"
 
 defaults: &defaults
   macos:
@@ -413,16 +413,12 @@ workflows:
   # Scheduled smoke test workflow
   # Jobs are pulled from the getting-started-smoke-test inline orb defined below
   canaries:
-    when:
-      and:
-        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-        - equal: [ "Canaries", << pipeline.schedule.name >> ]
     jobs:
       - getting-started-smoke-test/ios:
-          xcode-version: "13.3.0"
-          simulator-os-version: "15.4"
-          simulator-device: "iPhone 13"
+          xcode-version: "14.1.0"
+          simulator-os-version: "16.1"
+          simulator-device: "iPhone 14 Pro"
       - getting-started-smoke-test/ios:
-          xcode-version: "12.5.1"
-          simulator-os-version: "14.5"
-          simulator-device: "iPhone 12"
+          xcode-version: "13.4.1"
+          simulator-os-version: "15.5"
+          simulator-device: "iPhone 13 Pro"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,11 +388,11 @@ workflows:
           destination: << pipeline.parameters.macos-destination >>
           requires:
             - build_amplify_macos_spm
-      - getting-started-smoke-test/latest-supported-version:
+      - getting-started-smoke-test/ios:
           xcode-version: "14.1.0"
           simulator-os-version: "16.1"
           simulator-device: "iPhone 14 Pro"
-      - getting-started-smoke-test/minimum-supported-version:
+      - getting-started-smoke-test/ios:
           xcode-version: "13.4.1"
           simulator-os-version: "15.5"
           simulator-device: "iPhone 13 Pro"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,6 +257,8 @@ deploy_requires: &deploy_requires
     - macos_unit_test_datastore
     - macos_unit_test_geo
     - macos_unit_test_storage
+    - getting-started-smoke-test/latest-supported-version
+    - getting-started-smoke-test/minimum-supported-version
 
 workflows:
   build_test_deploy:
@@ -386,6 +388,14 @@ workflows:
           destination: << pipeline.parameters.macos-destination >>
           requires:
             - build_amplify_macos_spm
+      - getting-started-smoke-test/latest-supported-version:
+          xcode-version: "14.1.0"
+          simulator-os-version: "16.1"
+          simulator-device: "iPhone 14 Pro"
+      - getting-started-smoke-test/minimum-supported-version:
+          xcode-version: "13.4.1"
+          simulator-os-version: "15.5"
+          simulator-device: "iPhone 13 Pro"
       - deploy:
           name: deploy unstable
           <<: *deploy_requires
@@ -411,7 +421,7 @@ workflows:
                 - release
 
   # Scheduled smoke test workflow
-  # Jobs are pulled from the getting-started-smoke-test inline orb defined below
+  # Jobs are pulled from the getting-started-smoke-test inline orb defined above
   canaries:
     jobs:
       - getting-started-smoke-test/ios:

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -71,7 +71,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     public func save<M: Model>(_ model: M,
                                modelSchema: ModelSchema,
                                where condition: QueryPredicate? = nil) async throws -> M {
-        try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<M, Error>) in
             save(model, modelSchema: model.schema, where: condition) { result in
                 continuation.resume(with: result)
             }
@@ -103,7 +103,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     @available(*, deprecated, renamed: "query(byIdentifier:)")
     public func query<M: Model>(_ modelType: M.Type,
                                 byId id: String) async throws -> M? {
-        try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<M?, Error>)  in
             query(modelType, byId: id) { result in
                 continuation.resume(with: result)
             }
@@ -171,7 +171,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     private func queryByIdentifier<M: Model>(_ modelType: M.Type,
                                              modelSchema: ModelSchema,
                                              identifier: ModelIdentifierProtocol) async throws -> M? {
-        try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<M?, Error>)  in
             queryByIdentifier(modelType, modelSchema: modelSchema, identifier: identifier) { result in
                 continuation.resume(with: result)
             }
@@ -222,7 +222,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                 where predicate: QueryPredicate? = nil,
                                 sort sortInput: [QuerySortDescriptor]? = nil,
                                 paginate paginationInput: QueryPaginationInput? = nil) async throws -> [M] {
-        try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[M], Error>)  in
             query(modelType, modelSchema: modelSchema, where: predicate, sort: sortInput, paginate: paginationInput) { result in
                 continuation.resume(with: result)
             }
@@ -314,7 +314,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                                               modelSchema: ModelSchema,
                                               identifier: ModelIdentifierProtocol,
                                               where predicate: QueryPredicate?) async throws where M: ModelIdentifiable {
-        try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>)  in
             deleteByIdentifier(modelType, modelSchema: modelSchema, identifier: identifier, where: predicate) { result in
                 continuation.resume(with: result)
             }
@@ -348,7 +348,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     public func delete<M: Model>(_ model: M,
                                  modelSchema: ModelSchema,
                                  where predicate: QueryPredicate? = nil) async throws {
-        try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             delete(model, modelSchema: modelSchema, where: predicate) { result in
                 continuation.resume(with: result)
             }
@@ -391,7 +391,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     public func delete<M: Model>(_ modelType: M.Type,
                                  modelSchema: ModelSchema,
                                  where predicate: QueryPredicate) async throws {
-        try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             delete(modelType, modelSchema: modelSchema, where: predicate) { result in
                 continuation.resume(with: result)
             }
@@ -405,7 +405,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
     
     public func start() async throws {
-        _ = try await withCheckedThrowingContinuation { continuation in
+        _ = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<DataStoreResult<Void>, Error>) in
             start { result in
                 continuation.resume(returning: result)
             }
@@ -432,7 +432,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
     
     public func stop() async throws {
-        try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             stop { result in
                 continuation.resume(with: result)
             }
@@ -462,7 +462,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     }
     
     public func clear() async throws {
-        try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             clear { result in
                 continuation.resume(with: result)
             }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/SyncEngineTestBase.swift
@@ -211,7 +211,7 @@ class SyncEngineTestBase: XCTestCase {
     /// Starts amplify by invoking `Amplify.configure(amplifyConfig)`, and waits to receive a `syncStarted` Hub message
     /// before returning.
     func startAmplifyAndWaitForSync() async throws {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             startAmplifyAndWaitForSync { result in
                 continuation.resume(with: result)
             }

--- a/canaries/example/Gemfile.lock
+++ b/canaries/example/Gemfile.lock
@@ -209,6 +209,7 @@ GEM
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
+  arm64-darwin-21
   universal-darwin-20
   x86_64-darwin-19
   x86_64-darwin-21


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update the canaries script to use the right devices. Now it has two test, one against the latest supported device and the other against minimum support
- Made some the datastore plugin to have explicit type info 

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
