### PR TITLE
chore(geo): Add stress tests for Geo category

### DIFF
--- a/AmplifyPlugins/Geo/Tests/GeoHostApp/AWSLocationGeoPluginIntegrationTests/AWSLocationGeoPluginIntegrationTests.swift
+++ b/AmplifyPlugins/Geo/Tests/GeoHostApp/AWSLocationGeoPluginIntegrationTests/AWSLocationGeoPluginIntegrationTests.swift
@@ -138,7 +138,7 @@ class AWSLocationGeoPluginIntergrationTests: XCTestCase {
     ///
     func testMultipleSearchForText() async {
         let successExpectation = asyncExpectation(description: "searchForText was successful", expectedFulfillmentCount: concurrencyLimit)
-        for _ in 0...concurrencyLimit {
+        for _ in 1...concurrencyLimit {
             Task {
                 do {
                     let options = Geo.SearchForTextOptions(area: .near(coordinates))
@@ -163,7 +163,7 @@ class AWSLocationGeoPluginIntergrationTests: XCTestCase {
     ///
     func testMultipleSearchForCoordinates() async {
         let successExpectation = asyncExpectation(description: "searchForCoordinates was successful", expectedFulfillmentCount: concurrencyLimit)
-        for _ in 0...concurrencyLimit {
+        for _ in 1...concurrencyLimit {
             Task {
                 do {
                     let places = try await Amplify.Geo.search(for: coordinates, options: nil)

--- a/AmplifyPlugins/Geo/Tests/GeoHostApp/AWSLocationGeoPluginIntegrationTests/AWSLocationGeoPluginIntegrationTests.swift
+++ b/AmplifyPlugins/Geo/Tests/GeoHostApp/AWSLocationGeoPluginIntegrationTests/AWSLocationGeoPluginIntegrationTests.swift
@@ -17,7 +17,6 @@ class AWSLocationGeoPluginIntergrationTests: XCTestCase {
     let searchText = "coffee shop"
     let coordinates = Geo.Coordinates(latitude: 39.7392, longitude: -104.9903)
     let amplifyConfigurationFile = "testconfiguration/AWSLocationGeoPluginIntegrationTests-amplifyconfiguration"
-    let concurrencyLimit = 50
 
     override func setUp() {
         continueAfterFailure = false
@@ -124,58 +123,5 @@ class AWSLocationGeoPluginIntergrationTests: XCTestCase {
         } catch {
             XCTFail("Failed with error: \(error)")
         }
-    }
-    
-    
-    // MARK: - Stress Tests
-    
-    /// Test if concurrent execution of search(for: text) is successful
-    /// - Given: Geo plugin with a valid configuration.
-    /// - When:
-    ///    - I invoke search(for: text) from 50 tasks concurrently
-    /// - Then:
-    ///    - Place results are returned.
-    ///
-    func testMultipleSearchForText() async {
-        let successExpectation = asyncExpectation(description: "searchForText was successful", expectedFulfillmentCount: concurrencyLimit)
-        for _ in 1...concurrencyLimit {
-            Task {
-                do {
-                    let options = Geo.SearchForTextOptions(area: .near(coordinates))
-                    let places = try await Amplify.Geo.search(for: searchText, options: options)
-                    XCTAssertFalse(places.isEmpty)
-                    await successExpectation.fulfill()
-                } catch {
-                    XCTFail("Failed with error: \(error)")
-                }
-            }
-        }
-        
-        await waitForExpectations([successExpectation], timeout: timeout)
-    }
-    
-    /// Test if concurrent execution of search(for: coordinates) is successful
-    /// - Given: Geo plugin with a valid configuration.
-    /// - When:
-    ///    - I invoke search(for: coordinates) from 50 tasks concurrently
-    /// - Then:
-    ///    - Place results are returned.
-    ///
-    func testMultipleSearchForCoordinates() async {
-        let successExpectation = asyncExpectation(description: "searchForCoordinates was successful", expectedFulfillmentCount: concurrencyLimit)
-        for _ in 1...concurrencyLimit {
-            Task {
-                do {
-                    let places = try await Amplify.Geo.search(for: coordinates, options: nil)
-                    XCTAssertFalse(places.isEmpty)
-                    XCTAssertNotNil(places.first?.coordinates)
-                    await successExpectation.fulfill()
-                } catch {
-                    XCTFail("Failed with error: \(error)")
-                }
-            }
-        }
-        
-        await waitForExpectations([successExpectation], timeout: timeout)
     }
 }

--- a/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoHostApp.xcodeproj/project.pbxproj
@@ -10,6 +10,12 @@
 		978B1D6429515FFB0079E55A /* AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978B1D5E29515DEF0079E55A /* AsyncTesting.swift */; };
 		978B1D6529515FFB0079E55A /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978B1D5F29515DEF0079E55A /* AsyncExpectation.swift */; };
 		978B1D6629515FFB0079E55A /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978B1D6029515DEF0079E55A /* XCTestCase+AsyncTesting.swift */; };
+		97914B82295570E1002000EA /* AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978B1D5E29515DEF0079E55A /* AsyncTesting.swift */; };
+		97914B83295570E1002000EA /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978B1D5F29515DEF0079E55A /* AsyncExpectation.swift */; };
+		97914B84295570E1002000EA /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978B1D6029515DEF0079E55A /* XCTestCase+AsyncTesting.swift */; };
+		97914B86295570E1002000EA /* TestConfigHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97DB82542823466800FC2228 /* TestConfigHelper.swift */; };
+		97914B8F2955711A002000EA /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 97914B7829556F88002000EA /* README.md */; };
+		97914B9029557126002000EA /* GeoStressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97914B7029556F38002000EA /* GeoStressTests.swift */; };
 		97AD223228230B98001AFCC1 /* GeoHostAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AD223128230B98001AFCC1 /* GeoHostAppApp.swift */; };
 		97AD223428230B98001AFCC1 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AD223328230B98001AFCC1 /* ContentView.swift */; };
 		97AD223628230B9A001AFCC1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97AD223528230B9A001AFCC1 /* Assets.xcassets */; };
