### PR TITLE
fix(datastore): improve sync event error handling - cannotParseResponse

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
@@ -55,25 +55,42 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
             return
         }
 
-        if let apiError = apiError, isAuthSignedOutError(apiError: apiError) {
+        if let apiError = apiError {
+            if isAuthSignedOutError(apiError: apiError) {
+                log.verbose("User is signed out, passing error back to the error handler, and removing mutation event.")
+            } else if let underlyingError = apiError.underlyingError {
+                log.debug("Received APIError: \(apiError.localizedDescription) with underlying error: \(underlyingError.localizedDescription)")
+            } else {
+                log.debug("Received APIError: \(apiError.localizedDescription)")
+            }
             dataStoreConfiguration.errorHandler(DataStoreError.api(apiError, mutationEvent))
             finish(result: .success(nil))
             return
         }
 
-        guard let graphQLResponseError = graphQLResponseError,
-            case let .error(graphQLErrors) = graphQLResponseError else {
-                finish(result: .success(nil))
-                return
+        guard let graphQLResponseError = graphQLResponseError else {
+            dataStoreConfiguration.errorHandler(
+                DataStoreError.api(APIError.unknown("This is unexpected. Missing APIError and GraphQLError.", ""),
+                                   mutationEvent))
+            finish(result: .success(nil))
+            return
+        }
+
+        guard case let .error(graphQLErrors) = graphQLResponseError else {
+            dataStoreConfiguration.errorHandler(DataStoreError.api(graphQLResponseError, mutationEvent))
+            finish(result: .success(nil))
+            return
         }
 
         guard graphQLErrors.count == 1 else {
             log.error("Received more than one error response: \(String(describing: graphQLResponseError))")
+            dataStoreConfiguration.errorHandler(DataStoreError.api(graphQLResponseError, mutationEvent))
             finish(result: .success(nil))
             return
         }
 
         guard let graphQLError = graphQLErrors.first else {
+            dataStoreConfiguration.errorHandler(DataStoreError.api(graphQLResponseError, mutationEvent))
             finish(result: .success(nil))
             return
         }
@@ -85,22 +102,26 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
                 let payload = HubPayload(eventName: HubPayload.EventName.DataStore.conditionalSaveFailed,
                                          data: mutationEvent)
                 Amplify.Hub.dispatch(to: .dataStore, payload: payload)
+                dataStoreConfiguration.errorHandler(DataStoreError.api(graphQLResponseError, mutationEvent))
                 finish(result: .success(nil))
             case .conflictUnhandled:
                 processConflictUnhandled(extensions)
             case .unauthorized:
-                // TODO: dispatch Hub event
                 log.debug("Unauthorized mutation \(errorType)")
+                dataStoreConfiguration.errorHandler(DataStoreError.api(graphQLResponseError, mutationEvent))
                 finish(result: .success(nil))
             case .operationDisabled:
                 log.debug("Operation disabled \(errorType)")
+                dataStoreConfiguration.errorHandler(DataStoreError.api(graphQLResponseError, mutationEvent))
                 finish(result: .success(nil))
             case .unknown(let errorType):
                 log.debug("Unhandled error with errorType \(errorType)")
+                dataStoreConfiguration.errorHandler(DataStoreError.api(graphQLResponseError, mutationEvent))
                 finish(result: .success(nil))
             }
         } else {
             log.debug("GraphQLError missing extensions and errorType \(graphQLError)")
+            dataStoreConfiguration.errorHandler(DataStoreError.api(graphQLResponseError, mutationEvent))
             finish(result: .success(nil))
         }
     }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RequestRetryablePolicy.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/RequestRetryablePolicy.swift
