### PR TITLE
chore: enable lazy loading integration tests

### DIFF
--- a/.github/workflows/integ_test_api.yml
+++ b/.github/workflows/integ_test_api.yml
@@ -2,7 +2,7 @@ name: API Integration Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [data-dev-preview.github-workflows]
 
 permissions:
     id-token: write

--- a/.github/workflows/integ_test_datastore.yml
+++ b/.github/workflows/integ_test_datastore.yml
@@ -2,7 +2,7 @@ name: DataStore Integration Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [data-dev-preview.github-workflows]
 
 permissions:
     id-token: write

--- a/.github/workflows/integ_test_datastore_lazy_load.yml
+++ b/.github/workflows/integ_test_datastore_lazy_load.yml
@@ -1,6 +1,8 @@
 name: DataStore Lazy Load Tests
 on:
   workflow_dispatch:
+  push:
+    branches: [data-dev-preview]
 
 permissions:
     id-token: write
@@ -27,7 +29,7 @@ jobs:
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG }}
 
-  datastore-integration-v2-test:
+  datastore-integration-lazy-load-test:
     timeout-minutes: 30
     needs: prepare-for-test
     runs-on: macos-12
@@ -53,5 +55,3 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginLazyLoadTests
-
- 

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -2,7 +2,7 @@ name: DataStore TransformerV2 Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [data-dev-preview.github-workflows]
 
 permissions:
     id-token: write

--- a/Amplify/Core/Error/CoreError.swift
+++ b/Amplify/Core/Error/CoreError.swift
@@ -10,7 +10,7 @@ public enum CoreError {
 
     /// A related operation performed on `List` resulted in an error.
     case listOperation(ErrorDescription, RecoverySuggestion, Error? = nil)
-    
+
     /// A client side validation error occured.
     case clientValidation(ErrorDescription, RecoverySuggestion, Error? = nil)
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/README.md
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/README.md
@@ -8,9 +8,11 @@
 
 1. `amplify init`
 
-These tests were provisioned with V2 Transform:, and updates to `cli.json` 
-- "respectprimarykeyattributesonconnectionfield": true
-- "TODOlazyLoadiOS": true 
+These tests were provisioned with V2 Transform, CPK enabled, and with the lazy loading feature flag. Review or make updates to cli.json
+
+"transformerversion":2
+"respectprimarykeyattributesonconnectionfield": true
+"generateModelsForLazyLoadAndCustomSelectionSet": true
 
 2. `amplify add api`
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/README.md
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/README.md
@@ -8,9 +8,11 @@
 
 1. `amplify init`
 
-These tests were provisioned with V2 Transform:, and updates to `cli.json` 
+These tests were provisioned with V2 Transform, CPK enabled, and with the lazy loading feature flag.
+Review or make updates to `cli.json`
+- "transformerversion":2 
 - "respectprimarykeyattributesonconnectionfield": true
-- "TODOlazyLoadiOS": true 
+- "generateModelsForLazyLoadAndCustomSelectionSet": true 
 
 2. `amplify add api`
 
@@ -28,5 +30,6 @@ These tests were provisioned with V2 Transform:, and updates to `cli.json`
 4. Copy `amplifyconfiguration.json` to a new file named `AWSDataStoreCategoryPluginLazyLoadIntegrationTests-amplifyconfiguration.json` inside `~/.aws-amplify/amplify-ios/testconfiguration/`
 
 ```perl
-cp amplifyconfiguration.json ~/.aws-amplify/amplify-ios/testconfiguration/AWSDataStoreCategoryPluginLazyLoadIntegrationTests-amplifyconfiguration.json
+cp amplifyconfiguration.json AWSDataStoreCategoryPluginLazyLoadIntegrationTests-amplifyconfiguration.json
+cp AWSDataStoreCategoryPluginLazyLoadIntegrationTests-amplifyconfiguration.json ~/.aws-amplify/amplify-ios/testconfiguration/
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Enable DataStore and API LazyLoading integration tests

*Check points: (check or cross out if not relevant)*

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

*DataStore checkpoints (check when completed)*

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
