### PR TITLE
fix(auth): Add secrethash to the resetPassword/resendSignUpCode

### DIFF
--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/PinpointEvent+PinpointClientTypes.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Analytics/PinpointEvent+PinpointClientTypes.swift
@@ -22,7 +22,7 @@ extension PinpointEvent {
                                          appTitle: Bundle.main.appName,
                                          appVersionCode: Bundle.main.appVersion,
                                          attributes: attributes,
-                                         clientSdkVersion: AmplifyAWSServiceConfiguration.version,
+                                         clientSdkVersion: AmplifyAWSServiceConfiguration.amplifyVersion,
                                          eventType: eventType,
                                          metrics: metrics,
                                          sdkName: AmplifyAWSServiceConfiguration.platformName,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/SRPSignInHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/SRPSignInHelper.swift
@@ -27,20 +27,4 @@ struct SRPSignInHelper {
             throw error
         }
     }
-
-    static func clientSecretHash(
-        username: String,
-        userPoolClientId: String,
-        clientSecret: String
-    ) -> String {
-        let clientSecretData = clientSecret.data(using: .utf8)!
-        let clientSecretByteArray = [UInt8](clientSecretData)
-        let key = SymmetricKey(data: clientSecretByteArray)
-
-        let clientData = (username + userPoolClientId).data(using: .utf8)!
-
-        let mac = HMAC<SHA256>.authenticationCode(for: clientData, using: key)
-        let macBase64 = Data(mac).base64EncodedString()
-        return macBase64
-    }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ClientSecretHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ClientSecretHelper.swift
@@ -1,0 +1,45 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import CryptoKit
+
+enum ClientSecretHelper {
+
+    static func calculateSecretHash(
+        username: String,
+        userPoolConfiguration: UserPoolConfigurationData
+    ) -> String? {
+        let userPoolClientId = userPoolConfiguration.clientId
+        if let clientSecret = userPoolConfiguration.clientSecret {
+
+            return Self.clientSecretHash(
+                username: username,
+                userPoolClientId: userPoolClientId,
+                clientSecret: clientSecret
+            )
+        }
+        return nil
+    }
+
+    static func clientSecretHash(
+        username: String,
+        userPoolClientId: String,
+        clientSecret: String
+    ) -> String {
+        let clientSecretData = clientSecret.data(using: .utf8)!
+        let clientSecretByteArray = [UInt8](clientSecretData)
+        let key = SymmetricKey(data: clientSecretByteArray)
+
+        let clientData = (username + userPoolClientId).data(using: .utf8)!
+
+        let mac = HMAC<SHA256>.authenticationCode(for: clientData, using: key)
+        let macBase64 = Data(mac).base64EncodedString()
+        return macBase64
+    }
+
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/ConfirmSignUpInput+Amplify.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/ConfirmSignUpInput+Amplify.swift
@@ -17,7 +17,7 @@ extension ConfirmSignUpInput {
     ) {
 
         let configuration = environment.userPoolConfiguration
-        let secretHash = Self.calculateSecretHash(
+        let secretHash = ClientSecretHelper.calculateSecretHash(
             username: username,
             userPoolConfiguration: configuration)
         var userContextData: CognitoIdentityProviderClientTypes.UserContextDataType?
@@ -40,19 +40,4 @@ extension ConfirmSignUpInput {
             secretHash: secretHash,
             userContextData: userContextData, username: username)
     }
-
-    private static func calculateSecretHash(
-        username: String,
-        userPoolConfiguration: UserPoolConfigurationData) -> String? {
-            let userPoolClientId = userPoolConfiguration.clientId
-            if let clientSecret = userPoolConfiguration.clientSecret {
-
-                return SRPSignInHelper.clientSecretHash(
-                    username: username,
-                    userPoolClientId: userPoolClientId,
-                    clientSecret: clientSecret
-                )
-            }
-            return nil
-        }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/InitiateAuthInput+Amplify.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/InitiateAuthInput+Amplify.swift
@@ -109,7 +109,7 @@ extension InitiateAuthInput {
         let userPoolClientId = configuration.clientId
 
         if let clientSecret = configuration.clientSecret {
-            let clientSecretHash = SRPSignInHelper.clientSecretHash(
+            let clientSecretHash = ClientSecretHelper.clientSecretHash(
                 username: username,
                 userPoolClientId: userPoolClientId,
                 clientSecret: clientSecret

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/RespondToAuthChallengeInput+Amplify.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/RespondToAuthChallengeInput+Amplify.swift
@@ -116,7 +116,7 @@ extension RespondToAuthChallengeInput {
             let userPoolClientId = environment.userPoolConfiguration.clientId
             if let clientSecret = environment.userPoolConfiguration.clientSecret {
 
-                let clientSecretHash = SRPSignInHelper.clientSecretHash(
+                let clientSecretHash = ClientSecretHelper.clientSecretHash(
                     username: username,
                     userPoolClientId: userPoolClientId,
                     clientSecret: clientSecret

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/SignUpInput+Amplify.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/SignUpInput+Amplify.swift
@@ -22,7 +22,7 @@ extension SignUpInput {
          environment: UserPoolEnvironment) {
 
         let configuration = environment.userPoolConfiguration
-        let secretHash = Self.calculateSecretHash(username: username,
+        let secretHash = ClientSecretHelper.calculateSecretHash(username: username,
                                                   userPoolConfiguration: configuration)
         let validationData = Self.getValidationData(with: validationData)
         let convertedAttributes = Self.convertAttributes(attributes)
@@ -48,21 +48,6 @@ extension SignUpInput {
                   username: username,
                   validationData: validationData)
     }
-
-    private static func calculateSecretHash(
-        username: String,
-        userPoolConfiguration: UserPoolConfigurationData) -> String? {
-            let userPoolClientId = userPoolConfiguration.clientId
-            if let clientSecret = userPoolConfiguration.clientSecret {
-
-                return SRPSignInHelper.clientSecretHash(
-                    username: username,
-                    userPoolClientId: userPoolClientId,
-                    clientSecret: clientSecret
-                )
-            }
-            return nil
-        }
 
     private static func getValidationData(with devProvidedData: [String: String]?)
     -> [CognitoIdentityProviderClientTypes.AttributeType]? {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmResetPasswordTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmResetPasswordTask.swift
@@ -74,12 +74,18 @@ class AWSAuthConfirmResetPasswordTask: AuthConfirmResetPasswordTask {
         let analyticsMetadata = userPoolEnvironment
             .cognitoUserPoolAnalyticsHandlerFactory()
             .analyticsMetadata()
+        let secretHash = ClientSecretHelper.calculateSecretHash(
+            username: request.username,
+            userPoolConfiguration: userPoolConfigurationData
+        )
         let input = ConfirmForgotPasswordInput(
             analyticsMetadata: analyticsMetadata,
             clientId: userPoolConfigurationData.clientId,
             clientMetadata: clientMetaData,
             confirmationCode: request.confirmationCode,
-            password: request.newPassword, userContextData: userContextData,
+            password: request.newPassword,
+            secretHash: secretHash,
+            userContextData: userContextData,
             username: request.username)
 
         _ = try await userPoolService.confirmForgotPassword(input: input)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResendSignUpCodeTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResendSignUpCodeTask.swift
@@ -73,10 +73,15 @@ class AWSAuthResendSignUpCodeTask: AuthResendSignUpCodeTask {
         let analyticsMetadata = userPoolEnvironment
             .cognitoUserPoolAnalyticsHandlerFactory()
             .analyticsMetadata()
+        let secretHash = ClientSecretHelper.calculateSecretHash(
+            username: request.username,
+            userPoolConfiguration: userPoolConfigurationData
+        )
         let input = ResendConfirmationCodeInput(
             analyticsMetadata: analyticsMetadata,
             clientId: userPoolConfigurationData.clientId,
             clientMetadata: clientMetaData,
+            secretHash: secretHash,
             userContextData: userContextData,
             username: request.username)
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResetPasswordTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResetPasswordTask.swift
@@ -72,10 +72,15 @@ class AWSAuthResetPasswordTask: AuthResetPasswordTask {
         let analyticsMetadata = userPoolEnvironment
             .cognitoUserPoolAnalyticsHandlerFactory()
             .analyticsMetadata()
+        let secretHash = ClientSecretHelper.calculateSecretHash(
+            username: request.username,
+            userPoolConfiguration: userPoolConfigurationData
+        )
         let input = ForgotPasswordInput(
             analyticsMetadata: analyticsMetadata,
             clientId: userPoolConfigurationData.clientId,
             clientMetadata: clientMetaData,
+            secretHash: secretHash,
             userContextData: userContextData,
             username: request.username)
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/ClientSecretConfigurationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/ClientSecretConfigurationTests.swift
@@ -1,0 +1,290 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+import XCTest
+import AWSCognitoIdentity
+@testable import Amplify
+@testable import AWSCognitoAuthPlugin
+@testable import AWSPluginsTestCommon
+import AWSCognitoIdentityProvider
+
+class ClientSecretConfigurationTests: XCTestCase {
+
+    let networkTimeout = TimeInterval(2)
+    var mockIdentityProvider: CognitoUserPoolBehavior!
+    var plugin: AWSCognitoAuthPlugin!
+    
+    var initialState: AuthState {
+        AuthState.configured(
+            AuthenticationState.signedIn(
+                SignedInData(
+                    signedInDate: Date(),
+                    signInMethod: .apiBased(.userSRP),
+                    cognitoUserPoolTokens: AWSCognitoUserPoolTokens.testData)),
+            AuthorizationState.sessionEstablished(AmplifyCredentials.testData))
+    }
+
+    override func setUp() {
+        plugin = AWSCognitoAuthPlugin()
+
+        let getId: MockIdentity.MockGetIdResponse = { _ in
+            return .init(identityId: "mockIdentityId")
+        }
+
+        let getCredentials: MockIdentity.MockGetCredentialsResponse = { _ in
+            let credentials = CognitoIdentityClientTypes.Credentials(accessKeyId: "accessKey",
+                                                                     expiration: Date(),
+                                                                     secretKey: "secret",
+                                                                     sessionToken: "session")
+            return .init(credentials: credentials, identityId: "responseIdentityID")
+        }
+
+        let mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            identityPoolFactory: { mockIdentity },
+            userPoolFactory: { self.mockIdentityProvider })
+
+        let statemachine = Defaults.makeDefaultAuthStateMachine(
+            initialState: initialState,
+            identityPoolFactory: { mockIdentity },
+            userPoolFactory: { self.mockIdentityProvider })
+
+        plugin?.configure(
+            authConfiguration: Defaults.makeDefaultAuthConfigData(),
+            authEnvironment: environment,
+            authStateMachine: statemachine,
+            credentialStoreStateMachine: Defaults.makeDefaultCredentialStateMachine(),
+            hubEventHandler: MockAuthHubEventBehavior(),
+            analyticsHandler: MockAnalyticsHandler())
+    }
+
+
+
+    /// Test if client secret is used for reset password api
+    ///
+    /// - Given: Given auth plugin with client secret present in the configuration
+    /// - When:
+    ///    - Invoke reset password api
+    /// - Then:
+    ///    - Plugin should pass the secret hash created with client secret
+    ///
+    func testClientSecretWithResetPassword() async throws {
+        let codeDeliveryDetails = CognitoIdentityProviderClientTypes.CodeDeliveryDetailsType(
+            attributeName: "attribute",
+            deliveryMedium: .email,
+            destination: "Amplify@amazon.com"
+        )
+        mockIdentityProvider = MockIdentityProvider(
+            mockForgotPasswordOutputResponse: { request in
+                XCTAssertNotNil(request.secretHash)
+                return ForgotPasswordOutputResponse(codeDeliveryDetails: codeDeliveryDetails)
+            }
+        )
+        _ = try await plugin.resetPassword(for: "user", options: nil)
+    }
+
+    /// Test if client secret is used for confirmResetPassword api
+    ///
+    /// - Given: Given auth plugin with client secret present in the configuration
+    /// - When:
+    ///    - Invoke confirmResetPassword api
+    /// - Then:
+    ///    - Plugin should pass the secret hash created with client secret
+    ///
+    func testClientSecretWithConfirmResetPassword() async throws {
+        mockIdentityProvider = MockIdentityProvider(
+            mockConfirmForgotPasswordOutputResponse: { request in
+                XCTAssertNotNil(request.secretHash)
+                return try ConfirmForgotPasswordOutputResponse(httpResponse: MockHttpResponse.ok)
+            }
+        )
+        try await plugin.confirmResetPassword(
+            for: "username",
+            with: "newpassword",
+            confirmationCode: "code",
+            options: nil
+        )
+    }
+
+    /// Test if client secret is used for resendSignUpCode api
+    ///
+    /// - Given: Given auth plugin with client secret present in the configuration
+    /// - When:
+    ///    - Invoke resendSignUpCode api
+    /// - Then:
+    ///    - Plugin should pass the secret hash created with client secret
+    ///
+    func testClientSecretWithResendSignupCode() async throws {
+
+        let codeDeliveryDetails = CognitoIdentityProviderClientTypes.CodeDeliveryDetailsType(
+            attributeName: nil,
+            deliveryMedium: .email,
+            destination: nil
+        )
+        mockIdentityProvider = MockIdentityProvider(
+            mockResendConfirmationCodeOutputResponse: { request in
+                XCTAssertNotNil(request.secretHash)
+                return ResendConfirmationCodeOutputResponse(
+                    codeDeliveryDetails: codeDeliveryDetails
+                )
+            }
+        )
+
+        let authCodeDeliveryDetails = try await plugin.resendSignUpCode(for: "username", options: nil)
+        guard case .email = authCodeDeliveryDetails.destination else {
+            XCTFail("Result should be .email for the destination of AuthCodeDeliveryDetails")
+            return
+        }
+    }
+
+    /// Test if client secret is used for signUp api
+    ///
+    /// - Given: Given auth plugin with client secret present in the configuration
+    /// - When:
+    ///    - Invoke signUp api
+    /// - Then:
+    ///    - Plugin should pass the secret hash created with client secret
+    ///
+    func testClientSecretWithSignUp() async throws {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockSignUpResponse: { request in
+                XCTAssertNotNil(request.secretHash)
+                return .init(
+                    codeDeliveryDetails: .init(
+                        attributeName: "some attribute",
+                        deliveryMedium: .email,
+                        destination: "random@random.com"),
+                    userConfirmed: false,
+                    userSub: "userId")
+            }
+        )
+
+        let result = try await self.plugin.signUp(
+            username: "jeffb",
+            password: "Valid&99",
+            options: nil)
+
+        guard case .confirmUser = result.nextStep else {
+            XCTFail("Result should be .confirmUser for next step")
+            return
+        }
+    }
+
+    /// Test if client secret is used for confirmSignUp api
+    ///
+    /// - Given: Given auth plugin with client secret present in the configuration
+    /// - When:
+    ///    - Invoke confirmSignUp api
+    /// - Then:
+    ///    - Plugin should pass the secret hash created with client secret
+    ///
+    func testClientSecretWithConfirmSignUp() async throws {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockConfirmSignUpResponse: { request in
+                XCTAssertNotNil(request.secretHash)
+                return .init()
+            }
+        )
+
+        _ = try await self.plugin.confirmSignUp(
+            for: "someuser",
+            confirmationCode: "code",
+            options: nil
+        )
+    }
+
+    /// Test if client secret is used for revokeToken api
+    ///
+    /// - Given: Given auth plugin with client secret present in the configuration
+    /// - When:
+    ///    - Invoke signOut api
+    /// - Then:
+    ///    - Plugin should pass the secret hash created with client secret
+    ///
+    func testClientSecretWithRevokeToken() async {
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRevokeTokenResponse: { request in
+                XCTAssertNotNil(request.clientSecret)
+                return .testData
+            }, mockGlobalSignOutResponse: { _ in
+                return .testData
+            })
+        guard let result = await plugin.signOut() as? AWSCognitoSignOutResult,
+              case .complete = result else {
+            XCTFail("Did not return complete signOut")
+            return
+        }
+    }
+
+    /// Test if client secret is used for initiateAuth, respondToAuthChallenge api
+    ///
+    /// - Given: Given auth plugin with client secret present in the configuration
+    /// - When:
+    ///    - Invoke signOut api
+    /// - Then:
+    ///    - Plugin should pass the secret hash created with client secret
+    ///
+    func testClientSecretWithInitiateAuth() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRevokeTokenResponse: { request in
+                XCTAssertNotNil(request.clientSecret)
+                return .testData
+            }, mockInitiateAuthResponse: { request in
+                XCTAssertNotNil(request.authParameters?["SECRET_HASH"])
+                return InitiateAuthOutputResponse(
+                    authenticationResult: .none,
+                    challengeName: .passwordVerifier,
+                    challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                    session: "someSession")
+
+            }, mockGlobalSignOutResponse: { _ in
+                return .testData
+
+            }, mockRespondToAuthChallengeResponse: { request in
+                XCTAssertNotNil(request.challengeResponses?["SECRET_HASH"])
+                return RespondToAuthChallengeOutputResponse(
+                    authenticationResult: .init(
+                        accessToken: Defaults.validAccessToken,
+                        expiresIn: 300,
+                        idToken: "idToken",
+                        newDeviceMetadata: nil,
+                        refreshToken: "refreshToken",
+                        tokenType: ""),
+                    challengeName: .none,
+                    challengeParameters: [:],
+                    session: "session")
+            })
+
+        _ = await plugin.signOut()
+        
+        let pluginOptions = AWSAuthSignInOptions(validationData: ["somekey": "somevalue"],
+                                                 metadata: ["somekey": "somevalue"])
+        let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
+
+        do {
+            let result = try await plugin.signIn(
+                username: "username",
+                password: "password",
+                options: options)
+            guard case .done = result.nextStep else {
+                XCTFail("Result should be .done for next step")
+                return
+            }
+            XCTAssertTrue(result.isSignedIn, "Signin result should be complete")
+        } catch {
+            XCTFail("Received failure with error \(error)")
+        }
+    }
+}

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthSignUpAPITests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthSignUpAPITests.swift
@@ -87,7 +87,7 @@ class AWSAuthSignUpAPITests: BasePluginTest {
             options: options)
 
         guard case .confirmUser(let deliveryDetails, let additionalInfo, let userId) = result.nextStep else {
-            XCTFail("Result should be .done for next step")
+            XCTFail("Result should be .confirmUser for next step")
             return
         }
 

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/ServiceConfiguration/AmplifyAWSServiceConfigurationTests.swift
@@ -27,7 +27,7 @@ class AmplifyAWSServiceConfigurationTests: XCTestCase {
         let frameworkMetaData = AmplifyAWSServiceConfiguration.frameworkMetaData()
         XCTAssertNotNil(frameworkMetaData)
         XCTAssertEqual(frameworkMetaData.sanitizedName, "amplify-ios")
-        XCTAssertEqual(frameworkMetaData.sanitizedVersion, AmplifyAWSServiceConfiguration.version)
+        XCTAssertEqual(frameworkMetaData.sanitizedVersion, AmplifyAWSServiceConfiguration.amplifyVersion)
     }
 
     /// Test adding a new platform to AmplifyAWSServiceConfiguration
@@ -46,6 +46,6 @@ class AmplifyAWSServiceConfigurationTests: XCTestCase {
         XCTAssertEqual(frameworkMetaData.sanitizedVersion, "1.1")
 
         XCTAssertNotNil(frameworkMetaData.extras)
-        XCTAssertEqual(frameworkMetaData.extras["amplify-ios"], AmplifyAWSServiceConfiguration.version)
+        XCTAssertEqual(frameworkMetaData.extras["amplify-ios"], AmplifyAWSServiceConfiguration.amplifyVersion)
     }
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-swift/issues/2524

*Description of changes:*

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
