### PR TITLE
[TEST] chore(datastore): modify timeout for TransformerV2 tests in CI

### DIFF
--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -30,7 +30,7 @@ jobs:
 
   datastore-integration-v2-test:
     continue-on-error: true
-    timeout-minutes: 17
+    timeout-minutes: 20
     needs: prepare-for-test
     runs-on: macos-12
     environment: IntegrationTest

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -1,7 +1,7 @@
-name: DataStore Integration V2 Tests
+name: DataStore TransformerV2 Tests
 on:
   push:
-    branches: [chore/test-run-V2]
+    branches: [main]
 
 permissions:
     id-token: write

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -1,0 +1,59 @@
+name: DataStore Integration V2 Tests
+on:
+  push:
+    branches: [chore/test-run-V2]
+
+permissions:
+    id-token: write
+    contents: read 
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  prepare-for-test:
+    runs-on: macos-12
+    environment: IntegrationTest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          persist-credentials: false
+
+      - name: Verify copy resources
+        uses: ./.github/composite_actions/download_test_configuration
+        with:
+          resource_subfolder: NA
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
+
+  datastore-integration-v2-test:
+    continue-on-error: true
+    timeout-minutes: 15
+    needs: prepare-for-test
+    runs-on: macos-12
+    environment: IntegrationTest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          persist-credentials: false
+
+      - name: Make directory
+        run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
+
+      - name: Copy integration test resouces
+        uses: ./.github/composite_actions/download_test_configuration
+        with:
+          resource_subfolder: datastore
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
+
+      - name: Run Integration test
+        uses: ./.github/composite_actions/run_xcodebuild_test
+        with:
+          project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests
+          scheme: AWSDataStorePluginV2Tests
+
+ 

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -30,7 +30,7 @@ jobs:
 
   datastore-integration-v2-test:
     continue-on-error: true
-    timeout-minutes: 20
+    timeout-minutes: 30
     needs: prepare-for-test
     runs-on: macos-12
     environment: IntegrationTest

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run Integration test
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
-          project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests
+          project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginV2Tests
 
  

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -30,7 +30,7 @@ jobs:
 
   datastore-integration-v2-test:
     continue-on-error: true
-    timeout-minutes: 15
+    timeout-minutes: 25
     needs: prepare-for-test
     runs-on: macos-12
     environment: IntegrationTest

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -30,7 +30,7 @@ jobs:
 
   datastore-integration-v2-test:
     continue-on-error: true
-    timeout-minutes: 25
+    timeout-minutes: 20
     needs: prepare-for-test
     runs-on: macos-12
     environment: IntegrationTest

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -30,7 +30,7 @@ jobs:
 
   datastore-integration-v2-test:
     continue-on-error: true
-    timeout-minutes: 20
+    timeout-minutes: 17
     needs: prepare-for-test
     runs-on: macos-12
     environment: IntegrationTest

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run Integration test
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
-          project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
+          project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests
           scheme: AWSDataStorePluginV2Tests
 
  


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