@@ -23,6 +29,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		97914B80295570E1002000EA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97AD222628230B98001AFCC1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 97AD222D28230B98001AFCC1;
+			remoteInfo = GeoHostApp;
+		};
 		97DB823F282339B700FC2228 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 97AD222628230B98001AFCC1 /* Project object */;
@@ -36,6 +49,9 @@
 		978B1D5E29515DEF0079E55A /* AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncTesting.swift; sourceTree = "<group>"; };
 		978B1D5F29515DEF0079E55A /* AsyncExpectation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncExpectation.swift; sourceTree = "<group>"; };
 		978B1D6029515DEF0079E55A /* XCTestCase+AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AsyncTesting.swift"; sourceTree = "<group>"; };
+		97914B7029556F38002000EA /* GeoStressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoStressTests.swift; sourceTree = "<group>"; };
+		97914B7829556F88002000EA /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		97914B8E295570E1002000EA /* GeoStressTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GeoStressTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		97AD222E28230B98001AFCC1 /* GeoHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GeoHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		97AD223128230B98001AFCC1 /* GeoHostAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoHostAppApp.swift; sourceTree = "<group>"; };
 		97AD223328230B98001AFCC1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -49,6 +65,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		97914B87295570E1002000EA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97AD222B28230B98001AFCC1 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -80,12 +103,22 @@
 			path = ../../../../../AmplifyAsyncTesting/Sources/AsyncTesting;
 			sourceTree = "<group>";
 		};
+		97914B6F29556F38002000EA /* GeoStressTests */ = {
+			isa = PBXGroup;
+			children = (
+				97914B7829556F88002000EA /* README.md */,
+				97914B7029556F38002000EA /* GeoStressTests.swift */,
+			);
+			path = GeoStressTests;
+			sourceTree = "<group>";
+		};
 		97AD222528230B98001AFCC1 = {
 			isa = PBXGroup;
 			children = (
 				97DB824C28233F2B00FC2228 /* Packages */,
 				97AD223028230B98001AFCC1 /* GeoHostApp */,
 				97DB823C282339B700FC2228 /* AWSLocationGeoPluginIntegrationTests */,
+				97914B6F29556F38002000EA /* GeoStressTests */,
 				97AD222F28230B98001AFCC1 /* Products */,
 				97DB824E2823417000FC2228 /* Frameworks */,
 			);
@@ -96,6 +129,7 @@
 			children = (
 				97AD222E28230B98001AFCC1 /* GeoHostApp.app */,
 				97DB823B282339B700FC2228 /* AWSLocationGeoPluginIntegrationTests.xctest */,
+				97914B8E295570E1002000EA /* GeoStressTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -148,6 +182,25 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		97914B7E295570E1002000EA /* GeoStressTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 97914B8B295570E1002000EA /* Build configuration list for PBXNativeTarget "GeoStressTests" */;
+			buildPhases = (
+				97914B81295570E1002000EA /* Sources */,
+				97914B87295570E1002000EA /* Frameworks */,
+				97914B88295570E1002000EA /* Resources */,
+				97914B8A295570E1002000EA /* Copy Configuration Folder */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				97914B7F295570E1002000EA /* PBXTargetDependency */,
+			);
+			name = GeoStressTests;
+			productName = AWSLocationGeoPluginIntegrationTests;
+			productReference = 97914B8E295570E1002000EA /* GeoStressTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		97AD222D28230B98001AFCC1 /* GeoHostApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97AD223C28230B9A001AFCC1 /* Build configuration list for PBXNativeTarget "GeoHostApp" */;
@@ -196,7 +249,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
+				LastSwiftUpdateCheck = 1400;
 				LastUpgradeCheck = 1320;
 				TargetAttributes = {
 					97AD222D28230B98001AFCC1 = {
@@ -224,11 +277,20 @@
 			targets = (
 				97AD222D28230B98001AFCC1 /* GeoHostApp */,
 				97DB823A282339B700FC2228 /* AWSLocationGeoPluginIntegrationTests */,
+				97914B7E295570E1002000EA /* GeoStressTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		97914B88295570E1002000EA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				97914B8F2955711A002000EA /* README.md in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97AD222C28230B98001AFCC1 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -249,6 +311,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		97914B8A295570E1002000EA /* Copy Configuration Folder */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Configuration Folder";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "TEMP_FILE=$HOME/.aws-amplify/amplify-ios/testconfiguration/.\nDEST_PATH=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/testconfiguration/\"\n\nif [[ ! -d $TEMP_FILE ]] ; then\n    echo \"${TEMP_FILE} does not exist. Using empty configuration.\"\n    exit 0\nfi\n      \nif [[ -f $DEST_PATH ]] ; then\n    rm $DEST_PATH\nfi\n      \ncp -r $TEMP_FILE $DEST_PATH\n";
+		};
 		97DB82512823429C00FC2228 /* Copy Configuration Folder */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -270,6 +350,18 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		97914B81295570E1002000EA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				97914B9029557126002000EA /* GeoStressTests.swift in Sources */,
+				97914B82295570E1002000EA /* AsyncTesting.swift in Sources */,
+				97914B83295570E1002000EA /* AsyncExpectation.swift in Sources */,
+				97914B84295570E1002000EA /* XCTestCase+AsyncTesting.swift in Sources */,
+				97914B86295570E1002000EA /* TestConfigHelper.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97AD222A28230B98001AFCC1 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -294,6 +386,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		97914B7F295570E1002000EA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 97AD222D28230B98001AFCC1 /* GeoHostApp */;
+			targetProxy = 97914B80295570E1002000EA /* PBXContainerItemProxy */;
+		};
 		97DB8240282339B700FC2228 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 97AD222D28230B98001AFCC1 /* GeoHostApp */;
@@ -302,6 +399,53 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		97914B8C295570E1002000EA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazon.com.AWSLocationGeoPluginIntegrationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/GeoHostApp.app/GeoHostApp";
+			};
+			name = Debug;
+		};
+		97914B8D295570E1002000EA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazon.com.GeoStressTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/GeoHostApp.app/GeoHostApp";
+			};
+			name = Release;
+		};
 		97AD223A28230B9A001AFCC1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -524,6 +668,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		97914B8B295570E1002000EA /* Build configuration list for PBXNativeTarget "GeoStressTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				97914B8C295570E1002000EA /* Debug */,
