### PR TITLE
chore: Add github action for stress tests in all categories

### DIFF
--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Make directory
         run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
 
-      - name: Copy integration test resouces
+      - name: Copy stress test resouces
         uses: ./.github/composite_actions/download_test_configuration
         with:
           resource_subfolder: auth
@@ -49,8 +49,61 @@ jobs:
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG_V2 }}
 
-      - name: Run Integration test
+      - name: Run stress test
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           project_path: ./AmplifyPlugins/Auth/Tests/AuthHostApp/
           scheme: AuthStressTests
+
+  geo-stress-test:
+    needs: prepare-for-test
+    runs-on: macos-12
+    environment: IntegrationTest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          persist-credentials: false
+
+      - name: Make directory
+        run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
+
+      - name: Copy stress test resouces
+        uses: ./.github/composite_actions/download_test_configuration
+        with:
+          resource_subfolder: geo
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG_V2 }}
+
+      - name: Run stress test
+        uses: ./.github/composite_actions/run_xcodebuild_test
+        with:
+          project_path: ./AmplifyPlugins/Geo/Tests/GeoHostApp/
+          scheme: AWSLocationGeoPluginIntegrationTests
+
+
+  storage-stress-test:
+    needs: prepare-for-test
+    runs-on: macos-12
+    environment: IntegrationTest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          persist-credentials: false
+
+      - name: Make directory
+        run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
+
+      - name: Copy stress test resouces
+        uses: ./.github/composite_actions/download_test_configuration
+        with:
+          resource_subfolder: storage
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG_V2 }}
+
+      - name: Run stress test
+        uses: ./.github/composite_actions/run_xcodebuild_test
+        with:
+          project_path: ./AmplifyPlugins/Storage/Tests/StorageHostApp/
+          scheme: GeoStressTests

--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -79,7 +79,7 @@ jobs:
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           project_path: ./AmplifyPlugins/Geo/Tests/GeoHostApp/
-          scheme: AWSLocationGeoPluginIntegrationTests
+          scheme: GeoStressTests
 
 
   storage-stress-test:
@@ -106,4 +106,4 @@ jobs:
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           project_path: ./AmplifyPlugins/Storage/Tests/StorageHostApp/
-          scheme: GeoStressTests
+          scheme: StorageStressTests

--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Copy stress test resouces
         uses: ./.github/composite_actions/download_test_configuration
         with:
-          resource_subfolder: auth
+          resource_subfolder: stresstest
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG_V2 }}
@@ -70,7 +70,7 @@ jobs:
       - name: Copy stress test resouces
         uses: ./.github/composite_actions/download_test_configuration
         with:
-          resource_subfolder: geo
+          resource_subfolder: stresstest
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG_V2 }}
@@ -97,7 +97,7 @@ jobs:
       - name: Copy stress test resouces
         uses: ./.github/composite_actions/download_test_configuration
         with:
-          resource_subfolder: storage
+          resource_subfolder: stresstest
           aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG_V2 }}
@@ -107,3 +107,55 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Storage/Tests/StorageHostApp/
           scheme: StorageStressTests
+  
+  datastore-stress-test:
+    needs: prepare-for-test
+    runs-on: macos-12
+    environment: IntegrationTest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          persist-credentials: false
+
+      - name: Make directory
+        run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
+
+      - name: Copy stress test resouces
+        uses: ./.github/composite_actions/download_test_configuration
+        with:
+          resource_subfolder: stresstest
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG_V2 }}
+
+      - name: Run stress test
+        uses: ./.github/composite_actions/run_xcodebuild_test
+        with:
+          project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
+          scheme: DatastoreStressTests
+
+  grapql-api-stress-test:
+    needs: prepare-for-test
+    runs-on: macos-12
+    environment: IntegrationTest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          persist-credentials: false
+
+      - name: Make directory
+        run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
+
+      - name: Copy stress test resouces
+        uses: ./.github/composite_actions/download_test_configuration
+        with:
+          resource_subfolder: stresstest
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG_V2 }}
+
+      - name: Run stress test
+        uses: ./.github/composite_actions/run_xcodebuild_test
+        with:
+          project_path: ./AmplifyPlugins/API/Tests/APIHostApp
+          scheme: GraphQLAPIStressTests

--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -134,7 +134,7 @@ jobs:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: DatastoreStressTests
 
-  grapql-api-stress-test:
+  graphql-api-stress-test:
     needs: prepare-for-test
     runs-on: macos-12
     environment: IntegrationTest

