### PR TITLE
fix(datastore): fix stop then start API call pattern

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -281,15 +281,15 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                 dispatchedModelSynced.set(false)
             }
             if storageEngine == nil {
-                workQueue.async {
+                queue.async {
                     completion(.successfulVoid)
                 }
                 return
             }
 
             storageEngine.stopSync { result in
-                self.workQueue.async {
-                    self.storageEngine = nil
+                self.storageEngine = nil
+                self.queue.async {
                     completion(result)
                 }
             }
@@ -312,14 +312,14 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                 dispatchedModelSynced.set(false)
             }
             if storageEngine == nil {
-                workQueue.async {
+                queue.async {
                     completion(.successfulVoid)
                 }
                 return
             }
             storageEngine.clear { result in
-                self.workQueue.async {
-                    self.storageEngine = nil
+                self.storageEngine = nil
+                self.queue.async {
                     completion(result)
                 }
             }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -281,14 +281,17 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                 dispatchedModelSynced.set(false)
             }
             if storageEngine == nil {
-
-                completion(.successfulVoid)
+                workQueue.async {
+                    completion(.successfulVoid)
+                }
                 return
             }
 
             storageEngine.stopSync { result in
-                self.storageEngine = nil
-                completion(result)
+                self.workQueue.async {
+                    self.storageEngine = nil
+                    completion(result)
+                }
             }
         }
     }
@@ -309,12 +312,16 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
                 dispatchedModelSynced.set(false)
             }
             if storageEngine == nil {
-                completion(.successfulVoid)
+                workQueue.async {
+                    completion(.successfulVoid)
+                }
                 return
             }
             storageEngine.clear { result in
-                self.storageEngine = nil
-                completion(result)
+                self.workQueue.async {
+                    self.storageEngine = nil
+                    completion(result)
+                }
             }
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -46,6 +46,8 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
 
     var storageEngine: StorageEngineBehavior!
     var storageEngineInitQueue = DispatchQueue(label: "AWSDataStorePlugin.storageEngineInitQueue")
+    let workQueue = DispatchQueue(label: "AWSDataStorePlugin.storageEngineInitQueue",
+                                  target: DispatchQueue.global())
     var storageEngineBehaviorFactory: StorageEngineBehaviorFactory
 
     var iStorageEngineSink: Any?

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/AWSDataStorePlugin.swift
@@ -46,8 +46,7 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
 
     var storageEngine: StorageEngineBehavior!
     var storageEngineInitQueue = DispatchQueue(label: "AWSDataStorePlugin.storageEngineInitQueue")
-    let workQueue = DispatchQueue(label: "AWSDataStorePlugin.storageEngineInitQueue",
-                                  target: DispatchQueue.global())
+    let queue = DispatchQueue(label: "AWSDataStorePlugin.queue", target: DispatchQueue.global())
     var storageEngineBehaviorFactory: StorageEngineBehaviorFactory
 
     var iStorageEngineSink: Any?

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -431,13 +431,13 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
 
     }
 
-    /// Ensure DataStore.stop followed by DataStore.start is successful on
-    ///  a DispatchQueue
+    /// Ensure DataStore.stop followed by DataStore.start on a DispatchQueue
+    ///  of a background thread is successful
     ///
     /// - Given:  DataStore has just configured, but not started
     /// - When:
     ///    - DataStore.stop
-    ///    - Followed by DataStore.start in the completion of the stop
+    ///    - Followed by DataStore.start on a background thread in the completion of the stop
     /// - Then:
     ///    - Datastore should be started successfully
     ///
@@ -445,34 +445,34 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
         setUp(withModels: TestModelRegistration())
         try startAmplify()
         let stopStartSuccess = expectation(description: "stop then start successful")