+				97914B8D295570E1002000EA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		97AD222928230B98001AFCC1 /* Build configuration list for PBXProject "GeoHostApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoHostApp.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		978B1D6429515FFB0079E55A /* AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978B1D5E29515DEF0079E55A /* AsyncTesting.swift */; };
+		978B1D6529515FFB0079E55A /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978B1D5F29515DEF0079E55A /* AsyncExpectation.swift */; };
+		978B1D6629515FFB0079E55A /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978B1D6029515DEF0079E55A /* XCTestCase+AsyncTesting.swift */; };
 		97AD223228230B98001AFCC1 /* GeoHostAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AD223128230B98001AFCC1 /* GeoHostAppApp.swift */; };
 		97AD223428230B98001AFCC1 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AD223328230B98001AFCC1 /* ContentView.swift */; };
 		97AD223628230B9A001AFCC1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97AD223528230B9A001AFCC1 /* Assets.xcassets */; };
@@ -30,6 +33,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		978B1D5E29515DEF0079E55A /* AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncTesting.swift; sourceTree = "<group>"; };
+		978B1D5F29515DEF0079E55A /* AsyncExpectation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncExpectation.swift; sourceTree = "<group>"; };
+		978B1D6029515DEF0079E55A /* XCTestCase+AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AsyncTesting.swift"; sourceTree = "<group>"; };
 		97AD222E28230B98001AFCC1 /* GeoHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GeoHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		97AD223128230B98001AFCC1 /* GeoHostAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoHostAppApp.swift; sourceTree = "<group>"; };
 		97AD223328230B98001AFCC1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -63,6 +69,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		978B1D5D29515DEF0079E55A /* AsyncTesting */ = {
+			isa = PBXGroup;
+			children = (
+				978B1D5E29515DEF0079E55A /* AsyncTesting.swift */,
+				978B1D5F29515DEF0079E55A /* AsyncExpectation.swift */,
+				978B1D6029515DEF0079E55A /* XCTestCase+AsyncTesting.swift */,
+			);
+			name = AsyncTesting;
+			path = ../../../../../AmplifyAsyncTesting/Sources/AsyncTesting;
+			sourceTree = "<group>";
+		};
 		97AD222528230B98001AFCC1 = {
 			isa = PBXGroup;
 			children = (
@@ -86,6 +103,7 @@
 		97AD223028230B98001AFCC1 /* GeoHostApp */ = {
 			isa = PBXGroup;
 			children = (
+				978B1D5D29515DEF0079E55A /* AsyncTesting */,
 				97AD223128230B98001AFCC1 /* GeoHostAppApp.swift */,
 				97AD223328230B98001AFCC1 /* ContentView.swift */,
 				97AD223528230B9A001AFCC1 /* Assets.xcassets */,
@@ -265,6 +283,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				978B1D6429515FFB0079E55A /* AsyncTesting.swift in Sources */,
+				978B1D6529515FFB0079E55A /* AsyncExpectation.swift in Sources */,
+				978B1D6629515FFB0079E55A /* XCTestCase+AsyncTesting.swift in Sources */,
 				97DB824728233A1D00FC2228 /* AWSLocationGeoPluginIntegrationTests.swift in Sources */,
 				97DB82552823466800FC2228 /* TestConfigHelper.swift in Sources */,
 			);

--- a/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift.git",
       "state" : {
-        "revision" : "1846c60b9d50034f684384d8eef5e5aef7c40d6b",
-        "version" : "0.3.1"
+        "revision" : "afe23a2a2f6cf78e6d8803d7c9e0c8e6f50b6915",
+        "version" : "0.4.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "3a2b88928888b90feeec203137642fee7f1329e2",
-        "version" : "0.5.0"
+        "revision" : "c54c028cfc3ee70fde8c077547a1a1f6ef1137d9",
+        "version" : "0.6.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/smithy-swift.git",
       "state" : {
-        "revision" : "e4285fe2b80bcc4eabe67f82b1c84344ec86124d",
-        "version" : "0.5.0"
+        "revision" : "f59ed07c29d4e03f91ea8324edf7a2486bd86a9c",
+        "version" : "0.6.0"
       }
     },
     {

--- a/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoHostApp.xcodeproj/xcshareddata/xcschemes/GeoHostApp.xcscheme
+++ b/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoHostApp.xcodeproj/xcshareddata/xcschemes/GeoHostApp.xcscheme
@@ -32,9 +32,20 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "97AD225F28231287001AFCC1"
+               BlueprintIdentifier = "97DB823A282339B700FC2228"
                BuildableName = "AWSLocationGeoPluginIntegrationTests.xctest"
                BlueprintName = "AWSLocationGeoPluginIntegrationTests"
+               ReferencedContainer = "container:GeoHostApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97914B6D29556F38002000EA"
+               BuildableName = "GeoStressTests.xctest"
+               BlueprintName = "GeoStressTests"
                ReferencedContainer = "container:GeoHostApp.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoHostApp.xcodeproj/xcshareddata/xcschemes/GeoStressTests.xcscheme
+++ b/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoHostApp.xcodeproj/xcshareddata/xcschemes/GeoStressTests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "97914B7E295570E1002000EA"
+               BuildableName = "GeoStressTests.xctest"
+               BlueprintName = "GeoStressTests"
+               ReferencedContainer = "container:GeoHostApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoStressTests/GeoStressTests.swift
+++ b/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoStressTests/GeoStressTests.swift
@@ -1,0 +1,89 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+@testable import AWSCognitoAuthPlugin
+@testable import AWSLocationGeoPlugin
+
+final class GeoStressTests: XCTestCase {
+    let timeout = 30.0
+    let searchText = "coffee shop"
+    let coordinates = Geo.Coordinates(latitude: 39.7392, longitude: -104.9903)
+    let concurrencyLimit = 50
+    let amplifyConfigurationFile = "testconfiguration/AWSGeoStressTests-amplifyconfiguration"
+
+    override func setUp() {
+        continueAfterFailure = false
+        do {
+            try Amplify.add(plugin: AWSCognitoAuthPlugin())
+            try Amplify.add(plugin: AWSLocationGeoPlugin())
+            let configuration = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: amplifyConfigurationFile)
+            try Amplify.configure(configuration)
+        } catch {
+            XCTFail("Failed to initialize and configure Amplify: \(error)")
+        }
+        XCTAssertNotNil(Amplify.Geo.plugin)
+    }
+
+    override func tearDown() async throws {
+        await Amplify.reset()
+    }
+    
+    // MARK: - Stress Tests
+    
+    /// Test if concurrent execution of search(for: text) is successful
+    /// - Given: Geo plugin with a valid configuration.
+    /// - When:
+    ///    - I invoke search(for: text) from 50 tasks concurrently
+    /// - Then:
+    ///    - Place results are returned.
+    ///
+    func testMultipleSearchForText() async {
+        let successExpectation = asyncExpectation(description: "searchForText was successful", expectedFulfillmentCount: concurrencyLimit)
+        for _ in 1...concurrencyLimit {
+            Task {
+                do {
+                    let options = Geo.SearchForTextOptions(area: .near(coordinates))
+                    let places = try await Amplify.Geo.search(for: searchText, options: options)
+                    XCTAssertFalse(places.isEmpty)
+                    await successExpectation.fulfill()
+                } catch {
+                    XCTFail("Failed with error: \(error)")
+                }
+            }
+        }
+        
+        await waitForExpectations([successExpectation], timeout: timeout)
+    }
+    
+    /// Test if concurrent execution of search(for: coordinates) is successful
+    /// - Given: Geo plugin with a valid configuration.
+    /// - When:
+    ///    - I invoke search(for: coordinates) from 50 tasks concurrently
+    /// - Then:
+    ///    - Place results are returned.
+    ///
+    func testMultipleSearchForCoordinates() async {
+        let successExpectation = asyncExpectation(description: "searchForCoordinates was successful", expectedFulfillmentCount: concurrencyLimit)
+        for _ in 1...concurrencyLimit {
+            Task {
+                do {
+                    let places = try await Amplify.Geo.search(for: coordinates, options: nil)
+                    XCTAssertFalse(places.isEmpty)
+                    XCTAssertNotNil(places.first?.coordinates)
+                    await successExpectation.fulfill()
+                } catch {
+                    XCTFail("Failed with error: \(error)")
+                }
+            }
+        }
+        
+        await waitForExpectations([successExpectation], timeout: timeout)
+    }
+
+}

--- a/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoStressTests/README.md
+++ b/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoStressTests/README.md
@@ -1,0 +1,37 @@
+## Geo Stress Tests
+
+The following steps demonstrate how to set up Geo. Auth category is also required to allow unauthenticated and authenticated access.
+
+### Set-up
+
+1. `amplify init`
+
+2. `amplify add geo`
+
+```perl
+? Select which capability you want to add: `Map (visualize the geospatial data)` 
+? geo category resources require auth (Amazon Cognito). Do you want to add auth now? `Yes`
+  Do you want to use the default authentication and security configuration? `Default configuration`
+  How do you want users to be able to sign in? `Username`
+  Do you want to configure advanced settings? `No, I am done.`
+? Provide a name for the Map: `<default>`
+? Who can access this Map? `Authorized and Guest users`
+? Are you tracking commercial assets for your business in your app? `No, I do not track devices or I only need to track consumers' personal devices`
+? Do you want to configure advanced settings? `No`
+```
+
+3. `amplify add geo`
+
+```perl
+? Select which capability you want to add: `Location search (search by places, addresses, coordinates)`
+? geo category resources require auth (Amazon Cognito). Do you want to add auth now? `Yes`
+? Provide a name for the location search index (place index): `<default>`
+? Who can access this search index? `Authorized and Guest users`
+? Do you want to configure advanced settings? `No`
+```
+
+4. `amplify push`
+
+5. Copy `amplifyconfiguration.json` to a new file named `AWSGeoStressTests-amplifyconfiguration.json` inside `~/.aws-amplify/amplify-ios/testconfiguration/`.
+
+6. You can now run all of the integration tests. 


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Add stress tests for Geo checking for concurrent executions of `searchForText()` and `searchForCoordinates()` API.

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
~~- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
