### PR TITLE
fix: Avoid potential package resolution issues when integrating other libraries that also depend on SQLite.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let platforms: [SupportedPlatform] = [.iOS(.v13), .macOS(.v10_15)]
 let dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/awslabs/aws-sdk-swift.git", exact: "0.5.0"),
     .package(url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git", from: "2.1.1"),
-    .package(url: "https://github.com/stephencelis/SQLite.swift.git", exact: "0.13.2"),
+    .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.13.2"),
     .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.1.0")
 ]
 


### PR DESCRIPTION
[Issue 2592](https://github.com/aws-amplify/amplify-swift/issues/2592)

Change version requirement for [SQLite.swift](https://github.com/stephencelis/SQLite.swift) from exact match starting on 0.13.2.

This avoids potential resolution conflicts for projects that depend on other libraries that also depend on SQLite.swift, but with requirements for newer versions (current version is 0.14.1).

*Check points: (check or cross out if not relevant)*

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] ~Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
