### PR TITLE
chore: remove todo comments for appsec

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
@@ -151,9 +151,10 @@ public class AWSGraphQLSubscriptionTaskRunner<R: Decodable>: InternalTaskRunner,
         } catch let error as APIError {
             fail(error)
         } catch {
-            // TODO: Verify with the team that terminating a subscription after failing to decode/cast one
+            // Verify with the team that terminating a subscription after failing to decode/cast one
             // payload is the right thing to do. Another option would be to propagate a GraphQL error, but
             // leave the subscription alive.
+            // see https://github.com/aws-amplify/amplify-swift/issues/2577
             
             fail(APIError.operationError("Failed to deserialize", "", error))
         }
@@ -180,7 +181,7 @@ public class AWSGraphQLSubscriptionTaskRunner<R: Decodable>: InternalTaskRunner,
     }
 }
 
-// TODO: Remove this code, it has replaced been with AWSGraphQLSubscriptionTaskRunner above.
+// Class is still necessary. See https://github.com/aws-amplify/amplify-swift/issues/2252
 final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscriptionOperation<R> {
 
     let pluginConfig: AWSAPICategoryPluginConfiguration
@@ -337,9 +338,11 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
             dispatch(result: .failure(error))
             finish()
         } catch {
-            // TODO: Verify with the team that terminating a subscription after failing to decode/cast one
+            // Verify with the team that terminating a subscription after failing to decode/cast one
             // payload is the right thing to do. Another option would be to propagate a GraphQL error, but
             // leave the subscription alive.
+            // see https://github.com/aws-amplify/amplify-swift/issues/2577
+
             dispatch(result: .failure(APIError.operationError("Failed to deserialize", "", error)))
             finish()
         }


### PR DESCRIPTION
*Issue #, if available:*

AppSec has requested that todo comments are removed.

*Description of changes:*

Remove todo comments and reference open issues.

*Check points: (check or cross out if not relevant)*

- [x] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [x] ~If breaking change, documentation/changelog update with migration instructions~

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
