### PR TITLE
[DRAFT] chore(auth): migrate auth error from enum to struct

### DIFF
--- a/Amplify/Categories/API/Operation/RetryableGraphQLOperation.swift
+++ b/Amplify/Categories/API/Operation/RetryableGraphQLOperation.swift
@@ -124,12 +124,11 @@ public final class RetryableGraphQLOperation<Payload: Decodable>: Operation, Ret
                   return false
               }
 
-        switch authError {
-        case .signedOut, .notAuthorized:
+        if authError.type == AuthError.signedOutError || authError.type == AuthError.notAuthorizedError {
             return attempts < maxRetries
-        default:
-            return false
         }
+        
+        return false
     }
 }
 

--- a/Amplify/Categories/Auth/Error/AuthError.swift
+++ b/Amplify/Categories/Auth/Error/AuthError.swift
@@ -8,79 +8,75 @@
 import Foundation
 
 /// Amplify error raised in the Auth category.
-public enum AuthError {
+public struct AuthError {
 
+    public let field: Field?
+    public let errorDescription: ErrorDescription
+    public let recoverySuggestion: RecoverySuggestion
+    public let underlyingError: Error?
+    public let type: String
+    
+    private init(type: String, errorDescription: ErrorDescription, recoverySuggestion: RecoverySuggestion, error: Error?, field: Field? = nil) {
+        self.type = type
+        self.field = field
+        self.errorDescription = errorDescription
+        self.recoverySuggestion = recoverySuggestion
+        self.underlyingError = error
+    }
+    
     /// Caused by issue in the way auth category is configured
-    case configuration(ErrorDescription, RecoverySuggestion, Error? = nil)
-
+    public static func configuration(_ errorDescription: ErrorDescription, _ recoverySuggestion: RecoverySuggestion = "", _ error: Error? = nil) -> AuthError {
+        return AuthError(type: AuthError.configurationError, errorDescription: errorDescription, recoverySuggestion: recoverySuggestion, error: error)
+    }
+    
     /// Caused by some error in the underlying service. Check the associated error for more details.
-    case service(ErrorDescription, RecoverySuggestion, Error? = nil)
-
+    public static func service(_ errorDescription: ErrorDescription, _ recoverySuggestion: RecoverySuggestion = "", _ error: Error? = nil) -> AuthError {
+        return AuthError(type: AuthError.serviceError, errorDescription: errorDescription, recoverySuggestion: recoverySuggestion, error: error)
+    }
+    
     /// Caused by an unknown reason
-    case unknown(ErrorDescription, Error? = nil)
-
+    public static func unknown(_ errorDescription: ErrorDescription, _ error: Error? = nil) -> AuthError {
+        return AuthError(type: AuthError.unknownError, errorDescription: errorDescription, recoverySuggestion: "", error: error)
+    }
+    
     /// Caused when one of the input field is invalid
-    case validation(Field, ErrorDescription, RecoverySuggestion, Error? = nil)
-
+    public static func validation(_ field: Field, _ errorDescription: ErrorDescription, _ recoverySuggestion: RecoverySuggestion = "", _ error: Error? = nil) -> AuthError {
+        return AuthError(type: AuthError.validationError, errorDescription: errorDescription, recoverySuggestion: recoverySuggestion, error: error, field: field)
+    }
+    
     /// Caused when the current session is not authorized to perform an operation
-    case notAuthorized(ErrorDescription, RecoverySuggestion, Error? = nil)
-
+    public static func notAuthorized(_ errorDescription: ErrorDescription, _ recoverySuggestion: RecoverySuggestion = "", _ error: Error? = nil) -> AuthError {
+        return AuthError(type: AuthError.notAuthorizedError, errorDescription: errorDescription, recoverySuggestion: recoverySuggestion, error: error)
+    }
+    
     /// Caused when an operation is not valid with the current state of Auth category
-    case invalidState(ErrorDescription, RecoverySuggestion, Error? = nil)
-
+    public static func invalidState(_ errorDescription: ErrorDescription, _ recoverySuggestion: RecoverySuggestion = "", _ error: Error? = nil) -> AuthError {
+        return AuthError(type: AuthError.invalidStateError, errorDescription: errorDescription, recoverySuggestion: recoverySuggestion, error: error)
+    }
+    
     /// Caused when an operation needs the user to be in signedIn state
-    case signedOut(ErrorDescription, RecoverySuggestion, Error? = nil)
-
+    public static func signedOut(_ errorDescription: ErrorDescription, _ recoverySuggestion: RecoverySuggestion = "", _ error: Error? = nil) -> AuthError {
+        return AuthError(type: AuthError.signedOutError, errorDescription: errorDescription, recoverySuggestion: recoverySuggestion, error: error)
+    }
+    
     /// Caused when a session is expired and needs the user to be re-authenticated
-    case sessionExpired(ErrorDescription, RecoverySuggestion, Error? = nil)
+    public static func sessionExpired(_ errorDescription: ErrorDescription, _ recoverySuggestion: RecoverySuggestion = "", _ error: Error? = nil) -> AuthError {
+        return AuthError(type: AuthError.sessionExpiredError, errorDescription: errorDescription, recoverySuggestion: recoverySuggestion, error: error)
+    }
+}
+
+extension AuthError {
+    public static let configurationError = "AuthError.Configuration"
+    public static let serviceError = "AuthError.Service"
+    public static let validationError = "AuthError.Validation"
+    public static let notAuthorizedError = "AuthError.notAuthorized"
+    public static let invalidStateError = "AuthError.InvalidState"
+    public static let signedOutError = "AuthError.SignedOut"
+    public static let sessionExpiredError = "AuthError.SessionExpired"
+    public static let unknownError = "AuthError.Unknown"
 }
 
 extension AuthError: AmplifyError {
-
-    public var underlyingError: Error? {
-        switch self {
-        case .configuration(_, _, let underlyingError),
-             .service(_, _, let underlyingError),
-             .unknown(_, let underlyingError),
-             .validation(_, _, _, let underlyingError),
-             .notAuthorized(_, _, let underlyingError),
-             .sessionExpired(_, _, let underlyingError),
-             .signedOut(_, _, let underlyingError),
-             .invalidState(_, _, let underlyingError):
-            return underlyingError
-        }
-    }
-
-    public var errorDescription: ErrorDescription {
-        switch self {
-        case .configuration(let errorDescription, _, _),
-             .service(let errorDescription, _, _),
-             .validation(_, let errorDescription, _, _),
-             .notAuthorized(let errorDescription, _, _),
-             .signedOut(let errorDescription, _, _),
-             .sessionExpired(let errorDescription, _, _),
-             .invalidState(let errorDescription, _, _):
-            return errorDescription
-        case .unknown(let errorDescription, _):
-            return "Unexpected error occurred with message: \(errorDescription)"
-        }
-    }
-
-    public var recoverySuggestion: RecoverySuggestion {
-        switch self {
-        case .configuration(_, let recoverySuggestion, _),
-             .service(_, let recoverySuggestion, _),
-             .validation(_, _, let recoverySuggestion, _),
-             .notAuthorized(_, let recoverySuggestion, _),
-             .signedOut(_, let recoverySuggestion, _),
-             .sessionExpired(_, let recoverySuggestion, _),
-             .invalidState(_, let recoverySuggestion, _):
-            return recoverySuggestion
-        case .unknown:
-            return AmplifyErrorMessages.shouldNotHappenReportBugToAWS()
-        }
-    }
-
     public init(
         errorDescription: ErrorDescription = "An unknown error occurred",
         recoverySuggestion: RecoverySuggestion = "(Ignored)",
@@ -94,22 +90,10 @@ extension AuthError: AmplifyError {
             self = .unknown(errorDescription, error)
         }
     }
-
 }
 
 extension AuthError: Equatable {
     public static func == (lhs: AuthError, rhs: AuthError) -> Bool {
-        switch (lhs, rhs) {
-        case (.configuration, .configuration),
-            (.service, .service),
-            (.validation, .validation),
-            (.notAuthorized, .notAuthorized),
-            (.signedOut, .signedOut),
-            (.sessionExpired, .sessionExpired),
-            (.invalidState, .invalidState):
-            return true
-        default:
-            return false
-        }
+        return lhs.type == rhs.type
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/HubEvents/AuthHubEventHandler.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/HubEvents/AuthHubEventHandler.swift
@@ -110,7 +110,7 @@ class AuthHubEventHandler: AuthHubEventBehavior {
               case let .failure(authError) = tokensProvider.getCognitoTokens() else {
             return
         }
-        guard case .sessionExpired = authError else {
+        guard case AuthError.sessionExpiredError = authError.type else {
             return
         }
         sendSessionExpiredEvent()

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSAuthCognitoSession.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSAuthCognitoSession.swift
@@ -60,10 +60,6 @@ public struct AWSAuthCognitoSession: AuthSession,
                 return .failure(error)
             }
             return .success(userSub)
-        } catch AuthError.signedOut {
-            return .failure(AuthError.signedOut(
-                            AuthPluginErrorConstants.userSubSignOutError.errorDescription,
-                            AuthPluginErrorConstants.userSubSignOutError.recoverySuggestion))
         } catch let error as AuthError {
             return .failure(error)
         } catch {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInTask.swift
@@ -58,13 +58,13 @@ class AWSAuthConfirmSignInTask: AuthConfirmSignInTask {
                    if case .resolvingChallenge(let challengeState, _, _) = signInState,
                       case .error(_, let signInError) = challengeState {
                        let authError = signInError.authError
-                       if case .service(_, _, let serviceError) = authError,
-                          let cognitoError = serviceError as? AWSCognitoAuthError,
+                       if authError.type == AuthError.serviceError,
+                          let cognitoError = authError.underlyingError as? AWSCognitoAuthError,
                           case .passwordResetRequired = cognitoError {
                            return AuthSignInResult(nextStep: .resetPassword(nil))
 
-                       } else if case .service(_, _, let serviceError) = authError,
-                                 let cognitoError = serviceError as? AWSCognitoAuthError,
+                       } else if authError.type == AuthError.serviceError,
+                           let cognitoError = authError.underlyingError as? AWSCognitoAuthError,
                                  case .userNotConfirmed = cognitoError {
                            return AuthSignInResult(nextStep: .confirmSignUp(nil))
                        } else {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthAttributeResendConfirmationCodeTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthAttributeResendConfirmationCodeTask.swift
@@ -57,7 +57,7 @@ class AWSAuthAttributeResendConfirmationCodeTask: AuthAttributeResendConfirmatio
 
         let result = try await userPoolService.getUserAttributeVerificationCode(input: input)
         guard let deliveryDetails = result.codeDeliveryDetails?.toAuthCodeDeliveryDetails() else {
-            let authError = AuthError.unknown("Unable to get Auth code delivery details", nil)
+            let authError = AuthError.unknown("Unable to get Auth code delivery details")
             throw authError
         }
         return deliveryDetails

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ClientBehaviorTests/AuthGetCurrentUserTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ClientBehaviorTests/AuthGetCurrentUserTests.swift
@@ -34,9 +34,11 @@ class AuthGetCurrentUserTests: XCTestCase {
             _ = try await plugin.getCurrentUser()
             XCTFail("Should throw AuthError.signedOut")
         }
-        catch AuthError.signedOut { }
         catch {
-            XCTFail("Should throw AuthError.signedOut")
+            guard let authError = error as? AuthError, authError.type == AuthError.signedOutError else {
+                XCTFail("Should throw AuthError.signedOut")
+                return
+            }
         }
 
     }
@@ -50,9 +52,11 @@ class AuthGetCurrentUserTests: XCTestCase {
             _ = try await plugin.getCurrentUser()
             XCTFail("Should throw AuthError.configuration")
         }
-        catch AuthError.configuration { }
         catch {
-            XCTFail("Should throw AuthError.configuration")
+            guard let authError = error as? AuthError, authError.type == AuthError.configurationError else {
+                XCTFail("Should throw AuthError.configuration")
+                return
+            }
         }
 
     }
@@ -66,11 +70,12 @@ class AuthGetCurrentUserTests: XCTestCase {
             _ = try await plugin.getCurrentUser()
             XCTFail("Should throw AuthError.invalidState")
         }
-        catch AuthError.invalidState { }
         catch {
-            XCTFail("Should throw AuthError.invalidState")
+            guard let authError = error as? AuthError, authError.type == AuthError.invalidStateError else {
+                XCTFail("Should throw AuthError.invalidState")
+                return
+            }
         }
-
     }
 
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
@@ -160,7 +160,7 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
             try Amplify.configure(amplifyConfig)
             XCTFail("Should have thrown a AuthError.configuration error if both cognito service config are invalid")
         } catch {
-            guard case AuthError.configuration = error else {
+            guard let authError = error as? AuthError, AuthError.configurationError == authError.type else {
                 XCTFail("Should have thrown a AuthError.configuration error if both cognito service config are invalid")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/CustomEndpoint/CustomEndpoint+AuthConfigurationJSONTestCase.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/CustomEndpoint/CustomEndpoint+AuthConfigurationJSONTestCase.swift
@@ -136,7 +136,7 @@ class CustomEndpoint_AuthConfigurationJSONTestCase: XCTestCase {
 
 extension AuthError {
     static func validateConfigurationError(_ error: Error) {
-        guard case .configuration = (error as? AuthError) else {
+        guard let authError = error as? AuthError, authError.type == AuthError.configurationError else {
             return XCTFail("Expected error AuthError.configuration")
         }
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthMigrationSignInTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthMigrationSignInTaskTests.swift
@@ -102,7 +102,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
             XCTFail("Should not produce a success result")
 
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce unknown error")
                 return
             }
@@ -125,11 +125,11 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
             XCTFail("Should not produce a success result")
 
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be lambda \(error)")
                 return
             }
@@ -152,11 +152,11 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
             XCTFail("Should not produce a success result")
 
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .invalidParameter = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalid parameter \(error)")
                 return
             }
@@ -180,11 +180,11 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
             XCTFail("Should not produce a success result")
 
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .smsRole = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .smsRole = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be sms role \(error)")
                 return
             }
@@ -208,7 +208,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
             XCTFail("Should not produce a success result")
 
         } catch {
-            guard case AuthError.configuration = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.configurationError else {
                 XCTFail("Should produce configuration error instead of \(error)")
                 return
             }
@@ -232,7 +232,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
             XCTFail("Should not produce a success result")
 
         } catch {
-            guard case AuthError.notAuthorized = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Should produce not authorized error instead of \(error)")
                 return
             }
@@ -278,11 +278,11 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
             _ = try await plugin.signIn(username: "username", password: "password", options: AuthSignInRequest.Options(pluginOptions: pluginOptions))
             XCTFail("Should not produce a success result")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .resourceNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce resource error instead of \(error)")
                 return
             }
@@ -305,11 +305,11 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
             _ = try await plugin.signIn(username: "username", password: "password", options: AuthSignInRequest.Options(pluginOptions: pluginOptions))
             XCTFail("Should not produce a success result")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .requestLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce limit exceeded error instead of \(error)")
                 return
             }
@@ -332,11 +332,11 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
             _ = try await plugin.signIn(username: "username", password: "password", options: AuthSignInRequest.Options(pluginOptions: pluginOptions))
             XCTFail("Should not produce a success result")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce lambda error instead of \(error)")
                 return
             }
@@ -359,11 +359,11 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
             _ = try await plugin.signIn(username: "username", password: "password", options: AuthSignInRequest.Options(pluginOptions: pluginOptions))
             XCTFail("Should not produce a success result")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce lambda error instead of \(error)")
                 return
             }
