### PR TITLE
fix: ModelPath missing int field path, UserPostComment schema set up

### DIFF
--- a/Amplify/Categories/DataStore/Model/PropertyPath.swift
+++ b/Amplify/Categories/DataStore/Model/PropertyPath.swift
@@ -123,4 +123,8 @@ open class ModelPath<ModelType: Model> : PropertyContainerPath {
     public func time(_ name: String) -> FieldPath<Temporal.Time> {
         FieldPath(name: name, parent: self)
     }
+    
+    public func int(_ name: String) -> FieldPath<Int> {
+        FieldPath(name: name, parent: self)
+    }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
@@ -164,6 +164,16 @@
 		21908A79291D7631005021F7 /* Post8+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21908A74291D7631005021F7 /* Post8+Schema.swift */; };
 		21908A7A291D7631005021F7 /* Comment8+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21908A75291D7631005021F7 /* Comment8+Schema.swift */; };
 		219253C428BFEBE400820737 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 219253C328BFEBE200820737 /* XCTest.framework */; };
+		21BC111B2971ADA4000E189E /* UserSettings14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11122971ADA4000E189E /* UserSettings14+Schema.swift */; };
+		21BC111C2971ADA4000E189E /* Comment14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11132971ADA4000E189E /* Comment14.swift */; };
+		21BC111D2971ADA4000E189E /* UserSettings14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11142971ADA4000E189E /* UserSettings14.swift */; };
+		21BC111E2971ADA4000E189E /* User14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11152971ADA4000E189E /* User14+Schema.swift */; };
+		21BC111F2971ADA4000E189E /* User14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11162971ADA4000E189E /* User14.swift */; };
+		21BC11202971ADA4000E189E /* Comment14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11172971ADA4000E189E /* Comment14+Schema.swift */; };
+		21BC11212971ADA4000E189E /* Post14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11182971ADA4000E189E /* Post14+Schema.swift */; };
+		21BC11222971ADA4000E189E /* Post14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11192971ADA4000E189E /* Post14.swift */; };
+		21BC11232971ADA4000E189E /* PostStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC111A2971ADA4000E189E /* PostStatus.swift */; };
+		21BC11252971ADBD000E189E /* GraphQLLazyLoadUserPostCommentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11242971ADBD000E189E /* GraphQLLazyLoadUserPostCommentTests.swift */; };
 		21DFAEAE295F9F8C00B4A883 /* Person+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAEA8295F9F8C00B4A883 /* Person+Schema.swift */; };
 		21DFAEAF295F9F8C00B4A883 /* PhoneCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAEA9295F9F8C00B4A883 /* PhoneCall.swift */; };
 		21DFAEB0295F9F8C00B4A883 /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAEAA295F9F8C00B4A883 /* Person.swift */; };
