### PR TITLE
fix(datastore): retry on subscription connection error

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
@@ -174,6 +174,11 @@ public class AWSGraphQLSubscriptionTaskRunner<R: Decodable>: InternalTaskRunner,
             return
         } else if case ConnectionProviderError.unauthorized = error {
             errorDescription += ": \(APIError.UnauthorizedMessageString)"
+        } else if case ConnectionProviderError.connection = error {
+            errorDescription += ": connection"
+            let error = URLError(.networkConnectionLost)
+            fail(APIError.networkError(errorDescription, nil, error))
+            return
         }
 
         fail(APIError.operationError(errorDescription, "", error))

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
@@ -373,7 +373,6 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
             finish()
             return
         }
-        
         dispatch(result: .failure(APIError.operationError(errorDescription, "", error)))
         finish()
     }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
@@ -361,8 +361,14 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
             return
         } else if case ConnectionProviderError.unauthorized = error {
             errorDescription += ": \(APIError.UnauthorizedMessageString)"
+        } else if case ConnectionProviderError.connection = error {
+            errorDescription += ": connection"
+            let error = URLError(.networkConnectionLost)
+            dispatch(result: .failure(APIError.networkError(errorDescription, nil, error)))
+            finish()
+            return
         }
-
+        
         dispatch(result: .failure(APIError.operationError(errorDescription, "", error)))
         finish()
     }

--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "eea9a9ac6aab16e99eec10169a56336f79ce2e37",
-        "version" : "0.2.6"
+        "revision" : "76d1b43bfc3eeafd9d09e5aa307e629882192a7d",
+        "version" : "0.2.7"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephencelis/SQLite.swift.git",
       "state" : {
-        "revision" : "0a9893ec030501a3956bee572d6b4fdd3ae158a1",
-        "version" : "0.12.2"
+        "revision" : "5f5ad81ac0d0a0f3e56e39e646e8423c617df523",
+        "version" : "0.13.2"
       }
     },
     {

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine+Retryable.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine+Retryable.swift
@@ -35,6 +35,12 @@ extension RemoteSyncEngine {
             urlErrorOptional = underlyingError
         } else if let urlError = error as? URLError {
             urlErrorOptional = urlError
+        } else if let dataStoreError = error as? DataStoreError,
+                  case .api(let amplifyError, _) = dataStoreError,
+                  let apiError = amplifyError as? APIError,
+                  case .networkError(_, _, let error) = apiError,
+                  let urlError = error as? URLError {
+            urlErrorOptional = urlError
         }
 
         let advice = requestRetryablePolicy.retryRequestAdvice(urlError: urlErrorOptional,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RequestRetryablePolicy.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RequestRetryablePolicy.swift
@@ -39,7 +39,8 @@ class RequestRetryablePolicy: RequestRetryable {
              .cannotFindHost,
              .timedOut,
              .dataNotAllowed,
-             .cannotParseResponse:
+             .cannotParseResponse,
+             .networkConnectionLost:
             let waitMillis = retryDelayInMillseconds(for: attemptNumber)
             return RequestRetryAdvice(shouldRetry: true, retryInterval: .milliseconds(waitMillis))
         default:

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RequestRetryablePolicyTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RequestRetryablePolicyTests.swift
@@ -187,6 +187,17 @@ class RequestRetryablePolicyTests: XCTestCase {
         XCTAssert(retryAdvice.shouldRetry)
         assertMilliseconds(retryAdvice.retryInterval, greaterThan: 200, lessThan: 300)
     }
+    
+    func testNetworkConnectionLostError() {
+        let retryableErrorCode = URLError.init(.networkConnectionLost)
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: retryableErrorCode,
+                                                         httpURLResponse: nil,
+                                                         attemptNumber: 1)
+
+        XCTAssert(retryAdvice.shouldRetry)
+        assertMilliseconds(retryAdvice.retryInterval, greaterThan: 200, lessThan: 300)
+    }
 
     func testHTTPTooManyRedirectsError() {
         let nonRetryableErrorCode = URLError.init(.httpTooManyRedirects)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-swift/issues/2152

- `main` PR https://github.com/aws-amplify/amplify-swift/pull/2571 (This PR)
- `v1` PR https://github.com/aws-amplify/amplify-swift/pull/2581 

*Description of changes:*
Once DataStore is in an active state, then the network goes down, then recovers, the subscription websocket will send an error on network recovery. This error propagated back to API/DataStore which handles the error by moving DataStore to a stopped state. It is not processed as retryable. This delays the recoverability of DataStore until the next DataStore operation is called, since it remains in a stopped state. The scenario is reproducible by running an iOS app on a device or running a macOS app on the macbook. Running on an iOS simulator does not have the same effect and the websockets do not disconnect, rather the subscription event is received with a delay (~5-10 seconds) after network recovers.

The AppSyncRealTime websocket client, used by Amplify.API (API plugin) does have its own retry logic on classification of errors coming from the underlying websocket, but in certain scenarios, whether it's an unclassifed error or retry has been exhausted, will eventually propagate a `ConnectionProviderError.connection` error back to the caller and close the websocket connection. In this case, the API Plugin receives this terminating error and sends back `API.operationError` to DataStore. 

DataStore’s sync engine used to be much more aggressive in retrying the sync process. This caused retry storms on AppSync and was fixed in https://github.com/aws-amplify/amplify-swift/pull/1901 It was a code bug that retried on all errors, regardless of the underlying error. By fixing this, it has created another issue where in this scenario where retry would have fixed the problem, was not initiated until the next explicit DataStore operation (start/save/query/delete/etc..) was called, because it has transitioned to the stopped state. When the network is turned back on, DataStore gets the `API.operationError` and stops. We were able to observe this on multiple attempts, https://github.com/aws-amplify/amplify-swift/issues/2152#issuecomment-1217173993 and https://github.com/aws-amplify/amplify-swift/issues/2152#issuecomment-1289616392.

1. API plugin should classify `ConnectionProvider.connection` errors from AppSyncRealTimeClient as an `APIError.networkError`. Convert `ConnectionProvider.connection` to some Foundation’s URLError case that makes sense like `URLError.networkConnectionLost`
2. DataStore should not handle anything related to AppSyncRealTimeClient errors and should only act on `APIError` and extract out the URLError when it is a `APIError.networkError` as an indication to retry the sync process. It passes the URLError to RequestRetryablePolicy, which now classifies `.networkConnectionLost` as retryable.

With this change, when the wifi is turned back on from off, DataStore receives the websocket error and restarts the sync process, and transitions to the active state successfully.

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [x] Ran AWSDataStorePluginIntegrationTests
- [x] Ran AWSDataStorePluginV2Tests
- [x] Ran AWSDataStorePluginMultiAuthTests
- [x] Ran AWSDataStorePluginCPKTests
- [x] Ran AWSDataStorePluginAuthCognitoTests
- [x] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