@@ -409,11 +409,11 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
             _ = try await plugin.signIn(username: "username", password: "password", options: AuthSignInRequest.Options(pluginOptions: pluginOptions))
             XCTFail("Should not produce a success result")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce userNotFound error instead of \(error)")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
@@ -132,7 +132,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             let result = try await plugin.signIn(username: "", password: "password", options: options)
             XCTFail("Should not receive a success response \(result)")
         } catch {
-            guard case AuthError.validation = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.validationError else {
                 XCTFail("Should receive validation error instead got \(error)")
                 return
             }
@@ -202,7 +202,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             let result = try await plugin.signIn(username: "username", password: "password", options: options)
             XCTFail("Should not receive a success response \(result)")
         } catch {
-            guard case AuthError.service = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should receive unknown error instead got \(error)")
                 return
             }
@@ -535,7 +535,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             let result = try await plugin.signIn(username: "username", password: "password", options: options)
             XCTFail("Should not produce result - \(result)")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce unknown error")
                 return
             }
@@ -578,7 +578,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
                 options: options)
             XCTFail("Should not produce result - \(result)")
         } catch {
-            guard case AuthError.service = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce as service error")
                 return
             }
@@ -656,7 +656,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             let result = try await plugin.signIn(username: "username", password: "password", options: options)
             XCTFail("Should not produce result - \(result)")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce unknown error")
                 return
             }