--- a/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AnalyticsStressTests/AnalyticsStressTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AnalyticsStressTests/AnalyticsStressTests.swift
@@ -15,7 +15,7 @@ import Network
 
 final class AnalyticsStressTests: XCTestCase {
 
-    static let amplifyConfiguration = "testconfiguration/AWSAnalyticsStressTests-amplifyconfiguration"
+    static let amplifyConfiguration = "testconfiguration/AWSAmplifyStressTests-amplifyconfiguration"
     static let analyticsPluginKey = "awsPinpointAnalyticsPlugin"
     let concurrencyLimit = 50
     

--- a/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AnalyticsStressTests/README.md
+++ b/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AnalyticsStressTests/README.md
@@ -17,10 +17,10 @@ Auth category is also required for signing with AWS Pinpoint service and request
 
 3. `amplify push`
 
-4. Copy `amplifyconfiguration.json` as `AWSAnalyticsStressTests-amplifyconfiguration.json` inside `~/.aws-amplify/amplify-ios/testconfiguration/`
+4. Copy `amplifyconfiguration.json` as `AWSAmplifyStressTests-amplifyconfiguration.json` inside `~/.aws-amplify/amplify-ios/testconfiguration/`
 
 ```perl
-cp amplifyconfiguration.json ~/.aws-amplify/amplify-ios/testconfiguration/AWSAnalyticsStressTests-amplifyconfiguration.json
+cp amplifyconfiguration.json ~/.aws-amplify/amplify-ios/testconfiguration/AWSAmplifyStressTests-amplifyconfiguration.json
 ```
 
 5. You can now run all of the integration tests. 

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		681DFEAB28E747B80000C36A /* AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEA828E747B80000C36A /* AsyncTesting.swift */; };
 		681DFEAC28E747B80000C36A /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEA928E747B80000C36A /* AsyncExpectation.swift */; };
 		681DFEAD28E747B80000C36A /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEAA28E747B80000C36A /* XCTestCase+AsyncTesting.swift */; };
+		970333F0295D793B0019981E /* AuthStressBaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970333EF295D793B0019981E /* AuthStressBaseTest.swift */; };
 		9737C74E287E208400DA0D2B /* AuthRememberDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9737C74D287E208400DA0D2B /* AuthRememberDeviceTests.swift */; };
 		9737C7502880BFD600DA0D2B /* AuthForgetDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9737C74F2880BFD600DA0D2B /* AuthForgetDeviceTests.swift */; };
 		97829201286B802E000DE190 /* AuthResetPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97829200286B802E000DE190 /* AuthResetPasswordTests.swift */; };
@@ -39,7 +40,6 @@
 		97914B4E2955099A002000EA /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEAA28E747B80000C36A /* XCTestCase+AsyncTesting.swift */; };
 		97914B4F295509A2002000EA /* AuthStressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97914AD72954FE0A002000EA /* AuthStressTests.swift */; };
 		97914B51295509AB002000EA /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 97914AF6295503D4002000EA /* README.md */; };
-		97914B5529552D0C002000EA /* AWSAuthBaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB5AF27B61EAA006CCEC7 /* AWSAuthBaseTest.swift */; };
 		97914B5629552D2B002000EA /* AuthSessionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB5B727B61F0F006CCEC7 /* AuthSessionHelper.swift */; };
 		97914B5729552D2B002000EA /* AuthSignInHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB5B827B61F0F006CCEC7 /* AuthSignInHelper.swift */; };
 		97B370C52878DA5A00F1C088 /* AuthFetchDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97B370C42878DA5A00F1C088 /* AuthFetchDeviceTests.swift */; };
@@ -93,6 +93,7 @@
 		681DFEA828E747B80000C36A /* AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncTesting.swift; sourceTree = "<group>"; };
 		681DFEA928E747B80000C36A /* AsyncExpectation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncExpectation.swift; sourceTree = "<group>"; };
 		681DFEAA28E747B80000C36A /* XCTestCase+AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AsyncTesting.swift"; sourceTree = "<group>"; };
+		970333EF295D793B0019981E /* AuthStressBaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthStressBaseTest.swift; sourceTree = "<group>"; };
 		9737C74D287E208400DA0D2B /* AuthRememberDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRememberDeviceTests.swift; sourceTree = "<group>"; };
 		9737C74F2880BFD600DA0D2B /* AuthForgetDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthForgetDeviceTests.swift; sourceTree = "<group>"; };
 		97829200286B802E000DE190 /* AuthResetPasswordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthResetPasswordTests.swift; sourceTree = "<group>"; };
@@ -306,6 +307,7 @@
 			children = (
 				97914AF6295503D4002000EA /* README.md */,
 				97914AD72954FE0A002000EA /* AuthStressTests.swift */,