@@ -463,6 +473,16 @@
 		21908A74291D7631005021F7 /* Post8+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post8+Schema.swift"; sourceTree = "<group>"; };
 		21908A75291D7631005021F7 /* Comment8+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Comment8+Schema.swift"; sourceTree = "<group>"; };
 		219253C328BFEBE200820737 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		21BC11122971ADA4000E189E /* UserSettings14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserSettings14+Schema.swift"; sourceTree = "<group>"; };
+		21BC11132971ADA4000E189E /* Comment14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment14.swift; sourceTree = "<group>"; };
+		21BC11142971ADA4000E189E /* UserSettings14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserSettings14.swift; sourceTree = "<group>"; };
+		21BC11152971ADA4000E189E /* User14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "User14+Schema.swift"; sourceTree = "<group>"; };
+		21BC11162971ADA4000E189E /* User14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User14.swift; sourceTree = "<group>"; };
+		21BC11172971ADA4000E189E /* Comment14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Comment14+Schema.swift"; sourceTree = "<group>"; };
+		21BC11182971ADA4000E189E /* Post14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post14+Schema.swift"; sourceTree = "<group>"; };
+		21BC11192971ADA4000E189E /* Post14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post14.swift; sourceTree = "<group>"; };
+		21BC111A2971ADA4000E189E /* PostStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostStatus.swift; sourceTree = "<group>"; };
+		21BC11242971ADBD000E189E /* GraphQLLazyLoadUserPostCommentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLLazyLoadUserPostCommentTests.swift; sourceTree = "<group>"; };
 		21D335B7289867FC00657B12 /* amplify-ios-staging */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-ios-staging"; path = ../../../..; sourceTree = "<group>"; };
 		21DFAEA8295F9F8C00B4A883 /* Person+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Person+Schema.swift"; sourceTree = "<group>"; };
 		21DFAEA9295F9F8C00B4A883 /* PhoneCall.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneCall.swift; sourceTree = "<group>"; };
@@ -883,6 +903,23 @@
 			path = LL12;
 			sourceTree = "<group>";
 		};
+		21BC11112971AD5F000E189E /* LL14 */ = {
+			isa = PBXGroup;
+			children = (
+				21BC11242971ADBD000E189E /* GraphQLLazyLoadUserPostCommentTests.swift */,
+				21BC11132971ADA4000E189E /* Comment14.swift */,
+				21BC11172971ADA4000E189E /* Comment14+Schema.swift */,
+				21BC11192971ADA4000E189E /* Post14.swift */,
+				21BC11182971ADA4000E189E /* Post14+Schema.swift */,
+				21BC111A2971ADA4000E189E /* PostStatus.swift */,
+				21BC11162971ADA4000E189E /* User14.swift */,
+				21BC11152971ADA4000E189E /* User14+Schema.swift */,
+				21BC11142971ADA4000E189E /* UserSettings14.swift */,
+				21BC11122971ADA4000E189E /* UserSettings14+Schema.swift */,
+			);
+			path = LL14;
+			sourceTree = "<group>";
+		};
 		21D335B6289867FC00657B12 /* Packages */ = {
 			isa = PBXGroup;
 			children = (
@@ -981,6 +1018,7 @@
 				219089E3291D6B20005021F7 /* LL11 */,
 				219089E4291D6B2A005021F7 /* LL12 */,
 				21DFAEA7295F9F4100B4A883 /* L13 */,
+				21BC11112971AD5F000E189E /* LL14 */,
 				21EA888328F9BD2D0000BA75 /* lazyload-schema.graphql */,
 				21EA888128F9BCD90000BA75 /* TestConfigHelper.swift */,
 				21EA887D28F9BCBB0000BA75 /* README.md */,
@@ -1760,6 +1798,7 @@
 				21908A48291D7608005021F7 /* Comment7.swift in Sources */,
 				21908A24291D75E4005021F7 /* Team2.swift in Sources */,
 				21908A0C291D75D6005021F7 /* GraphQLLazyLoadPostTagTests.swift in Sources */,
+				21BC11222971ADA4000E189E /* Post14.swift in Sources */,
 				21EA887628F9BC610000BA75 /* GraphQLLazyLoadBaseTest.swift in Sources */,
 				218D0195291AE3750068D133 /* Comment4V2+Schema.swift in Sources */,
 				21908A79291D7631005021F7 /* Post8+Schema.swift in Sources */,
@@ -1806,8 +1845,11 @@
 				21908A0D291D75D6005021F7 /* TagWithCompositeKey.swift in Sources */,
 				21FA8EF7295C9609009F6A07 /* GraphQLLazyLoadHasOneTests.swift in Sources */,
 				21908A6F291D762B005021F7 /* StrangeExplicitChild.swift in Sources */,
+				21BC111C2971ADA4000E189E /* Comment14.swift in Sources */,
 				21908A10291D75D6005021F7 /* PostWithTagsCompositeKey+Schema.swift in Sources */,
 				21908A63291D762B005021F7 /* HasOneParent+Schema.swift in Sources */,
+				21BC11252971ADBD000E189E /* GraphQLLazyLoadUserPostCommentTests.swift in Sources */,
+				21BC111D2971ADA4000E189E /* UserSettings14.swift in Sources */,
 				21908A35291D75F4005021F7 /* Team5.swift in Sources */,
 				21908A77291D7631005021F7 /* Comment8.swift in Sources */,
 				21FA8EFB295C9647009F6A07 /* GraphQLLazyLoadCompositePKTests.swift in Sources */,
@@ -1818,9 +1860,12 @@
 				21EA888228F9BCD90000BA75 /* TestConfigHelper.swift in Sources */,
 				21908A0E291D75D6005021F7 /* TagWithCompositeKey+Schema.swift in Sources */,
 				21908A6B291D762B005021F7 /* CompositePKParent+Schema.swift in Sources */,
+				21BC111F2971ADA4000E189E /* User14.swift in Sources */,
+				21BC111E2971ADA4000E189E /* User14+Schema.swift in Sources */,
 				219089F3291D75C3005021F7 /* Blog8V2.swift in Sources */,
 				21908A67291D762B005021F7 /* DefaultPKParent.swift in Sources */,
 				21DFAEB5295F9FA600B4A883 /* GraphQLLazyLoadPhoneCallTests.swift in Sources */,
+				21BC11232971ADA4000E189E /* PostStatus.swift in Sources */,
 				21908A42291D75FE005021F7 /* Team6+Schema.swift in Sources */,
 				21FA8EF9295C962E009F6A07 /* GraphQLLazyLoadDefaultPKTests.swift in Sources */,
 				21908A2C291D75EB005021F7 /* Comment4+Schema.swift in Sources */,
@@ -1829,6 +1874,7 @@
 				21908A69291D762B005021F7 /* HasOneParent.swift in Sources */,
 				21908A4C291D7608005021F7 /* Comment7+Schema.swift in Sources */,
 				21DFAEAF295F9F8C00B4A883 /* PhoneCall.swift in Sources */,
+				21BC111B2971ADA4000E189E /* UserSettings14+Schema.swift in Sources */,
 				21908A2B291D75EB005021F7 /* GraphQLLazyLoadPostComment4Tests.swift in Sources */,
 				21908A65291D762B005021F7 /* ChildSansBelongsTo+Schema.swift in Sources */,
 				21DFAEB0295F9F8C00B4A883 /* Person.swift in Sources */,
@@ -1836,6 +1882,8 @@
 				21908A02291D75CE005021F7 /* CommentWithCompositeKey+Schema.swift in Sources */,
 				21EA887E28F9BCC10000BA75 /* AsyncTesting.swift in Sources */,
 				219089EF291D75C3005021F7 /* MyCustomModel8+Schema.swift in Sources */,
+				21BC11202971ADA4000E189E /* Comment14+Schema.swift in Sources */,
+				21BC11212971ADA4000E189E /* Post14+Schema.swift in Sources */,
 				21908A21291D75E4005021F7 /* GraphQLLazyLoadProjectTeam2Tests.swift in Sources */,
 				219089FE291D75CE005021F7 /* GraphQLLazyLoadPostCommentWithCompositeKeyTests.swift in Sources */,
 				21908A76291D7631005021F7 /* GraphQLLazyLoadPostComment8Tests.swift in Sources */,

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/Comment14+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/Comment14+Schema.swift
@@ -1,0 +1,69 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Comment14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case content
+    case post
+    case author
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let comment14 = Comment14.keys
+    
+    model.authRules = [
+      rule(allow: .public, operations: [.create, .update, .delete, .read])
+    ]
+    
+    model.pluralName = "Comment14s"
+    
+    model.attributes(
+      .primaryKey(fields: [comment14.id])
+    )
+    
+    model.fields(
+      .field(comment14.id, is: .required, ofType: .string),
+      .field(comment14.content, is: .optional, ofType: .string),
+      .belongsTo(comment14.post, is: .optional, ofType: Post14.self, targetNames: ["post14CommentsId"]),
+      .belongsTo(comment14.author, is: .required, ofType: User14.self, targetNames: ["user14CommentsId"]),
+      .field(comment14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(comment14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Comment14> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Comment14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == Comment14 {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var content: FieldPath<String>   {
+      string("content") 
+    }
+  public var post: ModelPath<Post14>   {
+      Post14.Path(name: "post", parent: self) 
+    }
+  public var author: ModelPath<User14>   {
+      User14.Path(name: "author", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/Comment14.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/Comment14.swift
@@ -1,0 +1,71 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Comment14: Model {
+  public let id: String
+  public var content: String?
+  internal var _post: LazyReference<Post14>
+  public var post: Post14?   {
+      get async throws { 
+        try await _post.get()
+      } 
+    }
+  internal var _author: LazyReference<User14>
+  public var author: User14   {
+      get async throws { 
+        try await _author.require()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      content: String? = nil,
+      post: Post14? = nil,
+      author: User14) {
+    self.init(id: id,
+      content: content,
+      post: post,
+      author: author,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      content: String? = nil,
+      post: Post14? = nil,
+      author: User14,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.content = content
+      self._post = LazyReference(post)
+      self._author = LazyReference(author)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setPost(_ post: Post14? = nil) {
+    self._post = LazyReference(post)
+  }
+  public mutating func setAuthor(_ author: User14) {
+    self._author = LazyReference(author)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      content = try? values.decode(String?.self, forKey: .content)
+      _post = try values.decodeIfPresent(LazyReference<Post14>.self, forKey: .post) ?? LazyReference(identifiers: nil)
+      _author = try values.decodeIfPresent(LazyReference<User14>.self, forKey: .author) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(content, forKey: .content)
+      try container.encode(_post, forKey: .post)
+      try container.encode(_author, forKey: .author)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/GraphQLLazyLoadUserPostCommentTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/GraphQLLazyLoadUserPostCommentTests.swift
@@ -1,0 +1,87 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Combine
+import XCTest
+
+@testable import Amplify
+
+final class GraphQLLazyLoadUserPostCommentTests: GraphQLLazyLoadBaseTest {
+
+    func testConfigure() async throws {
+        await setup(withModels: UserPostCommentModels(), logLevel: .verbose)
+    }
+
+    func testSaveUser() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        try await mutate(.create(user))
+    }
+    
+    func testSaveUserSettings() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        let savedUser = try await mutate(.create(user))
+        
+        let userSettings = UserSettings(language: "en-us", user: savedUser)
+        try await mutate(.create(userSettings))
+    }
+    
+    func testSavePost() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        let savedUser = try await mutate(.create(user))
+        let post = Post(title: "title", rating: 1, status: .active, author: savedUser)
+        try await mutate(.create(post))
+    }
+    
+    func testSaveComment() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        let savedUser = try await mutate(.create(user))
+        let post = Post(title: "title", rating: 1, status: .active, author: savedUser)
+        let savedPost = try await mutate(.create(post))
+        
+        let comment = Comment(content: "content", post: savedPost, author: savedUser)
+        try await mutate(.create(comment))
+    }
+    
+    func testQueryComment() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        let savedUser = try await mutate(.create(user))
+        let post = Post(title: "title", rating: 1, status: .active, author: savedUser)
+        let savedPost = try await mutate(.create(post))
+        let comment = Comment(content: "content", post: savedPost, author: savedUser)
+        let savedComment = try await mutate(.create(comment))
+        
+        let response = try await Amplify.API.query(request: .get(Comment.self, byId: comment.id))
+        guard case .success(let queriedComment) = response,
+              let queriedComment = queriedComment else {
+            return
+        }
+        XCTAssertEqual(queriedComment.id, savedComment.id)
+    }
+}
+
+extension GraphQLLazyLoadUserPostCommentTests {
+    typealias User = User14
+    typealias Post = Post14
+    typealias Comment = Comment14
+    typealias UserSettings = UserSettings14
+    
+    struct UserPostCommentModels: AmplifyModelRegistration {
+        public let version: String = "version"
+        func registerModels(registry: ModelRegistry.Type) {
+            ModelRegistry.register(modelType: User14.self)
+            ModelRegistry.register(modelType: Post14.self)
+            ModelRegistry.register(modelType: Comment14.self)
+            ModelRegistry.register(modelType: UserSettings14.self)
+        }
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/Post14+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/Post14+Schema.swift
@@ -1,0 +1,76 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case title
+    case rating
+    case status
+    case comments
+    case author
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post14 = Post14.keys
+    
+    model.authRules = [
+      rule(allow: .public, operations: [.create, .update, .delete, .read])
+    ]
+    
+    model.pluralName = "Post14s"
+    
+    model.attributes(
+      .primaryKey(fields: [post14.id])
+    )
+    
+    model.fields(
+      .field(post14.id, is: .required, ofType: .string),
+      .field(post14.title, is: .required, ofType: .string),
+      .field(post14.rating, is: .required, ofType: .int),
+      .field(post14.status, is: .required, ofType: .enum(type: PostStatus.self)),
+      .hasMany(post14.comments, is: .optional, ofType: Comment14.self, associatedWith: Comment14.keys.post),
+      .belongsTo(post14.author, is: .required, ofType: User14.self, targetNames: ["user14PostsId"]),
+      .field(post14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Post14> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Post14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == Post14 {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var title: FieldPath<String>   {
+      string("title") 
+    }
+  public var rating: FieldPath<Int>   {
+      int("rating") 
+    }
+  public var comments: ModelPath<Comment14>   {
+      Comment14.Path(name: "comments", isCollection: true, parent: self) 
+    }
+  public var author: ModelPath<User14>   {
+      User14.Path(name: "author", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/Post14.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/Post14.swift
@@ -1,0 +1,77 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post14: Model {
+  public let id: String
+  public var title: String
+  public var rating: Int
+  public var status: PostStatus
+  public var comments: List<Comment14>?
+  internal var _author: LazyReference<User14>
+  public var author: User14   {
+      get async throws { 
+        try await _author.require()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      title: String,
+      rating: Int,
+      status: PostStatus,
+      comments: List<Comment14>? = [],
+      author: User14) {
+    self.init(id: id,
+      title: title,
+      rating: rating,
+      status: status,
+      comments: comments,
+      author: author,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      title: String,
+      rating: Int,
+      status: PostStatus,
+      comments: List<Comment14>? = [],
+      author: User14,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.title = title
+      self.rating = rating
+      self.status = status
+      self.comments = comments
+      self._author = LazyReference(author)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setAuthor(_ author: User14) {
+    self._author = LazyReference(author)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      title = try values.decode(String.self, forKey: .title)
+      rating = try values.decode(Int.self, forKey: .rating)
+      status = try values.decode(PostStatus.self, forKey: .status)
+      comments = try values.decodeIfPresent(List<Comment14>?.self, forKey: .comments) ?? .init()
+      _author = try values.decodeIfPresent(LazyReference<User14>.self, forKey: .author) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(title, forKey: .title)
+      try container.encode(rating, forKey: .rating)
+      try container.encode(status, forKey: .status)
+      try container.encode(comments, forKey: .comments)
+      try container.encode(_author, forKey: .author)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/PostStatus.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/PostStatus.swift
@@ -1,0 +1,8 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public enum PostStatus: String, EnumPersistable {
+  case active = "ACTIVE"
+  case inactive = "INACTIVE"
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/User14+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/User14+Schema.swift
@@ -1,0 +1,79 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension User14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case username
+    case posts
+    case comments
+    case settings
+    case createdAt
+    case updatedAt
+    case user14SettingsId
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let user14 = User14.keys
+    
+    model.authRules = [
+      rule(allow: .public, operations: [.create, .update, .delete, .read])
+    ]
+    
+    model.pluralName = "User14s"
+    
+    model.attributes(
+      .primaryKey(fields: [user14.id])
+    )
+    
+    model.fields(
+      .field(user14.id, is: .required, ofType: .string),
+      .field(user14.username, is: .required, ofType: .string),
+      .hasMany(user14.posts, is: .optional, ofType: Post14.self, associatedWith: Post14.keys.author),
+      .hasMany(user14.comments, is: .optional, ofType: Comment14.self, associatedWith: Comment14.keys.author),
+      .hasOne(user14.settings, is: .optional, ofType: UserSettings14.self, associatedWith: UserSettings14.keys.user, targetNames: ["user14SettingsId"]),
+      .field(user14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(user14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(user14.user14SettingsId, is: .optional, ofType: .string)
+    )
+    }
+    public class Path: ModelPath<User14> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension User14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == User14 {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var username: FieldPath<String>   {
+      string("username") 
+    }
+  public var posts: ModelPath<Post14>   {
+      Post14.Path(name: "posts", isCollection: true, parent: self) 
+    }
+  public var comments: ModelPath<Comment14>   {
+      Comment14.Path(name: "comments", isCollection: true, parent: self) 
+    }
+  public var settings: ModelPath<UserSettings14>   {
+      UserSettings14.Path(name: "settings", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+  public var user14SettingsId: FieldPath<String>   {
+      string("user14SettingsId") 
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/User14.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/User14.swift
@@ -1,0 +1,77 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct User14: Model {
+  public let id: String
+  public var username: String
+  public var posts: List<Post14>?
+  public var comments: List<Comment14>?
+  internal var _settings: LazyReference<UserSettings14>
+  public var settings: UserSettings14?   {
+      get async throws { 
+        try await _settings.get()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  public var user14SettingsId: String?
+  
+  public init(id: String = UUID().uuidString,
+      username: String,
+      posts: List<Post14>? = [],
+      comments: List<Comment14>? = [],
+      settings: UserSettings14? = nil,
+      user14SettingsId: String? = nil) {
+    self.init(id: id,
+      username: username,
+      posts: posts,
+      comments: comments,
+      settings: settings,
+      createdAt: nil,
+      updatedAt: nil,
+      user14SettingsId: user14SettingsId)
+  }
+  internal init(id: String = UUID().uuidString,
+      username: String,
+      posts: List<Post14>? = [],
+      comments: List<Comment14>? = [],
+      settings: UserSettings14? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil,
+      user14SettingsId: String? = nil) {
+      self.id = id
+      self.username = username
+      self.posts = posts
+      self.comments = comments
+      self._settings = LazyReference(settings)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+      self.user14SettingsId = user14SettingsId
+  }
+  public mutating func setSettings(_ settings: UserSettings14? = nil) {
+    self._settings = LazyReference(settings)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      username = try values.decode(String.self, forKey: .username)
+      posts = try values.decodeIfPresent(List<Post14>?.self, forKey: .posts) ?? .init()
+      comments = try values.decodeIfPresent(List<Comment14>?.self, forKey: .comments) ?? .init()
+      _settings = try values.decodeIfPresent(LazyReference<UserSettings14>.self, forKey: .settings) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+      user14SettingsId = try? values.decode(String?.self, forKey: .user14SettingsId)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(username, forKey: .username)
+      try container.encode(posts, forKey: .posts)
+      try container.encode(comments, forKey: .comments)
+      try container.encode(_settings, forKey: .settings)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+      try container.encode(user14SettingsId, forKey: .user14SettingsId)
+  }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/UserSettings14+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/UserSettings14+Schema.swift
@@ -1,0 +1,64 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension UserSettings14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case language
+    case user
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let userSettings14 = UserSettings14.keys
+    
+    model.authRules = [
+      rule(allow: .public, operations: [.create, .update, .delete, .read])
+    ]
+    
+    model.pluralName = "UserSettings14s"
+    
+    model.attributes(
+      .primaryKey(fields: [userSettings14.id])
+    )
+    
+    model.fields(
+      .field(userSettings14.id, is: .required, ofType: .string),
+      .field(userSettings14.language, is: .optional, ofType: .string),
+      .belongsTo(userSettings14.user, is: .required, ofType: User14.self, targetNames: ["userSettings14UserId"]),
+      .field(userSettings14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(userSettings14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<UserSettings14> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension UserSettings14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == UserSettings14 {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var language: FieldPath<String>   {
+      string("language") 
+    }
+  public var user: ModelPath<User14>   {
+      User14.Path(name: "user", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/UserSettings14.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/UserSettings14.swift
@@ -1,0 +1,56 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct UserSettings14: Model {
+  public let id: String
+  public var language: String?
+  internal var _user: LazyReference<User14>
+  public var user: User14   {
+      get async throws { 
+        try await _user.require()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      language: String? = nil,
+      user: User14) {
+    self.init(id: id,
+      language: language,
+      user: user,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      language: String? = nil,
+      user: User14,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.language = language
+      self._user = LazyReference(user)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setUser(_ user: User14) {
+    self._user = LazyReference(user)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      language = try? values.decode(String?.self, forKey: .language)
+      _user = try values.decodeIfPresent(LazyReference<User14>.self, forKey: .user) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(language, forKey: .language)
+      try container.encode(_user, forKey: .user)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/lazyload-schema.graphql
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/lazyload-schema.graphql
@@ -283,3 +283,40 @@ type Transcript @model {
   language: String
   phoneCall: PhoneCall @belongsTo
 }
+
+# LL.14
+
+enum PostStatus {
+  ACTIVE
+  INACTIVE
+}
+
+type User14 @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  username: String!
+  posts: [Post14] @hasMany
+  comments: [Comment14] @hasMany
+  settings: UserSettings14 @hasOne
+}
+
+type UserSettings14 @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  language: String
+  user: User14! @belongsTo
+}
+
+type Post14 @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  title: String!
+  rating: Int!
+  status: PostStatus!
+  comments: [Comment14] @hasMany
+  author: User14! @belongsTo
+}
+
+type Comment14 @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  content: String
+  post: Post14 @belongsTo
+  author: User14! @belongsTo
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/AWSDataStoreLazyLoadUserPostCommentTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/AWSDataStoreLazyLoadUserPostCommentTests.swift
@@ -1,0 +1,72 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Combine
+import XCTest
+
+@testable import Amplify
+
+final class AWSDataStoreLazyLoadUserPostCommentTests: AWSDataStoreLazyLoadBaseTest {
+
+    func testStart() async throws {
+        await setup(withModels: UserPostCommentModels())
+        try await startAndWaitForReady()
+    }
+
+    func testSaveUser() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        try await saveAndWaitForSync(user)
+    }
+    
+    func testSaveUserSettings() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        let savedUser = try await saveAndWaitForSync(user)
+        
+        let userSettings = UserSettings(language: "en-us", user: savedUser)
+        try await saveAndWaitForSync(userSettings)
+    }
+    
+    func testSavePost() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        let savedUser = try await saveAndWaitForSync(user)
+        let post = Post(title: "title", rating: 1, status: .active, author: savedUser)
+        try await saveAndWaitForSync(post)
+    }
+    
+    func testSaveComment() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        let savedUser = try await saveAndWaitForSync(user)
+        let post = Post(title: "title", rating: 1, status: .active, author: savedUser)
+        let savedPost = try await saveAndWaitForSync(post)
+        
+        let comment = Comment(content: "content", post: savedPost, author: savedUser)
+        try await saveAndWaitForSync(comment)
+    }
+}
+
+
+extension AWSDataStoreLazyLoadUserPostCommentTests {
+    typealias User = User14
+    typealias Post = Post14
+    typealias Comment = Comment14
+    typealias UserSettings = UserSettings14
+    
+    struct UserPostCommentModels: AmplifyModelRegistration {
+        public let version: String = "version"
+        func registerModels(registry: ModelRegistry.Type) {
+            ModelRegistry.register(modelType: User14.self)
+            ModelRegistry.register(modelType: Post14.self)
+            ModelRegistry.register(modelType: Comment14.self)
+            ModelRegistry.register(modelType: UserSettings14.self)
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/Comment14+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/Comment14+Schema.swift
@@ -1,0 +1,69 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Comment14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case content
+    case post
+    case author
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let comment14 = Comment14.keys
+    
+    model.authRules = [
+      rule(allow: .public, operations: [.create, .update, .delete, .read])
+    ]
+    
+    model.pluralName = "Comment14s"
+    
+    model.attributes(
+      .primaryKey(fields: [comment14.id])
+    )
+    
+    model.fields(
+      .field(comment14.id, is: .required, ofType: .string),
+      .field(comment14.content, is: .optional, ofType: .string),
+      .belongsTo(comment14.post, is: .optional, ofType: Post14.self, targetNames: ["post14CommentsId"]),
+      .belongsTo(comment14.author, is: .required, ofType: User14.self, targetNames: ["user14CommentsId"]),
+      .field(comment14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(comment14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Comment14> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Comment14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == Comment14 {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var content: FieldPath<String>   {
+      string("content") 
+    }
+  public var post: ModelPath<Post14>   {
+      Post14.Path(name: "post", parent: self) 
+    }
+  public var author: ModelPath<User14>   {
+      User14.Path(name: "author", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/Comment14.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/Comment14.swift
@@ -1,0 +1,71 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Comment14: Model {
+  public let id: String
+  public var content: String?
+  internal var _post: LazyReference<Post14>
+  public var post: Post14?   {
+      get async throws { 
+        try await _post.get()
+      } 
+    }
+  internal var _author: LazyReference<User14>
+  public var author: User14   {
+      get async throws { 
+        try await _author.require()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      content: String? = nil,
+      post: Post14? = nil,
+      author: User14) {
+    self.init(id: id,
+      content: content,
+      post: post,
+      author: author,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      content: String? = nil,
+      post: Post14? = nil,
+      author: User14,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.content = content
+      self._post = LazyReference(post)
+      self._author = LazyReference(author)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setPost(_ post: Post14? = nil) {
+    self._post = LazyReference(post)
+  }
+  public mutating func setAuthor(_ author: User14) {
+    self._author = LazyReference(author)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      content = try? values.decode(String?.self, forKey: .content)
+      _post = try values.decodeIfPresent(LazyReference<Post14>.self, forKey: .post) ?? LazyReference(identifiers: nil)
+      _author = try values.decodeIfPresent(LazyReference<User14>.self, forKey: .author) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(content, forKey: .content)
+      try container.encode(_post, forKey: .post)
+      try container.encode(_author, forKey: .author)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/Post14+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/Post14+Schema.swift
@@ -1,0 +1,76 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case title
+    case rating
+    case status
+    case comments
+    case author
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post14 = Post14.keys
+    
+    model.authRules = [
+      rule(allow: .public, operations: [.create, .update, .delete, .read])
+    ]
+    
+    model.pluralName = "Post14s"
+    
+    model.attributes(
+      .primaryKey(fields: [post14.id])
+    )
+    
+    model.fields(
+      .field(post14.id, is: .required, ofType: .string),
+      .field(post14.title, is: .required, ofType: .string),
+      .field(post14.rating, is: .required, ofType: .int),
+      .field(post14.status, is: .required, ofType: .enum(type: PostStatus.self)),
+      .hasMany(post14.comments, is: .optional, ofType: Comment14.self, associatedWith: Comment14.keys.post),
+      .belongsTo(post14.author, is: .required, ofType: User14.self, targetNames: ["user14PostsId"]),
+      .field(post14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Post14> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Post14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == Post14 {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var title: FieldPath<String>   {
+      string("title") 
+    }
+  public var rating: FieldPath<Int>   {
+      int("rating") 
+    }
+  public var comments: ModelPath<Comment14>   {
+      Comment14.Path(name: "comments", isCollection: true, parent: self) 
+    }
+  public var author: ModelPath<User14>   {
+      User14.Path(name: "author", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/Post14.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/Post14.swift
@@ -1,0 +1,77 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post14: Model {
+  public let id: String
+  public var title: String
+  public var rating: Int
+  public var status: PostStatus
+  public var comments: List<Comment14>?
+  internal var _author: LazyReference<User14>
+  public var author: User14   {
+      get async throws { 
+        try await _author.require()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      title: String,
+      rating: Int,
+      status: PostStatus,
+      comments: List<Comment14>? = [],
+      author: User14) {
+    self.init(id: id,
+      title: title,
+      rating: rating,
+      status: status,
+      comments: comments,
+      author: author,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      title: String,
+      rating: Int,
+      status: PostStatus,
+      comments: List<Comment14>? = [],
+      author: User14,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.title = title
+      self.rating = rating
+      self.status = status
+      self.comments = comments
+      self._author = LazyReference(author)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setAuthor(_ author: User14) {
+    self._author = LazyReference(author)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      title = try values.decode(String.self, forKey: .title)
+      rating = try values.decode(Int.self, forKey: .rating)
+      status = try values.decode(PostStatus.self, forKey: .status)
+      comments = try values.decodeIfPresent(List<Comment14>?.self, forKey: .comments) ?? .init()
+      _author = try values.decodeIfPresent(LazyReference<User14>.self, forKey: .author) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(title, forKey: .title)
+      try container.encode(rating, forKey: .rating)
+      try container.encode(status, forKey: .status)
+      try container.encode(comments, forKey: .comments)
+      try container.encode(_author, forKey: .author)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/PostStatus.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/PostStatus.swift
@@ -1,0 +1,8 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public enum PostStatus: String, EnumPersistable {
+  case active = "ACTIVE"
+  case inactive = "INACTIVE"
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/User14+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/User14+Schema.swift
@@ -1,0 +1,79 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension User14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case username
+    case posts
+    case comments
+    case settings
+    case createdAt
+    case updatedAt
+    case user14SettingsId
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let user14 = User14.keys
+    
+    model.authRules = [
+      rule(allow: .public, operations: [.create, .update, .delete, .read])
+    ]
+    
+    model.pluralName = "User14s"
+    
+    model.attributes(
+      .primaryKey(fields: [user14.id])
+    )
+    
+    model.fields(
+      .field(user14.id, is: .required, ofType: .string),
+      .field(user14.username, is: .required, ofType: .string),
+      .hasMany(user14.posts, is: .optional, ofType: Post14.self, associatedWith: Post14.keys.author),
+      .hasMany(user14.comments, is: .optional, ofType: Comment14.self, associatedWith: Comment14.keys.author),
+      .hasOne(user14.settings, is: .optional, ofType: UserSettings14.self, associatedWith: UserSettings14.keys.user, targetNames: ["user14SettingsId"]),
+      .field(user14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(user14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(user14.user14SettingsId, is: .optional, ofType: .string)
+    )
+    }
+    public class Path: ModelPath<User14> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension User14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == User14 {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var username: FieldPath<String>   {
+      string("username") 
+    }
+  public var posts: ModelPath<Post14>   {
+      Post14.Path(name: "posts", isCollection: true, parent: self) 
+    }
+  public var comments: ModelPath<Comment14>   {
+      Comment14.Path(name: "comments", isCollection: true, parent: self) 
+    }
+  public var settings: ModelPath<UserSettings14>   {
+      UserSettings14.Path(name: "settings", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+  public var user14SettingsId: FieldPath<String>   {
+      string("user14SettingsId") 
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/User14.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/User14.swift
@@ -1,0 +1,77 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct User14: Model {
+  public let id: String
+  public var username: String
+  public var posts: List<Post14>?
+  public var comments: List<Comment14>?
+  internal var _settings: LazyReference<UserSettings14>
+  public var settings: UserSettings14?   {
+      get async throws { 
+        try await _settings.get()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  public var user14SettingsId: String?
+  
+  public init(id: String = UUID().uuidString,
+      username: String,
+      posts: List<Post14>? = [],
+      comments: List<Comment14>? = [],
+      settings: UserSettings14? = nil,
+      user14SettingsId: String? = nil) {
+    self.init(id: id,
+      username: username,
+      posts: posts,
+      comments: comments,
+      settings: settings,
+      createdAt: nil,
+      updatedAt: nil,
+      user14SettingsId: user14SettingsId)
+  }
+  internal init(id: String = UUID().uuidString,
+      username: String,
+      posts: List<Post14>? = [],
+      comments: List<Comment14>? = [],
+      settings: UserSettings14? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil,
+      user14SettingsId: String? = nil) {
+      self.id = id
+      self.username = username
+      self.posts = posts
+      self.comments = comments
+      self._settings = LazyReference(settings)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+      self.user14SettingsId = user14SettingsId
+  }
+  public mutating func setSettings(_ settings: UserSettings14? = nil) {
+    self._settings = LazyReference(settings)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      username = try values.decode(String.self, forKey: .username)
+      posts = try values.decodeIfPresent(List<Post14>?.self, forKey: .posts) ?? .init()
+      comments = try values.decodeIfPresent(List<Comment14>?.self, forKey: .comments) ?? .init()
+      _settings = try values.decodeIfPresent(LazyReference<UserSettings14>.self, forKey: .settings) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+      user14SettingsId = try? values.decode(String?.self, forKey: .user14SettingsId)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(username, forKey: .username)
+      try container.encode(posts, forKey: .posts)
+      try container.encode(comments, forKey: .comments)
+      try container.encode(_settings, forKey: .settings)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+      try container.encode(user14SettingsId, forKey: .user14SettingsId)
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/UserSettings14+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/UserSettings14+Schema.swift
@@ -1,0 +1,64 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension UserSettings14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case language
+    case user
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let userSettings14 = UserSettings14.keys
+    
+    model.authRules = [
+      rule(allow: .public, operations: [.create, .update, .delete, .read])
+    ]
+    
+    model.pluralName = "UserSettings14s"
+    
+    model.attributes(
+      .primaryKey(fields: [userSettings14.id])
+    )
+    
+    model.fields(
+      .field(userSettings14.id, is: .required, ofType: .string),
+      .field(userSettings14.language, is: .optional, ofType: .string),
+      .belongsTo(userSettings14.user, is: .required, ofType: User14.self, targetNames: ["userSettings14UserId"]),
+      .field(userSettings14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(userSettings14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<UserSettings14> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension UserSettings14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == UserSettings14 {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var language: FieldPath<String>   {
+      string("language") 
+    }
+  public var user: ModelPath<User14>   {
+      User14.Path(name: "user", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/UserSettings14.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/UserSettings14.swift
@@ -1,0 +1,56 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct UserSettings14: Model {
+  public let id: String
+  public var language: String?
+  internal var _user: LazyReference<User14>
+  public var user: User14   {
+      get async throws { 
+        try await _user.require()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      language: String? = nil,
+      user: User14) {
+    self.init(id: id,
+      language: language,
+      user: user,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      language: String? = nil,
+      user: User14,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.language = language
+      self._user = LazyReference(user)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setUser(_ user: User14) {
+    self._user = LazyReference(user)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      language = try? values.decode(String?.self, forKey: .language)
+      _user = try values.decodeIfPresent(LazyReference<User14>.self, forKey: .user) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(language, forKey: .language)
+      try container.encode(_user, forKey: .user)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/lazyload-schema.graphql
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/lazyload-schema.graphql
@@ -283,3 +283,40 @@ type Transcript @model {
   language: String
   phoneCall: PhoneCall @belongsTo
 }
+
+# LL.14
+
+enum PostStatus {
+  ACTIVE
+  INACTIVE
+}
+
+type User14 @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  username: String!
+  posts: [Post14] @hasMany
+  comments: [Comment14] @hasMany
+  settings: UserSettings14 @hasOne
+}
+
+type UserSettings14 @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  language: String
+  user: User14! @belongsTo
+}
+
+type Post14 @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  title: String!
+  rating: Int!
+  status: PostStatus!
+  comments: [Comment14] @hasMany
+  author: User14! @belongsTo
+}
+
+type Comment14 @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  content: String
+  post: Post14 @belongsTo
+  author: User14! @belongsTo
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
@@ -491,6 +491,21 @@
 		21BBFE10289C06E400B32A39 /* UserAccount+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BBFD2A289C06E400B32A39 /* UserAccount+Schema.swift */; };
 		21BBFE11289C06E400B32A39 /* UserAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BBFD2B289C06E400B32A39 /* UserAccount.swift */; };
 		21BBFE12289C06E400B32A39 /* Author+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BBFD2C289C06E400B32A39 /* Author+Schema.swift */; };
+		21BC10CD296DDB4B000E189E /* Comment4V2+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10C9296DDB4B000E189E /* Comment4V2+Schema.swift */; };
+		21BC10CE296DDB4B000E189E /* Comment4V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10CA296DDB4B000E189E /* Comment4V2.swift */; };
+		21BC10CF296DDB4B000E189E /* Post4V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10CB296DDB4B000E189E /* Post4V2.swift */; };
+		21BC10D0296DDB4B000E189E /* Post4V2+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10CC296DDB4B000E189E /* Post4V2+Schema.swift */; };
+		21BC10D2296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10D1296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift */; };
+		21BC11062971A82A000E189E /* PostStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10FD2971A82A000E189E /* PostStatus.swift */; };
+		21BC11072971A82A000E189E /* Post14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10FE2971A82A000E189E /* Post14.swift */; };
+		21BC11082971A82A000E189E /* User14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10FF2971A82A000E189E /* User14.swift */; };
+		21BC11092971A82A000E189E /* UserSettings14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11002971A82A000E189E /* UserSettings14.swift */; };
+		21BC110A2971A82A000E189E /* Comment14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11012971A82A000E189E /* Comment14+Schema.swift */; };
+		21BC110B2971A82A000E189E /* Comment14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11022971A82A000E189E /* Comment14.swift */; };
+		21BC110C2971A82A000E189E /* Post14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11032971A82A000E189E /* Post14+Schema.swift */; };
+		21BC110D2971A82A000E189E /* User14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11042971A82A000E189E /* User14+Schema.swift */; };
+		21BC110E2971A82A000E189E /* UserSettings14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11052971A82A000E189E /* UserSettings14+Schema.swift */; };
+		21BC11102971A87F000E189E /* AWSDataStoreLazyLoadUserPostCommentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC110F2971A87F000E189E /* AWSDataStoreLazyLoadUserPostCommentTests.swift */; };
 		21C3C4C1293FD9BD009194A0 /* AWSDataStoreLazyLoadDefaultPKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C3C4C0293FD9BD009194A0 /* AWSDataStoreLazyLoadDefaultPKTests.swift */; };
 		21C3C4C3293FD9FF009194A0 /* AWSDataStoreLazyLoadHasOneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C3C4C2293FD9FF009194A0 /* AWSDataStoreLazyLoadHasOneTests.swift */; };
 		21C3C4C5293FDA12009194A0 /* AWSDataStoreLazyLoadCompositePKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C3C4C4293FDA12009194A0 /* AWSDataStoreLazyLoadCompositePKTests.swift */; };
@@ -501,11 +516,6 @@
 		21DFAEA3295F4E8600B4A883 /* PhoneCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAE9D295F4E8600B4A883 /* PhoneCall.swift */; };
 		21DFAEA4295F4E8600B4A883 /* Transcript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAE9E295F4E8600B4A883 /* Transcript.swift */; };
 		21DFAEA6295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAEA5295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift */; };
-		21BC10CD296DDB4B000E189E /* Comment4V2+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10C9296DDB4B000E189E /* Comment4V2+Schema.swift */; };
-		21BC10CE296DDB4B000E189E /* Comment4V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10CA296DDB4B000E189E /* Comment4V2.swift */; };
-		21BC10CF296DDB4B000E189E /* Post4V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10CB296DDB4B000E189E /* Post4V2.swift */; };
-		21BC10D0296DDB4B000E189E /* Post4V2+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10CC296DDB4B000E189E /* Post4V2+Schema.swift */; };
-		21BC10D2296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10D1296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift */; };
 		681DFE8328E746C10000C36A /* AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8028E746C10000C36A /* AsyncTesting.swift */; };
 		681DFE8428E746C10000C36A /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8128E746C10000C36A /* AsyncExpectation.swift */; };
 		681DFE8528E746C10000C36A /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8228E746C10000C36A /* XCTestCase+AsyncTesting.swift */; };
@@ -708,9 +718,9 @@
 		21182133289BFB4F001B5945 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		21182136289BFB4F001B5945 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2118213E289BFB63001B5945 /* amplify-ios-staging */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-ios-staging"; path = ../../../..; sourceTree = "<group>"; };
+		211F5093296DD4C30040EB62 /* AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift; sourceTree = "<group>"; };
 		213848292947ACCF00BBA647 /* AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift; sourceTree = "<group>"; };
 		2138482B2947F89C00BBA647 /* AWSDataStoreLazyLoadingBlogPostCmment8V2SnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadingBlogPostCmment8V2SnapshotTests.swift; sourceTree = "<group>"; };
-		211F5093296DD4C30040EB62 /* AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift; sourceTree = "<group>"; };
 		213DBB6128A4172000B30280 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		213DBB6228A5743200B30280 /* ModelImplicitDefaultPk+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ModelImplicitDefaultPk+Schema.swift"; sourceTree = "<group>"; };
 		213DBB6328A5743200B30280 /* ModelImplicitDefaultPk.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelImplicitDefaultPk.swift; sourceTree = "<group>"; };
@@ -1222,6 +1232,21 @@
 		21BBFD2B289C06E400B32A39 /* UserAccount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAccount.swift; sourceTree = "<group>"; };
 		21BBFD2C289C06E400B32A39 /* Author+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Author+Schema.swift"; sourceTree = "<group>"; };
 		21BBFE13289C073100B32A39 /* HubListenerTestUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HubListenerTestUtilities.swift; sourceTree = "<group>"; };
+		21BC10C9296DDB4B000E189E /* Comment4V2+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Comment4V2+Schema.swift"; sourceTree = "<group>"; };
+		21BC10CA296DDB4B000E189E /* Comment4V2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment4V2.swift; sourceTree = "<group>"; };
+		21BC10CB296DDB4B000E189E /* Post4V2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post4V2.swift; sourceTree = "<group>"; };
+		21BC10CC296DDB4B000E189E /* Post4V2+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post4V2+Schema.swift"; sourceTree = "<group>"; };
+		21BC10D1296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStorePrimaryKeyPostComment4V2Test.swift; sourceTree = "<group>"; };
+		21BC10FD2971A82A000E189E /* PostStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostStatus.swift; sourceTree = "<group>"; };
+		21BC10FE2971A82A000E189E /* Post14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post14.swift; sourceTree = "<group>"; };
+		21BC10FF2971A82A000E189E /* User14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User14.swift; sourceTree = "<group>"; };
+		21BC11002971A82A000E189E /* UserSettings14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserSettings14.swift; sourceTree = "<group>"; };
+		21BC11012971A82A000E189E /* Comment14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Comment14+Schema.swift"; sourceTree = "<group>"; };
+		21BC11022971A82A000E189E /* Comment14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment14.swift; sourceTree = "<group>"; };
+		21BC11032971A82A000E189E /* Post14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post14+Schema.swift"; sourceTree = "<group>"; };
+		21BC11042971A82A000E189E /* User14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "User14+Schema.swift"; sourceTree = "<group>"; };
+		21BC11052971A82A000E189E /* UserSettings14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserSettings14+Schema.swift"; sourceTree = "<group>"; };
+		21BC110F2971A87F000E189E /* AWSDataStoreLazyLoadUserPostCommentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadUserPostCommentTests.swift; sourceTree = "<group>"; };
 		21C3C4C0293FD9BD009194A0 /* AWSDataStoreLazyLoadDefaultPKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadDefaultPKTests.swift; sourceTree = "<group>"; };
 		21C3C4C2293FD9FF009194A0 /* AWSDataStoreLazyLoadHasOneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadHasOneTests.swift; sourceTree = "<group>"; };
 		21C3C4C4293FDA12009194A0 /* AWSDataStoreLazyLoadCompositePKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadCompositePKTests.swift; sourceTree = "<group>"; };
@@ -1232,11 +1257,6 @@
 		21DFAE9D295F4E8600B4A883 /* PhoneCall.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneCall.swift; sourceTree = "<group>"; };
 		21DFAE9E295F4E8600B4A883 /* Transcript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transcript.swift; sourceTree = "<group>"; };
 		21DFAEA5295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadPhoneCallTests.swift; sourceTree = "<group>"; };
-		21BC10C9296DDB4B000E189E /* Comment4V2+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Comment4V2+Schema.swift"; sourceTree = "<group>"; };
-		21BC10CA296DDB4B000E189E /* Comment4V2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment4V2.swift; sourceTree = "<group>"; };
-		21BC10CB296DDB4B000E189E /* Post4V2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post4V2.swift; sourceTree = "<group>"; };
-		21BC10CC296DDB4B000E189E /* Post4V2+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post4V2+Schema.swift"; sourceTree = "<group>"; };
-		21BC10D1296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStorePrimaryKeyPostComment4V2Test.swift; sourceTree = "<group>"; };
 		681DFE8028E746C10000C36A /* AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncTesting.swift; sourceTree = "<group>"; };
 		681DFE8128E746C10000C36A /* AsyncExpectation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncExpectation.swift; sourceTree = "<group>"; };
 		681DFE8228E746C10000C36A /* XCTestCase+AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AsyncTesting.swift"; sourceTree = "<group>"; };
@@ -1563,6 +1583,7 @@
 				21801D472902E0FD00FFA37E /* LL11 */,
 				21801D4B29097CAB00FFA37E /* LL12 */,
 				21DFAE98295F4E4C00B4A883 /* LL13 */,
+				21BC10FC2971A7DE000E189E /* LL14 */,
 			);
 			path = AWSDataStorePluginLazyLoadTests;
 			sourceTree = "<group>";
@@ -2501,6 +2522,35 @@
 			path = Associations;
 			sourceTree = "<group>";
 		};
+		21BC10C8296DDB2B000E189E /* 10 */ = {
+			isa = PBXGroup;
+			children = (
+				21BC10D1296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift */,
+				21BC10CA296DDB4B000E189E /* Comment4V2.swift */,
+				21BC10C9296DDB4B000E189E /* Comment4V2+Schema.swift */,
+				21BC10CB296DDB4B000E189E /* Post4V2.swift */,
+				21BC10CC296DDB4B000E189E /* Post4V2+Schema.swift */,
+			);
+			path = 10;
+			sourceTree = "<group>";
+		};
+		21BC10FC2971A7DE000E189E /* LL14 */ = {
+			isa = PBXGroup;
+			children = (
+				21BC110F2971A87F000E189E /* AWSDataStoreLazyLoadUserPostCommentTests.swift */,
+				21BC11022971A82A000E189E /* Comment14.swift */,
+				21BC11012971A82A000E189E /* Comment14+Schema.swift */,
+				21BC10FE2971A82A000E189E /* Post14.swift */,
+				21BC11032971A82A000E189E /* Post14+Schema.swift */,
+				21BC10FD2971A82A000E189E /* PostStatus.swift */,
+				21BC10FF2971A82A000E189E /* User14.swift */,
+				21BC11042971A82A000E189E /* User14+Schema.swift */,
+				21BC11002971A82A000E189E /* UserSettings14.swift */,
+				21BC11052971A82A000E189E /* UserSettings14+Schema.swift */,
+			);
+			path = LL14;
+			sourceTree = "<group>";
+		};
 		21C3C4BD293FD84C009194A0 /* HasOneParentChild */ = {
 			isa = PBXGroup;
 			children = (
@@ -2555,18 +2605,6 @@
 				21DFAE9B295F4E8500B4A883 /* Transcript+Schema.swift */,
 			);
 			path = LL13;
-			sourceTree = "<group>";
-		};
-		21BC10C8296DDB2B000E189E /* 10 */ = {
-			isa = PBXGroup;
-			children = (
-				21BC10D1296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift */,
-				21BC10CA296DDB4B000E189E /* Comment4V2.swift */,
-				21BC10C9296DDB4B000E189E /* Comment4V2+Schema.swift */,
-				21BC10CB296DDB4B000E189E /* Post4V2.swift */,
-				21BC10CC296DDB4B000E189E /* Post4V2+Schema.swift */,
-			);
-			path = 10;
 			sourceTree = "<group>";
 		};
 		681DFE7F28E746C10000C36A /* AsyncTesting */ = {
@@ -3442,11 +3480,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21BC11082971A82A000E189E /* User14.swift in Sources */,
 				21801CE328F9A86800FFA37E /* Project6.swift in Sources */,
 				21801CE628F9A86800FFA37E /* TagWithCompositeKey+Schema.swift in Sources */,
 				21801D2F29006DA900FFA37E /* Team1.swift in Sources */,
+				21BC11102971A87F000E189E /* AWSDataStoreLazyLoadUserPostCommentTests.swift in Sources */,
 				21801D6529097D5800FFA37E /* DefaultPKParent+Schema.swift in Sources */,
 				21801CE728F9A86800FFA37E /* Project2.swift in Sources */,
+				21BC110D2971A82A000E189E /* User14+Schema.swift in Sources */,
+				21BC110E2971A82A000E189E /* UserSettings14+Schema.swift in Sources */,
 				217AA7C32909EF050042CD5D /* AWSDataStoreLazyLoadPostComment8Tests.swift in Sources */,
 				21801D6A29097D5800FFA37E /* ChildSansBelongsTo+Schema.swift in Sources */,
 				21619C1129480AA100E0900F /* AWSDataStoreLazyLoadProjectTeam1SnapshotTests.swift in Sources */,
@@ -3455,6 +3497,7 @@
 				21801CFB28F9A86800FFA37E /* Team2+Schema.swift in Sources */,
 				21801D6F29097D5800FFA37E /* ChildSansBelongsTo.swift in Sources */,
 				21801D6B29097D5800FFA37E /* HasOneParent.swift in Sources */,
+				21BC110B2971A82A000E189E /* Comment14.swift in Sources */,
 				21801D0328F9A86800FFA37E /* Post7+Schema.swift in Sources */,
 				21801D3329006DB500FFA37E /* Team5.swift in Sources */,
 				21801CEF28F9A86800FFA37E /* Blog8V2+Schema.swift in Sources */,
@@ -3462,6 +3505,7 @@
 				21801D3629006DC200FFA37E /* Project5+Schema.swift in Sources */,
 				21801D6229097D5800FFA37E /* CompositePKChild.swift in Sources */,
 				21801CE028F9A86800FFA37E /* Post8V2.swift in Sources */,
+				21BC11062971A82A000E189E /* PostStatus.swift in Sources */,
 				21801D3E2900A10600FFA37E /* AWSDataStoreLazyLoadProjectTeam1Tests.swift in Sources */,
 				21801C7D28F9A22900FFA37E /* AWSDataStoreLazyLoadBaseTest.swift in Sources */,
 				21DFAEA6295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift in Sources */,
@@ -3469,10 +3513,12 @@
 				217AA7BF2909C6330042CD5D /* AWSDataStoreLazyLoadProjectTeam6Tests.swift in Sources */,
 				21DFAEA1295F4E8600B4A883 /* Transcript+Schema.swift in Sources */,
 				21DFAE9F295F4E8600B4A883 /* Person.swift in Sources */,
+				21BC11072971A82A000E189E /* Post14.swift in Sources */,
 				21801D0228F9A86800FFA37E /* Comment8+Schema.swift in Sources */,
 				21801D5F29097D5800FFA37E /* HasOneChild+Schema.swift in Sources */,
 				21801CFC28F9A86800FFA37E /* Comment4V2+Schema.swift in Sources */,
 				21801CEC28F9A86800FFA37E /* Team6+Schema.swift in Sources */,
+				21BC110C2971A82A000E189E /* Post14+Schema.swift in Sources */,
 				21801CEA28F9A86800FFA37E /* Comment8.swift in Sources */,
 				21801D6329097D5800FFA37E /* StrangeExplicitChild+Schema.swift in Sources */,
 				21801C8728F9A38000FFA37E /* TestConfigHelper.swift in Sources */,
@@ -3483,6 +3529,7 @@
 				21801CE828F9A86800FFA37E /* Comment4V2.swift in Sources */,
 				21DFAEA2295F4E8600B4A883 /* Person+Schema.swift in Sources */,
 				21C3C4C1293FD9BD009194A0 /* AWSDataStoreLazyLoadDefaultPKTests.swift in Sources */,
+				21BC11092971A82A000E189E /* UserSettings14.swift in Sources */,
 				21801CD528F9A86800FFA37E /* CommentWithCompositeKey+Schema.swift in Sources */,
 				217AA7BD2909C1D00042CD5D /* AWSDataStoreLazyLoadProjectTeam5Tests.swift in Sources */,
 				21801CED28F9A86800FFA37E /* Post4.swift in Sources */,
@@ -3508,6 +3555,7 @@
 				21801D2A29006DA300FFA37E /* Project1.swift in Sources */,
 				2138482A2947ACCF00BBA647 /* AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift in Sources */,
 				21801CF128F9A86800FFA37E /* Project2+Schema.swift in Sources */,
+				21BC110A2971A82A000E189E /* Comment14+Schema.swift in Sources */,
 				21C3C4C5293FDA12009194A0 /* AWSDataStoreLazyLoadCompositePKTests.swift in Sources */,
 				21801D0428F9A86800FFA37E /* MyNestedModel8.swift in Sources */,
 				21C3C4C3293FD9FF009194A0 /* AWSDataStoreLazyLoadHasOneTests.swift in Sources */,


### PR DESCRIPTION
## Issue \#
Model Path is missing `int`. This PR also adds the schema used in the migration guide, which contains a field of type int.

## Description
<!-- Why is this change required? What problem does it solve? -->

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
