### PR TITLE
fix(auth): Return session expired on revoke token

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/FetchAuthorizationSession/FetchIdentity/FetchAuthIdentityId.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/FetchAuthorizationSession/FetchIdentity/FetchAuthIdentityId.swift
@@ -65,10 +65,8 @@ struct FetchAuthIdentityId: Action {
     }
 
     func isNotAuthorizedError(_ error: Error) -> Bool {
-        if case .client(let clientError, _) = error as? SdkError<GetIdOutputError>,
-           case .retryError(let serviceError) = clientError,
-           let sdkError = serviceError as? SdkError<GetIdOutputError>,
-           case .service(let getIdError, _ ) = sdkError,
+
+        if let getIdError: GetIdOutputError = error.internalAWSServiceError(),
            case .notAuthorizedException = getIdError {
             return true
         }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/FetchAuthorizationSession/InformSessionError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/FetchAuthorizationSession/InformSessionError.swift
@@ -39,32 +39,13 @@ struct InformSessionError: Action {
 
     func isNotAuthorizedError(_ error: Error) -> Bool {
 
-        if let sdkError = error as? SdkError<InitiateAuthOutputError>,
-           case .client(let clientError, _) = sdkError,
-           case .retryError(let retryError) = clientError,
-           let serviceError = retryError as? SdkError<InitiateAuthOutputError>,
-           case .service(let internalError, _) = serviceError
-        {
-            return isNotAuthorizedError(internalError)
-        }
 
-
-        if let sdkError = error as? SdkError<GetCredentialsForIdentityOutputError>,
-           case .client(let clientError, _) = sdkError,
-           case .retryError(let retryError) = clientError,
-           let serviceError = retryError as? SdkError<GetCredentialsForIdentityOutputError>,
-           case .service(let internalError, _) = serviceError
-        {
-            return isNotAuthorizedError(internalError)
-        }
-
-        if let initiateAuthError = error as? InitiateAuthOutputError,
-           case .notAuthorizedException = initiateAuthError {
+        if let serviceError: GetCredentialsForIdentityOutputError = error.internalAWSServiceError(),
+           case .notAuthorizedException = serviceError {
             return true
         }
-
-        if let credentialError = error as? GetCredentialsForIdentityOutputError,
-           case .notAuthorizedException = credentialError {
+        if let serviceError: InitiateAuthOutputError = error.internalAWSServiceError(),
+           case .notAuthorizedException = serviceError {
             return true
         }
         return false

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/FetchAuthorizationSession/InformSessionError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/FetchAuthorizationSession/InformSessionError.swift
@@ -9,7 +9,6 @@ import Amplify
 import Foundation
 import AWSCognitoIdentityProvider
 import AWSCognitoIdentity
-import ClientRuntime
 
 struct InformSessionError: Action {
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/SdkError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/SdkError+AuthError.swift
@@ -82,3 +82,51 @@ extension SdkError: AuthErrorConvertible {
     }
 
 }
+
+extension Error {
+    func internalAWSServiceError<E>() -> E? {
+        if let internalError = self as? E {
+            return internalError
+        }
+
+        if let sdkError = self as? SdkError<E> {
+            return sdkError.internalAWSServiceError()
+        }
+        return nil
+    }
+}
+
+extension SdkError {
+
+    func internalAWSServiceError<E>() -> E? {
+        switch self {
+
+        case .service(let error, _):
+            if let serviceError = error as? E {
+                return serviceError
+            }
+
+        case .client(let clientError, _):
+            return clientError.internalAWSServiceError()
+
+        default: break
+
+        }
+        return nil
+    }
+}
+
+extension ClientError {
+
+    func internalAWSServiceError<E>() -> E? {
+        switch self {
+        case .retryError(let retryError):
+            if let sdkError = retryError as? SdkError<E> {
+                return sdkError.internalAWSServiceError()
+            }
+
+        default: break
+        }
+        return nil
+    }
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/ErrorMapping/SignInError+Helper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/ErrorMapping/SignInError+Helper.swift
@@ -12,80 +12,39 @@ import AWSCognitoIdentityProvider
 
 extension SignInError {
 
-    var isUserUnConfirmed: Bool {
+    var isUserNotConfirmed: Bool {
         switch self {
         case .service(error: let serviceError):
-            if let cognitoError = serviceError as? SdkError<InitiateAuthOutputError>,
-               case .service(let serviceError, _) = cognitoError,
-               case .userNotConfirmedException = serviceError {
-                return true
-            } else if let cognitoError = serviceError as? SdkError<InitiateAuthOutputError>,
-                      case .client(let clientError, _) = cognitoError,
-                      case .retryError(let retryError) = clientError,
-                      let cognitoServiceError = retryError as? SdkError<InitiateAuthOutputError>,
-                      case .service(let internalServiceError, _) = cognitoServiceError,
-                      case .userNotConfirmedException = internalServiceError {
-                return true
-            } else if let cognitoError = serviceError as? SdkError<RespondToAuthChallengeOutputError>,
-                      case .service(let serviceError, _) = cognitoError,
-                      case .userNotConfirmedException = serviceError {
-                return true
-            } else if let cognitoError = serviceError as? SdkError<RespondToAuthChallengeOutputError>,
-                       case .client(let clientError, _) = cognitoError,
-                       case .retryError(let retryError) = clientError,
-                       let cognitoServiceError = retryError as? SdkError<RespondToAuthChallengeOutputError>,
-                       case .service(let internalServiceError, _) = cognitoServiceError,
-                       case .userNotConfirmedException = internalServiceError {
-                 return true
-             } else if let cognitoError = serviceError as? InitiateAuthOutputError,
-                      case .userNotConfirmedException = cognitoError {
-                return true
-            } else if let cognitoError = serviceError as? RespondToAuthChallengeOutputError,
-                      case .userNotConfirmedException = cognitoError {
+
+            if let internalError: InitiateAuthOutputError = serviceError.internalAWSServiceError(),
+               case .userNotConfirmedException = internalError {
                 return true
             }
-            return false
-        default:
-            return false
+
+            if let internalError: RespondToAuthChallengeOutputError = serviceError.internalAWSServiceError(),
+               case .userNotConfirmedException = internalError {
+                return true
+            }
+        default: break
         }
+        return false
     }
 
     var isResetPassword: Bool {
         switch self {
         case .service(error: let serviceError):
-            if let cognitoError = serviceError as? SdkError<InitiateAuthOutputError>,
-               case .service(let serviceError, _) = cognitoError,
-               case .passwordResetRequiredException = serviceError {
-                return true
-            }  else if let cognitoError = serviceError as? SdkError<InitiateAuthOutputError>,
-                       case .client(let clientError, _) = cognitoError,
-                       case .retryError(let retryError) = clientError,
-                       let cognitoServiceError = retryError as? SdkError<InitiateAuthOutputError>,
-                       case .service(let internalServiceError, _) = cognitoServiceError,
-                       case .passwordResetRequiredException = internalServiceError {
-                 return true
-             } else if let cognitoError = serviceError as? SdkError<RespondToAuthChallengeOutputError>,
-                      case .service(let serviceError, _) = cognitoError,
-                      case .passwordResetRequiredException = serviceError {
-                return true
-            } else if let cognitoError = serviceError as? SdkError<RespondToAuthChallengeOutputError>,
-                      case .client(let clientError, _) = cognitoError,
-                      case .retryError(let retryError) = clientError,
-                      let cognitoServiceError = retryError as? SdkError<RespondToAuthChallengeOutputError>,
-                      case .service(let internalServiceError, _) = cognitoServiceError,
-                      case .passwordResetRequiredException = internalServiceError {
-                return true
-            } else if let cognitoError = serviceError as? InitiateAuthOutputError,
-                      case .passwordResetRequiredException = cognitoError {
-                return true
-            } else if let cognitoError = serviceError as? RespondToAuthChallengeOutputError,
-                      case .passwordResetRequiredException = cognitoError {
+            if let internalError: InitiateAuthOutputError = serviceError.internalAWSServiceError(),
+               case .passwordResetRequiredException = internalError {
                 return true
             }
-            return false
-        default:
-            return false
+
+            if let internalError: RespondToAuthChallengeOutputError = serviceError.internalAWSServiceError(),
+               case .passwordResetRequiredException = internalError {
+                return true
+            }
+        default: break
         }
+        return false
     }
 }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/UserPoolSignInHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/UserPoolSignInHelper.swift
@@ -53,7 +53,7 @@ struct UserPoolSignInHelper {
     }
 
     private static func validateError(signInError: SignInError) throws -> AuthSignInResult {
-        if signInError.isUserUnConfirmed {
+        if signInError.isUserNotConfirmed {
             return AuthSignInResult(nextStep: .confirmSignUp(nil))
         } else if signInError.isResetPassword {
             return AuthSignInResult(nextStep: .resetPassword(nil))


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-swift/issues/2599

*Description of changes:*

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