@@ -38,7 +38,8 @@ class RequestRetryablePolicy: RequestRetryable {
              .cannotConnectToHost,
              .cannotFindHost,
              .timedOut,
-             .dataNotAllowed:
+             .dataNotAllowed,
+             .cannotParseResponse:
             let waitMillis = retryDelayInMillseconds(for: attemptNumber)
             return RequestRetryAdvice(shouldRetry: true, retryInterval: .milliseconds(waitMillis))
         default:

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -23,6 +23,8 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     let defaultAsyncWaitTimeout = 10.0
     var mockAPIPlugin: MockAPICategoryPlugin!
     var storageAdapter: StorageEngineAdapter!
+    var localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
+    let queue = OperationQueue()
 
     override func setUp() {
         tryOrFail {
@@ -39,18 +41,13 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     ///    - APIError contains AuthError indicating user is not authenticated
     /// - Then:
     ///    - `DataStoreErrorHandler` is called
-    func testProcessMutationErrorFromCloudOperationSuccessForAuthErroor() throws {
-        let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
+    func testProcessMutationErrorFromCloudOperationSuccessForAuthError() throws {
         let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .update)
         let authError = AuthError.signedOut("User is not authenticated", "Authenticate user", nil)
         let apiError = APIError.operationError("not signed in", "Sign In User", authError)
         let expectCompletion = expectation(description: "Expect to complete error processing")
         let completion: (Result<MutationEvent?, Error>) -> Void = { result in
-            guard case .success(let mutationEventOptional) = result else {
-                XCTFail("Should have been successful")
-                return
-            }
-            XCTAssertNil(mutationEventOptional)
+            self.assertSuccessfulNil(result)
             expectCompletion.fulfill()
         }
         let expectErrorHandlerCalled = expectation(description: "Expect error handler called")
@@ -82,107 +79,353 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                                storageAdapter: storageAdapter,
                                                                apiError: apiError,
                                                                completion: completion)
-
-        let queue = OperationQueue()
         queue.addOperation(operation)
-
-        wait(for: [expectErrorHandlerCalled], timeout: defaultAsyncWaitTimeout)
-        wait(for: [expectCompletion], timeout: defaultAsyncWaitTimeout)
+        wait(for: [expectErrorHandlerCalled, expectCompletion], timeout: defaultAsyncWaitTimeout)
     }
 
-    func testProcessMutationErrorFromCloudOperationSuccessForUnknownError() throws {
-        let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
-        let remotePost = Post(id: localPost.id, title: "remoteTitle", content: "remoteContent", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .delete)
-        guard let graphQLResponseError = try getGraphQLResponseError(withRemote: remotePost,
-                                                                     deleted: true,
-                                                                     version: 1,
-                                                                     errorType: .unknown("unknownErrorType")) else {
-            XCTFail("Couldn't get GraphQL response with remote post")
-            return
-        }
+    /// - Given: APIError
+    /// - When:
+    ///    - APIError unrelated to AuthError
+    /// - Then:
+    ///    - `DataStoreErrorHandler` is called
+    func testProcessMutationErrorFromCloudOperationSuccessForAPIError() throws {
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .update)
+        let apiError = APIError.operationError("Operation failed", "", nil)
         let expectCompletion = expectation(description: "Expect to complete error processing")
         let completion: (Result<MutationEvent?, Error>) -> Void = { result in
-            guard case .success = result else {
-                XCTFail("Should have been successful")
-                return
-            }
+            self.assertSuccessfulNil(result)
             expectCompletion.fulfill()
         }
-        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: .default,
+        let expectErrorHandlerCalled = expectation(description: "Expect error handler called")
+        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+            guard let dataStoreError = error as? DataStoreError,
+                  case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
+                XCTFail("Expected API error with mutationEvent")
+                return
+            }
+            guard let actualAPIError = amplifyError as? APIError,
+                  case .operationError = actualAPIError else {
+                XCTFail("Missing APIError.operationError")
+                return
+            }
+            guard let actualMutationEvent = mutationEventOptional else {
+                XCTFail("Missing mutationEvent for api error")
+                return
+            }
+            XCTAssertEqual(actualMutationEvent.id, mutationEvent.id)
+            expectErrorHandlerCalled.fulfill()
+        })
+
+        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: configuration,
+                                                               mutationEvent: mutationEvent,
+                                                               api: mockAPIPlugin,
+                                                               storageAdapter: storageAdapter,
+                                                               apiError: apiError,
+                                                               completion: completion)
+        queue.addOperation(operation)
+        wait(for: [expectErrorHandlerCalled, expectCompletion], timeout: defaultAsyncWaitTimeout)
+    }
+
+    /// - Given: GraphQLError with no errors
+    /// - When:
+    ///    - GraphQLError with no errors
+    /// - Then:
+    ///    - `DataStoreErrorHandler` is called
+    func testProcessMutationErrorFromCloudOperationSuccessForGraphQLResponseWithNoErrors() throws {
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .delete)
+        let graphQLResponseError = GraphQLResponseError<MutationSync<AnyModel>>.unknown("", "", nil)
+        let expectCompletion = expectation(description: "Expect to complete error processing")
+        let completion: (Result<MutationEvent?, Error>) -> Void = { result in
+            self.assertSuccessfulNil(result)
+            expectCompletion.fulfill()
+        }
+        let expectErrorHandlerCalled = expectation(description: "Expect error handler called")
+        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+            guard let dataStoreError = error as? DataStoreError,
+                  case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
+                XCTFail("Expected API error with mutationEvent")
+                return
+            }
+            guard let graphQLResponseError = amplifyError as?  GraphQLResponseError<MutationSync<AnyModel>>,
+                  case .unknown = graphQLResponseError else {
+                XCTFail("Missing GraphQLResponseError.unknown")
+                return
+            }
+            guard let actualMutationEvent = mutationEventOptional else {
+                XCTFail("Missing mutationEvent for api error")
+                return
+            }
+            XCTAssertEqual(actualMutationEvent.id, mutationEvent.id)
+            expectErrorHandlerCalled.fulfill()
+        })
+
+        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: configuration,
                                                                mutationEvent: mutationEvent,
                                                                api: mockAPIPlugin,
                                                                storageAdapter: storageAdapter,
                                                                graphQLResponseError: graphQLResponseError,
                                                                completion: completion)
