### PR TITLE
feat(storage) Support AWS SDK S3 transfer acceleration (feature parity with JavaScript/React)

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Configuration/AWSS3PluginOptions.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Configuration/AWSS3PluginOptions.swift
@@ -1,0 +1,47 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Foundation
+
+/// - Tag: AWSS3PluginOptions
+struct AWSS3PluginOptions {
+
+    /// - Tag: AWSS3PluginOptionsCodingKeys
+    enum CodingKeys: String, CodingKey {
+        
+        /// See: https://docs.amplify.aws/lib/storage/transfer-acceleration/q/platform/js/
+        /// - Tag: AWSS3PluginOptionsCodingKeys.useAccelerateEndpoint
+        case useAccelerateEndpoint
+    }
+
+    /// Attempts to extract the boolean under the
+    /// [useAccelerateEndpoint](x-source-tag://AWSS3PluginOptionsCodingKeys.useAccelerateEndpoint)
+    /// contained in the given dictionary.
+    ///
+    /// In other words,  a non-nil boolean is returned if:
+    ///
+    /// * The `pluginOptions` parameter is a dictionary ([String: Any])
+    /// * The `pluginOptions` dictionary contains a boolean key under the [useAccelerateEndpoint](x-source-tag://AWSS3PluginOptionsCodingKeys.useAccelerateEndpoint) key.
+    ///
+    /// - Tag: AWSS3PluginOptions.accelerateValue
+    static func accelerateValue(pluginOptions: Any?) throws -> Bool? {
+        guard let pluginOptions = pluginOptions as? [String:Any] else {
+            return nil
+        }
+        guard let value = pluginOptions[CodingKeys.useAccelerateEndpoint.rawValue] else {
+            return nil
+        }
+        guard let boolValue = value as? Bool else {
+            throw StorageError.validation(CodingKeys.useAccelerateEndpoint.rawValue,
+                                          "Expecting boolean value for key \(CodingKeys.useAccelerateEndpoint.rawValue)",
+                                          "Ensure the value associated with \(CodingKeys.useAccelerateEndpoint.rawValue) is a boolean",
+                                          nil)
+        }
+        return boolValue
+    }
+}

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3PreSignedURLBuilderAdapter.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3PreSignedURLBuilderAdapter.swift
@@ -34,9 +34,12 @@ class AWSS3PreSignedURLBuilderAdapter: AWSS3PreSignedURLBuilderBehavior {
     /// - Returns: Pre-Signed URL
     func getPreSignedURL(key: String,
                          signingOperation: AWSS3SigningOperation,
+                         accelerate: Bool? = nil,
                          expires: Int64? = nil) async throws -> URL {
         let expiresDate = Date(timeIntervalSinceNow: Double(expires ?? defaultExpiration))
         let expiration = Int64(expiresDate.timeIntervalSinceNow)
+        let config = (accelerate == nil) ? self.config : S3ClientConfigurationProxy(target: self.config,
+                                                                                    accelerateOverride: accelerate)
         let preSignedUrl: URL?
         switch signingOperation {
         case .getObject:

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3PreSignedURLBuilderBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3PreSignedURLBuilderBehavior.swift
@@ -12,26 +12,35 @@ import AWSS3
 import ClientRuntime
 import AWSClientRuntime
 
+/// - Tag: AWSS3PreSignedURLBuilderError
 enum AWSS3PreSignedURLBuilderError: Error {
+
+    /// Returned by an implementation of a
+    /// [AWSS3PreSignedURLBuilderBehavior](x-source-tag://AWSS3PreSignedURLBuilderBehavior)
+    ///
+    /// - Tag: AWSS3PreSignedURLBuilderError.failed
     case failed(reason: String, error: Error?)
 }
 
-// Behavior that the implemenation class for AWSS3PreSignedURLBuilder will use.
+/// Behavior that the implemenation class for AWSS3PreSignedURLBuilder will use.
+///
+/// - Tag: AWSS3PreSignedURLBuilderBehavior
 protocol AWSS3PreSignedURLBuilderBehavior {
 
-    /// Gets a pre-signed URL.
+    /// Attempts to generate a pre-signed URL.
+    ///
+    /// - Parameters:
+    ///     - key: String represnting the key of an S3 object.
+    ///     - signingOperation: [AWSS3SigningOperation](x-source-tag://AWSS3SigningOperation)
+    ///                    (get, put, upload part) for which the URL will be generated.
+    ///     - accelerate: Optional boolean indicating wether or not to enable S3 bucket
+    ///                [transfer acceleration](https://docs.amplify.aws/lib/storage/transfer-acceleration/q/platform/js/)
+    ///     - expires: Int64 indicating the expiration as the number of milliseconds since the 1970 epoc.
     /// - Returns: Pre-Signed URL
-    func getPreSignedURL(key: String, signingOperation: AWSS3SigningOperation, expires: Int64?) async throws -> URL
-}
-
-extension AWSS3PreSignedURLBuilderBehavior {
-
-    func getPreSignedURL(key: String, signingOperation: AWSS3SigningOperation, expires: Int64? = nil) async throws -> URL {
-        try await getPreSignedURL(key: key, signingOperation: signingOperation, expires: expires)
-    }
-
-    func getPreSignedURL(key: String, expires: Int64? = nil) async throws -> URL {
-        try await getPreSignedURL(key: key, signingOperation: .getObject, expires: expires)
-    }
-
+    ///
+    /// - Tag: AWSS3PreSignedURLBuilderBehavior.getPreSignedURL
+    func getPreSignedURL(key: String,
+                         signingOperation: AWSS3SigningOperation,
+                         accelerate: Bool?,
+                         expires: Int64?) async throws -> URL
 }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/S3ClientConfigurationProxy.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/S3ClientConfigurationProxy.swift
@@ -1,0 +1,133 @@
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import AWSS3
+import AWSClientRuntime
+import ClientRuntime
+import Foundation
+
+/// Convenience proxy class around a
+/// [S3ClientConfigurationProtocol](x-source-tag://S3ClientConfigurationProtocol)
+/// implementaitons that allows Amplify to change configuration values JIT.
+///
+/// - Tag: S3ClientConfigurationProxy
+struct S3ClientConfigurationProxy {
+
+    /// - Tag: S3ClientConfigurationProxy.target
+    var target: S3ClientConfigurationProtocol
+
+    /// - Tag: S3ClientConfigurationProxy.accelerateOverride
+    var accelerateOverride: Bool?
+}
+
+extension S3ClientConfigurationProxy: S3ClientConfigurationProtocol {
+    
+    var accelerate: Bool? {
+        if let accelerateOverride = accelerateOverride {
+            return accelerateOverride
+        }
+        return target.accelerate
+    }
+    
+    var disableMultiRegionAccessPoints: Bool? {
+        return target.disableMultiRegionAccessPoints
+    }
+    
+    var endpointResolver: EndpointResolver {
+        return target.endpointResolver
+    }
+    
+    var forcePathStyle: Bool? {
+        return target.forcePathStyle
+    }
+    
+    var useArnRegion: Bool? {
+        return target.useArnRegion
+    }
+    
+    var useGlobalEndpoint: Bool? {
+        return target.useGlobalEndpoint
+    }
+    
+    var credentialsProvider: AWSClientRuntime.CredentialsProvider {
+        get {
+            return target.credentialsProvider
+        }
+        set(newValue) {
+            target.credentialsProvider = newValue
+        }
+    }
+    
+    var region: String? {
+        get {
+            return target.region
+        }
+        set(newValue) {
+            target.region = newValue
+        }
+    }
+    
+    var signingRegion: String? {
+        get {
+            return target.signingRegion
+        }
+        set(newValue) {
+            target.signingRegion = newValue
+        }
+    }
+    
+    var regionResolver: RegionResolver? {
+        get {
+            return target.regionResolver
+        }
+        set(newValue) {
+            target.regionResolver = newValue
+        }
+    }
+    
+    var frameworkMetadata: FrameworkMetadata? {
+        get {
+            return target.frameworkMetadata
+        }
+        set(newValue) {
+            target.frameworkMetadata = newValue
+        }
+    }
+    
+    var useFIPS: Bool? {
+        get {
+            return target.useFIPS
+        }
+        set(newValue) {
+            target.useFIPS = newValue
+        }
+    }
+    
+    var useDualStack: Bool? {
+        get {
+            return target.useDualStack
+        }
+        set(newValue) {
+            target.useDualStack = newValue
+        }
+    }
+    
+    var logger: LogAgent {
+        return target.logger
+    }
+    
+    var retryer: ClientRuntime.SDKRetryer {
+        return target.retryer
+    }
+    
+    var endpoint: String? {
+        get {
+            return target.endpoint
+        }
+        set(newValue) {
+            target.endpoint = newValue
+        }
+    }
+}

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadDataOperation.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadDataOperation.swift
@@ -91,7 +91,8 @@ class AWSS3StorageDownloadDataOperation: AmplifyInProcessReportingOperation<
             do {
                 let prefix = try await prefixResolver.resolvePrefix(for: request.options.accessLevel, targetIdentityId: request.options.targetIdentityId)
                 let serviceKey = prefix + request.key
-                storageService.download(serviceKey: serviceKey, fileURL: nil) { [weak self] event in
+                let accelerate = try AWSS3PluginOptions.accelerateValue(pluginOptions: request.options.pluginOptions)
+                storageService.download(serviceKey: serviceKey, fileURL: nil, accelerate: accelerate) { [weak self] event in
                     self?.onServiceEvent(event: event)
                 }
             } catch {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadFileOperation.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadFileOperation.swift
@@ -94,7 +94,8 @@ class AWSS3StorageDownloadFileOperation: AmplifyInProcessReportingOperation<
             do {
                 let prefix = try await prefixResolver.resolvePrefix(for: request.options.accessLevel, targetIdentityId: request.options.targetIdentityId)
                 let serviceKey = prefix + request.key
-                storageService.download(serviceKey: serviceKey, fileURL: self.request.local) { [weak self] event in
+                let accelerate = try AWSS3PluginOptions.accelerateValue(pluginOptions: request.options.pluginOptions)
+                storageService.download(serviceKey: serviceKey, fileURL: self.request.local, accelerate: accelerate) { [weak self] event in
                     self?.onServiceEvent(event: event)
                 }
             } catch {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageGetURLOperation.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageGetURLOperation.swift
@@ -63,8 +63,11 @@ class AWSS3StorageGetURLOperation: AmplifyOperation<
             do {
                 let prefix = try await prefixResolver.resolvePrefix(for: request.options.accessLevel, targetIdentityId: request.options.targetIdentityId)
                 let serviceKey = prefix + request.key
+                let accelerate = try AWSS3PluginOptions.accelerateValue(pluginOptions: request.options.pluginOptions)
                 storageService.getPreSignedURL(serviceKey: serviceKey,
-                                                    expires: request.options.expires) { [weak self] event in
+                                               signingOperation: .getObject,
+                                               accelerate: accelerate,
+                                               expires: request.options.expires) { [weak self] event in
                     self?.onServiceEvent(event: event)
                 }
             } catch {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadDataOperation.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadDataOperation.swift
@@ -92,18 +92,21 @@ class AWSS3StorageUploadDataOperation: AmplifyInProcessReportingOperation<
                 let prefix = try await prefixResolver.resolvePrefix(for: request.options.accessLevel, targetIdentityId: request.options.targetIdentityId)
                 let serviceKey = prefix + request.key
                 let serviceMetadata = StorageRequestUtils.getServiceMetadata(request.options.metadata)
+                let accelerate = try AWSS3PluginOptions.accelerateValue(pluginOptions: request.options.pluginOptions)
                 if request.data.count > StorageUploadDataRequest.Options.multiPartUploadSizeThreshold {
                     storageService.multiPartUpload(serviceKey: serviceKey,
                                                         uploadSource: .data(request.data),
                                                         contentType: request.options.contentType,
-                                                        metadata: serviceMetadata) { [weak self] event in
+                                                        metadata: serviceMetadata,
+                                                        accelerate: accelerate) { [weak self] event in
                         self?.onServiceEvent(event: event)
                     }
                 } else {
                     storageService.upload(serviceKey: serviceKey,
                                                uploadSource: .data(request.data),
                                                contentType: request.options.contentType,
-                                               metadata: serviceMetadata) { [weak self] event in
+                                               metadata: serviceMetadata,
+                                               accelerate: accelerate) { [weak self] event in
                         self?.onServiceEvent(event: event)
                     }
                 }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadFileOperation.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadFileOperation.swift
@@ -105,18 +105,21 @@ class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation<
                 let prefix = try await prefixResolver.resolvePrefix(for: request.options.accessLevel, targetIdentityId: request.options.targetIdentityId)
                 let serviceKey = prefix + request.key
                 let serviceMetadata = StorageRequestUtils.getServiceMetadata(request.options.metadata)
+                let accelerate = try AWSS3PluginOptions.accelerateValue(pluginOptions: request.options.pluginOptions)
                 if uploadSize > StorageUploadFileRequest.Options.multiPartUploadSizeThreshold {
                     storageService.multiPartUpload(serviceKey: serviceKey,
                                                         uploadSource: .local(request.local),
                                                         contentType: request.options.contentType,
-                                                        metadata: serviceMetadata) { [weak self] event in
+                                                        metadata: serviceMetadata,
+                                                        accelerate: accelerate) { [weak self] event in
                         self?.onServiceEvent(event: event)
                     }
                 } else {
                     storageService.upload(serviceKey: serviceKey,
                                                uploadSource: .local(request.local),
                                                contentType: request.options.contentType,
-                                               metadata: serviceMetadata) { [weak self] event in
+                                               metadata: serviceMetadata,
+                                               accelerate: accelerate) { [weak self] event in
                         self?.onServiceEvent(event: event)
                     }
                 }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+DownloadBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+DownloadBehavior.swift
@@ -12,7 +12,8 @@ extension AWSS3StorageService {
 
     func download(serviceKey: String,
                   fileURL: URL?,
-                  onEvent: @escaping StorageServiceDownloadEventHandler) {
+                  accelerate: Bool?,
+              onEvent: @escaping StorageServiceDownloadEventHandler) {
         let fail: (Error) -> Void = { error in
             let storageError = StorageError(error: error)
             onEvent(.failed(storageError))
@@ -27,7 +28,10 @@ extension AWSS3StorageService {
 
         Task {
             do {
-                let preSignedURL = try await preSignedURLBuilder.getPreSignedURL(key: serviceKey)
+                let preSignedURL = try await preSignedURLBuilder.getPreSignedURL(key: serviceKey,
+                                                                                 signingOperation: .getObject,
+                                                                                 accelerate: accelerate,
+                                                                                 expires: nil)
                 startDownload(preSignedURL: preSignedURL, transferTask: transferTask)
             } catch {
                 onEvent(.failed(StorageError.unknown("Failed to get pre-signed URL", nil)))

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+GetPreSignedURLBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+GetPreSignedURLBehavior.swift
@@ -12,11 +12,14 @@ extension AWSS3StorageService {
 
     func getPreSignedURL(serviceKey: String,
                          signingOperation: AWSS3SigningOperation = .getObject,
+                         accelerate: Bool?,
                          expires: Int,
                          onEvent: @escaping StorageServiceGetPreSignedURLEventHandler) {
         Task {
             do {
                 onEvent(.completed(try await preSignedURLBuilder.getPreSignedURL(key: serviceKey,
+                                                                                 signingOperation: signingOperation,
+                                                                                 accelerate: accelerate,
                                                                                  expires: Int64(expires))))
             } catch {
                 onEvent(.failed(StorageError.unknown("Failed to get pre-signed URL", nil)))

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+MultiPartUploadBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+MultiPartUploadBehavior.swift
@@ -14,6 +14,7 @@ extension AWSS3StorageService {
                          uploadSource: UploadSource,
                          contentType: String?,
                          metadata: [String: String]?,
+                         accelerate: Bool?,
                          onEvent: @escaping StorageServiceMultiPartUploadEventHandler) {
         let fail: (Error) -> Void = { error in
             let storageError = StorageError(error: error)

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+UploadBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+UploadBehavior.swift
@@ -14,6 +14,7 @@ extension AWSS3StorageService {
                 uploadSource: UploadSource,
                 contentType: String?,
                 metadata: [String: String]?,
+                accelerate: Bool?,
                 onEvent: @escaping StorageServiceUploadEventHandler) {
         let fail: (Error) -> Void = { error in
             let storageError = StorageError(error: error)
@@ -34,7 +35,9 @@ extension AWSS3StorageService {
 
             do {
                 let preSignedURL = try await preSignedURLBuilder.getPreSignedURL(key: serviceKey,
-                                                                                 signingOperation: .putObject)
+                                                                                 signingOperation: .putObject,
+                                                                                 accelerate: accelerate,
+                                                                                 expires: nil)
                 startUpload(preSignedURL: preSignedURL,
                             fileURL: uploadFileURL,
                             contentType: contentType,

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageServiceBehaviour.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageServiceBehaviour.swift
@@ -39,10 +39,12 @@ protocol AWSS3StorageServiceBehaviour {
 
     func download(serviceKey: String,
                   fileURL: URL?,
+                  accelerate: Bool?,
                   onEvent: @escaping StorageServiceDownloadEventHandler)
 
     func getPreSignedURL(serviceKey: String,
                          signingOperation: AWSS3SigningOperation,
+                         accelerate: Bool?,
                          expires: Int,
                          onEvent: @escaping StorageServiceGetPreSignedURLEventHandler)
 
@@ -50,12 +52,14 @@ protocol AWSS3StorageServiceBehaviour {
                 uploadSource: UploadSource,
                 contentType: String?,
                 metadata: [String: String]?,
+                accelerate: Bool?,
                 onEvent: @escaping StorageServiceUploadEventHandler)
 
     func multiPartUpload(serviceKey: String,
                          uploadSource: UploadSource,
                          contentType: String?,
                          metadata: [String: String]?,
+                         accelerate: Bool?,
                          onEvent: @escaping StorageServiceMultiPartUploadEventHandler)
 
     func list(prefix: String,
@@ -70,6 +74,6 @@ extension AWSS3StorageServiceBehaviour {
     func getPreSignedURL(serviceKey: String,
                          expires: Int,
                          onEvent: @escaping StorageServiceGetPreSignedURLEventHandler) {
-        getPreSignedURL(serviceKey: serviceKey, signingOperation: .getObject, expires: expires, onEvent: onEvent)
+        getPreSignedURL(serviceKey: serviceKey, signingOperation: .getObject, accelerate: nil, expires: expires, onEvent: onEvent)
     }
 }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
@@ -128,7 +128,9 @@ class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
                     let operation = AWSS3SigningOperation.uploadPart(partNumber: partNumber, uploadId: uploadId)
                     let preSignedURL = try await serviceProxy.preSignedURLBuilder.getPreSignedURL(
                         key: self.key,
-                        signingOperation: operation
+                        signingOperation: operation,
+                        accelerate: nil,
+                        expires: nil
                     )
                     startUploadPart(partialFileURL, preSignedURL)
                 } catch {

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Configuration/S3ClientConfigurationProxyTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Configuration/S3ClientConfigurationProxyTests.swift
@@ -1,0 +1,79 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import AWSS3
+import AWSClientRuntime
+import ClientRuntime
+import Foundation
+import XCTest
+
+@testable import AWSS3StoragePlugin
+
+final class S3ClientConfigurationProxyTests: XCTestCase {
+
+    /// Given: A client configuration that has a value for a property such as `accelerate`.
+    /// When: An override is set on its proxy configuration.
+    /// Then: The proxy returns the value from the override.
+    func testPropertyOverrides() async throws {
+        let target = try await S3Client.S3ClientConfiguration()
+        target.accelerate = true
+        
+        let sut = S3ClientConfigurationProxy(target: target, accelerateOverride: false)
+        XCTAssertEqual(sut.accelerate, false)
+        XCTAssertEqual(target.accelerate, true)
+    }
+
+    /// Given: A client configuration with random values.
+    /// When: A proxy configuration around it is created **without overrides**.
+    /// Then: The values returned by the proxy are equal to those from the **client configuration**.
+    func testPropertyBypass() async throws {
+        let target = try await S3Client.S3ClientConfiguration(
+            accelerate: Bool.random(),
+            credentialsProvider: nil,
+            disableMultiRegionAccessPoints: Bool.random(),
+            endpoint: UUID().uuidString,
+            endpointResolver: nil,
+            forcePathStyle: Bool.random(),
+            frameworkMetadata: nil,
+            regionResolver: nil,
+            signingRegion: UUID().uuidString,
+            useArnRegion: Bool.random(),
+            useDualStack: Bool.random(),
+            useFIPS: Bool.random(),
+            useGlobalEndpoint: Bool.random()
+        )
+        
+        var sut = S3ClientConfigurationProxy(target: target, accelerateOverride: nil)
+        XCTAssertEqual(sut.accelerate, target.accelerate)
+        XCTAssertEqual(sut.disableMultiRegionAccessPoints, target.disableMultiRegionAccessPoints)
+        XCTAssertEqual(sut.forcePathStyle, target.forcePathStyle)
+        XCTAssertEqual(sut.useArnRegion, target.useArnRegion)
+        XCTAssertEqual(sut.useDualStack, target.useDualStack)
+        XCTAssertEqual(sut.region, target.region)
+        XCTAssertEqual(sut.signingRegion, target.signingRegion)
+        XCTAssertEqual(sut.useFIPS, target.useFIPS)
+        XCTAssertEqual(sut.useGlobalEndpoint, target.useGlobalEndpoint)
+        XCTAssertEqual(sut.endpoint, target.endpoint)
+
+        sut.region = UUID().uuidString
+        sut.signingRegion = UUID().uuidString
+        sut.useFIPS = !(sut.useFIPS ?? false)
+        sut.useDualStack = !(sut.useDualStack ?? false)
+        sut.endpoint = UUID().uuidString
+
+        XCTAssertEqual(sut.accelerate, target.accelerate)
+        XCTAssertEqual(sut.disableMultiRegionAccessPoints, target.disableMultiRegionAccessPoints)
+        XCTAssertEqual(sut.forcePathStyle, target.forcePathStyle)
+        XCTAssertEqual(sut.useArnRegion, target.useArnRegion)
+        XCTAssertEqual(sut.useDualStack, target.useDualStack)
+        XCTAssertEqual(sut.region, target.region)
+        XCTAssertEqual(sut.signingRegion, target.signingRegion)
+        XCTAssertEqual(sut.useFIPS, target.useFIPS)
+        XCTAssertEqual(sut.useGlobalEndpoint, target.useGlobalEndpoint)
+        XCTAssertEqual(sut.endpoint, target.endpoint)
+    }
+}

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockAWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockAWSS3StorageService.swift
@@ -68,7 +68,7 @@ public class MockAWSS3StorageService: AWSS3StorageServiceBehaviour {
     public func reset() {
     }
 
-    public func download(serviceKey: String, fileURL: URL?, onEvent: @escaping StorageServiceDownloadEventHandler) {
+    public func download(serviceKey: String, fileURL: URL?, accelerate: Bool?, onEvent: @escaping StorageServiceDownloadEventHandler) {
         downloadCalled += 1
 
         downloadServiceKey = serviceKey
@@ -80,7 +80,8 @@ public class MockAWSS3StorageService: AWSS3StorageServiceBehaviour {
     }
 
     public func getPreSignedURL(serviceKey: String,
-                         signingOperation: AWSS3SigningOperation = .getObject,
+                         signingOperation: AWSS3SigningOperation,
+                         accelerate: Bool?,
                          expires: Int,
                          onEvent: @escaping StorageServiceGetPreSignedURLEventHandler) {
         getPreSignedURLCalled += 1
@@ -97,6 +98,7 @@ public class MockAWSS3StorageService: AWSS3StorageServiceBehaviour {
                        uploadSource: UploadSource,
                        contentType: String?,
                        metadata: [String: String]?,
+                       accelerate: Bool?,
                        onEvent: @escaping StorageServiceUploadEventHandler) {
         uploadCalled += 1
 
@@ -114,6 +116,7 @@ public class MockAWSS3StorageService: AWSS3StorageServiceBehaviour {
                                 uploadSource: UploadSource,
                                 contentType: String?,
                                 metadata: [String: String]?,
+                                accelerate: Bool?,
                                 onEvent: @escaping StorageServiceMultiPartUploadEventHandler) {
         multiPartUploadCalled += 1
 

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginAccelerateIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginAccelerateIntegrationTests.swift
@@ -1,0 +1,100 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+import AWSS3StoragePlugin
+import var CommonCrypto.CC_MD5_DIGEST_LENGTH
+import func CommonCrypto.CC_MD5
+import typealias CommonCrypto.CC_LONG
+
+class AWSS3StoragePluginAccelerateIntegrationTests: AWSS3StoragePluginTestBase {
+
+    var useAccelerateEndpoint = false
+
+    /// Given: A data object.
+    /// When: It's uploaded with acceleration turned-off explicity.
+    /// Then: The operation completes successfully.
+    func testUploadDataWithAccelerateDisabledExplicitly() async throws {
+        let key = UUID().uuidString
+        let data = try XCTUnwrap(key.data(using: .utf8))
+        let task = Amplify.Storage.uploadData(key: key,
+                                              data: data,
+                                              options: .init(pluginOptions:["useAccelerateEndpoint": useAccelerateEndpoint]))
+        _ = try await task.value
+        try await Amplify.Storage.remove(key: key)
+    }
+
+    /// Given: A data object.
+    /// When: It's uploaded with acceleration misconfigured.
+    /// Then: The operation fails.
+    func testUploadDataWithAccelerateDisabledExplicitlyToWrongType() async throws {
+        let key = UUID().uuidString
+        let data = try XCTUnwrap(key.data(using: .utf8))
+        do {
+            let task = Amplify.Storage.uploadData(key: key,
+                                                  data: data,
+                                                  options: .init(pluginOptions:["useAccelerateEndpoint": "false"]))
+            _ = try await task.value
+            XCTFail("Expecting error from bogus useAccelerateEndpoint value type (String)")
+            try await Amplify.Storage.remove(key: key)
+        } catch {
+            XCTAssertNotNil(error)
+        }
+    }
+
+    /// Given: A file.
+    /// When: It's uploaded with acceleration turned-off explicity.
+    /// Then: The operation completes successfully.
+    func testUploadFile() async throws {
+        let key = UUID().uuidString
+        let filePath = NSTemporaryDirectory() + key + ".tmp"
+
+        let fileURL = URL(fileURLWithPath: filePath)
+        FileManager.default.createFile(atPath: filePath, contents: key.data(using: .utf8), attributes: nil)
+        defer {
+            try? FileManager.default.removeItem(at: fileURL)
+        }
+
+        let task = Amplify.Storage.uploadFile(key: key,
+                                              local: fileURL,
+                                              options: .init(pluginOptions:["useAccelerateEndpoint": useAccelerateEndpoint]))
+        _ = try await task.value
+        try await Amplify.Storage.remove(key: key)
+    }
+
+    /// Given: A large data object.
+    /// When: It's uploaded with acceleration turned-off explicity.
+    /// Then: The operation completes successfully.
+    func testUploadLargeData() async throws {
+        let key = UUID().uuidString
+        let task = Amplify.Storage.uploadData(key: key,
+                                              data: AWSS3StoragePluginTestBase.largeDataObject,
+                                              options: .init(pluginOptions:["useAccelerateEndpoint": useAccelerateEndpoint]))
+        _ = try await task.value
+        try await Amplify.Storage.remove(key: key)
+    }
+
+    /// Given: An object in storage.
+    /// When: It's downloaded with acceleration turned-off explicity.
+    /// Then: The operation completes successfully with the data retrieved.
+    func testDownloadDataToMemory() async throws {
+        let key = UUID().uuidString
+        let data = try XCTUnwrap(key.data(using: .utf8))
+        let uploadTask = Amplify.Storage.uploadData(key: key,
+                                                    data: data,
+                                                    options: .init(pluginOptions:["useAccelerateEndpoint": useAccelerateEndpoint]))
+        _ = try await uploadTask.value
+
+        let downloadTask = Amplify.Storage.downloadData(key: key,
+                                                        options: .init(pluginOptions:["useAccelerateEndpoint": useAccelerateEndpoint]))
+        let downloadedData = try await downloadTask.value
+        XCTAssertEqual(downloadedData, data)
+
+        try await Amplify.Storage.remove(key: key)
+    }
+}

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0311113528EBED6500D58441 /* Tests.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 0311113428EBED6500D58441 /* Tests.xcconfig */; };
 		031BC3F328EC9B2C0047B2E8 /* AppIcon.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 031BC3F228EC9B2C0047B2E8 /* AppIcon.xcassets */; };
+		565DF1702953BAEA000DCCF7 /* AWSS3StoragePluginAccelerateIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565DF16F2953BAEA000DCCF7 /* AWSS3StoragePluginAccelerateIntegrationTests.swift */; };
 		681DFEB228E748270000C36A /* AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEAF28E748270000C36A /* AsyncTesting.swift */; };
 		681DFEB328E748270000C36A /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEB028E748270000C36A /* AsyncExpectation.swift */; };
 		681DFEB428E748270000C36A /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEB128E748270000C36A /* XCTestCase+AsyncTesting.swift */; };
@@ -47,6 +48,7 @@
 		0311113428EBED6500D58441 /* Tests.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Tests.xcconfig; sourceTree = "<group>"; };
 		0311113828EBEEA700D58441 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		031BC3F228EC9B2C0047B2E8 /* AppIcon.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = AppIcon.xcassets; sourceTree = "<group>"; };
+		565DF16F2953BAEA000DCCF7 /* AWSS3StoragePluginAccelerateIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3StoragePluginAccelerateIntegrationTests.swift; sourceTree = "<group>"; };
 		681DFEAF28E748270000C36A /* AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncTesting.swift; sourceTree = "<group>"; };
 		681DFEB028E748270000C36A /* AsyncExpectation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncExpectation.swift; sourceTree = "<group>"; };
 		681DFEB128E748270000C36A /* XCTestCase+AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AsyncTesting.swift"; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 			children = (
 				684FB0C128BEB44700C8A6EB /* Helpers */,
 				684FB08628BEAF8E00C8A6EB /* AWSS3StoragePluginAccessLevelTests.swift */,
+				565DF16F2953BAEA000DCCF7 /* AWSS3StoragePluginAccelerateIntegrationTests.swift */,
 				684FB08428BEAF8E00C8A6EB /* AWSS3StoragePluginBasicIntegrationTests.swift */,
 				684FB08028BEAF8E00C8A6EB /* AWSS3StoragePluginConfigurationTests.swift */,
 				684FB08328BEAF8E00C8A6EB /* AWSS3StoragePluginNegativeTests.swift */,
@@ -343,6 +346,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				565DF1702953BAEA000DCCF7 /* AWSS3StoragePluginAccelerateIntegrationTests.swift in Sources */,
 				684FB0C328BEB45600C8A6EB /* AuthSignInHelper.swift in Sources */,
 				681DFEB228E748270000C36A /* AsyncTesting.swift in Sources */,
 				68828E4828C2AAA6006E7C0A /* AWSS3StoragePluginGetDataResumabilityTests.swift in Sources */,


### PR DESCRIPTION
# Issue #s

https://github.com/aws-amplify/amplify-swift/issues/2591
https://github.com/aws-amplify/amplify-swift/issues/1542

# Description of changes

This change makes it possible to leverage the existing AWS SDK S3 configuration in the same way [that it is done for Javascript/React](https://docs.amplify.aws/lib/storage/transfer-acceleration/q/platform/js/). #featureparity

# Check points: (check or cross out if not relevant)

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] If breaking change, documentation/changelog update with migration instructions

# Testing Procedure Followed

1. Ensure the S3 bucket used by Amplify has **Transfer Acceleration** _disabled_.
    ![Screenshot_2022-12-21_at_11_06_40_AM](https://user-images.githubusercontent.com/1117904/208966078-44b08198-447d-42b3-8431-a3a159e35ba4.png)
2. Ensure all integration tests pass.
3. Enable transfer acceleration locally by updating the tests under `AWSS3StoragePluginAccelerateIntegrationTests` setting `useAccelerateEndpoint` to  **true**.
4. Run the integration tests. They should all **fail**.
5. Enable **Transfer Acceleration**  using the AWS Console.
    ![Screenshot_2022-12-21_at_11_06_55_AM](https://user-images.githubusercontent.com/1117904/208967102-dcf0baff-4653-440d-8db9-0e28c7909b1b.png)
6. Ensure the integration tests now pass.
    ![Screenshot_2022-12-21_at_11_12_06_AM](https://user-images.githubusercontent.com/1117904/208967360-2361bd46-1a8a-4d65-8474-086ec245592c.png)
8. Disable  transfer acceleration locally by updating the tests under `AWSS3StoragePluginAccelerateIntegrationTests` setting `useAccelerateEndpoint` to  **false**.
9. Ensure the integration tests pass, even though the client is no longer using the `accelerate` feature and the S3 bucket still has it enabled.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
