### PR TITLE
chore: remove exit-with-failure from block-manual-release workflow

### DIFF
--- a/.github/workflows/release_block_manual_pr.yml
+++ b/.github/workflows/release_block_manual_pr.yml
@@ -30,4 +30,3 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           gh pr close $PR_NUMBER --comment "Invalid PR!  PRs targeting the release branch must be created by the GHA release workflow."
-          exit 1


### PR DESCRIPTION
*Description of changes:*

Remove exit-with-failure from block-manual-release workflow.  Because of the way the workflow works, it only runs when it’s not run by another workflow.  It closes the PR so that it cannot be merged.  It also previously exited the a failed check, but since it's designed to never run except when it should "fail", the failed check remained on subsequent PRs that were created by the release workflow.  This removes the failed exit on the end since it's not necessary and pollutes future release PRs.

*Check points: (check or cross out if not relevant)*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

*DataStore checkpoints (check when completed)*

- ~~[ ] Ran AWSDataStorePluginIntegrationTests~~
- ~~[ ] Ran AWSDataStorePluginV2Tests~~
- ~~[ ] Ran AWSDataStorePluginMultiAuthTests~~
- ~~[ ] Ran AWSDataStorePluginCPKTests~~
- ~~[ ] Ran AWSDataStorePluginAuthCognitoTests~~
- ~~[ ] Ran AWSDataStorePluginAuthIAMTests~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