@@ -683,8 +683,8 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             let result = try await plugin.signIn(username: "username", password: "password", options: options)
             XCTFail("Should not produce result - \(result)")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce lambda error but instead produced \(error)")
                 return
             }
@@ -711,8 +711,8 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             let result = try await plugin.signIn(username: "username", password: "password", options: options)
             XCTFail("Should not produce result - \(result)")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .invalidParameter = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce invalidParameter error but instead produced \(error)")
                 return
             }
@@ -739,7 +739,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             let result = try await plugin.signIn(username: "username", password: "password", options: options)
             XCTFail("Should not produce result - \(result)")
         } catch {
-            guard case AuthError.configuration = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.configurationError else {
                 XCTFail("Should produce configuration intead produced \(error)")
                 return
             }
@@ -766,7 +766,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             let result = try await plugin.signIn(username: "username", password: "password", options: options)
             XCTFail("Should not produce result - \(result)")
         } catch {
-            guard case AuthError.notAuthorized = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Should produce notAuthorized error but instead produced \(error)")
                 return
             }
@@ -852,8 +852,8 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             let result = try await plugin.signIn(username: "username", password: "password", options: options)
             XCTFail("Should not produce result - \(result)")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .resourceNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce resourceNotFound error but instead produced \(error)")
                 return
             }
@@ -880,8 +880,8 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             let result = try await plugin.signIn(username: "username", password: "password", options: options)
             XCTFail("Should not produce result - \(result)")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .requestLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce requestLimitExceeded error but instead produced \(error)")
                 return
             }
@@ -908,8 +908,8 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             let result = try await plugin.signIn(username: "username", password: "password", options: options)
             XCTFail("Should not produce result - \(result)")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce lambda error but instead produced \(error)")
                 return
             }
@@ -936,8 +936,8 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             let result = try await plugin.signIn(username: "username", password: "password", options: options)
             XCTFail("Should not produce result - \(result)")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce lambda error but instead produced \(error)")
                 return
             }
@@ -1023,8 +1023,8 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             let result = try await plugin.signIn(username: "username", password: "password", options: options)
             XCTFail("Should not produce result - \(result)")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .userNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce userNotFound error but instead produced \(error)")
                 return
             }
@@ -1059,8 +1059,8 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             let result = try await plugin.signIn(username: "username", password: "password", options: options)
             XCTFail("Should not produce result - \(result)")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .aliasExists = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .aliasExists = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce aliasExists error but instead produced \(error)")
                 return
             }
@@ -1093,8 +1093,8 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             let result = try await plugin.signIn(username: "username", password: "password", options: options)
             XCTFail("Should not produce result - \(result)")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .invalidPassword = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .invalidPassword = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce invalidPassword error but instead produced \(error)")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignOutTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignOutTaskTests.swift
@@ -85,7 +85,7 @@ class AWSAuthSignOutTaskTests: BasePluginTest {
 
         guard let result = await authPlugin.signOut() as? AWSCognitoSignOutResult,
               case .failed(let authError) = result,
-              case .invalidState = authError else {
+              authError.type == AuthError.invalidStateError else {
 
             XCTFail("Sign out during federation should not succeed")
             return

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthenticationProviderDeleteUserTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthenticationProviderDeleteUserTests.swift
@@ -62,7 +62,7 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
             try await plugin.deleteUser()
             XCTFail("Should not get success")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce unknown error instead of \(error)")
                 return
             }
@@ -95,8 +95,8 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
             try await plugin.deleteUser()
             XCTFail("Should not get success")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .invalidParameter = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce invalidParameter error instead of \(error)")
                 return
             }
@@ -129,7 +129,7 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
             try await plugin.deleteUser()
             XCTFail("Should not get success")
         } catch {
-            guard case AuthError.notAuthorized = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Should produce notAuthorized error instead of \(error)")
                 return
             }
@@ -162,8 +162,8 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
             try await plugin.deleteUser()
             XCTFail("Should not get success")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .passwordResetRequired = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .passwordResetRequired = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce unknown error instead of \(error)")
                 return
             }
@@ -196,8 +196,8 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
             try await plugin.deleteUser()
             XCTFail("Should not get success")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .resourceNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce unknown error instead of \(error)")
                 return
             }
@@ -230,8 +230,8 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
             try await plugin.deleteUser()
             XCTFail("Should not get success")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .requestLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce unknown error instead of \(error)")
                 return
             }
@@ -264,8 +264,8 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
             try await plugin.deleteUser()
             XCTFail("Should not get success")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .userNotConfirmed = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .userNotConfirmed = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce userNotConfirmed error instead of \(error)")
                 return
             }
@@ -298,8 +298,8 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
             try await plugin.deleteUser()
             XCTFail("Should not get success")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .userNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should produce userNotFound error but instead produced \(error)")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFederationToIdentityPoolTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFederationToIdentityPoolTests.swift
@@ -237,7 +237,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
                 _ = try await plugin.federateToIdentityPool(withProviderToken: authenticationToken, for: provider)
                 XCTFail("Should not succeed")
             } catch {
-                guard case AuthError.invalidState = error else {
+                guard let authError = error as? AuthError, authError.type == AuthError.invalidStateError else {
                     XCTFail("Should receive invalid state error")
                     return
                 }
@@ -402,7 +402,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
                 try await plugin.clearFederationToIdentityPool()
                 XCTFail("Should not succeed")
             } catch {
-                guard case AuthError.invalidState = error else {
+                guard let authError = error as? AuthError, authError.type == AuthError.invalidStateError else {
                     XCTFail("Should receive invalid state error")
                     return
                 }
@@ -490,7 +490,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
                 _ = try (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
             }
             catch let error as AuthError {
-                guard case .invalidState = error else {
+                guard let authError = error as? AuthError, authError.type == AuthError.invalidStateError else {
                     XCTFail("Should throw Auth Error with invalid state \(error)")
                     return
                 }
@@ -569,7 +569,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
                 _ = try (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
             }
             catch let error as AuthError {
-                guard case .invalidState = error else {
+                guard let authError = error as? AuthError, authError.type == AuthError.invalidStateError else {
                     XCTFail("Should throw Auth Error with invalid state \(error)")
                     return
                 }
@@ -661,7 +661,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
                 _ = try (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
             }
             catch let error as AuthError {
-                guard case .invalidState = error else {
+                guard let authError = error as? AuthError, authError.type == AuthError.invalidStateError else {
                     XCTFail("Should throw Auth Error with invalid state \(error)")
                     return
                 }
@@ -810,7 +810,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
         do {
             _ = try await plugin.federateToIdentityPool(withProviderToken: authenticationToken, for: provider)
         } catch let error as AuthError {
-            guard case .service = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should receive service error \(error)")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFetchSignInSessionOperationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFetchSignInSessionOperationTests.swift
@@ -182,7 +182,7 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
 
         let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
         guard case .failure(let error) = tokensResult,
-              case .signedOut = error else {
+              error.type == AuthError.signedOutError else {
             XCTFail("Should return signed out error")
             return
         }
@@ -217,21 +217,21 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
         XCTAssertTrue(session.isSignedIn)
 
         let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
-        guard case .failure(let error) = credentialsResult, case .sessionExpired = error else {
+        guard case .failure(let error) = credentialsResult, error.type == AuthError.sessionExpiredError else {
             XCTFail("Should return sessionExpired error")
             return
         }
 
         let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
         guard case .failure(let identityIdError) = identityIdResult,
-              case .sessionExpired = identityIdError else {
+            identityIdError.type == AuthError.sessionExpiredError else {
             XCTFail("Should return sessionExpired error")
             return
         }
 
         let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
         guard case .failure(let tokenError) = tokensResult,
-              case .sessionExpired = tokenError else {
+            tokenError.type == AuthError.sessionExpiredError else {
             XCTFail("Should return sessionExpired error")
             return
         }
@@ -278,21 +278,21 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
 
         XCTAssertTrue(session.isSignedIn)
         let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
-        guard case .failure(let error) = credentialsResult, case .sessionExpired = error else {
+        guard case .failure(let error) = credentialsResult, error.type == AuthError.sessionExpiredError else {
             XCTFail("Should return sessionExpired error")
             return
         }
 
         let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
         guard case .failure(let identityIdError) = identityIdResult,
-              case .sessionExpired = identityIdError else {
+            identityIdError.type == AuthError.sessionExpiredError else {
             XCTFail("Should return sessionExpired error")
             return
         }
 
         let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
         guard case .failure(let tokenError) = tokensResult,
-              case .sessionExpired = tokenError else {
+            tokenError.type == AuthError.sessionExpiredError else {
             XCTFail("Should return sessionExpired error")
             return
         }
@@ -505,21 +505,22 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
 
         XCTAssertTrue(session.isSignedIn)
         let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
-        guard case .failure(let error) = credentialsResult, case .unknown = error else {
+        guard case .failure(let error) = credentialsResult,
+            error.type == AuthError.unknownError else {
             XCTFail("Should return unknown error")
             return
         }
 
         let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
         guard case .failure(let identityIdError) = identityIdResult,
-              case .unknown = identityIdError else {
+            identityIdError.type == AuthError.unknownError else {
             XCTFail("Should return unknown error")
             return
         }
 
         let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
         guard case .failure(let tokenError) = tokensResult,
-              case .unknown = tokenError else {
+            tokenError.type == AuthError.unknownError else {
             XCTFail("Should return unknown error")
             return
         }
@@ -562,21 +563,22 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
 
         XCTAssertTrue(session.isSignedIn)
         let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
-        guard case .failure(let error) = credentialsResult, case .unknown = error else {
+        guard case .failure(let error) = credentialsResult,
+            error.type == AuthError.unknownError else {
             XCTFail("Should return unknown error")
             return
         }
 
         let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
         guard case .failure(let identityIdError) = identityIdResult,
-              case .unknown = identityIdError else {
+              identityIdError.type == AuthError.unknownError else {
             XCTFail("Should return unknown error")
             return
         }
 
         let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
         guard case .failure(let tokenError) = tokensResult,
-              case .unknown = tokenError else {
+            tokenError.type == AuthError.unknownError else {
             XCTFail("Should return unknown error")
             return
         }
@@ -629,7 +631,7 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
 
         let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
         guard case .failure(let tokenError) = tokensResult,
-              case .signedOut =  tokenError else {
+              tokenError.type == AuthError.signedOutError else {
             XCTFail("Should return signedOut error")
             return
         }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthConfirmSignInTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthConfirmSignInTaskTests.swift
@@ -70,7 +70,7 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "")
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.validation = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.validationError else {
                 XCTFail("Should produce validation error instead of \(error)")
                 return
             }
@@ -96,7 +96,7 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "")
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.validation = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.validationError else {
                 XCTFail("Should produce validation error instead of \(error)")
                 return
             }
@@ -169,11 +169,11 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .aliasExists = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .aliasExists = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be aliasExists \(error)")
                 return
             }
@@ -200,11 +200,11 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .codeMismatch = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .codeMismatch = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be codeMismatch \(error)")
                 return
             }
@@ -232,11 +232,11 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .codeExpired = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .codeExpired = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be codeExpired \(error)")
                 return
             }
@@ -263,7 +263,7 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce an unknown error instead of \(error)")
                 return
             }
@@ -290,11 +290,11 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be lambda \(error)")
                 return
             }
@@ -323,11 +323,11 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .invalidParameter = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidParameter \(error)")
                 return
             }
@@ -356,11 +356,11 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .invalidPassword = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .invalidPassword = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidPassword \(error)")
                 return
             }
@@ -387,11 +387,11 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .smsRole = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .smsRole = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidPassword \(error)")
                 return
             }
@@ -418,11 +418,11 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .smsRole = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .smsRole = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidPassword \(error)")
                 return
             }
@@ -467,7 +467,7 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.configuration(_, _, _) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.configurationError else {
                 XCTFail("Should produce configuration instead produced \(error)")
                 return
             }
@@ -497,11 +497,11 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .mfaMethodNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .mfaMethodNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be mfaMethodNotFound \(error)")
                 return
             }
@@ -530,7 +530,7 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.notAuthorized = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Should produce notAuthorized error instead of \(error)")
                 return
             }
@@ -588,11 +588,11 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .resourceNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be resourceNotFound \(error)")
                 return
             }
@@ -621,11 +621,11 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .softwareTokenMFANotEnabled = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .softwareTokenMFANotEnabled = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be softwareTokenMFANotEnabled \(error)")
                 return
             }
@@ -654,11 +654,11 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .requestLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be requestLimitExceeded \(error)")
                 return
             }
@@ -687,11 +687,11 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be lambda \(error)")
                 return
             }
@@ -720,11 +720,11 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be lambda \(error)")
                 return
             }
@@ -782,11 +782,11 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             _ = try await plugin.confirmSignIn(challengeResponse: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthConfirmSignUpAPITests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthConfirmSignUpAPITests.swift
@@ -154,16 +154,10 @@ class AWSAuthConfirmSignUpAPITests: BasePluginTest {
                 return
             }
 
-            guard case .notAuthorized(let errorDescription,
-                                      let recoverySuggestion,
-                                      let notAuthorizedError) = authError else {
-                XCTFail("Auth error should be of type notAuthorized")
-                return
-            }
 
-            XCTAssertNotNil(errorDescription)
-            XCTAssertNotNil(recoverySuggestion)
-            XCTAssertNil(notAuthorizedError)
+            XCTAssertNotNil(authError.errorDescription)
+            XCTAssertNotNil(authError.recoverySuggestion)
+            XCTAssertTrue(authError.type == AuthError.notAuthorizedError)
         }
     }
 
@@ -186,12 +180,12 @@ class AWSAuthConfirmSignUpAPITests: BasePluginTest {
                 return
             }
 
-            guard case .unknown(let errorMessage, _) = authError else {
+            guard authError.type == AuthError.unknownError else {
                 XCTFail("Auth error should be of type unknown")
                 return
             }
 
-            XCTAssertNotNil(errorMessage)
+            XCTAssertNotNil(authError.errorDescription)
         }
     }
 
@@ -215,12 +209,12 @@ class AWSAuthConfirmSignUpAPITests: BasePluginTest {
                 return
             }
 
-            guard case .unknown(let errorMessage, _) = authError else {
+            guard authError.type == AuthError.unknownError else {
                 XCTFail("Auth error should be of type unknown")
                 return
             }
 
-            XCTAssertNotNil(errorMessage)
+            XCTAssertNotNil(authError.errorDescription)
         }
     }
 
@@ -244,17 +238,15 @@ class AWSAuthConfirmSignUpAPITests: BasePluginTest {
                     return
                 }
 
-                guard case .service(let errorMessage,
-                                    let recovery,
-                                    let serviceError) = authError else {
+                guard authError.type == AuthError.serviceError else {
                     XCTFail("Auth error should be of type service error")
                     return
                 }
 
-                XCTAssertNotNil(errorMessage)
-                XCTAssertNotNil(recovery)
+                XCTAssertNotNil(authError.errorDescription)
+                XCTAssertNotNil(authError.recoverySuggestion)
 
-                guard let awsCognitoAuthError = serviceError as? AWSCognitoAuthError else {
+                guard let awsCognitoAuthError = authError.underlyingError as? AWSCognitoAuthError else {
                     XCTFail("Service error wrapped should be of type AWSCognitoAuthError")
                     return
                 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthResendSignUpCodeAPITests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthResendSignUpCodeAPITests.swift
@@ -99,7 +99,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resendSignUpCode(for: "", options: nil)
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.validation = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.validationError else {
                 XCTFail("Should produce validation error instead of \(error)")
                 return
             }
@@ -126,7 +126,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resendSignUpCode(for: "username", options: nil)
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce an unknown error")
                 return
             }
@@ -154,11 +154,11 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resendSignUpCode(for: "username", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .codeDelivery = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .codeDelivery = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be codedelivery \(error)")
                 return
             }
@@ -183,7 +183,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resendSignUpCode(for: "username", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce an unknown error instead of \(error)")
                 return
             }
@@ -209,11 +209,11 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resendSignUpCode(for: "username", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .emailRole = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .emailRole = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be sms role \(error)")
                 return
             }
@@ -239,11 +239,11 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resendSignUpCode(for: "username", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .smsRole = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .smsRole = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be sms role \(error)")
                 return
             }
@@ -269,11 +269,11 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resendSignUpCode(for: "username", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .smsRole = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .smsRole = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be sms role \(error)")
                 return
             }
@@ -299,11 +299,11 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resendSignUpCode(for: "username", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be lambda \(error)")
                 return
             }
@@ -330,11 +330,11 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resendSignUpCode(for: "username", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .invalidParameter = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidParameter \(error)")
                 return
             }
@@ -361,11 +361,11 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resendSignUpCode(for: "username", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .limitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be limitExceeded \(error)")
                 return
             }
@@ -392,7 +392,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resendSignUpCode(for: "username", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.notAuthorized = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Should produce notAuthorized error instead of \(error)")
                 return
             }
@@ -419,11 +419,11 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resendSignUpCode(for: "username", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .resourceNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be resourceNotFound \(error)")
                 return
             }
@@ -450,11 +450,11 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resendSignUpCode(for: "username", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .requestLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be requestLimitExceeded \(error)")
                 return
             }
@@ -481,11 +481,11 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resendSignUpCode(for: "username", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be lambda \(error)")
                 return
             }
@@ -512,11 +512,11 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resendSignUpCode(for: "username", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be lambda \(error)")
                 return
             }
@@ -543,11 +543,11 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resendSignUpCode(for: "username", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthSignUpAPITests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthSignUpAPITests.swift
@@ -169,16 +169,14 @@ class AWSAuthSignUpAPITests: BasePluginTest {
                 return
             }
 
-            guard case .notAuthorized(let errorDescription,
-                                      let recoverySuggestion,
-                                      let notAuthorizedError) = authError else {
+            guard authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Auth error should be of type notAuthorized")
                 return
             }
 
-            XCTAssertNotNil(errorDescription)
-            XCTAssertNotNil(recoverySuggestion)
-            XCTAssertNil(notAuthorizedError)
+            XCTAssertNotNil(authError.errorDescription)
+            XCTAssertNotNil(authError.recoverySuggestion)
+            XCTAssertNil(authError.underlyingError)
         }
     }
 
@@ -201,12 +199,12 @@ class AWSAuthSignUpAPITests: BasePluginTest {
                 return
             }
 
-            guard case .unknown(let errorMessage, _) = authError else {
+            guard authError.type == AuthError.unknownError else {
                 XCTFail("Auth error should be of type unknown")
                 return
             }
 
-            XCTAssertNotNil(errorMessage)
+            XCTAssertNotNil(authError.errorDescription)
         }
     }
 
@@ -230,17 +228,15 @@ class AWSAuthSignUpAPITests: BasePluginTest {
                     return
                 }
 
-                guard case .service(let errorMessage,
-                                    let recovery,
-                                    let serviceError) = authError else {
+                guard authError.type == AuthError.serviceError else {
                     XCTFail("Auth error should be of type service error")
                     return
                 }
 
-                XCTAssertNotNil(errorMessage)
-                XCTAssertNotNil(recovery)
+                XCTAssertNotNil(authError.errorDescription)
+                XCTAssertNotNil(authError.recoverySuggestion)
 
-                guard let awsCognitoAuthError = serviceError as? AWSCognitoAuthError else {
+                guard let awsCognitoAuthError = authError.underlyingError as? AWSCognitoAuthError else {
                     XCTFail("Service error wrapped should be of type AWSCognitoAuthError")
                     return
                 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/ClientBehaviorConfirmResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/ClientBehaviorConfirmResetPasswordTests.swift
@@ -87,7 +87,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "", with: "newpassword", confirmationCode: "code", options: nil)
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.validation = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.validationError else {
                 XCTFail("Should produce validation error instead of \(error)")
                 return
             }
@@ -137,7 +137,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "username", with: "", confirmationCode: "code", options: nil)
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.validation = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.validationError else {
                 XCTFail("Should produce validation error instead of \(error)")
                 return
             }
@@ -164,11 +164,11 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "username", with: "newpassword", confirmationCode: "code", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .codeMismatch = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .codeMismatch = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be codeMismatch \(error)")
                 return
             }
@@ -195,11 +195,11 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "username", with: "newpassword", confirmationCode: "code", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .codeExpired = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .codeExpired = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be codeExpired \(error)")
                 return
             }
@@ -225,7 +225,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "username", with: "newpassword", confirmationCode: "code", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce an unknown error instead of \(error)")
                 return
             }
@@ -251,11 +251,11 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "username", with: "newpassword", confirmationCode: "code", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be lambda \(error)")
                 return
             }
