### PR TITLE
chore(api): functional integ tests - paginate on list requests

### DIFF
--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+List.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+List.swift
@@ -130,10 +130,14 @@ extension GraphQLConnectionScenario3Tests {
 
         let post = Post3.keys
         let predicate = post.id == uuid && post.title == uniqueTitle
-        let graphQLResponse = try await Amplify.API.query(request: .list(Post3.self, where: predicate))
-        guard case let .success(posts) = graphQLResponse else {
+        let graphQLResponse = try await Amplify.API.query(request: .list(Post3.self, where: predicate, limit: 1000))
+        guard case var .success(posts) = graphQLResponse else {
             XCTFail("Missing successful response")
             return
+        }
+        
+        while posts.count == 0 && posts.hasNextPage() {
+            posts = try await posts.getNextPage()
         }
         XCTAssertEqual(posts.count, 1)
         guard let singlePost = posts.first else {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
@@ -178,10 +178,14 @@ class GraphQLModelBasedTests: XCTestCase {
         post.rating == 12.3 &&
         post.draft == true
         
-        let graphQLResponse = try await Amplify.API.query(request: .list(Post.self, where: predicate))
-        guard case .success(let posts) = graphQLResponse else {
+        let graphQLResponse = try await Amplify.API.query(request: .list(Post.self, where: predicate, limit: 1000))
+        guard case .success(var posts) = graphQLResponse else {
             XCTFail("Missing successful response")
             return
+        }
+        
+        while posts.count == 0 && posts.hasNextPage() {
+            posts = try await posts.getNextPage()
         }
         XCTAssertEqual(posts.count, 1)
         guard let singlePost = posts.first else {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
This API integration test, APIFunctionalTests, has been failing sometimes on asserting the count. This test code change will exhaust the pages until there's a count. If there are no pages left and count == 0, will break out of the loop and continue to fail on the count assertion.

Github Actions workflow run: https://github.com/aws-amplify/amplify-swift/actions/runs/3896568033 ✅

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