-        let queue = OperationQueue()
         queue.addOperation(operation)
-        wait(for: [expectCompletion], timeout: defaultAsyncWaitTimeout)
+        wait(for: [expectErrorHandlerCalled, expectCompletion], timeout: defaultAsyncWaitTimeout)
     }
 
-    func testProcessMutationErrorFromCloudOperationSuccessForMissingErrorType() throws {
-        let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
-        let remotePost = Post(id: localPost.id, title: "remoteTitle", content: "remoteContent", createdAt: .now())
+    /// - Given: GraphQLError with no error
+    /// - When:
+    ///    - GraphQLError with no error
+    /// - Then:
+    ///    - `DataStoreErrorHandler` is called
+    func testProcessMutationErrorFromCloudOperationSuccessForGraphQLResponseWithNoErrorsArray() throws {
         let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .delete)
-        guard let graphQLResponseError = try getGraphQLResponseError(withRemote: remotePost,
-                                                                     deleted: true,
-                                                                     version: 1,
-                                                                     errorType: nil) else {
-            XCTFail("Couldn't get GraphQL response with remote post")
-            return
-        }
+        let graphQLResponseError = GraphQLResponseError<MutationSync<AnyModel>>.error([])
         let expectCompletion = expectation(description: "Expect to complete error processing")
         let completion: (Result<MutationEvent?, Error>) -> Void = { result in
-            guard case .success = result else {
-                XCTFail("Should have been successful")
-                return
-            }
+            self.assertSuccessfulNil(result)
             expectCompletion.fulfill()
         }
-        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: .default,
+        let expectErrorHandlerCalled = expectation(description: "Expect error handler called")
+        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+            guard let dataStoreError = error as? DataStoreError,
+                  case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
+                XCTFail("Expected API error with mutationEvent")
+                return
+            }
+            guard let graphQLResponseError = amplifyError as?  GraphQLResponseError<MutationSync<AnyModel>>,
+                  case .error(let errors) = graphQLResponseError else {
+                XCTFail("Missing GraphQLResponseError.unknown")
+                return
+            }
+            XCTAssertEqual(errors.count, 0)
+            guard let actualMutationEvent = mutationEventOptional else {
+                XCTFail("Missing mutationEvent for api error")
+                return
+            }
+            XCTAssertEqual(actualMutationEvent.id, mutationEvent.id)
+            expectErrorHandlerCalled.fulfill()
+        })
+
+        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: configuration,
                                                                mutationEvent: mutationEvent,
                                                                api: mockAPIPlugin,
                                                                storageAdapter: storageAdapter,
                                                                graphQLResponseError: graphQLResponseError,
                                                                completion: completion)
-        let queue = OperationQueue()
         queue.addOperation(operation)