@@ -283,11 +283,11 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "username", with: "newpassword", confirmationCode: "code", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .invalidParameter = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidParameter \(error)")
                 return
             }
@@ -315,11 +315,11 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "username", with: "newpassword", confirmationCode: "code", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .invalidPassword = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .invalidPassword = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidPassword \(error)")
                 return
             }
@@ -347,11 +347,11 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "username", with: "newpassword", confirmationCode: "code", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .limitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be limitExceeded \(error)")
                 return
             }
@@ -379,7 +379,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "username", with: "newpassword", confirmationCode: "code", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.notAuthorized = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Should produce notAuthorized error instead of \(error)")
                 return
             }
@@ -407,11 +407,11 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "username", with: "newpassword", confirmationCode: "code", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .resourceNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be failedAttemptsLimitExceeded \(error)")
                 return
             }
@@ -439,11 +439,11 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "username", with: "newpassword", confirmationCode: "code", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .failedAttemptsLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .failedAttemptsLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be failedAttemptsLimitExceeded \(error)")
                 return
             }
@@ -471,11 +471,11 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "username", with: "newpassword", confirmationCode: "code", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .requestLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be requestLimitExceeded \(error)")
                 return
             }
@@ -503,11 +503,11 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "username", with: "newpassword", confirmationCode: "code", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be lambda \(error)")
                 return
             }
@@ -535,11 +535,11 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "username", with: "newpassword", confirmationCode: "code", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be lambda \(error)")
                 return
             }
@@ -567,11 +567,11 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "username", with: "newpassword", confirmationCode: "code", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotConfirmed = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotConfirmed = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }
@@ -599,11 +599,11 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
             try await plugin.confirmResetPassword(for: "username", with: "newpassword", confirmationCode: "code", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/ClientBehaviorResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/ClientBehaviorResetPasswordTests.swift
@@ -90,7 +90,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resetPassword(for: "user", options: nil)
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce unknown error instead of \(error)")
                 return
             }
@@ -120,7 +120,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resetPassword(for: "", options: nil)
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.validation = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.validationError else {
                 XCTFail("Should produce validation error instead of \(error)")
                 return
             }
