### PR TITLE
fix(Auth): Supporting the legacy use case of confirming sign in with TOTP with SMS next step

### DIFF
--- a/Amplify/Categories/Auth/Models/AuthSignInStep.swift
+++ b/Amplify/Categories/Auth/Models/AuthSignInStep.swift
@@ -15,6 +15,10 @@ public enum AuthSignInStep {
     /// Confirmation code for the MFA will be send to the provided SMS.
     case confirmSignInWithSMSMFACode(AuthCodeDeliveryDetails, AdditionalInfo?)
 
+    /// Auth step is Software Token multi factor authentication.
+    ///.
+    case confirmSignInWithSoftwareToken(AdditionalInfo?)
+
     /// Auth step is in a custom challenge depending on the plugin.
     ///
     case confirmSignInWithCustomChallenge(AdditionalInfo?)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AuthChallengeType.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AuthChallengeType.swift
@@ -16,6 +16,8 @@ enum AuthChallengeType {
 
     case newPasswordRequired
 
+    case softwareTokenMfa
+
     case unknown
 
 }
@@ -29,6 +31,8 @@ extension CognitoIdentityProviderClientTypes.ChallengeNameType {
             return .newPasswordRequired
         case .smsMfa:
             return .smsMfa
+        case .softwareTokenMfa:
+            return .softwareTokenMfa
         default:
             return .unknown
         }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/RespondToAuthChallenge.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/RespondToAuthChallenge.swift
@@ -49,8 +49,9 @@ extension RespondToAuthChallenge {
         case .customChallenge: return "ANSWER"
         case .smsMfa: return "SMS_MFA_CODE"
         case .newPasswordRequired: return "NEW_PASSWORD"
+        case .softwareTokenMfa: return "SOFTWARE_TOKEN_MFA_CODE"
         default:
-            let message = "UnSupported challenge response \(challenge)"
+            let message = "Unsupported challenge response \(challenge)"
             let error = SignInError.unknown(message: message)
             throw error
         }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/UserPoolSignInHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/UserPoolSignInHelper.swift
@@ -40,10 +40,11 @@ struct UserPoolSignInHelper {
                                        with challenge: RespondToAuthChallenge)
     throws -> AuthSignInResult {
         switch challengeType {
-        // TODO: FIX sending signInResult next step as `confirmSignInWithSMSMFACode` during `softwareTokenMfa` challenge. Potentially create a new nextStep case
-        case .smsMfa, .softwareTokenMfa:
+        case .smsMfa:
             let delivery = challenge.codeDeliveryDetails
             return .init(nextStep: .confirmSignInWithSMSMFACode(delivery, challenge.parameters))
+        case .softwareTokenMfa:
+            return .init(nextStep: .confirmSignInWithSoftwareToken(challenge.parameters))
         case .customChallenge:
             return .init(nextStep: .confirmSignInWithCustomChallenge(challenge.parameters))
         case .newPasswordRequired:

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/UserPoolSignInHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/UserPoolSignInHelper.swift
@@ -40,7 +40,8 @@ struct UserPoolSignInHelper {
                                        with challenge: RespondToAuthChallenge)
     throws -> AuthSignInResult {
         switch challengeType {
-        case .smsMfa:
+        // TODO: FIX sending signInResult next step as `confirmSignInWithSMSMFACode` during `softwareTokenMfa` challenge. Potentially create a new nextStep case
+        case .smsMfa, .softwareTokenMfa:
             let delivery = challenge.codeDeliveryDetails
             return .init(nextStep: .confirmSignInWithSMSMFACode(delivery, challenge.parameters))
         case .customChallenge:
@@ -116,12 +117,12 @@ struct UserPoolSignInHelper {
                     parameters: parameters)
 
                 switch challengeName {
-                case .smsMfa, .customChallenge, .newPasswordRequired:
+                case .smsMfa, .customChallenge, .newPasswordRequired, .softwareTokenMfa:
                     return SignInEvent(eventType: .receivedChallenge(respondToAuthChallenge))
                 case .deviceSrpAuth:
                     return SignInEvent(eventType: .initiateDeviceSRP(response))
                 default:
-                    let message = "UnSupported challenge response \(challengeName)"
+                    let message = "Unsupported challenge response \(challengeName)"
                     let error = SignInError.unknown(message: message)
                     return SignInEvent(eventType: .throwAuthError(error))
                 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
@@ -257,9 +257,9 @@ class AWSAuthSignInPluginTests: BasePluginTest {
         }
     }
 
-    /// Test a signIn with smsMFA as signIn result response
+    /// Test a signIn with softwareTokenMfa as signIn result response
     ///
-    /// - Given: Given an auth plugin with mocked service. Mock smsMFA response for signIn result
+    /// - Given: An auth plugin with mocked service. Mock softwareTokenMfa response for signIn result
     ///
     /// - When:
     ///    - I invoke signIn
@@ -277,7 +277,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
         }, mockRespondToAuthChallengeResponse: { _ in
             RespondToAuthChallengeOutputResponse(
                 authenticationResult: .none,
-                challengeName: .smsMfa,
+                challengeName: .softwareTokenMfa,
                 challengeParameters: [:],
                 session: "session")
         })
@@ -285,8 +285,8 @@ class AWSAuthSignInPluginTests: BasePluginTest {
         let options = AuthSignInRequest.Options()
         do {
             let result = try await plugin.signIn(username: "username", password: "password", options: options)
-            guard case .confirmSignInWithSMSMFACode = result.nextStep else {
-                XCTFail("Result should be .confirmSignInWithSMSMFACode for next step")
+            guard case .confirmSignInWithSoftwareToken = result.nextStep else {
+                XCTFail("Result should be .confirmSignInWithSoftwareToken for next step")
                 return
             }
             XCTAssertFalse(result.isSignedIn, "Signin result should not be complete")


### PR DESCRIPTION

*Issue #, if available:*
https://github.com/aws-amplify/amplify-swift/issues/2572

*Description of changes:*

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
