### PR TITLE
fix(auth): Delete user api get stuck on no network

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/DeleteUser/DeleteUser.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/DeleteUser/DeleteUser.swift
@@ -47,7 +47,7 @@ struct DeleteUser: Action {
                 _ = try await client.deleteUser(input: input)
                 event = DeleteUserEvent(eventType: .signOutDeletedUser)
                 logVerbose("\(#fileID) Delete User succeeded", environment: environment)
-            } catch let error as DeleteUserOutputError {
+            } catch let error as AuthErrorConvertible {
                 event = DeleteUserEvent(eventType: .throwError(error.authError))
                 logVerbose("\(#fileID) Delete User failed \(error)", environment: environment)
             } catch let error {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
@@ -159,7 +159,9 @@ extension AWSCognitoAuthPlugin: AuthCategoryBehavior {
     }
 
     public func deleteUser() async throws {
-        let task = AWSAuthDeleteUserTask(authStateMachine: self.authStateMachine)
+        let task = AWSAuthDeleteUserTask(
+            authStateMachine: self.authStateMachine,
+            authConfiguraiton: authConfiguration)
         _ = try await taskQueue.sync {
             return try await task.value
         }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/FetchAuthSessionOperationHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/FetchAuthSessionOperationHelper.swift
@@ -174,13 +174,18 @@ class FetchAuthSessionOperationHelper {
 
         switch error {
 
-        case .notAuthorized:
+        case .notAuthorized, .noCredentialsToRefresh:
             if !isSignedIn {
                 return AuthCognitoSignedOutSessionHelper.makeSessionWithNoGuestAccess()
             }
-        case .noCredentialsToRefresh:
-            if !isSignedIn {
-                return AuthCognitoSignedOutSessionHelper.makeSessionWithNoGuestAccess()
+
+        case .service(let error):
+            if let authError = (error as? AuthErrorConvertible)?.authError {
+                let session = AWSAuthCognitoSession(isSignedIn: isSignedIn,
+                                                    identityIdResult: .failure(authError),
+                                                    awsCredentialsResult: .failure(authError),
+                                                    cognitoTokensResult: .failure(authError))
+                return session
             }
         default: break
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/AuthErrorConvertible.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/AuthErrorConvertible.swift
@@ -14,3 +14,9 @@ protocol AuthErrorConvertible {
 
     var authError: AuthError { get }
 }
+
+extension AuthError: AuthErrorConvertible {
+    var authError: AuthError {
+        return self
+    }
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/SdkError+AuthError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/SdkError+AuthError.swift
@@ -70,9 +70,13 @@ extension SdkError: AuthErrorConvertible {
             if let authError = error as? AuthErrorConvertible {
                 return authError.authError
             } else {
-                return AuthError.service(error.localizedDescription,
-                                         "",
-                                         AWSCognitoAuthError.network)
+                return AuthError.service(
+                    error.localizedDescription,
+                    """
+                    Check your network connection, retry when the network is available.
+                    HTTP Response stauts code: \(String(describing: httpResponse?.statusCode))
+                    """,
+                    AWSCognitoAuthError.network)
 
             }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/AuthEvents.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/AuthEvents.swift
@@ -22,6 +22,8 @@ struct AuthEvent: StateMachineEvent {
         case authenticationConfigured(AuthConfiguration, AmplifyCredentials)
 
         case authorizationConfigured
+
+        case reconfigure(AuthConfiguration)
     }
 
     var id: String
@@ -38,6 +40,7 @@ struct AuthEvent: StateMachineEvent {
         case .authenticationConfigured: return "AuthEvent.authenticationConfigured"
         case .authorizationConfigured: return "AuthEvent.authorizationConfigured"
         case .validateCredentialAndConfiguration: return "AuthEvent.validateCredentialAndConfiguration"
+        case .reconfigure: return "AuthEvent.reconfigure"
         }
     }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/AuthState/AuthState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/AuthState/AuthState+Resolver.swift
@@ -80,6 +80,11 @@ extension AuthState {
                 return .init(newState: newState, actions: authNresolution.actions + authZresolution.actions)
 
             case .configured(let authenticationState, let authorizationState):
+                if case .reconfigure(let authConfiguration) = isAuthEvent(event)?.eventType {
+                    let newState = AuthState.configuringAuth
+                    let action = InitializeAuthConfiguration(authConfiguration: authConfiguration)
+                    return .init(newState: newState, actions: [action])
+                }
                 let authenticationResolver = AuthenticationState.Resolver()
                 let authorizationResolver = AuthorizationState.Resolver()
                 let authNresolution = authenticationResolver.resolve(oldState: authenticationState, byApplying: event)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/RefreshSession/RefreshSessionState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/RefreshSession/RefreshSessionState+Resolver.swift
@@ -18,6 +18,7 @@ extension RefreshSessionState {
                      byApplying event: StateMachineEvent) -> StateResolution<RefreshSessionState> {
 
             switch oldState {
+
             case .notStarted:
 
                 if case .refreshCognitoUserPool(let signedInData) = event.isRefreshSessionEvent {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-swift/issues/2643

*Description of changes:*
When delete user fails, the auth state machine reaches a terminal state and it never recovers from there. This PR changes that and if the delete user fails, auth state machine will try to configure back to the previous state using the cached credentials.

*Check points: (check or cross out if not relevant)*

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