@@ -147,11 +147,11 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resetPassword(for: "user", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .codeDelivery = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .codeDelivery = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be codeDelivery \(error)")
                 return
             }
@@ -177,7 +177,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resetPassword(for: "user", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce an unknown error instead of \(error)")
                 return
             }
@@ -203,11 +203,11 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resetPassword(for: "user", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .emailRole = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .emailRole = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be limitExceeded \(error)")
                 return
             }
@@ -233,11 +233,11 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resetPassword(for: "user", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be lambda \(error)")
                 return
             }
@@ -265,11 +265,11 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resetPassword(for: "user", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .invalidParameter = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidParameter \(error)")
                 return
             }
@@ -295,11 +295,11 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resetPassword(for: "user", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .smsRole = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .smsRole = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be limitExceeded \(error)")
                 return
             }
@@ -325,11 +325,11 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resetPassword(for: "user", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .smsRole = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .smsRole = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be limitExceeded \(error)")
                 return
             }
@@ -357,11 +357,11 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resetPassword(for: "user", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .limitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be limitExceeded \(error)")
                 return
             }
@@ -389,7 +389,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resetPassword(for: "user", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.notAuthorized = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Should produce notAuthorized error instead of \(error)")
                 return
             }
@@ -417,11 +417,11 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resetPassword(for: "user", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .resourceNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be resourceNotFound \(error)")
                 return
             }
@@ -449,11 +449,11 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resetPassword(for: "user", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .requestLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be requestLimitExceeded \(error)")
                 return
             }
@@ -481,11 +481,11 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resetPassword(for: "user", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be lambda \(error)")
                 return
             }
@@ -513,11 +513,11 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resetPassword(for: "user", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be lambda \(error)")
                 return
             }
@@ -588,11 +588,11 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
             _ = try await plugin.resetPassword(for: "user", options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorFetchDevicesTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorFetchDevicesTests.swift
@@ -100,7 +100,7 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
             let listDevicesResult = try await plugin.fetchDevices()
             XCTFail("Should not receive a success response \(listDevicesResult)")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should receive unknown error instead got \(error)")
                 return
             }
@@ -130,7 +130,7 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
             let listDevicesResult = try await plugin.fetchDevices()
             XCTFail("Should not receive a success response \(listDevicesResult)")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce unknown error")
                 return
             }
@@ -158,11 +158,11 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
             _ = try await plugin.fetchDevices()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .invalidParameter = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidParameter \(error)")
                 return
             }
@@ -190,7 +190,7 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
             _ = try await plugin.fetchDevices()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.configuration = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.configurationError else {
                 XCTFail("Should produce configuration error instead of \(error)")
                 return
             }
@@ -218,7 +218,7 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
             _ = try await plugin.fetchDevices()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.notAuthorized = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Should produce notAuthorized error instead of \(error)")
                 return
             }
@@ -246,11 +246,11 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
             _ = try await plugin.fetchDevices()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .passwordResetRequired = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .passwordResetRequired = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be passwordResetRequired \(error)")
                 return
             }
@@ -278,11 +278,11 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
             _ = try await plugin.fetchDevices()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .resourceNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be resourceNotFound \(error)")
                 return
             }
@@ -310,11 +310,11 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
             _ = try await plugin.fetchDevices()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .requestLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be requestLimitExceeded \(error)")
                 return
             }
@@ -342,11 +342,11 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
             _ = try await plugin.fetchDevices()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotConfirmed = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotConfirmed = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }
@@ -374,11 +374,11 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
             _ = try await plugin.fetchDevices()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorForgetDeviceTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorForgetDeviceTests.swift
@@ -79,7 +79,7 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice()
             XCTFail("Should return an error")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce unknown error")
                 return
             }
@@ -113,7 +113,7 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice(awsAuthDevice, options: AuthForgetDeviceRequest.Options())
             XCTFail("Should return an error")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce unknown error")
                 return
             }
@@ -141,8 +141,8 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .invalidParameter = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidParameter \(error)")
                 return
             }
@@ -176,8 +176,8 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice(awsAuthDevice, options: AuthForgetDeviceRequest.Options())
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                  case .invalidParameter = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidParameter \(error)")
                 return
             }
@@ -205,7 +205,7 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.configuration = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.configurationError else {
                 XCTFail("Should produce configuration error instead of \(error)")
                 return
             }
@@ -239,7 +239,7 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice(awsAuthDevice, options: AuthForgetDeviceRequest.Options())
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.configuration = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.configurationError else {
                 XCTFail("Should produce configuration error instead of \(error)")
                 return
             }
@@ -267,7 +267,7 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.notAuthorized = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Should produce notAuthorized error instead of \(error)")
                 return
             }
@@ -301,7 +301,7 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice(awsAuthDevice, options: AuthForgetDeviceRequest.Options())
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.notAuthorized = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Should produce notAuthorized error instead of \(error)")
                 return
             }
@@ -329,11 +329,11 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .passwordResetRequired = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .passwordResetRequired = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be passwordResetRequired \(error)")
                 return
             }
@@ -367,11 +367,11 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice(awsAuthDevice, options: AuthForgetDeviceRequest.Options())
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .passwordResetRequired = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .passwordResetRequired = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be passwordResetRequired \(error)")
                 return
             }
@@ -399,11 +399,11 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .resourceNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be resourceNotFound \(error)")
                 return
             }
@@ -437,11 +437,11 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice(awsAuthDevice, options: AuthForgetDeviceRequest.Options())
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .resourceNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be resourceNotFound \(error)")
                 return
             }
@@ -469,11 +469,11 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .requestLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be requestLimitExceeded \(error)")
                 return
             }
@@ -507,11 +507,11 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice(awsAuthDevice, options: AuthForgetDeviceRequest.Options())
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .requestLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be requestLimitExceeded \(error)")
                 return
             }
@@ -539,11 +539,11 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotConfirmed = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotConfirmed = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }
@@ -577,11 +577,11 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice(awsAuthDevice, options: AuthForgetDeviceRequest.Options())
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotConfirmed = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotConfirmed = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }
@@ -609,11 +609,11 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }
@@ -647,11 +647,11 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
             try await plugin.forgetDevice(awsAuthDevice, options: AuthForgetDeviceRequest.Options())
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorRememberDeviceTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorRememberDeviceTests.swift
@@ -83,7 +83,7 @@ class DeviceBehaviorRememberDeviceTests: BasePluginTest {
             try await plugin.rememberDevice(options: nil)
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce unknown error")
                 return
             }
