### PR TITLE
chore(Predictions): Fixing integration test.

### DIFF
--- a/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/IdentifyBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPluginIntegrationTests/IdentifyBasicIntegrationTests.swift
@@ -239,6 +239,33 @@ class IdentifyBasicIntegrationTests: AWSPredictionsPluginTestBase {
             XCTFail("Unable to find image")
             return
         }
+        // These are all the words that should be recognized on the image.
+        let expectedWords = [
+            "Personal",
+            "information",
+            "First",
+            "name",
+            "AWS",
+            "Middle",
+            "Last",
+            "Amazon",
+            "Address",
+            "410",
+            "Terry",
+            "Ave",
+            "N",
+            "City",
+            "or",
+            "Town",
+            "Seattle",
+            "State",
+            "Choose",
+            "a",
+            "State",
+            "Zip",
+            "code",
+            "98109"
+        ]
         let completeInvoked = expectation(description: "Completed is invoked")
 
         let operation = Amplify.Predictions.identify(type: .detectText(.form),
@@ -252,7 +279,9 @@ class IdentifyBasicIntegrationTests: AWSPredictionsPluginTestBase {
                 }
                 XCTAssertFalse(data.fullText.isEmpty)
                 XCTAssertFalse(data.words.isEmpty)
-                XCTAssertEqual(data.words.count, 33)
+                for word in expectedWords {
+                    XCTAssertTrue(data.words.contains(where: { $0.text.contains(word) }))
+                }
                 XCTAssertFalse(data.rawLineText.isEmpty)
                 XCTAssertEqual(data.rawLineText.count, 17)
                 XCTAssertFalse(data.identifiedLines.isEmpty)


### PR DESCRIPTION
*Description of changes:*
Updating the `testIdentifyTextForms` integration test to validate that it recognized the words instead of just the number of words, as the latter can change if the service is updated.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