-        wait(for: [expectCompletion], timeout: defaultAsyncWaitTimeout)
+        wait(for: [expectErrorHandlerCalled, expectCompletion], timeout: defaultAsyncWaitTimeout)
     }
 
+    /// - Given: GraphQLError more than one error to handle
+    /// - When:
+    ///    - GraphQLError with multiple errors
+    /// - Then:
+    ///    - `DataStoreErrorHandler` is called
+    func testProcessMutationErrorFromCloudOperationSuccessForGraphQLResponseWithMultipleErrors() throws {
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .delete)
+        let error = GraphQLError(message: "error message")
+        let graphQLResponseError = GraphQLResponseError<MutationSync<AnyModel>>.error([error, error])
+        let expectCompletion = expectation(description: "Expect to complete error processing")
+        let completion: (Result<MutationEvent?, Error>) -> Void = { result in
+            self.assertSuccessfulNil(result)
+            expectCompletion.fulfill()
+        }
+        let expectErrorHandlerCalled = expectation(description: "Expect error handler called")
+        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+            guard let dataStoreError = error as? DataStoreError,
+                  case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
+                XCTFail("Expected API error with mutationEvent")
+                return
+            }
+            guard let graphQLResponseError = amplifyError as?  GraphQLResponseError<MutationSync<AnyModel>>,
+                  case .error(let errors) = graphQLResponseError else {
+                XCTFail("Missing GraphQLResponseError.unknown")
+                return
+            }
+            XCTAssertEqual(errors.count, 2)
+            guard let actualMutationEvent = mutationEventOptional else {
+                XCTFail("Missing mutationEvent for api error")
+                return
+            }
+            XCTAssertEqual(actualMutationEvent.id, mutationEvent.id)
+            expectErrorHandlerCalled.fulfill()
+        })
+
+        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: configuration,
+                                                               mutationEvent: mutationEvent,
+                                                               api: mockAPIPlugin,
+                                                               storageAdapter: storageAdapter,
+                                                               graphQLResponseError: graphQLResponseError,
+                                                               completion: completion)
+        queue.addOperation(operation)
+        wait(for: [expectErrorHandlerCalled, expectCompletion], timeout: defaultAsyncWaitTimeout)
+    }
+
+    /// - Given: GraphQLError ConditionalCheck
+    /// - When:
+    ///    - GraphQLError with errors containing type ConditionalCheck
+    /// - Then:
+    ///    - `DataStoreErrorHandler` is called
     func testProcessMutationErrorFromCloudOperationSuccessForConditionalCheck() throws {
-        let expectCompletion = expectation(description: "Expect to complete error processing")
-        let expectHubEvent = expectation(description: "Hub is notified")
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .delete)
+        let graphQLResponseError = GraphQLResponseError<MutationSync<AnyModel>>.error([graphQLError(.conditionalCheck)])
 
+        let expectHubEvent = expectation(description: "Hub is notified")
+        let expectCompletion = expectation(description: "Expect to complete error processing")
+        let expectErrorHandlerCalled = expectation(description: "Expect error handler called")
         let hubListener = Amplify.Hub.listen(to: .dataStore) { payload in
             if payload.eventName == "DataStore.conditionalSaveFailed" {
                 expectHubEvent.fulfill()
             }
         }
-
         let completion: (Result<MutationEvent?, Error>) -> Void = { result in
+            self.assertSuccessfulNil(result)
             expectCompletion.fulfill()
         }
-        let post1 = Post(title: "post1", content: "content1", createdAt: .now())
-        let mutationEvent = try MutationEvent(model: post1, modelSchema: post1.schema, mutationType: .create)
-        let graphQLError = GraphQLError(message: "conditional request failed",
-                                        locations: nil,
-                                        path: nil,
-                                        extensions: ["errorType": .string(AppSyncErrorType.conditionalCheck.rawValue)])
-        let graphQLResponseError = GraphQLResponseError<MutationSync<AnyModel>>.error([graphQLError])
+        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+            guard let dataStoreError = error as? DataStoreError,
+                  case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
+                XCTFail("Expected API error with mutationEvent")
+                return
+            }
+            guard let graphQLResponseError = amplifyError as?  GraphQLResponseError<MutationSync<AnyModel>>,
+                  case .error(let errors) = graphQLResponseError else {
+                XCTFail("Missing GraphQLResponseError.unknown")
+                return
+            }
+            XCTAssertEqual(errors.count, 1)
+            guard let actualMutationEvent = mutationEventOptional else {
+                XCTFail("Missing mutationEvent for api error")
+                return
+            }
+            XCTAssertEqual(actualMutationEvent.id, mutationEvent.id)
+            expectErrorHandlerCalled.fulfill()
+        })
 
