### PR TITLE
fix(Analytics): Fixing issues when calling flushEvents

### DIFF
--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+ClientBehavior.swift
@@ -107,9 +107,14 @@ extension AWSPinpointAnalyticsPlugin {
         }
 
         pinpoint.submitEvents().continueWith { (task) -> Any? in
-            guard task.error == nil else {
-                // TODO: some error mapping
-                let error = task.error! as NSError
+            if let error = task.error as? NSError{
+                // For "No events to submit" errors, dispatch and empty array instead
+                if error.domain == AWSPinpointAnalyticsErrorDomain,
+                   error.localizedDescription == "No events to submit." {
+                    Amplify.Hub.dispatchFlushEvents([])
+                    return nil
+                }
+
                 Amplify.Hub.dispatchFlushEvents(AnalyticsErrorHelper.getDefaultError(error))
                 return nil
             }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Constants/AnalyticsErrorConstants.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Constants/AnalyticsErrorConstants.swift
@@ -97,4 +97,9 @@ struct AnalyticsPluginErrorConstant {
         "Could not instantiate service configuration from pinpoint targeting region",
         "Make sure the pinpoint targeting region and cognito credentials provider are correct"
     )
+
+    static let deviceOffline: AnalyticsPluginErrorString = (
+        "The device does not have internet access. Please ensure the device is online and try again.",
+        ""
+    )
 }

--- a/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Utils/AnalyticsErrorHelper.swift
+++ b/AmplifyPlugins/Analytics/AWSPinpointAnalyticsPlugin/Support/Utils/AnalyticsErrorHelper.swift
@@ -10,6 +10,13 @@ import Foundation
 
 class AnalyticsErrorHelper {
     static func getDefaultError(_ error: NSError) -> AnalyticsError {
+        if error.isConnectivityError {
+            return .unknown(
+                AnalyticsPluginErrorConstant.deviceOffline.errorDescription,
+                error
+            )
+        }
+
         let errorMessage = """
         Domain: [\(error.domain)
         Code: [\(error.code)
@@ -18,6 +25,20 @@ class AnalyticsErrorHelper {
         LocalizedRecoverySuggestion: [\(error.localizedRecoverySuggestion ?? "")
         """
 
-        return AnalyticsError.unknown(errorMessage)
+        return AnalyticsError.unknown(errorMessage, error)
+    }
+}
+
+private extension NSError {
+    private static let networkErrorCodes = [
+        NSURLErrorCannotFindHost,
+        NSURLErrorCannotConnectToHost,
+        NSURLErrorNetworkConnectionLost,
+        NSURLErrorDNSLookupFailed,
+        NSURLErrorNotConnectedToInternet
+    ]
+
+    var isConnectivityError: Bool {
+        return Self.networkErrorCodes.contains(where: { $0 == code })
     }
 }


### PR DESCRIPTION
*Description of changes:*
Fixing some issues when calling `Amplify.Analytics.flushEvents()` so they match what we do in `v2`:

- `AWSPinpointAnalyticsClient.submitEvents()` returns an error when there are no events to submit, which we are then dispatching to the Hub. This is problematic with Amplify's automatic flush of events, as it would spam the Hub with errors that are not really errors. So whenever we get a `"No events to submit."` error, I'm dispatching an empty array instead.
- Dispatching a customized error for connectivity issues, for better readability in logs.

*Check points: (check or cross out if not relevant)*

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
