### PR TITLE
chore(storage) Simplifying AWSS3StoragePluginAccessLevelTests and AWS…

### DIFF
--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginBasicIntegrationTests.swift
@@ -17,13 +17,10 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Given: An data object
     /// When: Upload the data
     /// Then: The operation completes successfully
-    func testUploadData() async {
+    func testUploadData() async throws {
         let key = UUID().uuidString
         let data = key.data(using: .utf8)!
-        let completeInvoked = asyncExpectation(description: "Completed is invoked")
-        await wait(with: completeInvoked) {
-            return try await Amplify.Storage.uploadData(key: key, data: data, options: nil).value
-        }
+        _ = try await Amplify.Storage.uploadData(key: key, data: data, options: nil).value
         
         // Remove the key
         await remove(key: key)
@@ -32,14 +29,11 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Given: A empty data object
     /// When: Upload the data
     /// Then: The operation completes successfully
-    func testUploadEmptyData() async {
+    func testUploadEmptyData() async throws {
         let key = UUID().uuidString
         let data = "".data(using: .utf8)!
-        let completeInvoked = asyncExpectation(description: "Completed is invoked")
-        await wait(with: completeInvoked) {
-            return try await Amplify.Storage.uploadData(key: key, data: data, options: nil).value
-        }
-        
+        _ = try await Amplify.Storage.uploadData(key: key, data: data, options: nil).value
+
         // Remove the key
         await remove(key: key)
     }
@@ -47,17 +41,14 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Given: A file with contents
     /// When: Upload the file
     /// Then: The operation completes successfully
-    func testUploadFile() async {
+    func testUploadFile() async throws {
         let key = UUID().uuidString
         let filePath = NSTemporaryDirectory() + key + ".tmp"
 
         let fileURL = URL(fileURLWithPath: filePath)
         FileManager.default.createFile(atPath: filePath, contents: key.data(using: .utf8), attributes: nil)
 
-        let completeInvoked = asyncExpectation(description: "Completed is invoked")
-        await wait(with: completeInvoked) {
-            return try await Amplify.Storage.uploadFile(key: key, local: fileURL, options: nil).value
-        }
+        _ = try await Amplify.Storage.uploadFile(key: key, local: fileURL, options: nil).value
         // Remove the key
         await remove(key: key)
     }
@@ -65,16 +56,13 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Given: A file with empty contents
     /// When: Upload the file
     /// Then: The operation completes successfully
-    func testUploadFileEmptyData() async {
+    func testUploadFileEmptyData() async throws {
         let key = UUID().uuidString
         let filePath = NSTemporaryDirectory() + key + ".tmp"
         let fileURL = URL(fileURLWithPath: filePath)
         FileManager.default.createFile(atPath: filePath, contents: "".data(using: .utf8), attributes: nil)
 
-        let completeInvoked = asyncExpectation(description: "Completed is invoked")
-        await wait(with: completeInvoked) {
-            return try await Amplify.Storage.uploadFile(key: key, local: fileURL, options: nil).value
-        }
+        _ = try await Amplify.Storage.uploadFile(key: key, local: fileURL, options: nil).value
         // Remove the key
         await remove(key: key)
     }
@@ -82,35 +70,21 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Given: A large  data object
     /// When: Upload the data
     /// Then: The operation completes successfully
-    func testUploadLargeData() async {
+    func testUploadLargeData() async throws {
         let key = UUID().uuidString
 
-        let done = asyncExpectation(description: "done")
-        Task {
-            do {
-                let uploadKey = try await Amplify.Storage.uploadData(key: key,
-                                                            data: AWSS3StoragePluginTestBase.largeDataObject,
-                                                            options: nil).value
-                XCTAssertEqual(uploadKey, key)
-            } catch {
-                XCTFail("Error: \(error)")
-            }
-            await done.fulfill()
-        }
-        await waitForExpectations([done], timeout: TestCommonConstants.networkTimeout)
+        let uploadKey = try await Amplify.Storage.uploadData(key: key,
+                                                             data: AWSS3StoragePluginTestBase.largeDataObject,
+                                                             options: nil).value
+        XCTAssertEqual(uploadKey, key)
 
-        let removeDone = asyncExpectation(description: "remove done")
-        Task {
-            try await Amplify.Storage.remove(key: key)
-            await removeDone.fulfill()
-        }
-        await waitForExpectations([removeDone], timeout: TestCommonConstants.networkTimeout)
+        try await Amplify.Storage.remove(key: key)
     }
 
     /// Given: A large file
     /// When: Upload the file
     /// Then: The operation completes successfully
-    func testUploadLargeFile() async {
+    func testUploadLargeFile() async throws {
         let key = UUID().uuidString
         let filePath = NSTemporaryDirectory() + key + ".tmp"
         let fileURL = URL(fileURLWithPath: filePath)
@@ -119,10 +93,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
                                        contents: AWSS3StoragePluginTestBase.largeDataObject,
                                        attributes: nil)
 
-        let completeInvoked = asyncExpectation(description: "Completed is invoked")
-        await wait(with: completeInvoked, timeout: 600) {
-            return try await Amplify.Storage.uploadFile(key: key, local: fileURL, options: nil).value
-        }
+        _ = try await Amplify.Storage.uploadFile(key: key, local: fileURL, options: nil).value
         // Remove the key
         await remove(key: key)
     }
@@ -130,13 +101,10 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Given: An object in storage
     /// When: Call the downloadData API
     /// Then: The operation completes successfully with the data retrieved
-    func testDownloadDataToMemory() async {
+    func testDownloadDataToMemory() async throws {
         let key = UUID().uuidString
         await uploadData(key: key, data: key.data(using: .utf8)!)
-        let completeInvoked = asyncExpectation(description: "Completed is invoked")
-        await wait(with: completeInvoked) {
-            return try await Amplify.Storage.downloadData(key: key, options: .init()).value
-        }
+        _ = try await Amplify.Storage.downloadData(key: key, options: .init()).value
         // Remove the key
         await remove(key: key)
     }
@@ -144,7 +112,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Given: An object in storage
     /// When: Call the downloadFile API
     /// Then: The operation completes successfully the local file containing the data from the object
-    func testDownloadFile() async {
+    func testDownloadFile() async throws {
         let key = UUID().uuidString
         let timestamp = String(Date().timeIntervalSince1970)
         let timestampData = timestamp.data(using: .utf8)!
@@ -153,10 +121,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
         let fileURL = URL(fileURLWithPath: filePath)
         removeIfExists(fileURL)
 
-        let completeInvoked = asyncExpectation(description: "Completed is invoked")
-        await wait(with: completeInvoked) {
-            return try await Amplify.Storage.downloadFile(key: key, local: fileURL, options: .init()).value
-        }
+        _ = try await Amplify.Storage.downloadFile(key: key, local: fileURL, options: .init()).value
 
         let fileExists = FileManager.default.fileExists(atPath: fileURL.path)
         XCTAssertTrue(fileExists)
@@ -174,7 +139,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Given: An object in storage
     /// When: Call the getURL API
     /// Then: The operation completes successfully with the URL retrieved
-    func testGetRemoteURL() async {
+    func testGetRemoteURL() async throws {
         let key = UUID().uuidString
         await uploadData(key: key, dataString: key)
 
@@ -218,32 +183,24 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Given: An object in storage
     /// When: Call the list API
     /// Then: The operation completes successfully with the key retrieved
-    func testListFromPublic() async {
+    func testListFromPublic() async throws {
         let key = UUID().uuidString
         let expectedMD5Hex = "\"\(MD5(string: key).map { String(format: "%02hhx", $0) }.joined())\""
         await uploadData(key: key, dataString: key)
-        let completeInvoked = asyncExpectation(description: "Completed is invoked")
         let options = StorageListRequest.Options(accessLevel: .guest,
                                                  targetIdentityId: nil,
                                                  path: key)
-        let result = await wait(with: completeInvoked) {
-            return try await Amplify.Storage.list(options: options)
-        }
+        let result = try await Amplify.Storage.list(options: options)
+        let items = try XCTUnwrap(result.items)
 
-        guard let items = result?.items else {
-            XCTFail("Failed to list items")
-            return
-        }
+        XCTAssertEqual(items.count, 1, String(describing: items))
+        let item = try XCTUnwrap(items.first)
+        XCTAssertEqual(item.key, key)
+        XCTAssertNotNil(item.eTag)
+        XCTAssertEqual(item.eTag, expectedMD5Hex)
+        XCTAssertNotNil(item.lastModified)
+        XCTAssertNotNil(item.size)
 
-        XCTAssertEqual(items.count, 1)
-        if let item = items.first {
-            XCTAssertEqual(item.key, key)
-            XCTAssertNotNil(item.eTag)
-            XCTAssertEqual(item.eTag, expectedMD5Hex)
-            XCTAssertNotNil(item.lastModified)
-            XCTAssertNotNil(item.size)
-        }
-        
         // Remove the key
         await remove(key: key)
     }
@@ -251,24 +208,21 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Given: No object in storage for the key
     /// When: Call the list API
     /// Then: The operation completes successfully with empty list of keys returned
-    func testListEmpty() async {
+    func testListEmpty() async throws {
         let key = UUID().uuidString
-        let completeInvoked = asyncExpectation(description: "Completed is invoked")
         let options = StorageListRequest.Options(accessLevel: .guest,
                                                  targetIdentityId: nil,
                                                  path: key)
-        let result = await wait(with: completeInvoked) {
-            return try await Amplify.Storage.list(options: options)
-        }
+        let result = try await Amplify.Storage.list(options: options)
 
         XCTAssertNotNil(result)
-        XCTAssertEqual(result?.items.count, 0)
+        XCTAssertEqual(result.items.count, 0)
     }
 
     /// Given: No object in storage for the key
     /// When: Call the list API
     /// Then: The operation completes successfully with empty list of keys returned
-    func testListWithPathUsingFolderNameWithForwardSlash() async {
+    func testListWithPathUsingFolderNameWithForwardSlash() async throws {
         let key = UUID().uuidString
         let folder = key + "/"
         var keys: [String] = []
@@ -277,18 +231,11 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
             keys.append(key)
             await uploadData(key: key, dataString: key)
         }
-        let completeInvoked = asyncExpectation(description: "Completed is invoked")
         let options = StorageListRequest.Options(accessLevel: .guest,
                                                  targetIdentityId: nil,
                                                  path: folder)
-        let result = await wait(with: completeInvoked) {
-            return try await Amplify.Storage.list(options: options)
-        }
-
-        guard let items = result?.items else {
-            XCTFail("Failed to list items")
-            return
-        }
+        let result = try await Amplify.Storage.list(options: options)
+        let items = result.items
 
         XCTAssertEqual(items.count, keys.count)
         for item in items {
@@ -302,7 +249,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Given: Objects with identifiers specified in `keys` array stored in folder named (`key1`+`key2`)
     /// When: Call the list API using the path `key1`
     /// Then: The operation completes successfully with list of keys returned from the folder.
-    func testListWithPathUsingIncompleteFolderName() async {
+    func testListWithPathUsingIncompleteFolderName() async throws {
         let key1 = UUID().uuidString + "testListWithPathUsingIncomp"
         let key2 = "leteFolderName"
         let folder = key1 + key2 + "/"
@@ -313,19 +260,12 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
             await uploadData(key: key, dataString: key)
         }
 
-        let completeInvoked = asyncExpectation(description: "Completed is invoked")
         let options = StorageListRequest.Options(accessLevel: .guest,
                                                  targetIdentityId: nil,
                                                  path: key1)
-        let result = await wait(with: completeInvoked) {
-            return try await Amplify.Storage.list(options: options)
-        }
-
-        guard let items = result?.items else {
-            XCTFail("Failed to list items")
-            return
-        }
-
+        let result = try await Amplify.Storage.list(options: options)
+        let items = result.items
+        
         XCTAssertEqual(items.count, keys.count)
         for item in items {
             XCTAssertTrue(keys.contains(item.key), "The key that was uploaded should match the key listed")
@@ -342,28 +282,22 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Given: An object in storage
     /// When: Call the remove API
     /// Then: The operation completes successfully with the key removed from storage
-    func testRemoveKey() async {
+    func testRemoveKey() async throws {
         let key = UUID().uuidString
         await uploadData(key: key, dataString: key)
 
-        let completeInvoked = asyncExpectation(description: "Completed is invoked")
-        let result = await wait(with: completeInvoked) {
-            return try await Amplify.Storage.remove(key: key, options: nil)
-        }
-        XCTAssertNotNil(result)
+        let result = try await Amplify.Storage.remove(key: key, options: nil)
+        XCTAssertEqual(result, key)
     }
 
     /// Given: Object with key `key` does not exist in storage
     /// When: Call the remove API
     /// Then: The operation completes successfully.
-    func testRemoveNonExistentKey() async {
+    func testRemoveNonExistentKey() async throws {
         let key = UUID().uuidString
 
-        let completeInvoked = asyncExpectation(description: "Completed is invoked")
-        let result = await wait(with: completeInvoked) {
-            return try await Amplify.Storage.remove(key: key, options: nil)
-        }
-        XCTAssertNotNil(result)
+        let result = try await Amplify.Storage.remove(key: key, options: nil)
+        XCTAssertEqual(result, key)
     }
 
 //    /// Given: Object with key `key` in storage


### PR DESCRIPTION
# Issue

https://github.com/aws-amplify/amplify-swift/issues/2633

# Description of changes:

This change removes the async expectations in favor of plain `try await` - there are also some updates to simplify error pattern matching.

# Check points: (check or cross out if not relevant)

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] If breaking change, documentation/changelog update with migration instructions

# Testing Procedure

1. Ensure all integration tests pass
![Screenshot_2022-12-21_at_1_11_03_PM](https://user-images.githubusercontent.com/1117904/208984915-bd881542-ea36-4b56-9781-940915a226bd.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
