### PR TITLE
fix(auth): Remove parallel event that moves auth plugin to an error state and other cleanups

### DIFF
--- a/Amplify/Categories/Auth/Error/AuthError.swift
+++ b/Amplify/Categories/Auth/Error/AuthError.swift
@@ -77,7 +77,7 @@ extension AuthError: AmplifyError {
              .invalidState(_, let recoverySuggestion, _):
             return recoverySuggestion
         case .unknown:
-            return AmplifyErrorMessages.shouldNotHappenReportBugToAWS()
+            return AmplifyErrorMessages.shouldNotHappenReportBugToAWSWithoutLineInfo()
         }
     }
 

--- a/Amplify/Core/Support/AmplifyErrorMessages.swift
+++ b/Amplify/Core/Support/AmplifyErrorMessages.swift
@@ -30,7 +30,7 @@ public struct AmplifyErrorMessages {
     public static func shouldNotHappenReportBugToAWSWithoutLineInfo() -> String {
         """
         This should not happen. There is a possibility that there is a bug if this error persists. \
-        Please take a look at https://github.com/aws-amplify/amplify-ios/issues to see if there \
+        Please take a look at https://github.com/aws-amplify/amplify-swift/issues to see if there \
         are any existing issues that match your scenario, and file an issue with the details of \
         the bug if there isn't.
         """

--- a/Amplify/Core/Support/AmplifyErrorMessages.swift
+++ b/Amplify/Core/Support/AmplifyErrorMessages.swift
@@ -27,4 +27,13 @@ public struct AmplifyErrorMessages {
         "This should not happen. \(reportBugToAWS(file: file, function: function, line: line))"
     }
 
+    public static func shouldNotHappenReportBugToAWSWithoutLineInfo() -> String {
+        """
+        This should not happen. There is a possibility that there is a bug if this error persists. \
+        Please take a look at https://github.com/aws-amplify/amplify-ios/issues to see if there \
+        are any existing issues that match your scenario, and file an issue with the details of \
+        the bug if there isn't.
+        """
+    }
+
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/HostedUISignInHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/HostedUISignInHelper.swift
@@ -91,7 +91,7 @@ struct HostedUISignInHelper {
                     }
                     return result
                 } catch {
-                    await waitforSignInCancel()
+                    await waitForSignInCancel()
                     throw error
                 }
             default:

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/HostedUISignInHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/HostedUISignInHelper.swift
@@ -127,7 +127,7 @@ struct HostedUISignInHelper {
         await authStateMachine.send(event)
     }
 
-    private func waitforSignInCancel() async {
+    private func waitForSignInCancel() async {
         await sendCancelSignInEvent()
         let stateSequences = await authStateMachine.listen()
         for await state in stateSequences {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/HostedUISignInHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/HostedUISignInHelper.swift
@@ -81,7 +81,7 @@ struct HostedUISignInHelper {
                 }
 
             case .error(let error):
-                await waitforSignInCancel()
+                await waitForSignInCancel()
                 throw error.authError
 
             case .signingIn(let signInState):

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/DeviceMetadata.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/DeviceMetadata.swift
@@ -33,6 +33,29 @@ extension DeviceMetadata: Codable { }
 
 extension DeviceMetadata: Equatable { }
 
+extension DeviceMetadata: CustomDebugDictionaryConvertible {
+
+    var debugDictionary: [String: Any] {
+        switch self {
+        case .noData:
+            return ["noData": "noData"]
+        case .metadata(let data):
+            return [
+                "deviceKey": data.deviceKey.masked(interiorCount: 5),
+                "deviceGroupKey": data.deviceGroupKey.masked(interiorCount: 5),
+                "deviceSecret": data.deviceSecret.masked(interiorCount: 5)
+            ]
+        }
+    }
+}
+
+extension DeviceMetadata: CustomDebugStringConvertible {
+
+    var debugDescription: String {
+        debugDictionary.debugDescription
+    }
+}
+
 extension CognitoIdentityProviderClientTypes.AuthenticationResultType {
 
     var deviceMetadata: DeviceMetadata {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/Authentication/AuthenticationState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/Authentication/AuthenticationState+Resolver.swift
@@ -221,8 +221,7 @@ extension AuthenticationState {
                                            event: StateMachineEvent) -> StateResolution<StateType> {
             if let authEvent = event as? AuthenticationEvent,
                case .error(let error) = authEvent.eventType {
-                let action = CancelSignIn()
-                return .init(newState: .error(error), actions: [action])
+                return .init(newState: .error(error))
             }
             /// Move to signedOut state if cancelSignIn
             if let authEvent = event as? AuthenticationEvent,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/CustomAuth/CustomSignInState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/CustomAuth/CustomSignInState+Resolver.swift
@@ -74,10 +74,8 @@ extension CustomSignInState {
 
         private func errorStateWithCancelSignIn(_ error: SignInError)
         -> StateResolution<CustomSignInState> {
-            let action = CancelSignIn()
             return StateResolution(
-                newState: CustomSignInState.error(error),
-                actions: [action]
+                newState: CustomSignInState.error(error)
             )
         }
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/MigrateAuth/MigrateSignInState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/MigrateAuth/MigrateSignInState+Resolver.swift
@@ -83,10 +83,8 @@ extension MigrateSignInState {
 
         private func errorStateWithCancelSignIn(_ error: SignInError)
         -> StateResolution<MigrateSignInState> {
-            let action = CancelSignIn()
             return StateResolution(
-                newState: MigrateSignInState.error(error),
-                actions: [action]
+                newState: MigrateSignInState.error(error)
             )
         }
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SRP/SRPSignInState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SRP/SRPSignInState+Resolver.swift
@@ -114,10 +114,8 @@ extension SRPSignInState {
 
         private func errorState(_ error: SignInError)
         -> StateResolution<SRPSignInState> {
-            let action = ThrowSignInError(error: error)
             return StateResolution(
-                newState: SRPSignInState.error(error),
-                actions: [action]
+                newState: SRPSignInState.error(error)
             )
         }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SignIn/HostedUISignInState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SignIn/HostedUISignInState+Resolver.swift
@@ -30,6 +30,7 @@ extension HostedUISignInState {
 
             case .showingUI:
                 if case .throwError(let error) = event.isHostedUIEvent {
+                    // Remove this?
                     let action = CancelSignIn()
                     return .init(newState: .error(error), actions: [action])
                 }
@@ -42,6 +43,7 @@ extension HostedUISignInState {
 
             case .fetchingToken:
                 if case .throwError(let error) = event.isHostedUIEvent {
+                    // Remove this?
                     let action = CancelSignIn()
                     return .init(newState: .error(error), actions: [action])
                 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift
@@ -42,7 +42,7 @@ class AWSAuthSignInTask: AuthSignInTask {
         do {
            return try await doSignIn(authflowType: authflowType)
         } catch {
-            await waitforSignInCancel()
+            await waitForSignInCancel()
             throw error
         }
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift
@@ -106,7 +106,7 @@ class AWSAuthSignInTask: AuthSignInTask {
         await authStateMachine.send(event)
     }
 
-    private func waitforSignInCancel() async {
+    private func waitForSignInCancel() async {
         await sendCancelSignInEvent()
         let stateSequences = await authStateMachine.listen()
         for await state in stateSequences {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
@@ -249,8 +249,8 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             })
 
             do {
-                let result = try await plugin.signIn(username: "username", password: "password", options: options)
-                XCTAssertTrue(result.isSignedIn, "Signin result should be complete")
+                let result2 = try await plugin.signIn(username: "username", password: "password", options: options)
+                XCTAssertTrue(result2.isSignedIn, "Signin result should be complete")
             } catch {
                 XCTFail("Received failure with error \(error)")
             }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- When an error happens in Auth signIn flow, we return the statemachine with an error and sends two parallel events: one for cancelling signIn flow and another to update authentication state to error. Both of these could be processed after the running signIn flow is completed, which can affect a new signIn flow that immediately follow. This PR removes the parallel events and moves the cancel signIn flow to the Task so that the current signIn flow is complete only when the state machine is cleared up.
- The line number and file info passed in recovery suggestion is not giving any useful information. This PR removes those details from the message.
- Masked device meta data information

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
