### PR TITLE
test: Add nightly repeated unit test

### DIFF
--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -12,6 +12,14 @@ inputs:
     required: false
     type: string
     default: 'platform=iOS Simulator,name=iPhone 13,OS=latest'
+  sdk:
+    required: false
+    type: string
+    default: 'iphonesimulator'
+  other_flags:
+    required: false
+    type: string
+    default: ''
 
 runs:
   using: "composite"
@@ -22,5 +30,5 @@ runs:
         PROJECT_PATH: ${{ inputs.project_path }}
       run: |
         cd $PROJECT_PATH
-        xcodebuild test -scheme $SCHEME -sdk iphonesimulator -destination '${{ inputs.destination }}' | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}        
+        xcodebuild test -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}        
       shell: bash 

--- a/.github/workflows/nightly_repeated_unittest.yml
+++ b/.github/workflows/nightly_repeated_unittest.yml
@@ -1,8 +1,8 @@
 name: Amplify Nightly Unit Test
 on:
   workflow_dispatch:
-  push:
-    branches: [royjit.repeattest]
+  schedule:
+    - cron: '30 1 * * *'
 
 permissions:
     contents: read

--- a/.github/workflows/nightly_repeated_unittest.yml
+++ b/.github/workflows/nightly_repeated_unittest.yml
@@ -1,4 +1,4 @@
-name: Amplify Nightly Unit Test
+name: Amplify Nightly Repeated Unit Test
 on:
   workflow_dispatch:
   schedule:
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - name: Run unit test iOS
+      - name: Run repeated unit test iOS
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           project_path: .
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - name: Run unit test macOS
+      - name: Run repeated unit test macOS
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           project_path: .

--- a/.github/workflows/nightly_repeated_unittest.yml
+++ b/.github/workflows/nightly_repeated_unittest.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  unit_test:
+  unit_test_ios:
     runs-on: macos-12
     strategy:
       matrix:
@@ -25,7 +25,15 @@ jobs:
         with:
           project_path: .
           scheme: ${{ matrix.scheme }}
-          other_flags: -test-iterations 2 -run-tests-until-failure
+          other_flags: -test-iterations 100 -run-tests-until-failure
+
+  unit_test_macos:
+    runs-on: macos-12
+    strategy:
+      matrix:
+        scheme: [Amplify, AWSPluginsCore, AWSPinpointAnalyticsPlugin, AWSAPIPlugin, AWSCognitoAuthPlugin, AWSDataStorePlugin, AWSLocationGeoPlugin, AWSS3StoragePlugin]
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       - name: Run unit test macOS
         uses: ./.github/composite_actions/run_xcodebuild_test
@@ -34,3 +42,5 @@ jobs:
           scheme: ${{ matrix.scheme }}
           sdk: macosx
           destination: platform=macOS,arch=x86_64
+          other_flags: -test-iterations 100 -run-tests-until-failure
+      

--- a/.github/workflows/nightly_repeated_unittest.yml
+++ b/.github/workflows/nightly_repeated_unittest.yml
@@ -1,0 +1,36 @@
+name: Amplify Nightly Unit Test
+on:
+  workflow_dispatch:
+  push:
+    branches: [royjit.repeattest]
+
+permissions:
+    contents: read
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  unit_test:
+    runs-on: macos-12
+    strategy:
+      matrix:
+        scheme: [Amplify, AWSPluginsCore, AWSPinpointAnalyticsPlugin, AWSAPIPlugin, AWSCognitoAuthPlugin, AWSDataStorePlugin, AWSLocationGeoPlugin, AWSS3StoragePlugin]
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - name: Run unit test iOS
+        uses: ./.github/composite_actions/run_xcodebuild_test
+        with:
+          project_path: .
+          scheme: ${{ matrix.scheme }}
+          other_flags: -test-iterations 2 -run-tests-until-failure
+
+      - name: Run unit test macOS
+        uses: ./.github/composite_actions/run_xcodebuild_test
+        with:
+          project_path: .
+          scheme: ${{ matrix.scheme }}
+          sdk: macosx
+          destination: platform=macOS,arch=x86_64


### PR DESCRIPTION
## Description
Adds the unit test to run repeated iteration nightly.
Sample test run - https://github.com/aws-amplify/amplify-swift/actions/runs/3899004585/jobs/6658264423

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] ~Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