-        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: .default,
+        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: configuration,
                                                                mutationEvent: mutationEvent,
                                                                api: mockAPIPlugin,
                                                                storageAdapter: storageAdapter,
                                                                graphQLResponseError: graphQLResponseError,
                                                                completion: completion)
-
-        let queue = OperationQueue()
         queue.addOperation(operation)
-
-        wait(for: [expectHubEvent, expectCompletion], timeout: defaultAsyncWaitTimeout)
+        wait(for: [expectHubEvent, expectErrorHandlerCalled, expectCompletion], timeout: defaultAsyncWaitTimeout)
         Amplify.Hub.removeListener(hubListener)
+    }
+
+    func testProcessMutationErrorFromCloudOperationSuccessForUnauthorized() throws {
+        let remotePost = Post(id: localPost.id, title: "remoteTitle", content: "remoteContent", createdAt: .now())
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .delete)
+        let graphQLResponseError = GraphQLResponseError<MutationSync<AnyModel>>.error([graphQLError(.unauthorized)])
+        let expectCompletion = expectation(description: "Expect to complete error processing")
+        let expectErrorHandlerCalled = expectation(description: "Expect error handler called")
+        let completion: (Result<MutationEvent?, Error>) -> Void = { result in
+            self.assertSuccessfulNil(result)
+            expectCompletion.fulfill()
+        }
+        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+            guard let dataStoreError = error as? DataStoreError,
+                  case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
+                XCTFail("Expected API error with mutationEvent")
+                return
+            }
+            guard let graphQLResponseError = amplifyError as?  GraphQLResponseError<MutationSync<AnyModel>>,
+                  case .error(let errors) = graphQLResponseError else {
+                XCTFail("Missing GraphQLResponseError.unknown")
+                return
+            }
+            XCTAssertEqual(errors.count, 1)
+            guard let actualMutationEvent = mutationEventOptional else {
+                XCTFail("Missing mutationEvent for api error")
+                return
+            }
+            XCTAssertEqual(actualMutationEvent.id, mutationEvent.id)
+            expectErrorHandlerCalled.fulfill()
+        })
+
+        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: configuration,
+                                                               mutationEvent: mutationEvent,
+                                                               api: mockAPIPlugin,
+                                                               storageAdapter: storageAdapter,
+                                                               graphQLResponseError: graphQLResponseError,
+                                                               completion: completion)
+        queue.addOperation(operation)
+        wait(for: [expectErrorHandlerCalled, expectCompletion], timeout: defaultAsyncWaitTimeout)
+    }
+
+    func testProcessMutationErrorFromCloudOperationSuccessForOperationDisabled() throws {
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .delete)
+        let graphQLResponseError = GraphQLResponseError<MutationSync<AnyModel>>.error([graphQLError(.operationDisabled)])
+        let expectCompletion = expectation(description: "Expect to complete error processing")
+        let expectErrorHandlerCalled = expectation(description: "Expect error handler called")
+        let completion: (Result<MutationEvent?, Error>) -> Void = { result in
+            self.assertSuccessfulNil(result)
+            expectCompletion.fulfill()
+        }
+        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+            guard let dataStoreError = error as? DataStoreError,
+                  case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
+                XCTFail("Expected API error with mutationEvent")
+                return
+            }
+            guard let graphQLResponseError = amplifyError as?  GraphQLResponseError<MutationSync<AnyModel>>,
+                  case .error(let errors) = graphQLResponseError else {
+                XCTFail("Missing GraphQLResponseError")
+                return
+            }
+            XCTAssertEqual(errors.count, 1)
+            guard let actualMutationEvent = mutationEventOptional else {
+                XCTFail("Missing mutationEvent for api error")
+                return
+            }
+            XCTAssertEqual(actualMutationEvent.id, mutationEvent.id)
+            expectErrorHandlerCalled.fulfill()
+        })
+
+        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: configuration,
+                                                               mutationEvent: mutationEvent,
+                                                               api: mockAPIPlugin,
+                                                               storageAdapter: storageAdapter,
+                                                               graphQLResponseError: graphQLResponseError,
+                                                               completion: completion)
+        queue.addOperation(operation)
+        wait(for: [expectErrorHandlerCalled, expectCompletion], timeout: defaultAsyncWaitTimeout)
+    }
+
+    func testProcessMutationErrorFromCloudOperationSuccessForUnknownError() throws {
+        let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .delete)
+        let graphQLResponseError = GraphQLResponseError<MutationSync<AnyModel>>.error([graphQLError(.unknown("unknownErrorType"))])
+        let expectCompletion = expectation(description: "Expect to complete error processing")
+        let expectErrorHandlerCalled = expectation(description: "Expect error handler called")
+        let completion: (Result<MutationEvent?, Error>) -> Void = { result in
+            self.assertSuccessfulNil(result)
+            expectCompletion.fulfill()
+        }
+        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+            guard let dataStoreError = error as? DataStoreError,
+                  case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
+                XCTFail("Expected API error with mutationEvent")
+                return
+            }
+            guard let graphQLResponseError = amplifyError as?  GraphQLResponseError<MutationSync<AnyModel>>,
+                  case .error(let errors) = graphQLResponseError else {
+                XCTFail("Missing GraphQLResponseError.unknown")
+                return
+            }
+            XCTAssertEqual(errors.count, 1)
+            guard let actualMutationEvent = mutationEventOptional else {
+                XCTFail("Missing mutationEvent for api error")
+                return
+            }
+            XCTAssertEqual(actualMutationEvent.id, mutationEvent.id)
+            expectErrorHandlerCalled.fulfill()
+        })
+
+        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: configuration,
+                                                               mutationEvent: mutationEvent,
+                                                               api: mockAPIPlugin,
+                                                               storageAdapter: storageAdapter,
+                                                               graphQLResponseError: graphQLResponseError,
+                                                               completion: completion)
+        queue.addOperation(operation)
+        wait(for: [expectErrorHandlerCalled, expectCompletion], timeout: defaultAsyncWaitTimeout)
     }
 
     /// - Given: Conflict Unhandled error
