### PR TITLE
feat(storage): Remove the async throws from the apis that return task

### DIFF
--- a/Amplify/Categories/Storage/StorageCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Storage/StorageCategory+ClientBehavior.swift
@@ -29,7 +29,7 @@ extension StorageCategory: StorageCategoryBehavior {
     public func downloadFile(
         key: String,
         local: URL,
-        options: StorageDownloadFileOperation.Request.Options?
+        options: StorageDownloadFileOperation.Request.Options? = nil
     ) -> StorageDownloadFileTask {
         plugin.downloadFile(key: key, local: local, options: options)
     }

--- a/Amplify/Categories/Storage/StorageCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Storage/StorageCategory+ClientBehavior.swift
@@ -10,46 +10,60 @@ import Foundation
 extension StorageCategory: StorageCategoryBehavior {
 
     @discardableResult
-    public func getURL(key: String,
-                       options: StorageGetURLOperation.Request.Options? = nil) async throws -> URL {
+    public func getURL(
+        key: String,
+        options: StorageGetURLOperation.Request.Options? = nil
+    ) async throws -> URL {
         try await plugin.getURL(key: key, options: options)
     }
 
     @discardableResult
-    public func downloadData(key: String,
-                             options: StorageDownloadDataOperation.Request.Options? = nil) async throws -> StorageDownloadDataTask {
-        try await plugin.downloadData(key: key, options: options)
+    public func downloadData(
+        key: String,
+        options: StorageDownloadDataOperation.Request.Options? = nil
+    ) -> StorageDownloadDataTask {
+        plugin.downloadData(key: key, options: options)
     }
 
     @discardableResult
-    public func downloadFile(key: String,
-                             local: URL,
-                             options: StorageDownloadFileOperation.Request.Options?) async throws -> StorageDownloadFileTask {
-        try await plugin.downloadFile(key: key, local: local, options: options)
+    public func downloadFile(
+        key: String,
+        local: URL,
+        options: StorageDownloadFileOperation.Request.Options?
+    ) -> StorageDownloadFileTask {
+        plugin.downloadFile(key: key, local: local, options: options)
     }
 
     @discardableResult
-    public func uploadData(key: String,
-                           data: Data,
-                           options: StorageUploadDataOperation.Request.Options? = nil) async throws -> StorageUploadDataTask {
-        try await plugin.uploadData(key: key, data: data, options: options)
+    public func uploadData(
+        key: String,
+        data: Data,
+        options: StorageUploadDataOperation.Request.Options? = nil
+    ) -> StorageUploadDataTask {
+        plugin.uploadData(key: key, data: data, options: options)
     }
 
     @discardableResult
-    public func uploadFile(key: String,
-                           local: URL,
-                           options: StorageUploadFileOperation.Request.Options? = nil) async throws -> StorageUploadFileTask {
-        try await plugin.uploadFile(key: key, local: local, options: options)
+    public func uploadFile(
+        key: String,
+        local: URL,
+        options: StorageUploadFileOperation.Request.Options? = nil
+    ) -> StorageUploadFileTask {
+        plugin.uploadFile(key: key, local: local, options: options)
     }
 
     @discardableResult
-    public func remove(key: String,
-                       options: StorageRemoveRequest.Options? = nil) async throws -> String {
+    public func remove(
+        key: String,
+        options: StorageRemoveRequest.Options? = nil
+    ) async throws -> String {
         try await plugin.remove(key: key, options: options)
     }
 
     @discardableResult
-    public func list(options: StorageListOperation.Request.Options? = nil) async throws -> StorageListResult {
+    public func list(
+        options: StorageListOperation.Request.Options? = nil
+    ) async throws -> StorageListResult {
         try await plugin.list(options: options)
     }
 

--- a/Amplify/Categories/Storage/StorageCategoryBehavior.swift
+++ b/Amplify/Categories/Storage/StorageCategoryBehavior.swift
@@ -28,7 +28,7 @@ public protocol StorageCategoryBehavior {
     /// - Returns: A task that provides progress updates and the key which was used to download
     @discardableResult
     func downloadData(key: String,
-                      options: StorageDownloadDataOperation.Request.Options?) async throws -> StorageDownloadDataTask
+                      options: StorageDownloadDataOperation.Request.Options?) -> StorageDownloadDataTask
 
     /// Download to file the object from storage.
     ///
@@ -40,7 +40,7 @@ public protocol StorageCategoryBehavior {
     @discardableResult
     func downloadFile(key: String,
                       local: URL,
-                      options: StorageDownloadFileOperation.Request.Options?) async throws -> StorageDownloadFileTask
+                      options: StorageDownloadFileOperation.Request.Options?) -> StorageDownloadFileTask
 
     /// Upload data to storage
     ///
@@ -52,7 +52,7 @@ public protocol StorageCategoryBehavior {
     @discardableResult
     func uploadData(key: String,
                     data: Data,
-                    options: StorageUploadDataOperation.Request.Options?) async throws -> StorageUploadDataTask
+                    options: StorageUploadDataOperation.Request.Options?) -> StorageUploadDataTask
 
     /// Upload local file to storage
     ///
@@ -64,7 +64,7 @@ public protocol StorageCategoryBehavior {
     @discardableResult
     func uploadFile(key: String,
                     local: URL,
-                    options: StorageUploadFileOperation.Request.Options?) async throws -> StorageUploadFileTask
+                    options: StorageUploadFileOperation.Request.Options?) -> StorageUploadFileTask
 
     /// Delete object from storage
     ///

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+AsyncClientBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+AsyncClientBehavior.swift
@@ -16,7 +16,7 @@ extension AWSS3StoragePlugin {
     @discardableResult
     public func getURL(
         key: String,
-        options: StorageGetURLOperation.Request.Options?
+        options: StorageGetURLOperation.Request.Options? = nil
     ) async throws -> URL {
         let options = options ?? StorageGetURLRequest.Options()
         let request = StorageGetURLRequest(key: key, options: options)
@@ -51,7 +51,7 @@ extension AWSS3StoragePlugin {
     public func downloadFile(
         key: String,
         local: URL,
-        options: StorageDownloadFileOperation.Request.Options?
+        options: StorageDownloadFileOperation.Request.Options? = nil
     ) -> StorageDownloadFileTask {
         let options = options ?? StorageDownloadFileRequest.Options()
         let request = StorageDownloadFileRequest(key: key, local: local, options: options)
@@ -69,7 +69,7 @@ extension AWSS3StoragePlugin {
     public func uploadData(
         key: String,
         data: Data,
-        options: StorageUploadDataOperation.Request.Options?
+        options: StorageUploadDataOperation.Request.Options? = nil
     ) -> StorageUploadDataTask {
         let options = options ?? StorageUploadDataRequest.Options()
         let request = StorageUploadDataRequest(key: key, data: data, options: options)
@@ -87,7 +87,7 @@ extension AWSS3StoragePlugin {
     public func uploadFile(
         key: String,
         local: URL,
-        options: StorageUploadFileOperation.Request.Options?
+        options: StorageUploadFileOperation.Request.Options? = nil
     ) -> StorageUploadFileTask {
         let options = options ?? StorageUploadFileRequest.Options()
         let request = StorageUploadFileRequest(key: key, local: local, options: options)
@@ -104,7 +104,7 @@ extension AWSS3StoragePlugin {
     @discardableResult
     public func remove(
         key: String,
-        options: StorageRemoveOperation.Request.Options?
+        options: StorageRemoveOperation.Request.Options? = nil
     ) async throws -> String {
         let options = options ?? StorageRemoveRequest.Options()
         let request = StorageRemoveRequest(key: key, options: options)

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+AsyncClientBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+AsyncClientBehavior.swift
@@ -14,8 +14,10 @@ import AWSPluginsCore
 extension AWSS3StoragePlugin {
 
     @discardableResult
-    public func getURL(key: String,
-                       options: StorageGetURLOperation.Request.Options?) async throws -> URL {
+    public func getURL(
+        key: String,
+        options: StorageGetURLOperation.Request.Options?
+    ) async throws -> URL {
         let options = options ?? StorageGetURLRequest.Options()
         let request = StorageGetURLRequest(key: key, options: options)
         let operation = AWSS3StorageGetURLOperation(request,
@@ -29,8 +31,10 @@ extension AWSS3StoragePlugin {
     }
 
     @discardableResult
-    public func downloadData(key: String,
-                             options: StorageDownloadDataOperation.Request.Options? = nil) async throws -> StorageDownloadDataTask {
+    public func downloadData(
+        key: String,
+        options: StorageDownloadDataOperation.Request.Options? = nil
+    ) -> StorageDownloadDataTask {
         let options = options ?? StorageDownloadDataRequest.Options()
         let request = StorageDownloadDataRequest(key: key, options: options)
         let operation = AWSS3StorageDownloadDataOperation(request,
@@ -44,9 +48,11 @@ extension AWSS3StoragePlugin {
     }
 
     @discardableResult
-    public func downloadFile(key: String,
-                             local: URL,
-                             options: StorageDownloadFileOperation.Request.Options?) async throws -> StorageDownloadFileTask {
+    public func downloadFile(
+        key: String,
+        local: URL,
+        options: StorageDownloadFileOperation.Request.Options?
+    ) -> StorageDownloadFileTask {
         let options = options ?? StorageDownloadFileRequest.Options()
         let request = StorageDownloadFileRequest(key: key, local: local, options: options)
         let operation = AWSS3StorageDownloadFileOperation(request,
@@ -60,9 +66,11 @@ extension AWSS3StoragePlugin {
     }
 
     @discardableResult
-    public func uploadData(key: String,
-                           data: Data,
-                           options: StorageUploadDataOperation.Request.Options?) async throws -> StorageUploadDataTask {
+    public func uploadData(
+        key: String,
+        data: Data,
+        options: StorageUploadDataOperation.Request.Options?
+    ) -> StorageUploadDataTask {
         let options = options ?? StorageUploadDataRequest.Options()
         let request = StorageUploadDataRequest(key: key, data: data, options: options)
         let operation = AWSS3StorageUploadDataOperation(request,
@@ -76,9 +84,11 @@ extension AWSS3StoragePlugin {
     }
 
     @discardableResult
-    public func uploadFile(key: String,
-                           local: URL,
-                           options: StorageUploadFileOperation.Request.Options?) async throws -> StorageUploadFileTask {
+    public func uploadFile(
+        key: String,
+        local: URL,
+        options: StorageUploadFileOperation.Request.Options?
+    ) -> StorageUploadFileTask {
         let options = options ?? StorageUploadFileRequest.Options()
         let request = StorageUploadFileRequest(key: key, local: local, options: options)
         let operation = AWSS3StorageUploadFileOperation(request,
@@ -92,8 +102,10 @@ extension AWSS3StoragePlugin {
     }
 
     @discardableResult
-    public func remove(key: String,
-                       options: StorageRemoveOperation.Request.Options?) async throws -> String {
+    public func remove(
+        key: String,
+        options: StorageRemoveOperation.Request.Options?
+    ) async throws -> String {
         let options = options ?? StorageRemoveRequest.Options()
         let request = StorageRemoveRequest(key: key, options: options)
         let operation = AWSS3StorageRemoveOperation(request,
@@ -106,7 +118,9 @@ extension AWSS3StoragePlugin {
         return try await taskAdapter.value
     }
 
-    public func list(options: StorageListRequest.Options? = nil) async throws -> StorageListResult {
+    public func list(
+        options: StorageListRequest.Options? = nil
+    ) async throws -> StorageListResult {
         let options = options ?? StorageListRequest.Options()
         let request = StorageListRequest(options: options)
         let operation = AWSS3StorageListOperation(request,

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginProgressTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginProgressTests.swift
@@ -33,7 +33,7 @@ class AWSS3StoragePluginProgressTests: AWSS3StoragePluginTestBase {
         let completionReceived = expectation(description: "resultReceived")
         let progressReceived = expectation(description: "progressReceived")
         progressReceived.assertForOverFulfill = false
-        let uploadOperation = try await Amplify.Storage.uploadData(
+        let uploadOperation = Amplify.Storage.uploadData(
             key: key,
             data: .testDataOfSize(.bytes(100)))
 
@@ -63,7 +63,7 @@ class AWSS3StoragePluginProgressTests: AWSS3StoragePluginTestBase {
         let key = "testUploadProgressDeliveryAfterCompletion-\(timestamp)"
 
         // Wait for the upload to complete
-        let uploadOperation = try await Amplify.Storage.uploadData(
+        let uploadOperation = Amplify.Storage.uploadData(
             key: key,
             data: .testDataOfSize(.bytes(100))
         )

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginTestBase.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginTestBase.swift
@@ -63,13 +63,13 @@ class AWSS3StoragePluginTestBase: XCTestCase {
 
     func uploadTask(key: String, data: Data) async -> StorageUploadDataTask? {
         return await wait(name: "Upload Task created") {
-            return try await Amplify.Storage.uploadData(key: key, data: data)
+            return Amplify.Storage.uploadData(key: key, data: data)
         }
     }
 
     func downloadTask(key: String) async -> StorageDownloadDataTask? {
         return await wait(name: "Upload Task created") {
-            return try await Amplify.Storage.downloadData(key: key)
+            return Amplify.Storage.downloadData(key: key)
         }
     }
 

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginGetDataResumabilityTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginGetDataResumabilityTests.swift
@@ -25,7 +25,7 @@ class AWSS3StoragePluginDownloadDataResumabilityTests: AWSS3StoragePluginTestBas
             XCTAssertEqual(uploadKey, key)
 
             Self.logger.debug("Downloading data")
-            let task = try await Amplify.Storage.downloadData(key: key)
+            let task = Amplify.Storage.downloadData(key: key)
 
             let didPause = asyncExpectation(description: "did pause")
             let didContinue = asyncExpectation(description: "did continue", isInverted: true)
@@ -79,7 +79,7 @@ class AWSS3StoragePluginDownloadDataResumabilityTests: AWSS3StoragePluginTestBas
             let uploadKey = try await Amplify.Storage.uploadData(key: key, data: data).value
             XCTAssertEqual(uploadKey, key)
 
-            let task = try await Amplify.Storage.downloadData(key: key)
+            let task = Amplify.Storage.downloadData(key: key)
 
             let progressInvoked = asyncExpectation(description: "Progress invoked")
             Task {
@@ -133,7 +133,7 @@ class AWSS3StoragePluginDownloadDataResumabilityTests: AWSS3StoragePluginTestBas
             XCTAssertEqual(uploadKey, key)
 
             Self.logger.debug("Downloading data")
-            let task = try await Amplify.Storage.downloadData(key: key)
+            let task = Amplify.Storage.downloadData(key: key)
 
             let didCancel = asyncExpectation(description: "did cancel")
             let didContinue = asyncExpectation(description: "did continue", isInverted: true)

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginPutDataResumabilityTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginPutDataResumabilityTests.swift
@@ -20,7 +20,7 @@ class AWSS3StoragePluginUploadDataResumabilityTests: AWSS3StoragePluginTestBase 
         try await testTask(timeout: 600) {
             let key = UUID().uuidString
             Self.logger.debug("Uploading data")
-            let task = try await Amplify.Storage.uploadData(key: key, data: AWSS3StoragePluginTestBase.largeDataObject)
+            let task = Amplify.Storage.uploadData(key: key, data: AWSS3StoragePluginTestBase.largeDataObject)
 
             let didPause = asyncExpectation(description: "did pause")
             let didContinue = asyncExpectation(description: "did continue", isInverted: true)
@@ -71,7 +71,7 @@ class AWSS3StoragePluginUploadDataResumabilityTests: AWSS3StoragePluginTestBase 
         try await testTask(timeout: 600) {
             let key = UUID().uuidString
             Self.logger.debug("Uploading data")
-            let task = try await Amplify.Storage.uploadData(key: key, data: AWSS3StoragePluginTestBase.largeDataObject)
+            let task = Amplify.Storage.uploadData(key: key, data: AWSS3StoragePluginTestBase.largeDataObject)
 
             let progressInvoked = asyncExpectation(description: "Progress invoked")
             Task {
@@ -118,7 +118,7 @@ class AWSS3StoragePluginUploadDataResumabilityTests: AWSS3StoragePluginTestBase 
         try await testTask(timeout: 600) {
             let key = UUID().uuidString
             Self.logger.debug("Uploading data")
-            let task = try await Amplify.Storage.uploadData(key: key, data: AWSS3StoragePluginTestBase.largeDataObject)
+            let task = Amplify.Storage.uploadData(key: key, data: AWSS3StoragePluginTestBase.largeDataObject)
 
             let didCancel = asyncExpectation(description: "did cancel")
             let didContinue = asyncExpectation(description: "did continue", isInverted: true)

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj/project.pbxproj
@@ -14,12 +14,9 @@
 		681DFEB428E748270000C36A /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEB128E748270000C36A /* XCTestCase+AsyncTesting.swift */; };
 		684FB06E28BEAF1500C8A6EB /* StorageHostAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB06D28BEAF1500C8A6EB /* StorageHostAppApp.swift */; };
 		684FB07028BEAF1500C8A6EB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB06F28BEAF1500C8A6EB /* ContentView.swift */; };
-		684FB0A228BEB02E00C8A6EB /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = 684FB0A128BEB02E00C8A6EB /* Amplify */; };
-		684FB0A428BEB02E00C8A6EB /* AWSS3StoragePlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 684FB0A328BEB02E00C8A6EB /* AWSS3StoragePlugin */; };
 		684FB0B328BEB08900C8A6EB /* AWSS3StoragePluginTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB07E28BEAF8E00C8A6EB /* AWSS3StoragePluginTestBase.swift */; };
 		684FB0B528BEB08900C8A6EB /* AWSS3StoragePluginAccessLevelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB08628BEAF8E00C8A6EB /* AWSS3StoragePluginAccessLevelTests.swift */; };
 		684FB0BE28BEB08F00C8A6EB /* TestConfigHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB09D28BEAFE700C8A6EB /* TestConfigHelper.swift */; };
-		684FB0C028BEB1AB00C8A6EB /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 684FB0BF28BEB1AB00C8A6EB /* AWSCognitoAuthPlugin */; };
 		684FB0C328BEB45600C8A6EB /* AuthSignInHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB0C228BEB45600C8A6EB /* AuthSignInHelper.swift */; };
 		68828E3D28C136EB006E7C0A /* AWSS3StoragePluginBasicIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB08428BEAF8E00C8A6EB /* AWSS3StoragePluginBasicIntegrationTests.swift */; };
 		68828E3E28C1546F006E7C0A /* AWSS3StoragePluginConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB08028BEAF8E00C8A6EB /* AWSS3StoragePluginConfigurationTests.swift */; };
@@ -31,6 +28,9 @@
 		68828E4628C2736C006E7C0A /* AWSS3StoragePluginProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB08C28BEAF8E00C8A6EB /* AWSS3StoragePluginProgressTests.swift */; };
 		68828E4728C27745006E7C0A /* AWSS3StoragePluginPutDataResumabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB08828BEAF8E00C8A6EB /* AWSS3StoragePluginPutDataResumabilityTests.swift */; };
 		68828E4828C2AAA6006E7C0A /* AWSS3StoragePluginGetDataResumabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB08B28BEAF8E00C8A6EB /* AWSS3StoragePluginGetDataResumabilityTests.swift */; };
+		B4A5B59B2919730700D873D2 /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = B4A5B59A2919730700D873D2 /* Amplify */; };
+		B4A5B59D2919730700D873D2 /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = B4A5B59C2919730700D873D2 /* AWSCognitoAuthPlugin */; };
+		B4A5B59F2919730700D873D2 /* AWSS3StoragePlugin in Frameworks */ = {isa = PBXBuildFile; productRef = B4A5B59E2919730700D873D2 /* AWSS3StoragePlugin */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,7 +53,6 @@
 		684FB06A28BEAF1500C8A6EB /* StorageHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StorageHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		684FB06D28BEAF1500C8A6EB /* StorageHostAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageHostAppApp.swift; sourceTree = "<group>"; };
 		684FB06F28BEAF1500C8A6EB /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		684FB07C28BEAF6300C8A6EB /* amplify-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-ios"; path = ../../../..; sourceTree = "<group>"; };
 		684FB07E28BEAF8E00C8A6EB /* AWSS3StoragePluginTestBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSS3StoragePluginTestBase.swift; sourceTree = "<group>"; };
 		684FB07F28BEAF8E00C8A6EB /* AWSS3StoragePluginPrefixKeyResolverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSS3StoragePluginPrefixKeyResolverTests.swift; sourceTree = "<group>"; };
 		684FB08028BEAF8E00C8A6EB /* AWSS3StoragePluginConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSS3StoragePluginConfigurationTests.swift; sourceTree = "<group>"; };
@@ -70,6 +69,8 @@
 		684FB0A928BEB07200C8A6EB /* AWSS3StoragePluginIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSS3StoragePluginIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		684FB0C228BEB45600C8A6EB /* AuthSignInHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSignInHelper.swift; sourceTree = "<group>"; };
 		684FB0C528BEB84800C8A6EB /* StorageHostApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StorageHostApp.entitlements; sourceTree = "<group>"; };
+		B4A5B5982919725100D873D2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		B4A5B5992919727700D873D2 /* amplify-swift */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-swift"; path = ../../../..; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,9 +78,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				684FB0A228BEB02E00C8A6EB /* Amplify in Frameworks */,
-				684FB0A428BEB02E00C8A6EB /* AWSS3StoragePlugin in Frameworks */,
-				684FB0C028BEB1AB00C8A6EB /* AWSCognitoAuthPlugin in Frameworks */,
+				B4A5B59B2919730700D873D2 /* Amplify in Frameworks */,
+				B4A5B59D2919730700D873D2 /* AWSCognitoAuthPlugin in Frameworks */,
+				B4A5B59F2919730700D873D2 /* AWSS3StoragePlugin in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -137,6 +138,7 @@
 		684FB06C28BEAF1500C8A6EB /* StorageHostApp */ = {
 			isa = PBXGroup;
 			children = (
+				B4A5B5982919725100D873D2 /* Info.plist */,
 				681DFEAE28E748270000C36A /* AsyncTesting */,
 				684FB0C528BEB84800C8A6EB /* StorageHostApp.entitlements */,
 				684FB06D28BEAF1500C8A6EB /* StorageHostAppApp.swift */,
@@ -149,7 +151,7 @@
 		684FB07B28BEAF5500C8A6EB /* Packages */ = {
 			isa = PBXGroup;
 			children = (
-				684FB07C28BEAF6300C8A6EB /* amplify-ios */,
+				B4A5B5992919727700D873D2 /* amplify-swift */,
 			);
 			name = Packages;
 			sourceTree = "<group>";
@@ -218,9 +220,9 @@
 			);
 			name = StorageHostApp;
 			packageProductDependencies = (
-				684FB0A128BEB02E00C8A6EB /* Amplify */,
-				684FB0A328BEB02E00C8A6EB /* AWSS3StoragePlugin */,
-				684FB0BF28BEB1AB00C8A6EB /* AWSCognitoAuthPlugin */,
+				B4A5B59A2919730700D873D2 /* Amplify */,
+				B4A5B59C2919730700D873D2 /* AWSCognitoAuthPlugin */,
+				B4A5B59E2919730700D873D2 /* AWSS3StoragePlugin */,
 			);
 			productName = StorageHostApp;
 			productReference = 684FB06A28BEAF1500C8A6EB /* StorageHostApp.app */;
@@ -509,7 +511,8 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_DISPLAY_NAME)";
+				INFOPLIST_FILE = StorageHostApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = IntegTests;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -538,7 +541,8 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = "$(APP_DISPLAY_NAME)";
+				INFOPLIST_FILE = StorageHostApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = IntegTests;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -631,17 +635,17 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = Amplify;
 		};
-		684FB0A128BEB02E00C8A6EB /* Amplify */ = {
+		B4A5B59A2919730700D873D2 /* Amplify */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Amplify;
 		};
-		684FB0A328BEB02E00C8A6EB /* AWSS3StoragePlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AWSS3StoragePlugin;
-		};
-		684FB0BF28BEB1AB00C8A6EB /* AWSCognitoAuthPlugin */ = {
+		B4A5B59C2919730700D873D2 /* AWSCognitoAuthPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = AWSCognitoAuthPlugin;
+		};
+		B4A5B59E2919730700D873D2 /* AWSS3StoragePlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSS3StoragePlugin;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp/Info.plist
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>INIntentsSupported</key>
+	<array>
+		<string>Intent</string>
+	</array>
+</dict>
+</plist>

--- a/AmplifyTestCommon/Mocks/MockStorageCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockStorageCategoryPlugin.swift
@@ -121,7 +121,7 @@ class MockStorageCategoryPlugin: MessageReporter, StorageCategoryPlugin {
 
     @discardableResult
     func downloadData(key: String,
-                      options: StorageDownloadDataOperation.Request.Options? = nil) async throws -> StorageDownloadDataTask {
+                      options: StorageDownloadDataOperation.Request.Options? = nil) -> StorageDownloadDataTask {
         notify("downloadData")
         let options = options ?? StorageDownloadDataRequest.Options()
         let request = StorageDownloadDataRequest(key: key, options: options)
@@ -133,7 +133,7 @@ class MockStorageCategoryPlugin: MessageReporter, StorageCategoryPlugin {
     @discardableResult
     func downloadFile(key: String,
                       local: URL,
-                      options: StorageDownloadFileOperation.Request.Options?) async throws -> StorageDownloadFileTask {
+                      options: StorageDownloadFileOperation.Request.Options?) -> StorageDownloadFileTask {
         notify("downloadFile")
         let options = options ?? StorageDownloadFileRequest.Options()
         let request = StorageDownloadFileRequest(key: key, local: local, options: options)
@@ -145,7 +145,7 @@ class MockStorageCategoryPlugin: MessageReporter, StorageCategoryPlugin {
     @discardableResult
     func uploadData(key: String,
                     data: Data,
-                    options: StorageUploadDataOperation.Request.Options?) async throws -> StorageUploadDataTask {
+                    options: StorageUploadDataOperation.Request.Options?) -> StorageUploadDataTask {
         notify("uploadData")
         let options = options ?? StorageUploadDataRequest.Options()
         let request = StorageUploadDataRequest(key: key, data: data, options: options)
@@ -157,7 +157,7 @@ class MockStorageCategoryPlugin: MessageReporter, StorageCategoryPlugin {
     @discardableResult
     func uploadFile(key: String,
                     local: URL,
-                    options: StorageUploadFileOperation.Request.Options?) async throws -> StorageUploadFileTask {
+                    options: StorageUploadFileOperation.Request.Options?) -> StorageUploadFileTask {
         notify("uploadFile")
         let options = options ?? StorageUploadFileRequest.Options()
         let request = StorageUploadFileRequest(key: key, local: local, options: options)

--- a/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
@@ -239,7 +239,7 @@ class MockDispatchingStoragePlugin: StorageCategoryPlugin {
 
     @discardableResult
     public func downloadData(key: String,
-                      options: StorageDownloadDataOperation.Request.Options? = nil) async throws -> StorageDownloadDataTask {
+                      options: StorageDownloadDataOperation.Request.Options? = nil) -> StorageDownloadDataTask {
         let options = options ?? StorageDownloadDataRequest.Options()
         let request = StorageDownloadDataRequest(key: key, options: options)
         let operation = MockDispatchingStorageDownloadDataOperation(request: request)
@@ -250,7 +250,7 @@ class MockDispatchingStoragePlugin: StorageCategoryPlugin {
     @discardableResult
     public func downloadFile(key: String,
                              local: URL,
-                             options: StorageDownloadFileOperation.Request.Options?) async throws -> StorageDownloadFileTask {
+                             options: StorageDownloadFileOperation.Request.Options?) -> StorageDownloadFileTask {
         let options = options ?? StorageDownloadFileRequest.Options()
         let request = StorageDownloadFileRequest(key: key, local: local, options: options)
         let operation = MockDispatchingStorageDownloadFileOperation(request: request)
@@ -261,7 +261,7 @@ class MockDispatchingStoragePlugin: StorageCategoryPlugin {
     @discardableResult
     public func uploadData(key: String,
                            data: Data,
-                           options: StorageUploadDataOperation.Request.Options?) async throws -> StorageUploadDataTask {
+                           options: StorageUploadDataOperation.Request.Options?) -> StorageUploadDataTask {
         let options = options ?? StorageUploadDataRequest.Options()
         let request = StorageUploadDataRequest(key: key, data: data, options: options)
         let operation = MockDispatchingStorageUploadDataOperation(request: request)
@@ -272,7 +272,7 @@ class MockDispatchingStoragePlugin: StorageCategoryPlugin {
     @discardableResult
     public func uploadFile(key: String,
                            local: URL,
-                           options: StorageUploadFileOperation.Request.Options?) async throws -> StorageUploadFileTask {
+                           options: StorageUploadFileOperation.Request.Options?) -> StorageUploadFileTask {
         let options = options ?? StorageUploadFileRequest.Options()
         let request = StorageUploadFileRequest(key: key, local: local, options: options)
         let operation = MockDispatchingStorageUploadFileOperation(request: request)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Features
+
+- **storage**: Remove `async throws` from public apis that returns a task (#2543). The change avoids checking for error at two places and the api will become sync. 
+              **Note:** This change would break customer who use storage api and have Xcode setting to treat warnings as error. 
+
 ## 2.0.2 (2022-11-02)
 
 ### Bug Fixes


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-swift/issues/2546

*Description of changes:*
Update the storage api to remove the `async throws` from apis that return task.

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] ~Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~
- [x] Documentation update for the change if required https://github.com/aws-amplify/docs/pull/4799
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
