### PR TITLE
fix(Auth): Add correct validation for initial state when executing confirm sign in

### DIFF
--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
@@ -587,7 +587,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
 
     /// Test a signIn with customAuthWIthoutSRP
     ///
-    /// - Given: Given an auth plugin with mocked service. Returning a new challenge after confirm sign in is called
+    /// - Given: An auth plugin with mocked service. Returning a new challenge after confirm sign in is called
     ///
     /// - When:
     ///    - I invoke signIn and then confirm sign in

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
@@ -585,6 +585,56 @@ class AWSAuthSignInPluginTests: BasePluginTest {
         }
     }
 
+    /// Test a signIn with customAuthWIthoutSRP
+    ///
+    /// - Given: Given an auth plugin with mocked service. Returning a new challenge after confirm sign in is called
+    ///
+    /// - When:
+    ///    - I invoke signIn and then confirm sign in
+    /// - Then:
+    ///    - The next step smsMfA should be triggered
+    ///
+    func testSignInWithCustomAuthIncorrectCode() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            InitiateAuthOutputResponse(
+                authenticationResult: .none,
+                challengeName: .customChallenge,
+                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                session: "someSession")
+        }, mockRespondToAuthChallengeResponse: { _ in
+            RespondToAuthChallengeOutputResponse(
+                authenticationResult: .none,
+                challengeName: .smsMfa,
+                challengeParameters: ["paramKey": "value"],
+                session: "session")
+        })
+
+        let pluginOptions = AWSAuthSignInOptions(validationData: ["somekey": "somevalue"],
+                                                 metadata: ["somekey": "somevalue"],
+                                                 authFlowType: .customWithoutSRP)
+        let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
+        do {
+            let result = try await plugin.signIn(
+                username: "username",
+                password: "password",
+                options: options)
+            if case .confirmSignInWithCustomChallenge = result.nextStep {
+                let confirmSignInResult = try await plugin.confirmSignIn(challengeResponse: "245234")
+                if case .confirmSignInWithSMSMFACode = confirmSignInResult.nextStep {
+
+                } else {
+                    XCTFail("Incorrect challenge type")
+                }
+            } else {
+                XCTFail("Incorrect challenge type")
+            }
+        } catch {
+            XCTFail("Should not fail with \(error)")
+        }
+    }
+
+
     // MARK: - Service error for initiateAuth
 
     /// Test a signIn with `InternalErrorException` from service

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
@@ -619,15 +619,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
                 username: "username",
                 password: "password",
                 options: options)
-            if case .confirmSignInWithCustomChallenge = result.nextStep {
-                let confirmSignInResult = try await plugin.confirmSignIn(challengeResponse: "245234")
-                if case .confirmSignInWithSMSMFACode = confirmSignInResult.nextStep {
-
-                } else {
-                    XCTFail("Incorrect challenge type")
-                }
-            } else {
-                XCTFail("Incorrect challenge type")
+            guard case .confirmSignInWithCustomChallenge = result.nextStep,
+                  case let confirmSignInResult = try await plugin.confirmSignIn(
+                    challengeResponse: "245234"
+                  ),
+                  case .confirmSignInWithSMSMFACode = confirmSignInResult.nextStep
+            else {
+                return XCTFail("Incorrect challenge type")
             }
         } catch {
             XCTFail("Should not fail with \(error)")


### PR DESCRIPTION

*#2586*

There are 2 changes being made: 
* Introduce sending of the `confirmSignIn` event outside of the state machine listener. 
* When in `waitingForAnswer` state, validate and return the `nextStep` based on the result

*Description of changes:*

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