@@ -111,11 +111,11 @@ class DeviceBehaviorRememberDeviceTests: BasePluginTest {
             try await plugin.rememberDevice(options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .invalidParameter = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidParameter \(error)")
                 return
             }
@@ -143,7 +143,7 @@ class DeviceBehaviorRememberDeviceTests: BasePluginTest {
             try await plugin.rememberDevice(options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.configuration = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.configurationError else {
                 XCTFail("Should produce configuration error instead of \(error)")
                 return
             }
@@ -171,7 +171,7 @@ class DeviceBehaviorRememberDeviceTests: BasePluginTest {
             try await plugin.rememberDevice(options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.notAuthorized = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Should produce notAuthorized error instead of \(error)")
                 return
             }
@@ -199,11 +199,11 @@ class DeviceBehaviorRememberDeviceTests: BasePluginTest {
             try await plugin.rememberDevice(options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .passwordResetRequired = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .passwordResetRequired = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be passwordResetRequired \(error)")
                 return
             }
@@ -231,11 +231,11 @@ class DeviceBehaviorRememberDeviceTests: BasePluginTest {
             try await plugin.rememberDevice(options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .resourceNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be resourceNotFound \(error)")
                 return
             }
@@ -263,11 +263,11 @@ class DeviceBehaviorRememberDeviceTests: BasePluginTest {
             try await plugin.rememberDevice(options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .requestLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be requestLimitExceeded \(error)")
                 return
             }
@@ -295,11 +295,11 @@ class DeviceBehaviorRememberDeviceTests: BasePluginTest {
             try await plugin.rememberDevice(options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotConfirmed = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotConfirmed = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }
@@ -327,11 +327,11 @@ class DeviceBehaviorRememberDeviceTests: BasePluginTest {
             try await plugin.rememberDevice(options: nil)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
@@ -88,8 +88,8 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             _ = try await plugin?.signInWithWebUI(presentationAnchor: ASPresentationAnchor(), options: nil)
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .userCancelled = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                    case .userCancelled = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should not fail with error = \(error)")
                 return
             }
@@ -106,8 +106,8 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             _ = try await plugin?.signInWithWebUI(presentationAnchor: ASPresentationAnchor(), options: nil)
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error,
-                  case .userCancelled = (underlyingError as? AWSCognitoAuthError) else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError,
+                    case .userCancelled = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Should not fail with error = \(error)")
                 return
             }
@@ -141,7 +141,7 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             _ = try await plugin?.signInWithWebUI(presentationAnchor: ASPresentationAnchor(), options: nil)
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.service = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should not fail with error = \(error)")
                 return
             }
@@ -158,7 +158,7 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             _ = try await plugin?.signInWithWebUI(presentationAnchor: ASPresentationAnchor(), options: nil)
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.invalidState = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.invalidStateError else {
                 XCTFail("Should not fail with error = \(error)")
                 return
             }
@@ -186,7 +186,7 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             _ = try await plugin?.signInWithWebUI(presentationAnchor: ASPresentationAnchor(), options: nil)
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.service = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should not fail with error = \(error)")
                 return
             }
@@ -214,7 +214,7 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             _ = try await plugin?.signInWithWebUI(presentationAnchor: ASPresentationAnchor(), options: nil)
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.service = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should not fail with error = \(error)")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorChangePasswordTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorChangePasswordTests.swift
@@ -46,7 +46,7 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
             try await plugin.update(oldPassword: "old password", to: "new password")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce an unknown error instead of \(error)")
                 return
             }
@@ -72,11 +72,11 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
             try await plugin.update(oldPassword: "old password", to: "new password")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .invalidParameter = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidParameter \(error)")
                 return
             }
@@ -102,11 +102,11 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
             try await plugin.update(oldPassword: "old password", to: "new password")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .invalidPassword = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .invalidPassword = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidPassword \(error)")
                 return
             }
@@ -132,11 +132,11 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
             try await plugin.update(oldPassword: "old password", to: "new password")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .limitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be limitExceeded \(error)")
                 return
             }
@@ -162,7 +162,7 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
             try await plugin.update(oldPassword: "old password", to: "new password")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.notAuthorized = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Should produce notAuthorized error instead of \(error)")
                 return
             }
@@ -188,11 +188,11 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
             try await plugin.update(oldPassword: "old password", to: "new password")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .passwordResetRequired = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .passwordResetRequired = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be passwordResetRequired \(error)")
                 return
             }
@@ -218,11 +218,11 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
             try await plugin.update(oldPassword: "old password", to: "new password")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .resourceNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be resourceNotFound \(error)")
                 return
             }
@@ -248,11 +248,11 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
             try await plugin.update(oldPassword: "old password", to: "new password")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .requestLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be requestLimitExceeded \(error)")
                 return
             }
@@ -278,11 +278,11 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
             try await plugin.update(oldPassword: "old password", to: "new password")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotConfirmed = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotConfirmed = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotConfirmed \(error)")
                 return
             }
@@ -308,11 +308,11 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
             try await plugin.update(oldPassword: "old password", to: "new password")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorConfirmAttributeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorConfirmAttributeTests.swift
@@ -46,11 +46,11 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
             try await plugin.confirm(userAttribute: .email, confirmationCode: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .codeMismatch = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .codeMismatch = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be codeMismatch \(error)")
                 return
             }
@@ -75,11 +75,11 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
             try await plugin.confirm(userAttribute: .email, confirmationCode: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .codeExpired = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .codeExpired = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be codeExpired \(error)")
                 return
             }
@@ -103,7 +103,7 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
             try await plugin.confirm(userAttribute: .email, confirmationCode: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce an unknown error instead of \(error)")
                 return
             }
@@ -129,11 +129,11 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
             try await plugin.confirm(userAttribute: .email, confirmationCode: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .invalidParameter = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidParameter \(error)")
                 return
             }
@@ -159,11 +159,11 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
             try await plugin.confirm(userAttribute: .email, confirmationCode: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .limitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be limitExceeded \(error)")
                 return
             }
@@ -189,7 +189,7 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
             try await plugin.confirm(userAttribute: .email, confirmationCode: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.notAuthorized = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Should produce notAuthorized error instead of \(error)")
                 return
             }
@@ -215,11 +215,11 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
             try await plugin.confirm(userAttribute: .email, confirmationCode: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .passwordResetRequired = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .passwordResetRequired = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be passwordResetRequired \(error)")
                 return
             }
@@ -245,11 +245,11 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
             try await plugin.confirm(userAttribute: .email, confirmationCode: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .resourceNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be resourceNotFound \(error)")
                 return
             }
@@ -276,11 +276,11 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
             try await plugin.confirm(userAttribute: .email, confirmationCode: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .requestLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be requestLimitExceeded \(error)")
                 return
             }
@@ -307,11 +307,11 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
             try await plugin.confirm(userAttribute: .email, confirmationCode: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotConfirmed = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotConfirmed = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotConfirmed \(error)")
                 return
             }
@@ -337,11 +337,11 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
             try await plugin.confirm(userAttribute: .email, confirmationCode: "code")
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorFetchAttributeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorFetchAttributeTests.swift
@@ -54,7 +54,7 @@ class UserBehaviorFetchAttributesTests: BasePluginTest {
             _ = try await plugin.fetchUserAttributes()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce an unknown error instead of \(error)")
                 return
             }
@@ -81,7 +81,7 @@ class UserBehaviorFetchAttributesTests: BasePluginTest {
             _ = try await plugin.fetchUserAttributes()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce an unknown error instead of \(error)")
                 return
             }
@@ -106,11 +106,11 @@ class UserBehaviorFetchAttributesTests: BasePluginTest {
             _ = try await plugin.fetchUserAttributes()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .invalidParameter = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidParameter \(error)")
                 return
             }
@@ -135,7 +135,7 @@ class UserBehaviorFetchAttributesTests: BasePluginTest {
             _ = try await plugin.fetchUserAttributes()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.notAuthorized = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Should produce notAuthorized error instead of \(error)")
                 return
             }
@@ -162,11 +162,11 @@ class UserBehaviorFetchAttributesTests: BasePluginTest {
             _ = try await plugin.fetchUserAttributes()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .passwordResetRequired = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .passwordResetRequired = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be passwordResetRequired \(error)")
                 return
             }
@@ -193,11 +193,11 @@ class UserBehaviorFetchAttributesTests: BasePluginTest {
             _ = try await plugin.fetchUserAttributes()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .resourceNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be passwordResetRequired \(error)")
                 return
             }
@@ -224,11 +224,11 @@ class UserBehaviorFetchAttributesTests: BasePluginTest {
             _ = try await plugin.fetchUserAttributes()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .requestLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be requestLimitExceeded \(error)")
                 return
             }
@@ -254,11 +254,11 @@ class UserBehaviorFetchAttributesTests: BasePluginTest {
             _ = try await plugin.fetchUserAttributes()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotConfirmed = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotConfirmed = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotConfirmed \(error)")
                 return
             }
