### PR TITLE
fix(auth): FetchauthSession call get stuck when a signIn is in progress

### DIFF
--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFetchSignInSessionOperationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFetchSignInSessionOperationTests.swift
@@ -671,12 +671,12 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
         let credentialsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
 
         guard case .failure(let error) = credentialsResult,
-                case .sessionExpired = error else {
+              case .sessionExpired = error else {
             XCTFail("Should return sessionExpired error")
             return
         }
         let identityIdResult = (session as? AuthCognitoIdentityProvider)?.getIdentityId()
-         guard case .failure(let identityIdError) = identityIdResult,
+        guard case .failure(let identityIdError) = identityIdResult,
               case .sessionExpired = identityIdError else {
             XCTFail("Should return sessionExpired error")
             return
@@ -684,9 +684,9 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
 
         let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
         guard case .failure(let tokenError) = tokensResult,
-         case .sessionExpired = tokenError else {
+              case .sessionExpired = tokenError else {
             XCTFail("Should return sessionExpired error")
-             return
+            return
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-swift/issues/2608

*Description of changes:*
FetchAuthSession statemachine was not configured to handle `signingIn` state for fetching the session. This PR cancels any existing signIn flow and fetches unauth session when the statemachine receives fetchAuthSession call while waiting for signIn next step (ie confirmSignIn).

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
