### PR TITLE
fix(auth): Enable retrying when confirm signIn fails

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
@@ -89,7 +89,9 @@ extension AWSCognitoAuthPlugin: AuthCategoryBehavior {
         let options = options ?? AuthConfirmSignInRequest.Options()
         let request = AuthConfirmSignInRequest(challengeResponse: challengeResponse,
                                                options: options)
-        let task = AWSAuthConfirmSignInTask(request, stateMachine: authStateMachine)
+        let task = AWSAuthConfirmSignInTask(request,
+                                            stateMachine: authStateMachine,
+                                            configuration: authConfiguration)
         return try await taskQueue.sync {
             return try await task.value
         } as! AuthSignInResult

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/DebugInfo/SignInChallengeState+Debug.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/DebugInfo/SignInChallengeState+Debug.swift
@@ -14,9 +14,9 @@ extension SignInChallengeState {
         switch self {
 
         case .waitingForAnswer(let respondAuthChallenge, _),
-                .verifying(let respondAuthChallenge, _):
+                .verifying(let respondAuthChallenge, _, _):
             additionalMetadataDictionary = respondAuthChallenge.debugDictionary
-        case .error(let respondAuthChallenge, let error):
+        case .error(let respondAuthChallenge, _, let error):
             additionalMetadataDictionary = respondAuthChallenge.debugDictionary
             additionalMetadataDictionary["error"] = error
         default: additionalMetadataDictionary = [:]

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/SignInChallengeState.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/SignInChallengeState.swift
@@ -13,11 +13,11 @@ enum SignInChallengeState: State {
 
     case waitingForAnswer(RespondToAuthChallenge, SignInMethod)
 
-    case verifying(RespondToAuthChallenge, String)
+    case verifying(RespondToAuthChallenge, SignInMethod, String)
 
     case verified
 
-    case error(RespondToAuthChallenge, SignInError)
+    case error(RespondToAuthChallenge, SignInMethod, SignInError)
 }
 
 extension SignInChallengeState {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift
@@ -29,13 +29,17 @@ class AWSAuthSignInTask: AuthSignInTask {
     }
 
     func execute() async throws -> AuthSignInResult {
+        await taskHelper.didStateMachineConfigured()
+        //Check if we have a user pool configuration
         guard let userPoolConfiguration = authConfiguration.getUserPoolConfiguration() else {
             let message = AuthPluginErrorConstants.configurationError
-            let authError = AuthenticationError.configuration(message: message)
+            let authError = AuthError.configuration(
+                "Could not find user pool configuration",
+                message)
             throw authError
         }
 
-        await taskHelper.didStateMachineConfigured()
+
         try await validateCurrentState()
 
         let authflowType = authFlowType(userPoolConfiguration: userPoolConfiguration)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-swift/issues/2615

*Description of changes:* Confirm signIn initial validation step did not check if the previous confirm signIn was in an error state. This PR enables that which allows to retry failed confirm signin. 

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
