### PR TITLE
fix(storage) Storage.uploadFile exits early on access denied

### DIFF
--- a/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests2.swift
+++ b/AmplifyPlugins/Storage/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests2.swift
@@ -1,0 +1,69 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSS3StoragePlugin
+@testable import AWSPluginsCore
+import AWSS3
+
+final class AWSS3StorageUploadFileOperationTests2: AWSS3StorageOperationTestBase {
+
+    func testUploadFileOperationAccessDenied() throws {
+        let url = try createInaccessibleFile(with: Data(UUID().uuidString.utf8))
+        defer {
+            try? FileManager.default.removeItem(at: url)
+        }
+
+        let key = (url.path as NSString).lastPathComponent
+        let options = StorageUploadFileRequest.Options(accessLevel: .protected)
+        let request = StorageUploadFileRequest(key: key, local: url, options: options)
+
+        let progressExpectation = expectation(description: "progress")
+        progressExpectation.isInverted = true
+        let progressListner: ProgressListener = { _ in progressExpectation.fulfill() }
+
+        let resultExpectation = expectation(description: "result")
+        let resultListener: StorageUploadFileOperation.ResultListener = { result in
+            switch result {
+            case .failure(let error):
+                guard case .accessDenied = error else {
+                    XCTFail("Should have failed with validation error")
+                    return
+                }
+                resultExpectation.fulfill()
+            case .success:
+                XCTFail("Expecting an error but got success")
+            }
+        }
+
+        let operation = AWSS3StorageUploadFileOperation(request,
+                                                        storageConfiguration: testStorageConfiguration,
+                                                        storageService: mockStorageService,
+                                                        authService: mockAuthService,
+                                                        progressListener: progressListner,
+                                                        resultListener: resultListener)
+        operation.start()
+
+        wait(for: [progressExpectation, resultExpectation], timeout: 1)
+        XCTAssertTrue(operation.isFinished)
+    }
+
+    private func createInaccessibleFile(with contents: Data) throws -> URL {
+        let url = try createTemporaryFile(with: Data(UUID().uuidString.utf8))
+        try FileManager.default.setAttributes([FileAttributeKey.posixPermissions: 000], ofItemAtPath: url.path)
+        return url
+    }
+
+    private func createTemporaryFile(with contents: Data) throws -> URL {
+        let path = NSTemporaryDirectory().appending(UUID().uuidString)
+        FileManager.default.createFile(atPath: path, contents: contents)
+        return URL(fileURLWithPath: path)
+    }
+
+}

--- a/AmplifyPlugins/Storage/StoragePlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Storage/StoragePlugin.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		21FF4E3E268B9D78009F5E5E /* AWSS3PluginPrefixResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FF4E3D268B9D78009F5E5E /* AWSS3PluginPrefixResolverTests.swift */; };
 		21FF4E40268B9D8E009F5E5E /* AWSS3StoragePluginConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FF4E3F268B9D8E009F5E5E /* AWSS3StoragePluginConfigurationTests.swift */; };
 		4A615AC1A34E1BA883AE760F /* Pods_HostApp_AWSS3StoragePluginFunctionalTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC784A86501873255662D8C7 /* Pods_HostApp_AWSS3StoragePluginFunctionalTests.framework */; };
+		567FD83C2968D01000A93127 /* AWSS3StorageUploadFileOperationTests2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567FD83B2968D01000A93127 /* AWSS3StorageUploadFileOperationTests2.swift */; };
 		81E7E9D6821EF0A560A93627 /* Pods_AWSS3StoragePlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B046927AA82214FE8EBAD505 /* Pods_AWSS3StoragePlugin.framework */; };
 		B478F64E2374DCE700C4F92B /* AWSS3StoragePlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B478F5FB2374DBF400C4F92B /* AWSS3StoragePlugin.framework */; };
 		B478F6DE2374E0CF00C4F92B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B478F6D12374E0CE00C4F92B /* ViewController.swift */; };
