### PR TITLE
chore(auth): remove unknown default enum case from error mapping

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ChangePasswordOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ChangePasswordOutputError+AuthError.swift
@@ -58,8 +58,6 @@ extension ChangePasswordOutputError: AuthErrorConvertible {
         case .forbiddenException(let forbiddenException):
             return .service(forbiddenException.message ?? "Access to the requested resource is forbidden",
                             AuthPluginErrorConstants.forbiddenError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ConfirmForgotPasswordOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ConfirmForgotPasswordOutputError+AuthError.swift
@@ -76,8 +76,6 @@ extension ConfirmForgotPasswordOutputError: AuthErrorConvertible {
         case .forbiddenException(let forbiddenException):
             return .service(forbiddenException.message ?? "Access to the requested resource is forbidden",
                             AuthPluginErrorConstants.forbiddenError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ConfirmSignUpOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ConfirmSignUpOutputError+AuthError.swift
@@ -115,8 +115,6 @@ extension ConfirmSignUpOutputError: AuthErrorConvertible {
         case .forbiddenException(let forbiddenException):
             return .service(forbiddenException.message ?? "Access to the requested resource is forbidden",
                             AuthPluginErrorConstants.forbiddenError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/DeleteUserOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/DeleteUserOutputError+AuthError.swift
@@ -50,8 +50,6 @@ extension DeleteUserOutputError: AuthErrorConvertible {
         case .forbiddenException(let forbiddenException):
             return .service(forbiddenException.message ?? "Access to the requested resource is forbidden",
                             AuthPluginErrorConstants.forbiddenError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ForgetDeviceOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ForgetDeviceOutputError+AuthError.swift
@@ -53,8 +53,6 @@ extension ForgetDeviceOutputError: AuthErrorConvertible {
         case .forbiddenException(let forbiddenException):
             return .service(forbiddenException.message ?? "Access to the requested resource is forbidden",
                             AuthPluginErrorConstants.forbiddenError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ForgotPasswordOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ForgotPasswordOutputError+AuthError.swift
@@ -85,8 +85,6 @@ extension ForgotPasswordOutputError: AuthErrorConvertible {
         case .forbiddenException(let forbiddenException):
             return .service(forbiddenException.message ?? "Access to the requested resource is forbidden",
                             AuthPluginErrorConstants.forbiddenError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/GetCredentialsForIdentityOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/GetCredentialsForIdentityOutputError+AuthError.swift
@@ -45,8 +45,6 @@ extension GetCredentialsForIdentityOutputError: AuthErrorConvertible {
             let statusCode = unknownAWSHttpServiceError._statusCode?.rawValue ?? -1
             let message = unknownAWSHttpServiceError._message ?? ""
             return .unknown("Unknown service error occurred with status \(statusCode) \(message)")
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/GetIdOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/GetIdOutputError+AuthError.swift
@@ -46,8 +46,6 @@ extension GetIdOutputError: AuthErrorConvertible {
             let statusCode = unknownAWSHttpServiceError._statusCode?.rawValue ?? -1
             let message = unknownAWSHttpServiceError._message ?? ""
             return .unknown("Unknown service error occurred with status \(statusCode) \(message)")
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/GetUserAttributeVerificationCodeOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/GetUserAttributeVerificationCodeOutputError+AuthError.swift
@@ -82,8 +82,6 @@ extension GetUserAttributeVerificationCodeOutputError: AuthErrorConvertible {
         case .forbiddenException(let forbiddenException):
             return .service(forbiddenException.message ?? "Access to the requested resource is forbidden",
                             AuthPluginErrorConstants.forbiddenError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/GetUserOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/GetUserOutputError+AuthError.swift
@@ -50,8 +50,6 @@ extension GetUserOutputError: AuthErrorConvertible {
         case .forbiddenException(let forbiddenException):
             return .service(forbiddenException.message ?? "Access to the requested resource is forbidden",
                             AuthPluginErrorConstants.forbiddenError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/InitiateAuthOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/InitiateAuthOutputError+AuthError.swift
@@ -73,8 +73,6 @@ extension InitiateAuthOutputError: AuthErrorConvertible {
         case .forbiddenException(let forbiddenException):
             return .service(forbiddenException.message ?? "Access to the requested resource is forbidden",
                             AuthPluginErrorConstants.forbiddenError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ListDevicesOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ListDevicesOutputError+AuthError.swift
@@ -53,8 +53,6 @@ extension ListDevicesOutputError: AuthErrorConvertible {
         case .forbiddenException(let forbiddenException):
             return .service(forbiddenException.message ?? "Access to the requested resource is forbidden",
                             AuthPluginErrorConstants.forbiddenError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ResendConfirmationCodeOutputError+Error.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/ResendConfirmationCodeOutputError+Error.swift
@@ -85,8 +85,6 @@ extension ResendConfirmationCodeOutputError: AuthErrorConvertible {
         case .forbiddenException(let forbiddenException):
             return .service(forbiddenException.message ?? "Access to the requested resource is forbidden",
                             AuthPluginErrorConstants.forbiddenError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/RespondToAuthChallengeOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/RespondToAuthChallengeOutputError+AuthError.swift
@@ -97,8 +97,6 @@ extension RespondToAuthChallengeOutputError: AuthErrorConvertible {
         case .forbiddenException(let forbiddenException):
             return .service(forbiddenException.message ?? "Access to the requested resource is forbidden",
                             AuthPluginErrorConstants.forbiddenError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/SdkError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/SdkError+AuthError.swift
@@ -75,8 +75,6 @@ extension SdkError: AuthErrorConvertible {
 
         case .unknownError(let message):
             return AuthError.unknown(message, clientError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/SignUpOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/SignUpOutputError+AuthError.swift
@@ -114,8 +114,6 @@ extension SignUpOutputError: AuthErrorConvertible {
         case .forbiddenException(let forbiddenException):
             return .service(forbiddenException.message ?? "Access to the requested resource is forbidden",
                             AuthPluginErrorConstants.forbiddenError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/UpdateDeviceStatusOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/UpdateDeviceStatusOutputError+AuthError.swift
@@ -53,8 +53,6 @@ extension UpdateDeviceStatusOutputError: AuthErrorConvertible {
         case .forbiddenException(let forbiddenException):
             return .service(forbiddenException.message ?? "Access to the requested resource is forbidden",
                             AuthPluginErrorConstants.forbiddenError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/UpdateUserAttributesOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/UpdateUserAttributesOutputError+AuthError.swift
@@ -90,8 +90,6 @@ extension UpdateUserAttributesOutputError: AuthErrorConvertible {
         case .forbiddenException(let forbiddenException):
             return .service(forbiddenException.message ?? "Access to the requested resource is forbidden",
                             AuthPluginErrorConstants.forbiddenError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/VerifyUserAttributeOutputError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/VerifyUserAttributeOutputError+AuthError.swift
@@ -100,8 +100,6 @@ extension VerifyUserAttributeOutputError: AuthErrorConvertible {
         case .forbiddenException(let forbiddenException):
             return .service(forbiddenException.message ?? "Access to the requested resource is forbidden",
                             AuthPluginErrorConstants.forbiddenError)
-        @unknown default:
-            return .unknown("Unknown service error occurred")
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Removing `unknown default` since it will never get executed

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