-        DispatchQueue.global(qos: .background).async {
             Amplify.DataStore.stop { result in
                 switch result {
                 case .success:
-                    Amplify.DataStore.start { result in
-                        switch result {
-                        case .success:
-                            stopStartSuccess.fulfill()
-                        case .failure(let error):
-                            XCTFail("\(error)")
+                    DispatchQueue.global(qos: .background).async {
+                        Amplify.DataStore.start { result in
+                            switch result {
+                            case .success:
+                                stopStartSuccess.fulfill()
+                            case .failure(let error):
+                                XCTFail("\(error)")
+                            }
                         }
                     }
                 case .failure(let error):
                     XCTFail("\(error)")
                 }
             }
-        }
         wait(for: [stopStartSuccess], timeout: networkTimeout)
 
     }
 
-    /// Ensure DataStore.clear followed by DataStore.start is successful on
-    ///  a DispatchQueue
+    /// Ensure DataStore.clear followed by DataStore.start on a DispatchQueue
+    /// of a background thread is successful
     ///
     /// - Given:  DataStore has just configured, but not started
     /// - When:
     ///    - DataStore.clear
-    ///    - Followed by DataStore.start in the completion of the stop
+    ///    - Followed by DataStore.start on a background thread in the completion of the stop
     /// - Then:
     ///    - Datastore should be started successfully
     ///
@@ -484,12 +484,14 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
             Amplify.DataStore.clear { result in
                 switch result {
                 case .success:
-                    Amplify.DataStore.start { result in
-                        switch result {
-                        case .success:
-                            clearStartSuccess.fulfill()
-                        case .failure(let error):
-                            XCTFail("\(error)")
+                    DispatchQueue.global(qos: .background).async {
+                        Amplify.DataStore.start { result in
+                            switch result {
+                            case .success:
+                                clearStartSuccess.fulfill()
+                            case .failure(let error):
+                                XCTFail("\(error)")
+                            }
                         }
                     }
                 case .failure(let error):

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -15,6 +15,7 @@ import Combine
 @testable import AmplifyTestCommon
 @testable import AWSDataStoreCategoryPlugin
 
+// swiftlint:disable all
 @available(iOS 13.0, *)
 class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
 
@@ -363,6 +364,175 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
         }
         wait(for: [stopStartSuccess], timeout: networkTimeout)
         try validateSavePost()
+
+    }
+
+    /// Ensure DataStore.stop followed by DataStore.start is successful
+    ///
+    /// - Given:  DataStore has just configured, but not started
+    /// - When:
+    ///    - DataStore.stop
+    ///    - Followed by DataStore.start in the completion of the stop
+    /// - Then:
+    ///    - Datastore should be started successfully
+    ///
+    func testConfigureAmplifyThenStopStart() throws {
+        setUp(withModels: TestModelRegistration())
+        try startAmplify()
+        let stopStartSuccess = expectation(description: "stop then start successful")
+        Amplify.DataStore.stop { result in
+            switch result {
+            case .success:
+                Amplify.DataStore.start { result in
+                    switch result {
+                    case .success:
+                        stopStartSuccess.fulfill()
+                    case .failure(let error):
+                        XCTFail("\(error)")
+                    }
+                }
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [stopStartSuccess], timeout: networkTimeout)
+
+    }
+
+    /// Ensure DataStore.clear followed by DataStore.start is successful
+    ///
+    /// - Given:  DataStore has just configured, but not started
+    /// - When:
+    ///    - DataStore.clear
+    ///    - Followed by DataStore.start in the completion of the stop
+    /// - Then:
+    ///    - Datastore should be started successfully
+    ///
+    func testConfigureAmplifyThenClearStart() throws {
+        setUp(withModels: TestModelRegistration())
+        try startAmplify()
+        let clearStartSuccess = expectation(description: "clear then start successful")
+        Amplify.DataStore.clear { result in
+            switch result {
+            case .success:
+                Amplify.DataStore.start { result in
+                    switch result {
+                    case .success:
+                        clearStartSuccess.fulfill()
+                    case .failure(let error):
+                        XCTFail("\(error)")
+                    }
+                }
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [clearStartSuccess], timeout: networkTimeout)
+
+    }
+
+    /// Ensure DataStore.stop followed by DataStore.start is successful on
+    ///  a DispatchQueue
+    ///
+    /// - Given:  DataStore has just configured, but not started
+    /// - When:
+    ///    - DataStore.stop
+    ///    - Followed by DataStore.start in the completion of the stop
+    /// - Then:
+    ///    - Datastore should be started successfully
+    ///
+    func testConfigureAmplifyThenStopStartonDispatch() throws {
+        setUp(withModels: TestModelRegistration())
+        try startAmplify()
+        let stopStartSuccess = expectation(description: "stop then start successful")
+        DispatchQueue.global(qos: .background).async {
+            Amplify.DataStore.stop { result in
+                switch result {
+                case .success:
+                    Amplify.DataStore.start { result in
+                        switch result {
+                        case .success:
+                            stopStartSuccess.fulfill()
+                        case .failure(let error):
+                            XCTFail("\(error)")
+                        }
+                    }
+                case .failure(let error):
+                    XCTFail("\(error)")
+                }
+            }
+        }
+        wait(for: [stopStartSuccess], timeout: networkTimeout)
+
+    }
+
+    /// Ensure DataStore.clear followed by DataStore.start is successful on
+    ///  a DispatchQueue
+    ///
+    /// - Given:  DataStore has just configured, but not started
+    /// - When:
+    ///    - DataStore.clear
+    ///    - Followed by DataStore.start in the completion of the stop
+    /// - Then:
+    ///    - Datastore should be started successfully
+    ///
+    func testConfigureAmplifyThenClearStartOnDispatch() throws {
+        setUp(withModels: TestModelRegistration())
+        try startAmplify()
+        let clearStartSuccess = expectation(description: "clear then start successful on DispatchQueue")
+        DispatchQueue.global(qos: .background).async {
+            Amplify.DataStore.clear { result in
+                switch result {
+                case .success:
+                    Amplify.DataStore.start { result in
+                        switch result {
+                        case .success:
+                            clearStartSuccess.fulfill()
+                        case .failure(let error):
+                            XCTFail("\(error)")
+                        }
+                    }
+                case .failure(let error):
+                    XCTFail("\(error)")
+                }
+            }
+        }
+        wait(for: [clearStartSuccess], timeout: networkTimeout)
+
+    }
+
+    /// Ensure DataStore.start followed by DataStore.stop & restarting with
+    /// DataStore.start is successful
+    ///
+    /// - Given:  DataStore has has just configured, but not started
+    /// - When:
+    ///    - DataStore.start
+    ///    - DataStore.stop
+    ///    - Followed by DataStore.start
+    /// - Then:
+    ///    - Datastore should be started successfully
+    ///
+    func testConfigureAmplifyThenStartStopStart() throws {
+        setUp(withModels: TestModelRegistration())
+        try startAmplify()
+        let startStopSuccess = expectation(description: "start then stop successful")
+        Amplify.DataStore.start { result in
+            switch result {
+            case .success:
+                Amplify.DataStore.stop { result in
+                    switch result {
+                    case .success:
+                        self.startDataStore()
+                        startStopSuccess.fulfill()
+                    case .failure(let error):
+                        XCTFail("\(error)")
+                    }
+                }
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [startStopSuccess], timeout: networkTimeout)
 
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -15,7 +15,7 @@ import Combine
 @testable import AmplifyTestCommon
 @testable import AWSDataStoreCategoryPlugin
 
-// swiftlint:disable all
+// swiftlint:disable type_body_length
 @available(iOS 13.0, *)
 class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
@@ -51,6 +51,19 @@ class SyncEngineIntegrationTestBase: DataStoreTestBase {
         }
     }
 
+    func startDataStore() {
+        let started = expectation(description: "DataStore started")
+        Amplify.DataStore.start { result in
+            switch result {
+            case .success:
+                started.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [started], timeout: 2)
+    }
+
     func stopDataStore() {
         let stopped = expectation(description: "DataStore stopped")
         Amplify.DataStore.stop { result in


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-swift/issues/2167
*Description of changes:*

This PR fixes a problem with the following code snippets:
```swift
Amplify.DataStore.stop { _ in 
    Amplify.DataStore.start { _ in       
    }
}
```
`stop` enters the queue.sync block and calls its completion handler which calls `start`. `start` attempts to enter the queue and waits for `stop` to finish, which will never happen. This PR prevents a crash by calling `completion` from a different thread.

`main` PR https://github.com/aws-amplify/amplify-swift/pull/2529

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
