### PR TITLE
chore(datastore): add logging to cascadeDelete

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
@@ -343,7 +343,7 @@ final class StorageEngine: StorageEngineBehavior {
             case .failure(let dataStoreError):
                 completion(.failure(dataStoreError))
             case .success(let mutationEvent):
-                self.log.verbose("\(#function) successfully submitted to sync engine \(mutationEvent)")
+                self.log.verbose("\(#function) successfully submitted \(mutationEvent.modelName) to sync engine \(mutationEvent)")
                 completion(.success(savedModel))
             }
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds logging to the cascadeDelete operation for simplified debugging into the cascadeDelete operation & provide better CX.
In any Amplify configured App with verbose logging enabled, searching `[cascadeDelete` will print out the state of cascadeDelete Operation like:
```
[cascadeDelete.1] Start cascade logic for Blog with id `blog123`
[cascadeDelete.2] Query for Blog associated models, found Post 1 Comment 1
[cascadeDelete.3] Local cascade delete of Blog successful!
[cascadeDelete.4] sending 3 delete mutations
```
*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
