### PR TITLE
chore: fix canaries workflow failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,6 +423,6 @@ workflows:
           simulator-os-version: "15.4"
           simulator-device: "iPhone 13"
       - getting-started-smoke-test/ios:
-          xcode-version: "12.5.1"
-          simulator-os-version: "14.5"
+          xcode-version: "14.0.0"
+          simulator-os-version: "15.4"
           simulator-device: "iPhone 12"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix smoke test canary with invalid xcode version

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