@@ -160,6 +161,7 @@
 		32FA30478A2D1E3534061E95 /* Pods-AWSPinpointAnalyticsPlugin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSPinpointAnalyticsPlugin.release.xcconfig"; path = "Target Support Files/Pods-AWSPinpointAnalyticsPlugin/Pods-AWSPinpointAnalyticsPlugin.release.xcconfig"; sourceTree = "<group>"; };
 		3504F0A7CDD9C0B83CC109CF /* Pods-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig"; path = "Target Support Files/Pods-AWSS3StoragePlugin-AWSS3StoragePluginTests/Pods-AWSS3StoragePlugin-AWSS3StoragePluginTests.debug.xcconfig"; sourceTree = "<group>"; };
 		55C25A32F11C14B88865E2C4 /* Pods-HostApp-AWSS3StoragePluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSS3StoragePluginTests.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSS3StoragePluginTests/Pods-HostApp-AWSS3StoragePluginTests.release.xcconfig"; sourceTree = "<group>"; };
+		567FD83B2968D01000A93127 /* AWSS3StorageUploadFileOperationTests2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3StorageUploadFileOperationTests2.swift; sourceTree = "<group>"; };
 		57D186E0D4EB50090BFC4EF4 /* Pods-HostApp-AWSPinpointAnalyticsPluginIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSPinpointAnalyticsPluginIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSPinpointAnalyticsPluginIntegrationTests/Pods-HostApp-AWSPinpointAnalyticsPluginIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		5AC7393AE2A0B932F0F38F7F /* Pods-HostApp-AWSPinpointAnalyticsPluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HostApp-AWSPinpointAnalyticsPluginTests.release.xcconfig"; path = "Target Support Files/Pods-HostApp-AWSPinpointAnalyticsPluginTests/Pods-HostApp-AWSPinpointAnalyticsPluginTests.release.xcconfig"; sourceTree = "<group>"; };
 		6747524CAA6E8CCA1012AF7D /* Pods-AWSPinpointAnalyticsPluginTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSPinpointAnalyticsPluginTests.release.xcconfig"; path = "Target Support Files/Pods-AWSPinpointAnalyticsPluginTests/Pods-AWSPinpointAnalyticsPluginTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -632,6 +634,7 @@
 				B4FEB6BB2375DA1500818CD2 /* AWSS3StoragePutDataOperationTests.swift */,
 				B4FEB6B22375DA1500818CD2 /* AWSS3StorageRemoveOperationTests.swift */,
 				B4FEB6B32375DA1500818CD2 /* AWSS3StorageUploadFileOperationTests.swift */,
+				567FD83B2968D01000A93127 /* AWSS3StorageUploadFileOperationTests2.swift */,
 			);
 			path = Operation;
 			sourceTree = "<group>";
@@ -1245,6 +1248,7 @@
 				B4FEB6E52375DA1500818CD2 /* AWSS3StorageOperationTestBase.swift in Sources */,
 				B4FEB6FE2375DA1600818CD2 /* AWSS3StorageServiceEscapeHatchBehaviorTests.swift in Sources */,
 				B4FEB6EE2375DA1500818CD2 /* StorageRequestUtilsGetterTests.swift in Sources */,
+				567FD83C2968D01000A93127 /* AWSS3StorageUploadFileOperationTests2.swift in Sources */,
 				B4FEB6E32375DA1500818CD2 /* AWSS3StorageDownloadFileOperationTests.swift in Sources */,
 				B4FEB6DE2375DA1500818CD2 /* MockAWSS3PreSignedURLBuilder.swift in Sources */,
 				B4FEB6FB2375DA1600818CD2 /* AWSS3StorageServiceListBehaviorTests.swift in Sources */,


### PR DESCRIPTION
# Issue #
https://github.com/aws-amplify/amplify-swift/issues/2355

# Description of changes:
**v1** fix for https://github.com/aws-amplify/amplify-swift/issues/2355 where upload will do an early return if the file represented by the given URL is innaccessible.

# Check points: (check or cross out if not relevant)

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
