### PR TITLE
fix(datastore): improve sync event error handling - cannotParseResponse

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RequestRetryablePolicy.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RequestRetryablePolicy.swift
@@ -38,7 +38,8 @@ class RequestRetryablePolicy: RequestRetryable {
              .cannotConnectToHost,
              .cannotFindHost,
              .timedOut,
-             .dataNotAllowed:
+             .dataNotAllowed,
+             .cannotParseResponse:
             let waitMillis = retryDelayInMillseconds(for: attemptNumber)
             return RequestRetryAdvice(shouldRetry: true, retryInterval: .milliseconds(waitMillis))
         default:

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RequestRetryablePolicyTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RequestRetryablePolicyTests.swift
@@ -177,6 +177,17 @@ class RequestRetryablePolicyTests: XCTestCase {
         assertMilliseconds(retryAdvice.retryInterval, greaterThan: 200, lessThan: 300)
     }
 
+    func testCannotParseResponseError() {
+        let retryableErrorCode = URLError.init(.cannotParseResponse)
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: retryableErrorCode,
+                                                         httpURLResponse: nil,
+                                                         attemptNumber: 1)
+
+        XCTAssert(retryAdvice.shouldRetry)
+        assertMilliseconds(retryAdvice.retryInterval, greaterThan: 200, lessThan: 300)
+    }
+
     func testHTTPTooManyRedirectsError() {
         let nonRetryableErrorCode = URLError.init(.httpTooManyRedirects)
 


### PR DESCRIPTION
*Issue #, if available:*
See `v1` bug fix for more information https://github.com/aws-amplify/amplify-swift/pull/2532

1. `v1` PR https://github.com/aws-amplify/amplify-swift/pull/2532
2. **`main` PR https://github.com/aws-amplify/amplify-swift/pull/2536** (You are here)

*Description of changes:*


*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [x] Ran AWSDataStorePluginIntegrationTests
- [x] Ran AWSDataStorePluginV2Tests
- [x] Ran AWSDataStorePluginMultiAuthTests
- [x] Ran AWSDataStorePluginCPKTests
- [x] Ran AWSDataStorePluginAuthCognitoTests
- [x] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
