### PR TITLE
fix(auth): Device binding in auth flows

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/RefreshAuthorizationSession/UserPool/RefreshUserPoolTokens.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/RefreshAuthorizationSession/UserPool/RefreshUserPoolTokens.swift
@@ -34,8 +34,8 @@ struct RefreshUserPoolTokens: Action {
             let existingTokens = existingSignedIndata.cognitoUserPoolTokens
 
             let deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
-                for: environment,
-                with: existingSignedIndata.username)
+                for: existingSignedIndata.username,
+                environment: environment)
 
             let asfDeviceId = try await CognitoUserPoolASF.asfDeviceID(
                 for: existingSignedIndata.username,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/InitiateAuthDeviceSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/InitiateAuthDeviceSRP.swift
@@ -30,8 +30,8 @@ struct InitiateAuthDeviceSRP: Action {
 
             // Get device metadata
             let deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
-                for: environment,
-                with: username)
+                for: username,
+                environment: environment)
 
             let srpStateData = SRPStateData(
                 username: username,
@@ -39,7 +39,6 @@ struct InitiateAuthDeviceSRP: Action {
                 NHexValue: nHexValue,
                 gHexValue: gHexValue,
                 srpKeyPair: srpKeyPair,
-                deviceMetadata: deviceMetadata,
                 clientTimestamp: Date())
 
             let request = RespondToAuthChallengeInput.deviceSRP(

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/VerifyDevicePasswordSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/VerifyDevicePasswordSRP.swift
@@ -33,12 +33,15 @@ struct VerifyDevicePasswordSRP: Action {
             let secretBlock = try secretBlock(secretBlockString)
             let serverPublicB = try serverPublic(parameters)
 
-            guard case .metadata(let deviceData) = stateData.deviceMetadata else {
+            let deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
+                for: username,
+                environment: environment)
+            guard
+                case .metadata(let deviceData) = deviceMetadata
+            else {
                 let authError = SignInError.service(error: SRPError.calculation)
                 logVerbose("\(#fileID) DevciceSRPSignInError \(authError)", environment: environment)
-                let event = SignInEvent(
-                    eventType: .throwPasswordVerifierError(authError)
-                )
+                let event = SignInEvent(eventType: .throwPasswordVerifierError(authError))
                 await dispatcher.send(event)
                 return
             }
@@ -58,6 +61,7 @@ struct VerifyDevicePasswordSRP: Action {
                 session: authResponse.session,
                 secretBlock: secretBlockString,
                 signature: signature,
+                deviceMetadata: deviceMetadata,
                 environment: userPoolEnv)
 
             let responseEvent = try await UserPoolSignInHelper.sendRespondToAuth(

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/IntializeSignInFlow.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/IntializeSignInFlow.swift
@@ -34,8 +34,8 @@ struct InitializeSignInFlow: Action {
         var deviceMetadata = DeviceMetadata.noData
         if let username = signInEventData.username {
             deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
-                for: environment,
-                with: username)
+                for: username,
+                environment: environment)
         }
 
         let event: SignInEvent

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/InitiateAuthSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/InitiateAuthSRP.swift
@@ -50,7 +50,6 @@ struct InitiateAuthSRP: Action {
                 NHexValue: nHexValue,
                 gHexValue: gHexValue,
                 srpKeyPair: srpKeyPair,
-                deviceMetadata: deviceMetadata,
                 clientTimestamp: Date())
 
             let asfDeviceId = try await CognitoUserPoolASF.asfDeviceID(

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/VerifyPasswordSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/VerifyPasswordSRP.swift
@@ -25,22 +25,25 @@ struct VerifyPasswordSRP: Action {
                  environment: Environment) async {
 
         logVerbose("\(#fileID) Starting execution", environment: environment)
-
+        let inputUsername = stateData.username
+        var username = inputUsername
+        var deviceMetadata = DeviceMetadata.noData
         do {
             let srpEnv = try environment.srpEnvironment()
             let userPoolEnv = try environment.userPoolEnvironment()
             let srpClient = try SRPSignInHelper.srpClient(srpEnv)
             let parameters = try challengeParameters()
 
-            let inputUsername = stateData.username
-            let username = parameters["USERNAME"] ?? inputUsername
+            username = parameters["USERNAME"] ?? inputUsername
             let userIdForSRP = parameters["USER_ID_FOR_SRP"] ?? inputUsername
-
             let saltHex = try saltHex(parameters)
             let secretBlockString = try secretBlockString(parameters)
             let secretBlock = try secretBlock(secretBlockString)
             let serverPublicB = try serverPublic(parameters)
 
+            deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
+                for: username,
+                environment: environment)
             let signature = try signature(userIdForSRP: userIdForSRP,
                                           saltHex: saltHex,
                                           secretBlock: secretBlock,
@@ -53,6 +56,7 @@ struct VerifyPasswordSRP: Action {
                 session: authResponse.session,
                 secretBlock: secretBlockString,
                 signature: signature,
+                deviceMetadata: deviceMetadata,
                 environment: userPoolEnv)
             let responseEvent = try await UserPoolSignInHelper.sendRespondToAuth(
                 request: request,
@@ -67,6 +71,16 @@ struct VerifyPasswordSRP: Action {
             let event = SignInEvent(
                 eventType: .throwPasswordVerifierError(error)
             )
+            logVerbose("\(#fileID) Sending event \(event)",
+                       environment: environment)
+            await dispatcher.send(event)
+        } catch let error where deviceNotFound(error: error, deviceMetadata: deviceMetadata) {
+            logVerbose("\(#fileID) Received device not found \(error)", environment: environment)
+            // Remove the saved device details and retry password verify
+            await DeviceMetadataHelper.removeDeviceMetaData(of: username, environment: environment)
+            let event = SignInEvent(eventType: .retryRespondPasswordVerifier(stateData, authResponse))
+            logVerbose("\(#fileID) Sending event \(event)",
+                       environment: environment)
             await dispatcher.send(event)
         } catch {
             logVerbose("\(#fileID) SRPSignInError Generic \(error)", environment: environment)
@@ -74,8 +88,24 @@ struct VerifyPasswordSRP: Action {
             let event = SignInEvent(
                 eventType: .throwAuthError(authError)
             )
+            logVerbose("\(#fileID) Sending event \(event)",
+                       environment: environment)
             await dispatcher.send(event)
         }
+    }
+
+    func deviceNotFound(error: Error, deviceMetadata: DeviceMetadata) -> Bool {
+
+        // If deviceMetadata was not send, the error returned is not from device not found.
+        if case .noData = deviceMetadata {
+            return false
+        }
+
+        if let serviceError: RespondToAuthChallengeOutputError = error.internalAWSServiceError(),
+           case .resourceNotFoundException = serviceError {
+            return true
+        }
+        return false
     }
 }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/VerifySignInChallenge.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/VerifySignInChallenge.swift
@@ -53,7 +53,7 @@ struct VerifySignInChallenge: Action {
                        environment: environment)
             await dispatcher.send(errorEvent)
         } catch {
-            let error = SignInError.invalidServiceResponse(message: error.localizedDescription)
+            let error = SignInError.service(error: error)
             let errorEvent = SignInEvent(eventType: .throwAuthError(error))
             logVerbose("\(#fileID) Sending event \(errorEvent)",
                        environment: environment)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/VerifySignInChallenge.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/VerifySignInChallenge.swift
@@ -29,6 +29,10 @@ struct VerifySignInChallenge: Action {
             let challengeType = challenge.challenge
             let responseKey = try challenge.getChallengeKey()
 
+            let deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
+                for: username,
+                environment: environment)
+
             let input = RespondToAuthChallengeInput.verifyChallenge(
                 username: username,
                 challengeType: challengeType,
@@ -37,6 +41,7 @@ struct VerifySignInChallenge: Action {
                 answer: confirmSignEventData.answer,
                 clientMetadata: confirmSignEventData.metadata,
                 attributes: confirmSignEventData.attributes,
+                deviceMetadata: deviceMetadata,
                 environment: userpoolEnv)
 
             let responseEvent = try await UserPoolSignInHelper.sendRespondToAuth(

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/SRPStateData.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/SRPStateData.swift
@@ -13,7 +13,6 @@ struct SRPStateData {
     let NHexValue: String
     let gHexValue: String
     let srpKeyPair: SRPKeys
-    let deviceMetadata: DeviceMetadata
     let clientTimestamp: Date
 
     init(
@@ -22,7 +21,6 @@ struct SRPStateData {
         NHexValue: String,
         gHexValue: String,
         srpKeyPair: SRPKeys,
-        deviceMetadata: DeviceMetadata,
         clientTimestamp: Date
     ) {
         self.username = username
@@ -30,7 +28,6 @@ struct SRPStateData {
         self.NHexValue = NHexValue
         self.gHexValue = gHexValue
         self.srpKeyPair = srpKeyPair
-        self.deviceMetadata = deviceMetadata
         self.clientTimestamp = clientTimestamp
     }
 
@@ -53,7 +50,6 @@ extension SRPStateData: CustomDebugDictionaryConvertible {
                 <privateKey \(srpKeyPair.privateKeyHexValue)>, \
                 <publicKey \(srpKeyPair.publicKeyHexValue)>
                 """,
-            "deviceMetadata": deviceMetadata,
             "clientTimestamp": clientTimestamp
         ]
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInChallengeEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInChallengeEvent.swift
@@ -15,6 +15,8 @@ struct SignInChallengeEvent: StateMachineEvent {
 
         case verifyChallengeAnswer(ConfirmSignInEventData)
 
+        case retryVerifyChallengeAnswer(ConfirmSignInEventData)
+
         case verified
 
     }
@@ -28,6 +30,7 @@ struct SignInChallengeEvent: StateMachineEvent {
         case .verified: return "SignInChallengeEvent.verified"
         case .verifyChallengeAnswer: return "SignInChallengeEvent.verifyChallengeAnswer"
         case .waitForAnswer: return "SignInChallengeEvent.waitForAnswer"
+        case .retryVerifyChallengeAnswer: return "SignInChallengeEvent.retryVerifyChallengeAnswer"
         }
     }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInEvent.swift
@@ -29,6 +29,8 @@ struct SignInEvent: StateMachineEvent {
 
         case respondPasswordVerifier(SRPStateData, InitiateAuthOutputResponse)
 
+        case retryRespondPasswordVerifier(SRPStateData, InitiateAuthOutputResponse)
+
         case initiateDeviceSRP(Username, SignInResponseBehavior)
 
         case respondDeviceSRPChallenge(Username, SignInResponseBehavior)
@@ -72,6 +74,7 @@ struct SignInEvent: StateMachineEvent {
         case .throwAuthError: return "SignInEvent.throwAuthError"
         case .receivedChallenge: return "SignInEvent.receivedChallenge"
         case .verifySMSChallenge: return "SignInEvent.verifySMSChallenge"
+        case . retryRespondPasswordVerifier: return "SignInEvent.retryRespondPasswordVerifier"
         }
     }
 
@@ -104,7 +107,8 @@ extension SignInEvent.EventType: Equatable {
             (.cancelSRPSignIn, .cancelSRPSignIn),
             (.throwAuthError, .throwAuthError),
             (.receivedChallenge, .receivedChallenge),
-            (.verifySMSChallenge, .verifySMSChallenge):
+            (.verifySMSChallenge, .verifySMSChallenge),
+            (.retryRespondPasswordVerifier, .retryRespondPasswordVerifier):
             return true
         default: return false
         }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SRP/SRPSignInState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SRP/SRPSignInState+Resolver.swift
@@ -102,6 +102,13 @@ extension SRPSignInState {
             byApplying signInEvent: SignInEvent)
         -> StateResolution<SRPSignInState> {
             switch signInEvent.eventType {
+            case .retryRespondPasswordVerifier(let srpStateData, let authResponse):
+                let action = VerifyPasswordSRP(stateData: srpStateData,
+                                               authResponse: authResponse)
+                return StateResolution(
+                    newState: SRPSignInState.respondingPasswordVerifier(srpStateData),
+                    actions: [action]
+                )
             case .finalizeSignIn(let signedInData):
                 return .init(newState: .signedIn(signedInData),
                              actions: [SignInComplete(signedInData: signedInData)])

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SignIn/SignInChallengeState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SignIn/SignInChallengeState+Resolver.swift
@@ -42,6 +42,17 @@ extension SignInChallengeState {
 
             case .verifying(let challenge, let signInMethod, _):
 
+                if case .retryVerifyChallengeAnswer(let answerEventData) = event.isChallengeEvent {
+                    let action = VerifySignInChallenge(
+                        challenge: challenge,
+                        confirmSignEventData: answerEventData,
+                        signInMethod: signInMethod)
+                    return .init(
+                        newState: .verifying(challenge, signInMethod, answerEventData.answer),
+                        actions: [action]
+                    )
+                }
+
                 if case .finalizeSignIn(let signedInData) = event.isSignInEvent {
                     return .init(newState: .verified,
                                  actions: [SignInComplete(signedInData: signedInData)])

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/DeviceMetadataHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/DeviceMetadataHelper.swift
@@ -10,8 +10,8 @@ import AWSPluginsCore
 struct DeviceMetadataHelper {
 
     static func getDeviceMetadata(
-        for environment: Environment,
-        with username: String) async -> DeviceMetadata {
+        for username: String,
+        environment: Environment) async -> DeviceMetadata {
             let credentialStoreClient = (environment as? AuthEnvironment)?.credentialsClient
             do {
                 let data = try await credentialStoreClient?.fetchData(type: .deviceMetadata(username: username))
@@ -29,6 +29,19 @@ struct DeviceMetadataHelper {
                 logger?.error("Unable to fetch device metadata with error: \(error)")
             }
             return .noData
+        }
+
+    static func removeDeviceMetaData(
+        of username: String,
+        environment: Environment) async {
+            let credentialStoreClient = (environment as? AuthEnvironment)?.credentialsClient
+            do {
+                try await credentialStoreClient?.deleteData(
+                    type: .deviceMetadata(username: username))
+            } catch {
+                let logger = (environment as? LoggerProvider)?.logger
+                logger?.error("Unable to fetch device metadata with error: \(error)")
+            }
         }
 
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/UserPoolSignInHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/UserPoolSignInHelper.swift
@@ -69,16 +69,12 @@ struct UserPoolSignInHelper {
         environment: UserPoolEnvironment) async throws -> StateMachineEvent {
 
             let client = try environment.cognitoUserPoolFactory()
-
-            do {
-                let response = try await client.respondToAuthChallenge(input: request)
-                let event = try self.parseResponse(response, for: username, signInMethod: signInMethod)
-                return event
-            } catch {
-                let authError = SignInError.service(error: error)
-                return SignInEvent(eventType: .throwAuthError(authError))
-            }
+            let response = try await client.respondToAuthChallenge(input: request)
+            let event = try self.parseResponse(response, for: username, signInMethod: signInMethod)
+            return event
         }
+
+
 
     static func parseResponse(
         _ response: SignInResponseBehavior,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/RespondToAuthChallengeInput+Amplify.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/RespondToAuthChallengeInput+Amplify.swift
@@ -84,6 +84,7 @@ extension RespondToAuthChallengeInput {
         answer: String,
         clientMetadata: [String: String]?,
         attributes: [String: String],
+        deviceMetadata: DeviceMetadata,
         environment: UserPoolEnvironment) -> RespondToAuthChallengeInput {
 
             var challengeResponses = [
@@ -101,7 +102,7 @@ extension RespondToAuthChallengeInput {
                 challengeResponses: challengeResponses,
                 session: session,
                 clientMetadata: clientMetadata ?? [:],
-                deviceMetadata: .noData,
+                deviceMetadata: deviceMetadata,
                 environment: environment)
         }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/RespondToAuthChallengeInput+Amplify.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/RespondToAuthChallengeInput+Amplify.swift
@@ -15,6 +15,7 @@ extension RespondToAuthChallengeInput {
                                  session: String?,
                                  secretBlock: String,
                                  signature: String,
+                                 deviceMetadata: DeviceMetadata,
                                  environment: UserPoolEnvironment) -> RespondToAuthChallengeInput {
         let dateStr = stateData.clientTimestamp.utcString
         let challengeResponses = [
@@ -28,7 +29,7 @@ extension RespondToAuthChallengeInput {
             challengeResponses: challengeResponses,
             session: session,
             clientMetadata: [:],
-            deviceMetadata: stateData.deviceMetadata,
+            deviceMetadata: deviceMetadata,
             environment: environment)
     }
 
@@ -56,6 +57,7 @@ extension RespondToAuthChallengeInput {
                                        session: String?,
                                        secretBlock: String,
                                        signature: String,
+                                       deviceMetadata: DeviceMetadata,
                                        environment: UserPoolEnvironment)
     -> RespondToAuthChallengeInput {
         let dateStr = stateData.clientTimestamp.utcString
@@ -70,7 +72,7 @@ extension RespondToAuthChallengeInput {
             challengeResponses: challengeResponses,
             session: session,
             clientMetadata: [:],
-            deviceMetadata: stateData.deviceMetadata,
+            deviceMetadata: deviceMetadata,
             environment: environment)
     }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthForgetDeviceTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthForgetDeviceTask.swift
@@ -62,8 +62,8 @@ class AWSAuthForgetDeviceTask: AuthForgetDeviceTask {
         let userPoolService = try environment.cognitoUserPoolFactory()
         guard let device = request.device else {
             let deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
-                for: environment,
-                with: username)
+                for: username,
+                environment: environment)
             if case .metadata(let data) = deviceMetadata {
                 let input = ForgetDeviceInput(accessToken: accessToken, deviceKey: data.deviceKey)
                 _ = try await userPoolService.forgetDevice(input: input)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthRememberDeviceTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthRememberDeviceTask.swift
@@ -60,8 +60,8 @@ class AWSAuthRememberDeviceTask: AuthRememberDeviceTask {
     private func rememberDevice(with accessToken: String, username: String) async throws {
         let userPoolService = try environment.cognitoUserPoolFactory()
         let deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
-            for: environment,
-            with: username)
+            for: username,
+            environment: environment)
         if case .metadata(let data) = deviceMetadata {
             let input = UpdateDeviceStatusInput(accessToken: accessToken,
                                                 deviceKey: data.deviceKey,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyPasswordSRPTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyPasswordSRPTests.swift
@@ -419,4 +419,135 @@ class VerifyPasswordSRPTests: XCTestCase {
         await waitForExpectations(timeout: 0.1)
     }
 
+    /// Test verify password retry on device not found
+    ///
+    /// - Given: VerifyPasswordSRP action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input and mock empty device not found error from Cognito
+    /// - Then:
+    ///    - Should send an event with retryRespondPasswordVerifier
+    ///
+    func testPasswordVerifierWithDeviceNotFound() async {
+
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    throw RespondToAuthChallengeOutputError.resourceNotFoundException(
+                        ResourceNotFoundException()
+                    )
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+
+        let data = InitiateAuthOutputResponse.validTestData
+        let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
+                                       authResponse: data)
+
+        let passwordVerifierError = expectation(description: "passwordVerifierError")
+
+        let dispatcher = MockDispatcher { event in
+            defer { passwordVerifierError.fulfill() }
+
+            guard let event = event as? SignInEvent else {
+                XCTFail("Expected event to be SignInEvent but got \(event)")
+                return
+            }
+
+            guard case .retryRespondPasswordVerifier = event.eventType
+            else {
+                XCTFail("Should receive retryRespondPasswordVerifier")
+                return
+            }
+        }
+
+        await action.execute(withDispatcher: dispatcher, environment: environment)
+        await waitForExpectations(timeout: 0.1)
+    }
+
+    /// Test  successful response from the VerifyPasswordSRP for confirmDevice
+    ///
+    /// - Given: VerifyPasswordSRP action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input and mock new device 
+    /// - Then:
+    ///    - Should send an event confirmDevice
+    ///
+    func testRespondToAuthChallengeWithConfirmDevice() async {
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    return RespondToAuthChallengeOutputResponse.testDataWithNewDevice()
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+
+        let data = InitiateAuthOutputResponse.validTestData
+        let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
+                                       authResponse: data)
+
+        let passwordVerifierCompletion = expectation(
+            description: "passwordVerifierCompletion")
+
+        let dispatcher = MockDispatcher { event in
+            guard let event = event as? SignInEvent else {
+                XCTFail("Expected event to be SignInEvent but got \(event)")
+                return
+            }
+
+            if case .confirmDevice(let signedInData) = event.eventType {
+                XCTAssertNotNil(signedInData)
+                passwordVerifierCompletion.fulfill()
+            }
+        }
+
+        await action.execute(withDispatcher: dispatcher, environment: environment)
+        await waitForExpectations(timeout: 0.1)
+    }
+
+    /// Test  successful response from the VerifyPasswordSRP for verifyDevice
+    ///
+    /// - Given: VerifyPasswordSRP action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input and mock verify device as response
+    /// - Then:
+    ///    - Should send an event initiateDeviceSRP
+    ///
+    func testRespondToAuthChallengeWithVerifyDevice() async {
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    return RespondToAuthChallengeOutputResponse.testDataWithVerifyDevice()
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+
+        let data = InitiateAuthOutputResponse.validTestData
+        let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
+                                       authResponse: data)
+
+        let passwordVerifierCompletion = expectation(
+            description: "passwordVerifierCompletion")
+
+        let dispatcher = MockDispatcher { event in
+            guard let event = event as? SignInEvent else {
+                XCTFail("Expected event to be SignInEvent but got \(event)")
+                return
+            }
+
+            if case .initiateDeviceSRP(_, let response) = event.eventType {
+                XCTAssertNotNil(response)
+                passwordVerifierCompletion.fulfill()
+            }
+        }
+
+        await action.execute(withDispatcher: dispatcher, environment: environment)
+        await waitForExpectations(timeout: 0.1)
+    }
+
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/VerifySignInChallenge/VerifySignInChallengeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/VerifySignInChallenge/VerifySignInChallengeTests.swift
@@ -1,0 +1,320 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AWSCognitoIdentityProvider
+@testable import AWSPluginsTestCommon
+@testable import AWSCognitoAuthPlugin
+
+class VerifySignInChallengeTests: XCTestCase {
+
+    typealias CognitoFactory = BasicSRPAuthEnvironment.CognitoUserPoolFactory
+
+    let mockRespondAuthChallenge = RespondToAuthChallenge(challenge: .smsMfa,
+                                                          username: "usernameMock",
+                                                          session: "mockSession",
+                                                          parameters: [:])
+    let mockConfirmEvent = ConfirmSignInEventData(answer: "1233",
+                                              attributes: [:],
+                                              metadata: [:])
+
+    /// Test if valid input are given the service call is made
+    ///
+    /// - Given: VerifySignInChallenge action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input
+    /// - Then:
+    ///    - Cognito client should invoke the api `respondToAuthChallengeCallback`
+    ///
+    func testInitiateVerifyChallenge() async {
+        let verifyPasswordInvoked = expectation(
+            description: "verifyChallengeInvoked"
+        )
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    verifyPasswordInvoked.fulfill()
+                    return RespondToAuthChallengeOutputResponse()
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+        let action = VerifySignInChallenge(challenge: mockRespondAuthChallenge,
+                                           confirmSignEventData: mockConfirmEvent,
+                                           signInMethod: .apiBased(.userSRP))
+
+        await action.execute(
+            withDispatcher: MockDispatcher { _ in },
+            environment: environment
+        )
+
+        await waitForExpectations(timeout: 0.1)
+    }
+
+    /// Test empty response is returned by Cognito proper error is thrown
+    ///
+    /// - Given: VerifySignInChallenge action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input and mock empty response from service
+    /// - Then:
+    ///    - Should send an event with proper error
+    ///
+    func testVerifyChallengeWithEmptyResponse() async {
+
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    return RespondToAuthChallengeOutputResponse()
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+
+        let action = VerifySignInChallenge(challenge: mockRespondAuthChallenge,
+                                           confirmSignEventData: mockConfirmEvent,
+                                           signInMethod: .apiBased(.userSRP))
+
+        let passwordVerifierError = expectation(description: "passwordVerifierError")
+
+        let dispatcher = MockDispatcher { event in
+            defer { passwordVerifierError.fulfill() }
+
+            guard let event = event as? SignInEvent else {
+                XCTFail("Expected event to be SignInEvent but got \(event)")
+                return
+            }
+
+            guard case let .throwAuthError(error) = event.eventType,
+                  case .invalidServiceResponse = error
+            else {
+                      XCTFail("Should receive invalid service response")
+                      return
+                  }
+
+        }
+
+        await action.execute(withDispatcher: dispatcher, environment: environment)
+        await waitForExpectations(timeout: 0.1)
+    }
+
+    /// Test  successful response from the VerifySignInChallenge
+    ///
+    /// - Given: VerifySignInChallenge action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input
+    /// - Then:
+    ///    - Should send an event with the result
+    ///
+    func testSuccessfulRespondToAuthChallengePropagatesSuccess() async {
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    return RespondToAuthChallengeOutputResponse.testData()
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+
+        let action = VerifySignInChallenge(challenge: mockRespondAuthChallenge,
+                                           confirmSignEventData: mockConfirmEvent,
+                                           signInMethod: .apiBased(.userSRP))
+
+        let verifyChallengeComplete = expectation(description: "verifyChallengeComplete")
+
+        let dispatcher = MockDispatcher { event in
+            guard let event = event as? SignInEvent else {
+                XCTFail("Expected event to be SignInEvent but got \(event)")
+                return
+            }
+
+            if case let .finalizeSignIn(signedInData) = event.eventType {
+                XCTAssertNotNil(signedInData)
+                verifyChallengeComplete.fulfill()
+            }
+        }
+
+        await action.execute(withDispatcher: dispatcher, environment: environment)
+        await waitForExpectations(timeout: 0.1)
+    }
+
+    /// Test  successful response from the VerifySignInChallenge
+    ///
+    /// - Given: VerifySignInChallenge action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input and mock error from service
+    /// - Then:
+    ///    - Should send an event with service error
+    ///
+    func testRespondToAuthChallengePropagatesError() async {
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    throw try RespondToAuthChallengeOutputError(httpResponse: MockHttpResponse.ok)
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+
+        let action = VerifySignInChallenge(challenge: mockRespondAuthChallenge,
+                                           confirmSignEventData: mockConfirmEvent,
+                                           signInMethod: .apiBased(.userSRP))
+
+        let passwordVerifierError = expectation(
+            description: "passwordVerifierError")
+
+        let dispatcher = MockDispatcher { event in
+            defer { passwordVerifierError.fulfill() }
+
+            guard let event = event as? SignInEvent else {
+                XCTFail("Expected event to be SignInEvent but got \(event)")
+                return
+            }
+
+            guard case let .throwAuthError(error) = event.eventType,
+                  case .service = error
+            else {
+                      XCTFail("Should receive invalid service response")
+                      return
+                  }
+        }
+
+        await action.execute(withDispatcher: dispatcher, environment: environment)
+        await waitForExpectations(timeout: 0.1)
+    }
+
+    /// Test verify password retry on device not found
+    ///
+    /// - Given: VerifySignInChallenge action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input and mock empty device not found error from Cognito
+    /// - Then:
+    ///    - Should send an event with retryVerifyChallengeAnswer
+    ///
+    func testPasswordVerifierWithDeviceNotFound() async {
+
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    throw RespondToAuthChallengeOutputError.resourceNotFoundException(
+                        ResourceNotFoundException()
+                    )
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+
+        let action = VerifySignInChallenge(challenge: mockRespondAuthChallenge,
+                                           confirmSignEventData: mockConfirmEvent,
+                                           signInMethod: .apiBased(.userSRP))
+        let passwordVerifierError = expectation(description: "passwordVerifierError")
+
+        let dispatcher = MockDispatcher { event in
+            defer { passwordVerifierError.fulfill() }
+
+            guard let event = event as? SignInChallengeEvent else {
+                XCTFail("Expected event to be SignInEvent but got \(event)")
+                return
+            }
+
+            guard case .retryVerifyChallengeAnswer = event.eventType
+            else {
+                XCTFail("Should receive retryRespondPasswordVerifier")
+                return
+            }
+        }
+
+        await action.execute(withDispatcher: dispatcher, environment: environment)
+        await waitForExpectations(timeout: 0.1)
+    }
+
+    /// Test  successful response from the VerifySignInChallenge for confirmDevice
+    ///
+    /// - Given: VerifySignInChallenge action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input and mock new device
+    /// - Then:
+    ///    - Should send an event confirmDevice
+    ///
+    func testRespondToAuthChallengeWithConfirmDevice() async {
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    return RespondToAuthChallengeOutputResponse.testDataWithNewDevice()
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+
+        let action = VerifySignInChallenge(challenge: mockRespondAuthChallenge,
+                                           confirmSignEventData: mockConfirmEvent,
+                                           signInMethod: .apiBased(.userSRP))
+
+        let verifyChallengeComplete = expectation(description: "verifyChallengeComplete")
+
+        let dispatcher = MockDispatcher { event in
+            guard let event = event as? SignInEvent else {
+                XCTFail("Expected event to be SignInEvent but got \(event)")
+                return
+            }
+
+            if case .confirmDevice(let signedInData) = event.eventType {
+                XCTAssertNotNil(signedInData)
+                verifyChallengeComplete.fulfill()
+            }
+        }
+
+        await action.execute(withDispatcher: dispatcher, environment: environment)
+        await waitForExpectations(timeout: 0.1)
+    }
+
+    /// Test  successful response from the VerifySignInChallenge for verify device
+    ///
+    /// - Given: VerifySignInChallenge action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input and mock new device
+    /// - Then:
+    ///    - Should send an event initiateDeviceSRP
+    ///
+    func testRespondToAuthChallengeWithVerifyDevice() async {
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    return RespondToAuthChallengeOutputResponse.testDataWithVerifyDevice()
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+
+        let action = VerifySignInChallenge(challenge: mockRespondAuthChallenge,
+                                           confirmSignEventData: mockConfirmEvent,
+                                           signInMethod: .apiBased(.userSRP))
+
+        let verifyChallengeComplete = expectation(description: "verifyChallengeComplete")
+
+        let dispatcher = MockDispatcher { event in
+            guard let event = event as? SignInEvent else {
+                XCTFail("Expected event to be SignInEvent but got \(event)")
+                return
+            }
+
+            if case .initiateDeviceSRP(_, let response) = event.eventType {
+                XCTAssertNotNil(response)
+                verifyChallengeComplete.fulfill()
+            }
+        }
+
+        await action.execute(withDispatcher: dispatcher, environment: environment)
+        await waitForExpectations(timeout: 0.1)
+    }
+}

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/SRPTestData.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/SRPTestData.swift
@@ -83,6 +83,30 @@ extension RespondToAuthChallengeOutputResponse {
             challengeParameters: [:],
             session: "session")
     }
+
+    static func testDataWithNewDevice() -> RespondToAuthChallengeOutputResponse {
+        let result = CognitoIdentityProviderClientTypes.AuthenticationResultType(
+            accessToken: Defaults.validAccessToken,
+            expiresIn: 3_600,
+            idToken: "idTokenXXX",
+            newDeviceMetadata: .init(deviceGroupKey: "mockGroupKey", deviceKey: "mockKey"),
+            refreshToken: "refreshTokenXXX",
+            tokenType: "Bearer")
+
+        return RespondToAuthChallengeOutputResponse(
+            authenticationResult: result,
+            challengeName: .none,
+            challengeParameters: [:],
+            session: "session")
+    }
+
+    static func testDataWithVerifyDevice() -> RespondToAuthChallengeOutputResponse {
+        return RespondToAuthChallengeOutputResponse(
+            authenticationResult: nil,
+            challengeName: .deviceSrpAuth,
+            challengeParameters: [:],
+            session: "session")
+    }
 }
 
 extension RespondToAuthChallenge {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/SRPTestData.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/SRPTestData.swift
@@ -19,7 +19,6 @@ extension SRPStateData {
         NHexValue: "",
         gHexValue: "",
         srpKeyPair: SRPKeys(publicKeyHexValue: "", privateKeyHexValue: ""),
-        deviceMetadata: .noData,
         clientTimestamp: Date()
     )
 }
@@ -171,7 +170,6 @@ extension SRPStateData {
                 "98bab9079c01ab6acd0e75518d0cda640b9a1f011c9a7cefab68b6ddce666c874659" +
                 "8a502c0e6adef0722bac",
             privateKeyHexValue: "c142c2d2471fd53bca99c2fdec84e522adec8ee2dcda0d9fff9dbea52ac4a65f"),
-        deviceMetadata: .noData,
         clientTimestamp: Date(timeIntervalSinceReferenceDate: 656_187_908.969623)
     )
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthConfirmSignInTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthConfirmSignInTaskTests.swift
@@ -599,39 +599,7 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             XCTFail("Should not return error \(error)")
         }
     }
-    
-    /// Test a confirmSignIn call with ResourceNotFoundException response from service
-    ///
-    /// - Given: an auth plugin with mocked service. Mocked service should mock a
-    ///   ResourceNotFoundException response
-    ///
-    /// - When:
-    ///    - I invoke confirmSignIn with a valid confirmation code
-    /// - Then:
-    ///    - I should get a .service error with .resourceNotFound as underlyingError
-    ///
-    func testConfirmSignInWithResourceNotFoundException() async {
-        
-        self.mockIdentityProvider = MockIdentityProvider(
-            mockRespondToAuthChallengeResponse: { _ in
-                throw RespondToAuthChallengeOutputError.resourceNotFoundException(
-                    .init(message: "Exception"))
-            })
-        
-        do {
-            _ = try await plugin.confirmSignIn(challengeResponse: "code")
-            XCTFail("Should return an error if the result from service is invalid")
-        } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
-                XCTFail("Should produce service error instead of \(error)")
-                return
-            }
-            guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
-                XCTFail("Underlying error should be resourceNotFound \(error)")
-                return
-            }
-        }
-    }
+
     
     /// Test a confirmSignIn call with SoftwareTokenMFANotFoundException response from service
     ///


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
- Removes static devicemetadata from auth flows
- Uses the returned username to find the deviceMetadata in RespondToAuthChallenge
- Retry challenge verification if device not found error was thrown
- Pass deviceMetadata in verifyPassword and verifyChallenge

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

## DataStore Checklist
<!-- Check when completed or remove section, if not applicable -->

- [ ] Ran AWSDataStorePluginIntegrationTests
- [ ] Ran AWSDataStorePluginV2Tests
- [ ] Ran AWSDataStorePluginMultiAuthTests
- [ ] Ran AWSDataStorePluginCPKTests
- [ ] Ran AWSDataStorePluginAuthCognitoTests
- [ ] Ran AWSDataStorePluginAuthIAMTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
