### PR TITLE
chore(geo): update startTracking() and update tests

### DIFF
--- a/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/Support/Constants/GeoPluginErrorConstants.swift
+++ b/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/Support/Constants/GeoPluginErrorConstants.swift
@@ -44,6 +44,10 @@ struct GeoPluginErrorConstants {
     static let errorSaveLocationsFailed: GeoPluginErrorString = (
         "Unable to send locations to service.",
         "Please ensure that AWS Geo Device Tracking is configured.")
+    
+    static let errorStartTrackingCalledBeforeStopTracking: GeoPluginErrorString = (
+        "startTracking() called when there is an existing device tracking session.",
+        "Please call stopTracking() before calling startTracking() again.")
 }
 
 // Recovery Messages

--- a/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Mocks/MockLocationManager.swift
+++ b/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Mocks/MockLocationManager.swift
@@ -12,7 +12,7 @@ import CoreLocation
 // Mock `CLLocationManager` class for simulating location update events from OS
 class MockLocationManager : CLLocationManager {
     
-    var locations : [CLLocation] = []
+    var locations : [CLLocation] = [CLLocation(latitude: 20, longitude: 30)]
     var mockAuthorizationStatus: CLAuthorizationStatus = .authorizedAlways
     
     override var authorizationStatus: CLAuthorizationStatus {

--- a/Package.swift
+++ b/Package.swift
@@ -253,7 +253,8 @@ let geoTargets: [Target] = [
         dependencies: [
             "AWSLocationGeoPlugin",
             "AmplifyTestCommon",
-            "AWSPluginsTestCommon"
+            "AWSPluginsTestCommon",
+            "AmplifyAsyncTesting"
             ],
         path: "AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests",
         exclude: [


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Update startTracking() to throw error when called multiple times with different devices and update tests

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
~~- [] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
