### PR TITLE
chore(datastore): add cascadeDelete logging on v1

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/StorageEngine.swift
@@ -359,7 +359,7 @@ final class StorageEngine: StorageEngineBehavior {
             case .failure(let dataStoreError):
                 completion(.failure(dataStoreError))
             case .success(let mutationEvent):
-                self.log.verbose("\(#function) successfully submitted to sync engine \(mutationEvent)")
+                self.log.verbose("\(#function) successfully submitted \(mutationEvent.modelName) to sync engine \(mutationEvent)")
                 completion(.success(savedModel))
             }
         }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario3aV2Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario3aV2Tests.swift
@@ -374,7 +374,7 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
     }
 
     func testDeletePostCascadeToComments() throws {
-        setUp(withModels: TestModelRegistration())
+        setUp(withModels: TestModelRegistration(), logLevel: .verbose)
         try startAmplifyAndWaitForSync()
 
         guard let post = savePost(title: "title") else {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario6V2Tests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/TransformerV2/DataStoreConnectionScenario6V2Tests.swift
@@ -420,7 +420,7 @@ class DataStoreConnectionScenario6V2Tests: SyncEngineIntegrationV2TestBase {
     }
 
     func testCascadeDeleteBlogDeletesPostAndComments() throws {
-        setUp(withModels: TestModelRegistration())
+        setUp(withModels: TestModelRegistration(), logLevel: .verbose)
         try startAmplifyAndWaitForSync()
         guard let blog = saveBlog(name: "name"),
               let post = savePost(title: "title", blog: blog),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR reflects cascadeDelete logging made on `main` branch (PR: https://github.com/aws-amplify/amplify-swift/pull/2553) onto here on `v1` branch.

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