@@ -191,7 +434,6 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     /// - Then:
     ///    - Unexpected scenario, there should never be an conflict unhandled error without error.data
     func testConflictUnhandledReturnsErrorForMissingRemoteModel() throws {
-        let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
         let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .create)
         let graphQLError = GraphQLError(message: "conflict unhandled",
                                         extensions: ["errorType": .string(AppSyncErrorType.conflictUnhandled.rawValue)])
@@ -214,7 +456,6 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                                storageAdapter: storageAdapter,
                                                                graphQLResponseError: graphQLResponseError,
                                                                completion: completion)
-        let queue = OperationQueue()
         queue.addOperation(operation)
         wait(for: [expectCompletion], timeout: defaultAsyncWaitTimeout)
     }
@@ -225,7 +466,6 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     /// - Then:
     ///    - Unexpected scenario, there should never get a conflict for create mutations
     func testConflictUnhandledReturnsErrorForCreateMutation() throws {
-        let localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
         let mutationEvent = try MutationEvent(model: localPost, modelSchema: localPost.schema, mutationType: .create)
         let remotePost = Post(title: "remoteTitle", content: "remoteContent", createdAt: .now())
         guard let graphQLResponseError = try getGraphQLResponseError(withRemote: remotePost,
@@ -252,7 +492,6 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                                storageAdapter: storageAdapter,
                                                                graphQLResponseError: graphQLResponseError,
                                                                completion: completion)
-        let queue = OperationQueue()
         queue.addOperation(operation)
         wait(for: [expectCompletion], timeout: defaultAsyncWaitTimeout)
     }
@@ -274,10 +513,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
         }
         let expectCompletion = expectation(description: "Expect to complete error processing")
         let completion: (Result<MutationEvent?, Error>) -> Void = { result in
-            guard case .success = result else {
-                XCTFail("Should have been successful")
-                return
-            }
+            self.assertSuccessfulNil(result)
             expectCompletion.fulfill()
         }
         let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: .default,
