### PR TITLE
fix(Storage) Use default URLSession configuration for non-multipart uploads #1542

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+DownloadBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+DownloadBehavior.swift
@@ -52,7 +52,7 @@ extension AWSS3StorageService {
 
         request.setHTTPRequestHeaders(transferTask: transferTask)
 
-        let downloadTask = urlSession.downloadTask(with: request)
+        let downloadTask = backgroundUrlSession.downloadTask(with: request)
         transferTask.sessionTask = downloadTask
 
         // log task identifier?

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+UploadBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+UploadBehavior.swift
@@ -66,7 +66,7 @@ extension AWSS3StorageService {
 
         request.setHTTPRequestHeaders(transferTask: transferTask)
 
-        let uploadTask = urlSession.uploadTask(with: request, fromFile: fileURL)
+        let uploadTask = foregroundUrlSession.uploadTask(with: request, fromFile: fileURL)
         transferTask.sessionTask = uploadTask
 
         // log task identifier?

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
@@ -106,7 +106,7 @@ class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
             request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
              */
 
-            let uploadTask = serviceProxy.urlSession.uploadTask(with: request, fromFile: partialFileURL)
+            let uploadTask = serviceProxy.backgroundUrlSession.uploadTask(with: request, fromFile: partialFileURL)
             subTask.sessionTask = uploadTask
             subTask.uploadPart = multipartUpload.part(for: partNumber)
 
@@ -180,7 +180,7 @@ class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
     func cancelUploadTasks(taskIdentifiers: [TaskIdentifier], done: @escaping () -> Void) {
         guard let service = serviceProxy else { return }
         service.unregister(taskIdentifiers: taskIdentifiers)
-        service.urlSession.getActiveTasks { tasks in
+        service.backgroundUrlSession.getActiveTasks { tasks in
             for task in tasks {
                 if taskIdentifiers.contains(task.taskIdentifier) {
                     task.cancel()

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageServiceProxy.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageServiceProxy.swift
@@ -11,7 +11,8 @@ import Amplify
 protocol StorageServiceProxy: AnyObject {
     var preSignedURLBuilder: AWSS3PreSignedURLBuilderBehavior! { get }
     var awsS3: AWSS3Behavior! { get }
-    var urlSession: URLSession { get }
+    var backgroundUrlSession: URLSession { get }
+    var foregroundUrlSession: URLSession { get }
 
     func register(task: StorageTransferTask)
     func unregister(task: StorageTransferTask)

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockAWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockAWSAuthServiceBehavior.swift
@@ -1,0 +1,53 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AWSPluginsCore
+@testable import AWSS3StoragePlugin
+
+import AWSClientRuntime
+import AWSS3
+import Amplify
+import Foundation
+
+/// Test-friendly implementation of a
+/// [AWSAuthServiceBehavior](x-source-tag://AWSAuthServiceBehavior) protocol.
+///
+/// - Tag: MockAWSAuthServiceBehavior
+final class MockAWSAuthServiceBehavior {
+    var interactions: [String] = []
+    var credentialsProvider = MockCredentialsProvider()
+    var tokenClaimsByToken: [String: [String : AnyObject]] = [:]
+    var identityID = UUID().uuidString
+    var userPoolAccessToken = UUID().uuidString
+}
+
+extension MockAWSAuthServiceBehavior: AWSAuthServiceBehavior {
+    
+    func getCredentialsProvider() -> CredentialsProvider {
+        interactions.append(#function)
+        return credentialsProvider
+    }
+    
+    func getTokenClaims(tokenString: String) -> Result<[String : AnyObject], AuthError> {
+        interactions.append(#function)
+        if let claims = tokenClaimsByToken[tokenString] {
+            return .success(claims)
+        }
+        return .failure(.unknown(tokenString))
+    }
+    
+    func getIdentityID() async throws -> String {
+        interactions.append(#function)
+        return identityID
+    }
+    
+    func getUserPoolAccessToken() async throws -> String {
+        interactions.append(#function)
+        return userPoolAccessToken
+    }
+    
+}

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockAWSS3PreSignedURLBuilder.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockAWSS3PreSignedURLBuilder.swift
@@ -5,15 +5,28 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-/*
-import Foundation
 @testable import AWSS3StoragePlugin
+
 import AWSS3
+import Foundation
 
-public class MockAWSS3PreSignedURLBuilder: AWSS3PreSignedURLBuilderBehavior {
-    public func getPreSignedURL(_ getPreSignedURLRequest: AWSS3GetPreSignedURLRequest) -> AWSTask<NSURL> {
-        return AWSTask()
-    }
-
+/// Test-friendly implementation of a
+/// [AWSS3PreSignedURLBuilderBehavior](x-source-tag://AWSS3PreSignedURLBuilderBehavior)
+/// protocol.
+///
+/// - Tag: MockAWSS3PreSignedURLBuilder
+final class MockAWSS3PreSignedURLBuilder {
+    var interactions: [String] = []
+    var defaultURL = URL(fileURLWithPath: NSTemporaryDirectory().appendingPathComponent(UUID().uuidString))
+    var preSignedURLs: [String: URL] = [:]
 }
-*/
+
+extension MockAWSS3PreSignedURLBuilder: AWSS3PreSignedURLBuilderBehavior {
+    func getPreSignedURL(key: String, signingOperation: AWSS3SigningOperation, expires: Int64?) async throws -> URL {
+        interactions.append(#function)
+        if let url = preSignedURLs[key] {
+            return url
+        }
+        return defaultURL
+    }
+}

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockCredentialsProvider.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockCredentialsProvider.swift
@@ -1,0 +1,27 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import AWSClientRuntime
+import Foundation
+
+/// Test-friendly implementation of a
+/// [CredentialsProvider](x-source-tag://CredentialsProvider) protocol.
+///
+/// - Tag: MockCredentialsProvider
+final class MockCredentialsProvider {
+    var interactions: [String] = []
+    var credentials = AWSCredentials(accessKey: UUID().uuidString,
+                                     secret: UUID().uuidString,
+                                     expirationTimeout: UInt64.random(in: 1..<100),
+                                     sessionToken: UUID().uuidString)
+}
+
+extension MockCredentialsProvider: CredentialsProvider {
+    func getCredentials() async throws -> AWSClientRuntime.AWSCredentials {
+        return credentials
+    }
+}

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockLogger.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockLogger.swift
@@ -1,0 +1,50 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+
+/// Test-friendly implementation of the Amplify
+/// [Logger](x-source-tag://Logger)
+/// protocol.
+///
+/// - Tag: MockLogger
+final class MockLogger {
+    struct Entry: Equatable {
+        var level: Amplify.LogLevel
+        var message: String
+    }
+    var logLevel: Amplify.LogLevel = .debug
+    var entries: [Entry] = []
+}
+
+extension MockLogger: Logger {
+
+    func error(_ message: @autoclosure () -> String) {
+        entries.append(.init(level: .error, message: message()))
+    }
+    
+    func error(error: Error) {
+        entries.append(.init(level: .error, message: "\(error)"))
+    }
+    
+    func warn(_ message: @autoclosure () -> String) {
+        entries.append(.init(level: .warn, message: message()))
+    }
+    
+    func info(_ message: @autoclosure () -> String) {
+        entries.append(.init(level: .info, message: message()))
+    }
+    
+    func debug(_ message: @autoclosure () -> String) {
+        entries.append(.init(level: .debug, message: message()))
+    }
+    
+    func verbose(_ message: @autoclosure () -> String) {
+        entries.append(.init(level: .verbose, message: message()))
+    }
+    
+}

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageServiceSessionControllerTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageServiceSessionControllerTests.swift
@@ -1,0 +1,143 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AWSS3StoragePlugin
+
+import Amplify
+import XCTest
+
+final class StorageServiceSessionControllerTests: XCTestCase {
+    
+    enum TestError: Error {
+        case urlSessionError
+    }
+    
+    var systemUnderTest: StorageServiceSessionController!
+    var serviceIdentifier: String!
+    var logger: MockLogger!
+    var tasksByIdentifier: [TaskIdentifier: StorageTransferTask]!
+    var delegateInteractions: [String]!
+    var notifications: [Notification]!
+    var fileURL: URL!
+    
+    override func setUp() async throws {
+        self.serviceIdentifier = "StorageServiceSessionControllerTests.\(UUID().uuidString)"
+        self.logger = MockLogger()
+        self.tasksByIdentifier = [:]
+        self.delegateInteractions = []
+        self.notifications = []
+        self.systemUnderTest = StorageServiceSessionController(identifier: UUID().uuidString,
+                                                               configuration: URLSessionConfiguration.ephemeral,
+                                                               logger: self.logger)
+        self.systemUnderTest.delegate = self
+        self.fileURL = URL(fileURLWithPath: NSTemporaryDirectory().appendingPathComponent(UUID().uuidString))
+        let data = try XCTUnwrap(UUID().uuidString.data(using: .utf8))
+        try data.write(to: fileURL, options: .atomic)
+    }
+    
+    override func tearDown() async throws {
+        NotificationCenter.default.removeObserver(self)
+        try FileManager.default.removeItem(at: self.fileURL)
+        self.systemUnderTest = nil
+        self.serviceIdentifier = nil
+        self.logger = nil
+        self.tasksByIdentifier = nil
+        self.delegateInteractions = nil
+        self.notifications = nil
+        self.fileURL = nil
+    }
+    
+    func testurlSessionDidFinishEvents() throws {
+        systemUnderTest.urlSessionDidFinishEvents(forBackgroundURLSession: systemUnderTest.session)
+        XCTAssertEqual(self.logger.entries, [.init(level: .info, message: "[URLSession] Session did finish background events")])
+    }
+    
+    func testUrlSessionDidBecomeInvalidWithError() throws {
+        NotificationCenter.default.addObserver(forName: Notification.Name.StorageURLSessionDidBecomeInvalidNotification, object: systemUnderTest.session, queue: nil) { [weak self] notification in
+            self?.notifications.append(notification)
+        }
+        
+        XCTAssertEqual(self.notifications, [])
+        let originalSession = systemUnderTest.session
+        let originalSessionObjectIdentifier = ObjectIdentifier(originalSession)
+        
+        systemUnderTest.urlSession(systemUnderTest.session, didBecomeInvalidWithError: TestError.urlSessionError)
+        
+        let updatedSession = systemUnderTest.session
+        let updatedSessionObjectIdentifier = ObjectIdentifier(updatedSession)
+        XCTAssertNotEqual(originalSessionObjectIdentifier, updatedSessionObjectIdentifier)
+        XCTAssertEqual(self.notifications.map { $0.name }, [Notification.Name.StorageURLSessionDidBecomeInvalidNotification])
+        XCTAssertEqual(self.logger.entries, [.init(level: .warn, message: "[URLSession] Session did become invalid: \(systemUnderTest.identifier) [urlSessionError]")])
+    }
+    
+    func testUrlSessionDidCompleteButNotHttp() throws {
+        let request = URLRequest(url: self.fileURL)
+        let task = systemUnderTest.session.downloadTask(with: request)
+        self.tasksByIdentifier[task.taskIdentifier] = StorageTransferTask(transferID: "\(task.taskIdentifier)",
+                                                                          transferType: .download(onEvent: { _ in }),
+                                                                          bucket: UUID().uuidString,
+                                                                          key: UUID().uuidString)
+        
+        systemUnderTest.urlSession(systemUnderTest.session, task: task, didCompleteWithError: nil)
+        XCTAssertEqual(self.logger.entries.count, 2)
+        XCTAssertEqual(self.logger.entries[0], .init(level: .info, message: "[URLSession] Session task did complete: \(task.taskIdentifier)"))
+        XCTAssertEqual(self.logger.entries[1].level, .warn)
+        XCTAssertTrue(self.logger.entries[1].message.hasPrefix("[URLSession] Failed with error: StorageError: Unexpected error occurred with message: Response is not an HTTP response"), self.logger.entries[1].message)
+    }
+    
+    func testUrlSessionDidCompleteWithoutRegisteredTask() throws {
+        let request = URLRequest(url: self.fileURL)
+        let task = systemUnderTest.session.downloadTask(with: request)
+        systemUnderTest.urlSession(systemUnderTest.session, task: task, didCompleteWithError: nil)
+        XCTAssertEqual(self.logger.entries, [
+            .init(level: .info, message: "[URLSession] Session task did complete: \(task.taskIdentifier)"),
+            .init(level: .debug, message: "Did not find transfer task: \(task.taskIdentifier)"),
+            .init(level: .info, message: "[URLSession] Session task not handled: \(task.taskIdentifier)"),
+        ])
+    }
+    
+    func testUrlSessionDidCompleteWithErrorWithoutRegisteredTask() throws {
+        let request = URLRequest(url: self.fileURL)
+        let task = systemUnderTest.session.downloadTask(with: request)
+        systemUnderTest.urlSession(systemUnderTest.session, task: task, didCompleteWithError: TestError.urlSessionError)
+        XCTAssertEqual(self.logger.entries, [
+            .init(level: .warn, message: "[URLSession] Session task did complete with error: \(task.taskIdentifier) [urlSessionError]"),
+            .init(level: .debug, message: "Did not find transfer task: \(task.taskIdentifier)"),
+            .init(level: .info, message: "[URLSession] Session task not handled: \(task.taskIdentifier)"),
+        ])
+    }
+    
+}
+
+extension StorageServiceSessionControllerTests: StorageServiceSessionControllerDelegate {
+    
+    var identifier: String {
+        delegateInteractions.append(#function)
+        return self.serviceIdentifier
+    }
+    
+    func unregister(task: StorageTransferTask) {
+        delegateInteractions.append(#function)
+        guard let taskIdentifier = task.taskIdentifier else { return }
+        self.tasksByIdentifier[taskIdentifier] = task
+    }
+    
+    func findTask(taskIdentifier: TaskIdentifier) -> StorageTransferTask? {
+        delegateInteractions.append(#function)
+        return self.tasksByIdentifier[taskIdentifier]
+    }
+    
+    func findMultipartUploadSession(uploadId: UploadID) -> StorageMultipartUploadSession? {
+        delegateInteractions.append(#function)
+        return nil
+    }
+    
+    func completeDownload(taskIdentifier: TaskIdentifier, sourceURL: URL) {
+        delegateInteractions.append(#function)
+    }
+    
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-swift/issues/1542

*Description of changes:*
This change maintains the use of the background URLSessionConfiguration + URLSession for `upload` operations that result in multi-part uploads and `download` operations but switches to a default URLSessionConfiguration for `upload` operations of smaller files that result in non-multipart uploads.

*Check points: (check or cross out if not relevant)*

- [x ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
