### PR TITLE
feat(api): Add no store for the cache in urlsession for API category

### DIFF
--- a/Amplify/Categories/API/Request/RESTRequest.swift
+++ b/Amplify/Categories/API/Request/RESTRequest.swift
@@ -35,7 +35,7 @@ public class RESTRequest {
         if let headers = headers,
             headers["Cache-Control"] == nil {
             var updatedHeaders = headers
-            updatedHeaders["Cache-Control"] = "no-key"
+            updatedHeaders["Cache-Control"] = "no-store"
             self.headers = updatedHeaders
         } else {
             self.headers = headers

--- a/Amplify/Categories/API/Request/RESTRequest.swift
+++ b/Amplify/Categories/API/Request/RESTRequest.swift
@@ -32,11 +32,11 @@ public class RESTRequest {
                 headers: [String: String]? = nil,
                 queryParameters: [String: String]? = nil,
                 body: Data? = nil) {
-        if headers?["Cache-Control"] == nil {
-            self.headers = ["Cache-Control": "no-store"]
-        } else {
-            self.headers = headers
-        }
+        let inputHeaders = headers ?? [:]
+        self.headers = inputHeaders.merging(
+            ["Cache-Control": "no-store"],
+            uniquingKeysWith: { current, _ in current}
+        )
 
         self.apiName = apiName
         self.path = path

--- a/Amplify/Categories/API/Request/RESTRequest.swift
+++ b/Amplify/Categories/API/Request/RESTRequest.swift
@@ -32,9 +32,17 @@ public class RESTRequest {
                 headers: [String: String]? = nil,
                 queryParameters: [String: String]? = nil,
                 body: Data? = nil) {
+        if let headers = headers,
+            headers["Cache-Control"] == nil {
+            var updatedHeaders = headers
+            updatedHeaders["Cache-Control"] = "no-key"
+            self.headers = updatedHeaders
+        } else {
+            self.headers = headers
+        }
+
         self.apiName = apiName
         self.path = path
-        self.headers = headers
         self.queryParameters = queryParameters
         self.body = body
     }

--- a/Amplify/Categories/API/Request/RESTRequest.swift
+++ b/Amplify/Categories/API/Request/RESTRequest.swift
@@ -32,11 +32,8 @@ public class RESTRequest {
                 headers: [String: String]? = nil,
                 queryParameters: [String: String]? = nil,
                 body: Data? = nil) {
-        if let headers = headers,
-            headers["Cache-Control"] == nil {
-            var updatedHeaders = headers
-            updatedHeaders["Cache-Control"] = "no-store"
-            self.headers = updatedHeaders
+        if headers?["Cache-Control"] == nil {
+            self.headers = ["Cache-Control": "no-store"]
         } else {
             self.headers = headers
         }

--- a/Amplify/Categories/DataStore/DataStoreCategory+Behavior+Combine.swift
+++ b/Amplify/Categories/DataStore/DataStoreCategory+Behavior+Combine.swift
@@ -53,7 +53,7 @@ public extension DataStoreBaseBehavior {
         _ modelType: M.Type,
         withIdentifier identifier: String,
         where predicate: QueryPredicate? = nil
-    )  -> DataStorePublisher<Void> where M: ModelIdentifiable, M.IdentifierFormat == ModelIdentifierFormat.Default {
+    ) -> DataStorePublisher<Void> where M: ModelIdentifiable, M.IdentifierFormat == ModelIdentifierFormat.Default {
         Future { promise in
             self.delete(modelType, withIdentifier: identifier, where: predicate) { promise($0) }
         }.eraseToAnyPublisher()
@@ -70,7 +70,7 @@ public extension DataStoreBaseBehavior {
         _ modelType: M.Type,
         withIdentifier identifier: ModelIdentifier<M, M.IdentifierFormat>,
         where predicate: QueryPredicate? = nil
-    )  -> DataStorePublisher<Void> where M: ModelIdentifiable {
+    ) -> DataStorePublisher<Void> where M: ModelIdentifiable {
         Future { promise in
             self.delete(modelType, withIdentifier: identifier, where: predicate) { promise($0) }
         }.eraseToAnyPublisher()

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/GraphQLOperationRequestUtils.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Support/Utils/GraphQLOperationRequestUtils.swift
@@ -22,7 +22,7 @@ class GraphQLOperationRequestUtils {
     // Construct a graphQL specific HTTP POST request with the request payload
     static func constructRequest(with baseUrl: URL, requestPayload: Data) -> URLRequest {
         var baseRequest = URLRequest(url: baseUrl)
-        let headers = ["content-type": "application/json"]
+        let headers = ["content-type": "application/json", "Cache-Control": "no-store"]
         baseRequest.allHTTPHeaderFields = headers
         baseRequest.httpMethod = "POST"
         baseRequest.httpBody = requestPayload

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Request/GraphQLOperationRequestUtilsTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Request/GraphQLOperationRequestUtilsTests.swift
@@ -1,0 +1,22 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import Amplify
+@testable import AWSAPICategoryPlugin
+
+class GraphQLOperationRequestUtilsTests: XCTestCase {
+
+    let baseURL = URL(string: "https://someurl")
+    let testDocument = "testDocument"
+
+    func testGraphQLOperationRequestWithCache() throws {
+        let request = GraphQLOperationRequestUtils.constructRequest(with: baseURL,
+                                                                    requestPayload: Data())
+        XCTAssertEqual(request.allHTTPHeaderFields["Cache-Control"], "no-store")
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -62,7 +62,7 @@ extension Model {
                 } else {
                     input.updateValue(nil, forKey: name)
                 }
-                
+
                 continue
             }
 

--- a/AmplifyTests/CategoryTests/API/APICategoryClientRESTTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryClientRESTTests.swift
@@ -39,6 +39,16 @@ class APICategoryClientRESTTests: XCTestCase {
         waitForExpectations(timeout: 0.5)
     }
 
+    func testCacheInRequest() {
+        let request = RESTRequest(apiName: "someapi")
+        XCTAssertEqual(request.headers?["Cache-Control"], "no-store")
+    }
+
+    func testCustomCacheInRequest() {
+        let request = RESTRequest(apiName: "someapi", headers: ["Cache-Control": "private"])
+        XCTAssertEqual(request.headers?["Cache-Control"], "private")
+    }
+
     // MARK: - Utilities
 
     func makeAndAddMockPlugin() throws -> MockAPICategoryPlugin {

--- a/AmplifyTests/CategoryTests/API/APICategoryClientRESTTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryClientRESTTests.swift
@@ -49,6 +49,12 @@ class APICategoryClientRESTTests: XCTestCase {
         XCTAssertEqual(request.headers?["Cache-Control"], "private")
     }
 
+    func testCacheWithExistingValuesInRequest() {
+        let request = RESTRequest(apiName: "someapi", headers: ["somekey": "somevalue"])
+        XCTAssertEqual(request.headers?["Cache-Control"], "no-store")
+        XCTAssertEqual(request.headers?["somekey"], "somevalue")
+    }
+
     // MARK: - Utilities
 
     func makeAndAddMockPlugin() throws -> MockAPICategoryPlugin {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Updates the cache control of API category to disable caching by default. This can be overridden by setting the Cache-Control request header for API rest category.

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