@@ -286,7 +522,6 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                                storageAdapter: storageAdapter,
                                                                graphQLResponseError: graphQLResponseError,
                                                                completion: completion)
-        let queue = OperationQueue()
         queue.addOperation(operation)
         wait(for: [expectCompletion], timeout: defaultAsyncWaitTimeout)
     }
@@ -308,11 +543,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
         }
         let expectCompletion = expectation(description: "Expect to complete error processing")
         let completion: (Result<MutationEvent?, Error>) -> Void = { result in
-            guard case .success(let mutationEventOptional) = result else {
-                XCTFail("Should have been successful")
-                return
-            }
-            XCTAssertNil(mutationEventOptional)
+            self.assertSuccessfulNil(result)
             expectCompletion.fulfill()
         }
 
@@ -352,7 +583,6 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                                graphQLResponseError: graphQLResponseError,
                                                                completion: completion)
 
-        let queue = OperationQueue()
         queue.addOperation(operation)
 
         wait(for: [expectConflicthandlerCalled], timeout: defaultAsyncWaitTimeout)
@@ -389,11 +619,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
         }
         let expectCompletion = expectation(description: "Expect to complete error processing")
         let completion: (Result<MutationEvent?, Error>) -> Void = { result in
-            guard case .success(let mutationEventOptional) = result else {
-                XCTFail("Should have been successful")
-                return
-            }
-            XCTAssertNil(mutationEventOptional)
+            self.assertSuccessfulNil(result)
             expectCompletion.fulfill()
         }
 
@@ -434,7 +660,6 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                                graphQLResponseError: graphQLResponseError,
                                                                completion: completion)
 
-        let queue = OperationQueue()
         queue.addOperation(operation)
 
         wait(for: [expectConflicthandlerCalled], timeout: defaultAsyncWaitTimeout)
@@ -514,8 +739,6 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                                storageAdapter: storageAdapter,
                                                                graphQLResponseError: graphQLResponseError,
                                                                completion: completion)
-
-        let queue = OperationQueue()
         queue.addOperation(operation)
 
         wait(for: [modelSavedEvent], timeout: defaultAsyncWaitTimeout)
@@ -580,7 +803,6 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                                graphQLResponseError: graphQLResponseError,
                                                                completion: completion)
 
-        let queue = OperationQueue()
         queue.addOperation(operation)
 
         wait(for: [modelDeletedEvent], timeout: defaultAsyncWaitTimeout)
@@ -662,8 +884,6 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                                storageAdapter: storageAdapter,
                                                                graphQLResponseError: graphQLResponseError,
                                                                completion: completion)
-
-        let queue = OperationQueue()
         queue.addOperation(operation)
 
         wait(for: [expectConflicthandlerCalled], timeout: defaultAsyncWaitTimeout)
@@ -734,7 +954,6 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                                graphQLResponseError: graphQLResponseError,
                                                                completion: completion)
 
-        let queue = OperationQueue()
         queue.addOperation(operation)
 
         wait(for: [expectConflicthandlerCalled], timeout: defaultAsyncWaitTimeout)
@@ -813,8 +1032,6 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                                storageAdapter: storageAdapter,
                                                                graphQLResponseError: graphQLResponseError,
                                                                completion: completion)
-
-        let queue = OperationQueue()
         queue.addOperation(operation)
 
         wait(for: [expectConflicthandlerCalled], timeout: defaultAsyncWaitTimeout)
@@ -896,8 +1113,6 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                                storageAdapter: storageAdapter,
                                                                graphQLResponseError: graphQLResponseError,
                                                                completion: completion)
-
-        let queue = OperationQueue()
         queue.addOperation(operation)
 
         wait(for: [expectConflicthandlerCalled], timeout: defaultAsyncWaitTimeout)
@@ -945,7 +1160,6 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             graphQLResponseError: graphQLError,
             completion: completion)
 
-        let queue = OperationQueue()
         queue.addOperation(operation)
         wait(for: [expectCompletion], timeout: defaultAsyncWaitTimeout)
     }
@@ -988,9 +1202,19 @@ extension ProcessMutationErrorFromCloudOperationTests {
         try Amplify.configure(configWithAPI)
     }
 