@@ -284,11 +284,11 @@ class UserBehaviorFetchAttributesTests: BasePluginTest {
             _ = try await plugin.fetchUserAttributes()
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorResendCodeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorResendCodeTests.swift
@@ -56,7 +56,7 @@ class UserBehaviorResendCodeTests: BasePluginTest {
             _ = try await plugin.resendConfirmationCode(forUserAttributeKey: .email)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce an unknown error")
                 return
             }
@@ -81,11 +81,11 @@ class UserBehaviorResendCodeTests: BasePluginTest {
             _ = try await plugin.resendConfirmationCode(forUserAttributeKey: .email)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .codeDelivery = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .codeDelivery = authError.underlyingError as? AWSCognitoAuthError else {
                 XCTFail("Underlying error should be codeMismatch \(error)")
                 return
             }
@@ -109,7 +109,7 @@ class UserBehaviorResendCodeTests: BasePluginTest {
             _ = try await plugin.resendConfirmationCode(forUserAttributeKey: .email)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce an unknown error instead of \(error)")
                 return
             }
@@ -135,11 +135,11 @@ class UserBehaviorResendCodeTests: BasePluginTest {
             _ = try await plugin.resendConfirmationCode(forUserAttributeKey: .email)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .invalidParameter = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidParameter \(error)")
                 return
             }
@@ -166,11 +166,11 @@ class UserBehaviorResendCodeTests: BasePluginTest {
             _ = try await plugin.resendConfirmationCode(forUserAttributeKey: .email)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .limitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .limitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be limitExceeded \(error)")
                 return
             }
@@ -196,7 +196,7 @@ class UserBehaviorResendCodeTests: BasePluginTest {
             _ = try await plugin.resendConfirmationCode(forUserAttributeKey: .email)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.notAuthorized = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Should produce notAuthorized error instead of \(error)")
                 return
             }
@@ -222,11 +222,11 @@ class UserBehaviorResendCodeTests: BasePluginTest {
             _ = try await plugin.resendConfirmationCode(forUserAttributeKey: .email)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .passwordResetRequired = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .passwordResetRequired = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be passwordResetRequired \(error)")
                 return
             }
@@ -252,11 +252,11 @@ class UserBehaviorResendCodeTests: BasePluginTest {
             _ = try await plugin.resendConfirmationCode(forUserAttributeKey: .email)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .resourceNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be resourceNotFound \(error)")
                 return
             }
@@ -282,11 +282,11 @@ class UserBehaviorResendCodeTests: BasePluginTest {
             _ = try await plugin.resendConfirmationCode(forUserAttributeKey: .email)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .requestLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be requestLimitExceeded \(error)")
                 return
             }
@@ -312,11 +312,11 @@ class UserBehaviorResendCodeTests: BasePluginTest {
             _ = try await plugin.resendConfirmationCode(forUserAttributeKey: .email)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotConfirmed = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotConfirmed = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotConfirmed \(error)")
                 return
             }
@@ -342,11 +342,11 @@ class UserBehaviorResendCodeTests: BasePluginTest {
             _ = try await plugin.resendConfirmationCode(forUserAttributeKey: .email)
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorUpdateAttributeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorUpdateAttributeTests.swift
@@ -72,11 +72,11 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .aliasExists = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .aliasExists = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be aliasExists \(error)")
                 return
             }
@@ -101,11 +101,11 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .codeDelivery = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .codeDelivery = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be codeDelivery \(error)")
                 return
             }
@@ -130,11 +130,11 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .codeMismatch = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .codeMismatch = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be codeMismatch \(error)")
                 return
             }
@@ -159,11 +159,11 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .codeExpired = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .codeExpired = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be codeExpired \(error)")
                 return
             }
@@ -187,7 +187,7 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.unknown = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.unknownError else {
                 XCTFail("Should produce an unknown error instead of \(error)")
                 return
             }
@@ -211,11 +211,11 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .emailRole = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .emailRole = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be email role \(error)")
                 return
             }
@@ -239,11 +239,11 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be lambda \(error)")
                 return
             }
@@ -269,11 +269,11 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .invalidParameter = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidParameter \(error)")
                 return
             }
@@ -297,11 +297,11 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .smsRole = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .smsRole = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be sms exists \(error)")
                 return
             }
@@ -325,11 +325,11 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .smsRole = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .smsRole = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be sms role \(error)")
                 return
             }
@@ -355,7 +355,7 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.notAuthorized = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.notAuthorizedError else {
                 XCTFail("Should produce notAuthorized error instead of \(error)")
                 return
             }
@@ -381,11 +381,11 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .passwordResetRequired = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .passwordResetRequired = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be passwordResetRequired \(error)")
                 return
             }
@@ -411,11 +411,11 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .resourceNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be resourceNotFound \(error)")
                 return
             }
@@ -441,11 +441,11 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .requestLimitExceeded = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be requestLimitExceeded \(error)")
                 return
             }
@@ -471,11 +471,11 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be lambda \(error)")
                 return
             }
@@ -501,11 +501,11 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .lambda = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be lambda \(error)")
                 return
             }
@@ -531,11 +531,11 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotConfirmed = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotConfirmed = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotConfirmed \(error)")
                 return
             }
@@ -561,11 +561,11 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
             XCTFail("Should return an error if the result from service is invalid")
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
+            guard let authError = error as? AuthError, authError.type == AuthError.serviceError else {
                 XCTFail("Should produce service error instead of \(error)")
                 return
             }
-            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            guard case .userNotFound = (authError.underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be userNotFound \(error)")
                 return
             }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AWSAuthServiceTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AWSAuthServiceTests.swift
@@ -68,7 +68,7 @@ class AWSAuthServiceTests: XCTestCase {
             XCTFail("passed in token with two parts, but expecting 3")
             return
         }
-        guard case .validation = error else {
+        guard error.type == AuthError.validationError else {
             XCTFail("expecting validation error")
             return
         }
@@ -94,11 +94,11 @@ class AWSAuthServiceTests: XCTestCase {
             XCTFail("passed in token with two parts, but expecting 3")
             return
         }
-        guard case .validation(_, _, _, let error) = authError else {
+        guard authError.type == AuthError.validationError else {
             XCTFail("expecting validation error")
             return
         }
-        guard let jsonDecodeError = error as NSError? else {
+        guard let jsonDecodeError = authError.underlyingError as NSError? else {
             XCTFail("expecting json decode error")
             return
         }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -219,8 +219,7 @@ final class InitialSyncOperation: AsynchronousOperation {
 
     private func isAuthSignedOutError(apiError: APIError) -> Bool {
         if case let .operationError(_, _, underlyingError) = apiError,
-            let authError = underlyingError as? AuthError,
-            case .signedOut = authError {
+            let authError = underlyingError as? AuthError, authError.type == AuthError.signedOutError {
             return true
         }
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
@@ -128,7 +128,7 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
     private func isAuthSignedOutError(apiError: APIError) -> Bool {
         if case let .operationError(_, _, underlyingError) = apiError,
             let authError = underlyingError as? AuthError,
-            case .signedOut = authError {
+           authError.type == AuthError.signedOutError {
             return true
         }
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -419,8 +419,7 @@ class InitialSyncOperationTests: XCTestCase {
             }
             guard let actualAPIError = amplifyError as? APIError,
                 case let .operationError(_, _, underlyingError) = actualAPIError,
-                let authError = underlyingError as? AuthError,
-                case .signedOut = authError else {
+                  let authError = underlyingError as? AuthError, authError.type == AuthError.signedOutError else {
                     XCTFail("Should be `signedOut` error but got \(amplifyError)")
                     return
             }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -58,8 +58,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             }
             guard let actualAPIError = amplifyError as? APIError,
                 case let .operationError(_, _, underlyingError) = actualAPIError,
-                let authError = underlyingError as? AuthError,
-                case .signedOut = authError else {
+                  let authError = underlyingError as? AuthError, authError.type == AuthError.signedOutError else {
                     XCTFail("Should be `signedOut` error")
                     return
             }

--- a/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
@@ -104,10 +104,10 @@ class AuthCategoryConfigurationTests: XCTestCase {
         await Amplify.reset()
         XCTAssertThrowsError(try Amplify.Auth.getPlugin(for: "MockAuthCategoryPlugin"),
                              "Getting a plugin after reset() should throw") { error in
-                                guard case AuthError.configuration = error else {
-                                    XCTFail("Expected PluginError.noSuchPlugin")
-                                    return
-                                }
+            guard let authError = error as? AuthError, authError.type == AuthError.configurationError else {
+                XCTFail("Expected PluginError.noSuchPlugin")
+                return
+            }
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
