### PR TITLE
feat(api): Update url cache for storage and api to nil

### DIFF
--- a/Amplify/Categories/API/Request/RESTRequest.swift
+++ b/Amplify/Categories/API/Request/RESTRequest.swift
@@ -32,9 +32,13 @@ public class RESTRequest {
                 headers: [String: String]? = nil,
                 queryParameters: [String: String]? = nil,
                 body: Data? = nil) {
+        if headers?["Cache-Control"] == nil {
+            self.headers = ["Cache-Control": "no-store"]
+        } else {
+            self.headers = headers
+        }
         self.apiName = apiName
         self.path = path
-        self.headers = headers
         self.queryParameters = queryParameters
         self.body = body
     }

--- a/Amplify/Categories/API/Request/RESTRequest.swift
+++ b/Amplify/Categories/API/Request/RESTRequest.swift
@@ -32,11 +32,11 @@ public class RESTRequest {
                 headers: [String: String]? = nil,
                 queryParameters: [String: String]? = nil,
                 body: Data? = nil) {
-        if headers?["Cache-Control"] == nil {
-            self.headers = ["Cache-Control": "no-store"]
-        } else {
-            self.headers = headers
-        }
+        let inputHeaders = headers ?? [:]
+        self.headers = inputHeaders.merging(
+            ["Cache-Control": "no-store"],
+            uniquingKeysWith: { current, _ in current}
+        )
         self.apiName = apiName
         self.path = path
         self.queryParameters = queryParameters

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/GraphQLOperationRequestUtils.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/GraphQLOperationRequestUtils.swift
@@ -22,7 +22,7 @@ class GraphQLOperationRequestUtils {
     // Construct a graphQL specific HTTP POST request with the request payload
     static func constructRequest(with baseUrl: URL, requestPayload: Data) -> URLRequest {
         var baseRequest = URLRequest(url: baseUrl)
-        let headers = ["content-type": "application/json"]
+        let headers = ["content-type": "application/json", "Cache-Control": "no-store"]
         baseRequest.allHTTPHeaderFields = headers
         baseRequest.httpMethod = "POST"
         baseRequest.httpBody = requestPayload

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Request/GraphQLOperationRequestUtilsTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Request/GraphQLOperationRequestUtilsTests.swift
@@ -6,7 +6,7 @@
 //
 import XCTest
 import Amplify
-@testable import AWSAPICategoryPlugin
+@testable import AWSAPIPlugin
 
 class GraphQLOperationRequestUtilsTests: XCTestCase {
 

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Request/GraphQLOperationRequestUtilsTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Request/GraphQLOperationRequestUtilsTests.swift
@@ -10,12 +10,12 @@ import Amplify
 
 class GraphQLOperationRequestUtilsTests: XCTestCase {
 
-    let baseURL = URL(string: "https://someurl")
+    let baseURL = URL(string: "https://someurl")!
     let testDocument = "testDocument"
 
     func testGraphQLOperationRequestWithCache() throws {
         let request = GraphQLOperationRequestUtils.constructRequest(with: baseURL,
                                                                     requestPayload: Data())
-        XCTAssertEqual(request.allHTTPHeaderFields["Cache-Control"], "no-store")
+        XCTAssertEqual(request.allHTTPHeaderFields?["Cache-Control"], "no-store")
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Request/GraphQLOperationRequestUtilsTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Request/GraphQLOperationRequestUtilsTests.swift
@@ -1,0 +1,21 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+import XCTest
+import Amplify
+@testable import AWSAPICategoryPlugin
+
+class GraphQLOperationRequestUtilsTests: XCTestCase {
+
+    let baseURL = URL(string: "https://someurl")
+    let testDocument = "testDocument"
+
+    func testGraphQLOperationRequestWithCache() throws {
+        let request = GraphQLOperationRequestUtils.constructRequest(with: baseURL,
+                                                                    requestPayload: Data())
+        XCTAssertEqual(request.allHTTPHeaderFields["Cache-Control"], "no-store")
+    }
+}

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
@@ -66,6 +66,7 @@ class AWSS3StorageService: AWSS3StorageServiceBehaviour, StorageServiceProxy {
             #else
             let sessionConfiguration = URLSessionConfiguration.background(withIdentifier: storageConfiguration.sessionIdentifier)
             #endif
+            sessionConfiguration.urlCache = nil
             sessionConfiguration.allowsCellularAccess = storageConfiguration.allowsCellularAccess
             sessionConfiguration.timeoutIntervalForResource = TimeInterval(storageConfiguration.timeoutIntervalForResource)
             _sessionConfiguration = sessionConfiguration

--- a/AmplifyTests/CategoryTests/API/APICategoryClientRESTTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryClientRESTTests.swift
@@ -44,6 +44,16 @@ class APICategoryClientRESTTests: XCTestCase {
         await waitForExpectations(timeout: 0.5)
     }
 
+    func testCacheInRequest() {
+        let request = RESTRequest(apiName: "someapi")
+        XCTAssertEqual(request.headers?["Cache-Control"], "no-store")
+    }
+
+    func testCustomCacheInRequest() {
+        let request = RESTRequest(apiName: "someapi", headers: ["Cache-Control": "private"])
+        XCTAssertEqual(request.headers?["Cache-Control"], "private")
+    }
+
     // MARK: - Utilities
 
     func makeAndAddMockPlugin() throws -> MockAPICategoryPlugin {

--- a/AmplifyTests/CategoryTests/API/APICategoryClientRESTTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryClientRESTTests.swift
@@ -54,6 +54,12 @@ class APICategoryClientRESTTests: XCTestCase {
         XCTAssertEqual(request.headers?["Cache-Control"], "private")
     }
 
+    func testCacheWithExistingValuesInRequest() {
+        let request = RESTRequest(apiName: "someapi", headers: ["somekey": "somevalue"])
+        XCTAssertEqual(request.headers?["Cache-Control"], "no-store")
+        XCTAssertEqual(request.headers?["somekey"], "somevalue")
+    }
+
     // MARK: - Utilities
 
     func makeAndAddMockPlugin() throws -> MockAPICategoryPlugin {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Updates the cache control of Storage and API category to disable caching by default. This can be overridden by setting the Cache-Control request header for API rest category.

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