-    private func getGraphQLResponseError(withRemote post: Post,
-                                         deleted: Bool,
-                                         version: Int,
+    private func assertSuccessfulNil(_ result: Result<MutationEvent?, Error>) {
+        guard case .success(let mutationEventOptional) = result else {
+            XCTFail("Should have been successful")
+            return
+        }
+        XCTAssertNil(mutationEventOptional)
+    }
+
+    private func getGraphQLResponseError(withRemote post: Post = Post(title: "remoteTitle",
+                                                                      content: "remoteContent",
+                                                                      createdAt: .now()),
+                                         deleted: Bool = false,
+                                         version: Int = 1,
                                          errorType: AppSyncErrorType? = .conflictUnhandled)
         throws -> GraphQLResponseError<MutationSync<AnyModel>>? {
         guard let data = try post.toJSON().data(using: .utf8) else {
@@ -1012,8 +1236,15 @@ extension ProcessMutationErrorFromCloudOperationTests {
                                                          "data": .object(remoteDataObject)])
             return GraphQLResponseError<MutationSync<AnyModel>>.error([graphQLError])
         } else {
-            let graphQLError = GraphQLError(message: "error messageb")
+            let graphQLError = GraphQLError(message: "error message")
             return GraphQLResponseError<MutationSync<AnyModel>>.error([graphQLError])
         }
+    }
+
+    private func graphQLError(_ errorType: AppSyncErrorType) -> GraphQLError {
+        GraphQLError(message: "message",
+                     locations: nil,
+                     path: nil,
+                     extensions: ["errorType": .string(errorType.rawValue)])
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RequestRetryablePolicyTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/RequestRetryablePolicyTests.swift
@@ -177,6 +177,17 @@ class RequestRetryablePolicyTests: XCTestCase {
         assertMilliseconds(retryAdvice.retryInterval, greaterThan: 200, lessThan: 300)
     }
 
+    func testCannotParseResponseError() {
+        let retryableErrorCode = URLError.init(.cannotParseResponse)
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: retryableErrorCode,
+                                                         httpURLResponse: nil,
+                                                         attemptNumber: 1)
+
+        XCTAssert(retryAdvice.shouldRetry)
+        assertMilliseconds(retryAdvice.retryInterval, greaterThan: 200, lessThan: 300)
+    }
+
     func testHTTPTooManyRedirectsError() {
         let nonRetryableErrorCode = URLError.init(.httpTooManyRedirects)
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-swift/issues/2523

1. **`v1` PR https://github.com/aws-amplify/amplify-swift/pull/2532**  (You are here)
2. `main` PR https://github.com/aws-amplify/amplify-swift/pull/2536

*Description of changes:*
In the scenario of toggling Wifi off and then saving a model, a mutation event will be produced and sent to AppSync. The API call can fail undeterministically with different URLError's. Most of the time it's the error "The Internet connection appears to be offline." corresponding to `.notConnectedToInternet` and the retry mechanism kicks in.

Sometimes it's "cannot parse response" which gets processed by `ProcessMutationErrorFromCloudOperation` as no-op, returns success to the OutgoingMutationQueue, which will then delete mutation event, dropping the event from being processed again, without notifying the ErrorHandler.

This PR adds `.cannotParseResponse` to the list for the retry strategy to consider as retryable. We maintain a list of URL errors that are considered for retry: 

```swift
case .notConnectedToInternet,
             .dnsLookupFailed,
             .cannotConnectToHost,
             .cannotFindHost,
             .timedOut,
             .dataNotAllowed,
             .cannotParseResponse: // This PR adds this one
```

Secondly, "without notifying the ErrorHandler" is a bug because DataStore should not drop a mutation event silently. Developers should be notified of sync failures. This PR ensures each level of error handling branch calls the ErrorHandler to pass back the mutationEvent before continue on to deleting the mutation event from the local database. In the future, the errorHandler payload should be more descriptive such as passing back a SyncError (similar to JS's current implementation).

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [x] Ran AWSDataStorePluginIntegrationTests
- [x] Ran AWSDataStorePluginV2Tests
- [x] Ran AWSDataStorePluginMultiAuthTests
- [x] Ran AWSDataStorePluginCPKTests
- [x] Ran AWSDataStorePluginAuthCognitoTests
- [x] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
