### PR TITLE
fix(auth): Enable signIn restart while another signIn is in progress

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift
@@ -56,6 +56,8 @@ class AWSAuthSignInTask: AuthSignInTask {
                     "There is already a user in signedIn state. SignOut the user first before calling signIn",
                     AuthPluginErrorConstants.invalidStateError, nil)
                 throw error
+            case .signingIn:
+                await sendCancelSignInEvent()
             case .signedOut:
                 return
             default: continue
@@ -92,6 +94,11 @@ class AWSAuthSignInTask: AuthSignInTask {
             }
         }
         throw AuthError.unknown("Sign in reached an error state")
+    }
+
+    private func sendCancelSignInEvent() async {
+        let event = AuthenticationEvent(eventType: .cancelSignIn)
+        await authStateMachine.send(event)
     }
 
     private func sendSignInEvent(authflowType: AuthFlowType) async {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
@@ -1100,4 +1100,70 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             }
         }
     }
+
+    /// Test a signIn restart while another sign in is in progress
+    ///
+    /// - Given: Given an auth plugin with mocked service and a in progress signIn waiting for SMS verification
+    ///
+    /// - When:
+    ///    - I invoke another signIn with valid values
+    /// - Then:
+    ///    - I should get a .done response
+    ///
+    func testRestartSignIn() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            InitiateAuthOutputResponse(
+                authenticationResult: .none,
+                challengeName: .passwordVerifier,
+                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                session: "someSession")
+        }, mockRespondToAuthChallengeResponse: { _ in
+            RespondToAuthChallengeOutputResponse(
+                authenticationResult: .none,
+                challengeName: .smsMfa,
+                challengeParameters: [:],
+                session: "session")
+        })
+
+        let pluginOptions = AWSAuthSignInOptions(validationData: ["somekey": "somevalue"],
+                                                 metadata: ["somekey": "somevalue"])
+        let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
+
+        do {
+            let result = try await plugin.signIn(username: "username", password: "password", options: options)
+            guard case .confirmSignInWithSMSMFACode =  result.nextStep else {
+                XCTFail("Result should be .confirmSignInWithSMSMFACode for next step")
+                return
+            }
+            XCTAssertFalse(result.isSignedIn)
+            self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+                InitiateAuthOutputResponse(
+                    authenticationResult: .none,
+                    challengeName: .passwordVerifier,
+                    challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                    session: "someSession")
+            }, mockRespondToAuthChallengeResponse: { _ in
+                RespondToAuthChallengeOutputResponse(
+                    authenticationResult: .init(
+                        accessToken: Defaults.validAccessToken,
+                        expiresIn: 300,
+                        idToken: "idToken",
+                        newDeviceMetadata: nil,
+                        refreshToken: "refreshToken",
+                        tokenType: ""),
+                    challengeName: .none,
+                    challengeParameters: [:],
+                    session: "session")
+            })
+            let result2 = try await plugin.signIn(username: "username2", password: "password", options: options)
+            guard case .done =  result2.nextStep else {
+                XCTFail("Result should be .confirmSignInWithSMSMFACode for next step")
+                return
+            }
+            XCTAssertTrue(result2.isSignedIn)
+        } catch {
+            XCTFail("Received failure with error \(error)")
+        }
+    }
 }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MaxDesiatov/XMLCoder.git",
       "state" : {
-        "revision" : "ca932442d7481700f5434a7b138c47dd42d9902b",
-        "version" : "0.14.0"
+        "revision" : "c438dad94f6a243b411b70a4b4bac54595064808",
+        "version" : "0.15.0"
       }
     }
   ],

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignInTests/AuthSRPSignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignInTests/AuthSRPSignInTests.swift
@@ -318,7 +318,7 @@ class AuthSRPSignInTests: AWSAuthBaseTest {
             signInExpectation.fulfill()
         }
 
-        wait(for: [signInExpectation, fetchAuthSessionExpectation], timeout: networkTimeout)
+        wait(for: [signInExpectation, fetchAuthSessionExpectation], timeout: 10)
     }
 
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-swift/issues/2605

*Description of changes:* 
Fix to allow user to restart a signIn flow in the middle of an existing signIn flow. This feature allows the user to retry a signIn with a different username if they entered a wrong username and the plugin is waiting for some signIn verification. 

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