+				970333EF295D793B0019981E /* AuthStressBaseTest.swift */,
 			);
 			path = AuthStressTests;
 			sourceTree = "<group>";
@@ -551,8 +553,8 @@
 			files = (
 				97914B5629552D2B002000EA /* AuthSessionHelper.swift in Sources */,
 				97914B5729552D2B002000EA /* AuthSignInHelper.swift in Sources */,
-				97914B5529552D0C002000EA /* AWSAuthBaseTest.swift in Sources */,
 				97914B4F295509A2002000EA /* AuthStressTests.swift in Sources */,
+				970333F0295D793B0019981E /* AuthStressBaseTest.swift in Sources */,
 				97914B4C2955099A002000EA /* AsyncTesting.swift in Sources */,
 				97914B4D2955099A002000EA /* AsyncExpectation.swift in Sources */,
 				97914B4E2955099A002000EA /* XCTestCase+AsyncTesting.swift in Sources */,

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthStressTests/AuthStressBaseTest.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthStressTests/AuthStressBaseTest.swift
@@ -1,0 +1,131 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+import AWSCognitoAuthPlugin
+
+class AuthStressBaseTest: XCTestCase {
+
+    let networkTimeout = TimeInterval(5)
+
+    var defaultTestEmail = "test-\(UUID().uuidString)@amazon.com"
+    var defaultTestPassword = UUID().uuidString
+
+    let amplifyConfigurationFile = "testconfiguration/AWSAmplifyStressTests-amplifyconfiguration"
+    let credentialsFile = "testconfiguration/AWSAmplifyStressTests-credentials"
+
+    var amplifyConfiguration: AmplifyConfiguration!
+    
+    override func setUp() async throws {
+        try await super.setUp()
+        initializeAmplify()
+        _ = await Amplify.Auth.signOut()
+    }
+    
+    override func tearDown() async throws {
+        try await super.tearDown()
+        await Amplify.reset()
+    }
+
+    func initializeAmplify() {
+        do {
+            let configuration = try TestConfigHelper.retrieveAmplifyConfiguration(
+                forResource: amplifyConfigurationFile)
+            amplifyConfiguration = configuration
+
+            let credentialsConfiguration = (try? TestConfigHelper.retrieveCredentials(forResource: credentialsFile)) ?? [:]
+            defaultTestEmail = credentialsConfiguration["test_email_1"] ?? defaultTestEmail
+            defaultTestPassword = credentialsConfiguration["password"] ?? defaultTestPassword
+            let authPlugin = AWSCognitoAuthPlugin()
+            try Amplify.add(plugin: authPlugin)
+            try Amplify.configure(configuration)
+            Amplify.Logging.logLevel = .verbose
+            print("Amplify configured with auth plugin")
+        } catch {
+            print(error)
+            initializeWithLocalResources()
+        }
+    }
+
+    func initializeWithLocalResources() {
+        let region = JSONValue(stringLiteral: "xx")
+        let userPoolID = JSONValue(stringLiteral: "xx")
+        let userPooldAppClientID = JSONValue(stringLiteral: "xx")
+        let userPooldAppClientSecret = JSONValue(stringLiteral: "xx")
+
+        let identityPoolID = JSONValue(stringLiteral: "xx")
+        do {
+            let authConfiguration = AuthCategoryConfiguration(plugins: [
+                "awsCognitoAuthPlugin": [
+                    "UserAgent": "aws-amplify/cli",
+                    "Version": "0.1.0",
+                    "IdentityManager": [
+                        "Default": []
+                    ],
+                    "CredentialsProvider": [
+                        "CognitoIdentity": [
+                            "Default": [
+                                "PoolId": identityPoolID,
+                                "Region": region
+                            ]
+                        ]
+                    ],
+                    "CognitoUserPool": [
+                        "Default": [
+                            "PoolId": userPoolID,
+                            "AppClientId": userPooldAppClientID,
+                            "Region": region
+                        ]
+                    ]]]
+            )
+            let configuration = AmplifyConfiguration(auth: authConfiguration)
+            let authPlugin = AWSCognitoAuthPlugin()
+            try Amplify.add(plugin: authPlugin)
+            try Amplify.configure(configuration)
+        } catch {
+            print(error)
+            XCTFail("Amplify configuration failed")
+        }
+    }
+}
+
+class TestConfigHelper {
+
+    static func retrieveAmplifyConfiguration(forResource: String) throws -> AmplifyConfiguration {
+
+        let data = try retrieve(forResource: forResource)
+        return try AmplifyConfiguration.decodeAmplifyConfiguration(from: data)
+    }
+
+    static func retrieveCredentials(forResource: String) throws -> [String: String] {
+        let data = try retrieve(forResource: forResource)
+
+        let jsonOptional = try JSONSerialization.jsonObject(with: data, options: []) as? [String: String]
+        guard let json = jsonOptional else {
+            throw TestConfigError.jsonError("Could not deserialize `\(forResource)` into JSON object")
+        }
+
+        return json
+    }
+
+    private static func retrieve(forResource: String) throws -> Data {
+        guard let path = Bundle(for: self).path(forResource: forResource, ofType: "json") else {
+            throw TestConfigError.bundlePathError("Could not retrieve configuration file: \(forResource)")
+        }
+
+        let url = URL(fileURLWithPath: path)
+        return try Data(contentsOf: url)
+    }
+}
+
+enum TestConfigError: Error {
+
+    case jsonError(String)
+
+    case bundlePathError(String)
+}

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthStressTests/AuthStressTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthStressTests/AuthStressTests.swift
@@ -10,7 +10,7 @@ import XCTest
 import AWSCognitoAuthPlugin
 import AWSPluginsCore
 
-final class AuthStressTests: AWSAuthBaseTest {
+final class AuthStressTests: AuthStressBaseTest {
 
     let concurrencyLimit = 50
     

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthStressTests/README.md
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthStressTests/README.md
@@ -82,7 +82,5 @@ Successfully added resource amplifyintegtest locally
 amplify push
 ```
 
-This will create a amplifyconfiguration.json file in your local, copy that file to `~/.aws-amplify/amplify-ios/testconfiguration/` and rename as `AWSAuthStressTests-amplifyconfiguration.json`.
+This will create a amplifyconfiguration.json file in your local, copy that file to `~/.aws-amplify/amplify-ios/testconfiguration/` and rename as `AWSAmplifyStressTests-amplifyconfiguration.json`.
 
-For Auth Device tests:
-Follow steps here (https://docs.amplify.aws/lib/auth/device_features/q/platform/ios/#configure-auth-category)[https://docs.amplify.aws/lib/auth/device_features/q/platform/ios/#configure-auth-category] and select "Always" for "Do you want to remember your user's devices?"

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressBaseTest.swift
@@ -28,7 +28,7 @@ class DataStoreStressBaseTest: XCTestCase {
         
         do {
             let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: Self.amplifyConfigurationFile)
-            try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models, configuration: .custom(syncMaxRecords: 500)))
+            try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models))
             try Amplify.add(plugin: AWSAPIPlugin(modelRegistration: models))
             try Amplify.configure(amplifyConfig)
         } catch {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressBaseTest.swift
@@ -22,19 +22,23 @@ class DataStoreStressBaseTest: XCTestCase {
     let networkTimeout = TimeInterval(180)
     
     func setUp(withModels models: AmplifyModelRegistration, logLevel: LogLevel = .error) async {
+        
         continueAfterFailure = false
-        await Amplify.reset()
         Amplify.Logging.logLevel = logLevel
         
         do {
             let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: Self.amplifyConfigurationFile)
-            try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models))
+            try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models, configuration: .custom(syncMaxRecords: 100)))
             try Amplify.add(plugin: AWSAPIPlugin(modelRegistration: models))
             try Amplify.configure(amplifyConfig)
         } catch {
             XCTFail(String(describing: error))
             return
         }
+    }
+    
+    override func tearDown() async throws {
+        await Amplify.reset()
     }
     
     func stopDataStore() async throws {
@@ -70,6 +74,6 @@ class DataStoreStressBaseTest: XCTestCase {
 
         try await Amplify.DataStore.start()
 
-        await waitForExpectations(timeout: 100.0)
+        await waitForExpectations(timeout: networkTimeout)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressBaseTest.swift
@@ -28,7 +28,7 @@ class DataStoreStressBaseTest: XCTestCase {
         
         do {
             let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: Self.amplifyConfigurationFile)
-            try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models, configuration: .custom(syncMaxRecords: 100)))
+            try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models, configuration: .custom(syncMaxRecords: 500)))
             try Amplify.add(plugin: AWSAPIPlugin(modelRegistration: models))
             try Amplify.configure(amplifyConfig)
         } catch {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressBaseTest.swift
@@ -17,7 +17,7 @@ import AWSAPIPlugin
 
 class DataStoreStressBaseTest: XCTestCase {
  
-    static let amplifyConfigurationFile = "testconfiguration/AWSDataStoreStressTests-amplifyconfiguration"
+    static let amplifyConfigurationFile = "testconfiguration/AWSAmplifyStressTests-amplifyconfiguration"
     let concurrencyLimit = 50
     let networkTimeout = TimeInterval(180)
     

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressTests.swift
@@ -48,15 +48,12 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
             posts.append(post)
         }
         
-        let observeQuerySetup = asyncExpectation(description: "ObserveQuery setup done")
         let postsSyncedToCloud = asyncExpectation(description: "All posts saved and synced to cloud",
                                                   expectedFulfillmentCount: concurrencyLimit)
 
         let postsCopy = posts
+        let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
-            var postsSyncedToCloudCount = 0
-            let mutationEvents = Amplify.DataStore.observe(Post.self)
-            await observeQuerySetup.fulfill()
             do {
                 for try await mutationEvent in mutationEvents {
                     guard postsCopy.contains(where: { $0.id == mutationEvent.modelId }) else {
@@ -65,7 +62,6 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
 
                     if mutationEvent.mutationType == MutationEvent.MutationType.create.rawValue,
                        mutationEvent.version == 1 {
-                        postsSyncedToCloudCount += 1
                         await postsSyncedToCloud.fulfill()
                     }
                 }
@@ -73,8 +69,6 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
                 XCTFail("Failed \(error)")
             }
         }
-        
-        await waitForExpectations([observeQuerySetup], timeout: networkTimeout)
         
         let capturedPosts = posts
 
@@ -176,11 +170,8 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
         let postsDeletedFromCloud = asyncExpectation(description: "All posts deleted and synced to cloud",
                                                      expectedFulfillmentCount: concurrencyLimit)
         
-        let observeQuerySetup = asyncExpectation(description: "ObserveQuery setup done")
+        let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
-            var postsDeletedFromCloudCount = 0
-            let mutationEvents = Amplify.DataStore.observe(Post.self)
-            await observeQuerySetup.fulfill()
             do {
                 for try await mutationEvent in mutationEvents {
                     guard posts.contains(where: { $0.id == mutationEvent.modelId }) else {
@@ -192,7 +183,6 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
                         await postsDeletedLocally.fulfill()
                     } else if mutationEvent.mutationType == MutationEvent.MutationType.delete.rawValue,
                               mutationEvent.version == 2 {
-                        postsDeletedFromCloudCount += 1
                         await postsDeletedFromCloud.fulfill()
                     }
                 }
@@ -200,8 +190,6 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
                 XCTFail("Failed \(error)")
             }
         }
-        
-        await waitForExpectations([observeQuerySetup], timeout: networkTimeout)
         
         DispatchQueue.concurrentPerform(iterations: concurrencyLimit) { index in
             Task {
@@ -230,10 +218,8 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
                                                   expectedFulfillmentCount: concurrencyLimit)
         
         let postsCopy = posts
+        let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
-            var postsSyncedToCloudCount = 0
-            let mutationEvents = Amplify.DataStore.observe(Post.self)
-            await observeQuerySetup.fulfill()
             do {
                 for try await mutationEvent in mutationEvents {
                     guard postsCopy.contains(where: { $0.id == mutationEvent.modelId }) else {
@@ -242,7 +228,6 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
                     
                     if mutationEvent.mutationType == MutationEvent.MutationType.create.rawValue,
                        mutationEvent.version == 1 {
-                        postsSyncedToCloudCount += 1
                         await postsSyncedToCloud.fulfill()
                     }
                 }
@@ -250,8 +235,6 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
                 XCTFail("Failed \(error)")
             }
         }
-        
-        await waitForExpectations([observeQuerySetup], timeout: networkTimeout)
         
         let capturedPosts = posts
         

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressTests.swift
@@ -213,7 +213,6 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
             posts.append(post)
         }
         
-        let observeQuerySetup = asyncExpectation(description: "ObserveQuery setup done")
         let postsSyncedToCloud = asyncExpectation(description: "All posts saved and synced to cloud",
                                                   expectedFulfillmentCount: concurrencyLimit)
         

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/README.md
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/README.md
@@ -39,10 +39,10 @@ type Post @model @auth(rules: [{ allow: public }]) {
 
 3. `amplify push`
 
-4. Copy `amplifyconfiguration.json` to a new file named `AWSDataStoreStressTests-amplifyconfiguration.json` inside `~/.aws-amplify/amplify-ios/testconfiguration/`
+4. Copy `amplifyconfiguration.json` to a new file named `AWSAmplifyStressTests-amplifyconfiguration.json` inside `~/.aws-amplify/amplify-ios/testconfiguration/`
 
 ```
-cp amplifyconfiguration.json ~/.aws-amplify/amplify-ios/testconfiguration/AWSDataStoreStressTests-amplifyconfiguration.json
+cp amplifyconfiguration.json ~/.aws-amplify/amplify-ios/testconfiguration/AWSAmplifyStressTests-amplifyconfiguration.json
 ```
 
 You should now be able to run all of the tests 

--- a/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoStressTests/GeoStressTests.swift
+++ b/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoStressTests/GeoStressTests.swift
@@ -15,7 +15,7 @@ final class GeoStressTests: XCTestCase {
     let searchText = "coffee shop"
     let coordinates = Geo.Coordinates(latitude: 39.7392, longitude: -104.9903)
     let concurrencyLimit = 50
-    let amplifyConfigurationFile = "testconfiguration/AWSGeoStressTests-amplifyconfiguration"
+    let amplifyConfigurationFile = "testconfiguration/AWSAmplifyStressTests-amplifyconfiguration"
 
     override func setUp() {
         continueAfterFailure = false

--- a/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoStressTests/README.md
+++ b/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoStressTests/README.md
@@ -32,6 +32,6 @@ The following steps demonstrate how to set up Geo. Auth category is also require
 
 4. `amplify push`
 
-5. Copy `amplifyconfiguration.json` to a new file named `AWSGeoStressTests-amplifyconfiguration.json` inside `~/.aws-amplify/amplify-ios/testconfiguration/`.
+5. Copy `amplifyconfiguration.json` to a new file named `AWSAmplifyStressTests-amplifyconfiguration.json` inside `~/.aws-amplify/amplify-ios/testconfiguration/`.
 
 6. You can now run all of the integration tests. 

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageStressTests/README.md
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageStressTests/README.md
@@ -93,8 +93,8 @@ Successfully added auth resource
 3. `amplify push`
 
 
-4. Copy `amplifyconfiguration.json` as `AWSStorageStressTests-amplifyconfiguration.json` inside `~/.aws-amplify/amplify-ios/testconfiguration/`
+4. Copy `amplifyconfiguration.json` as `AWSAmplifyStressTests-amplifyconfiguration.json` inside `~/.aws-amplify/amplify-ios/testconfiguration/`
 
 ```
-cp amplifyconfiguration.json ~/.aws-amplify/amplify-ios/testconfiguration/AWSStorageStressTests-amplifyconfiguration.json
+cp amplifyconfiguration.json ~/.aws-amplify/amplify-ios/testconfiguration/AWSAmplifyStressTests-amplifyconfiguration.json
 ```

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageStressTests/StorageStressTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageStressTests/StorageStressTests.swift
@@ -13,7 +13,7 @@ import AWSCognitoAuthPlugin
 final class StorageStressTests: XCTestCase {
 
     static let logger = Amplify.Logging.logger(forCategory: "Storage", logLevel: .verbose)
-    static let amplifyConfiguration = "testconfiguration/AWSStorageStressTests-amplifyconfiguration"
+    static let amplifyConfiguration = "testconfiguration/AWSAmplifyStressTests-amplifyconfiguration"
     
     let smallDataObjectForStressTest = Data(repeating: 0xff, count: 1_024 * 1_024) // 1MB
     let largeDataObjectForStressTest = Data(repeating: 0xff, count: 1_024 * 1_024 * 100) // 100MB


### PR DESCRIPTION
*Issue #, if available:* None 

*Description of changes:* 
Add github action for stress tests in all categories. 
All categories except GraphQLAPI use the same configuration file (all categories are added to a single Amplify app).

**Note: GraphQLAPI stress tests need a separate configuration file as conflict detection needs to be turned on for Datastore Stress tests.**


*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
