### PR TITLE
fix(api): Remove optional cleanUp() method from AWSAPIPlugin.reset()

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin+Resettable.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin+Resettable.swift
@@ -7,7 +7,6 @@
 
 import Amplify
 import Foundation
-// import AwsCommonRuntimeKit
 
 extension AWSAPIPlugin: Resettable {
 
@@ -27,9 +26,6 @@ extension AWSAPIPlugin: Resettable {
         }
 
         subscriptionConnectionFactory = nil
-
-        // Issue: https://github.com/aws-amplify/amplify-ios/issues/2120
-        // AwsCommonRuntimeKit.cleanUp()        
     }
 
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLIAMTests/GraphQLWithIAMIntegrationTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLIAMTests/GraphQLWithIAMIntegrationTests.swift
@@ -11,7 +11,6 @@ import AWSCognitoAuthPlugin
 
 @testable import Amplify
 @testable import APIHostApp
-import Combine
 
 class GraphQLWithIAMIntegrationTests: XCTestCase {
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLIAMTests/GraphQLWithIAMIntegrationTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLIAMTests/GraphQLWithIAMIntegrationTests.swift
@@ -11,6 +11,7 @@ import AWSCognitoAuthPlugin
 
 @testable import Amplify
 @testable import APIHostApp
+import Combine
 
 class GraphQLWithIAMIntegrationTests: XCTestCase {
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLIAMTests/README.md
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLIAMTests/README.md
@@ -44,7 +44,7 @@ Do you want to use the default authentication and security configuration?
  Please enter a name for your identity pool. 
     <amplifyintegtestCIDP>
  Allow unauthenticated logins? (Provides scoped down permissions that you can control via AWS IAM) 
-    No
+    Yes
  Do you want to enable 3rd party authentication providers in your identity pool? 
     No
  Please provide a name for your user pool: 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-swift/issues/2120

*Description of changes:* Use async APIs in GraphQL IAM integration tests and remove cleanUp() from AWSAPIPlugin.reset()

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
