### PR TITLE
feat(Analytics): Adding support for setting Pinpoint User Attributes.

### DIFF
--- a/Amplify/Categories/Analytics/AnalyticsProfile.swift
+++ b/Amplify/Categories/Analytics/AnalyticsProfile.swift
@@ -35,7 +35,7 @@ public struct AnalyticsUserProfile {
     public init(name: String? = nil,
                 email: String? = nil,
                 plan: String? = nil,
-                location: Location?,
+                location: Location? = nil,
                 properties: AnalyticsProperties? = nil) {
         self.name = name
         self.email = email

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Endpoint/PinpointEndpointProfile.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Dependency/Pinpoint/Endpoint/PinpointEndpointProfile.swift
@@ -61,8 +61,12 @@ class PinpointEndpointProfile: Codable, AnalyticsPropertiesModel {
             addAttribute(plan, forKey: Constants.AttributeKeys.plan)
         }
 
-        if let properties = userProfile.properties {
-            addProperties(properties)
+        if let customProperties = userProfile.endpointCustomProperties {
+            addCustomProperties(customProperties)
+        }
+
+        if let userProperties = userProfile.endpointUserProperties {
+            addUserProperties(userProperties)
         }
 
         if let userLocation = userProfile.location {
@@ -100,6 +104,26 @@ class PinpointEndpointProfile: Codable, AnalyticsPropertiesModel {
 
     func removeAllMetrics() {
         metrics = [:]
+    }
+
+    private func addCustomProperties(_ properties: [String: AnalyticsPropertyValue]) {
+        addProperties(properties)
+    }
+
+    private func addUserProperties(_ properties: [String: AnalyticsPropertyValue]) {
+        var userAttributes = user.userAttributes ?? [:]
+        for (key, value) in properties {
+            if let value = value as? String {
+                userAttributes[key] = [value]
+            } else if let value = value as? Int {
+                userAttributes[key] = [String(value)]
+            } else if let value = value as? Double {
+                userAttributes[key] = [String(value)]
+            } else if let value = value as? Bool {
+                userAttributes[key] = [String(value)]
+            }
+        }
+        user.userAttributes = userAttributes
     }
 }
 

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Extensions/AnalyticsUserProfile+Pinpoint.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Extensions/AnalyticsUserProfile+Pinpoint.swift
@@ -1,0 +1,124 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Foundation
+
+public extension AnalyticsUserProfile {
+    /// Defines constants used specificaly for AWS Pinpoint
+    enum AWSPinpoint {
+        public enum Endpoint {
+            /// Add this prefix to a property key to mark it as an Endpoint's Custom attribute.
+            public static let customAttributePrefix = "endpointCustomAttribute::"
+
+            /// Add this prefix to a property key to mark it as an Endpoint's User attribute.
+            public static let userAttributePrefix = "endpointUserAttribute::"
+        }
+    }
+
+    /// Adds a property to the Endpoint's Custom Attributes.
+    ///
+    /// The given key will be prefixed with `AnalyticsUserProfile.AWSPinpoint.endpointPrefix` in order to identify it.
+    ///
+    /// - Parameter property: The property value
+    /// - Parameter key: The property key
+    mutating func addPinpointEndpointCustomProperty(_ property: AnalyticsPropertyValue,
+                                                    forKey key: String) {
+        addProperty(
+            property,
+            forKey: key.prefixed(AnalyticsUserProfile.AWSPinpoint.Endpoint.customAttributePrefix)
+        )
+    }
+
+    /// Adds a property to the Endpoint's User Attributes.
+    ///
+    /// The given key will be prefixed with `AnalyticsUserProfile.AWSPinpoint.userPrefix` in order to identify it.
+    ///
+    /// - Parameter property: The property value
+    /// - Parameter key: The property key
+    mutating func addPinpointEndpointUserProperty(_ property: AnalyticsPropertyValue,
+                                                  forKey key: String) {
+        addProperty(
+            property,
+            forKey: key.prefixed(AnalyticsUserProfile.AWSPinpoint.Endpoint.userAttributePrefix)
+        )
+    }
+
+    /// Adds properties to the Endpoint's Custom Attributes.
+    ///
+    /// All keys will be prefixed with `AnalyticsUserProfile.AWSPinpoint.endpointPrefix` in order to identify them.
+    ///
+    /// - Parameter properties: A dictionary containing the properties keys and values
+    mutating func addPinpointEndpointProperties(_ properties: AnalyticsProperties) {
+        for (key, value) in properties {
+            addPinpointEndpointCustomProperty(value, forKey: key)
+        }
+    }
+
+    /// Adds properties to the Endpoint's User Attributes.
+    /// 
+    /// All keys will be prefixed with `AnalyticsUserProfile.AWSPinpoint.userPrefix` in order to identify them.
+    ///
+    /// - Parameter properties: A dictionary containing the properties keys and values
+    mutating func addPinpointUserProperties(_ properties: AnalyticsProperties) {
+        for (key, value) in properties {
+            addPinpointEndpointUserProperty(value, forKey: key)
+        }
+    }
+
+    private mutating func addProperty(_ property: AnalyticsPropertyValue,
+                                      forKey key: String) {
+        var properties = self.properties ?? [:]
+        properties[key] = property
+        self.properties = properties
+    }
+
+    /// The properties that are mapped to the Endpoint's Custom Attributes . The keys in this dictionary do not have any generated prefix.
+    var endpointCustomProperties: AnalyticsProperties? {
+        guard let properties = properties else {
+            return nil
+        }
+
+        var customProperties: AnalyticsProperties = [:]
+        for (key, value) in properties {
+            if key.hasPrefix(AWSPinpoint.Endpoint.customAttributePrefix) {
+                let newKey = String(key.dropFirst(AWSPinpoint.Endpoint.customAttributePrefix.count))
+                customProperties[newKey] = value
+            } else if !key.hasPrefix(AWSPinpoint.Endpoint.userAttributePrefix) {
+                // Unless the key is explicitly prefixed as a userAttribute,
+                // we should consider it a custom property as is.
+                customProperties[key] = value
+            }
+        }
+
+        return customProperties
+    }
+
+    /// The properties that are mapped to the Endpoint's User Attributes. The keys in this dictionary do not have any generated prefix.
+    var endpointUserProperties: AnalyticsProperties? {
+        guard let properties = properties else {
+            return nil
+        }
+
+        var userProperties: AnalyticsProperties = [:]
+        for (key, value) in properties where key.hasPrefix(AWSPinpoint.Endpoint.userAttributePrefix) {
+            let newKey = String(key.dropFirst(AWSPinpoint.Endpoint.userAttributePrefix.count))
+            userProperties[newKey] = value
+        }
+
+        return userProperties
+    }
+}
+
+private extension String {
+    func prefixed(_ prefix: String) -> String {
+        guard !hasPrefix(prefix) else {
+            return self
+        }
+        return "\(prefix)\(self)"
+    }
+}

--- a/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/Pinpoint/AnalyticsUserProfilePinpointTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/Pinpoint/AnalyticsUserProfilePinpointTests.swift
@@ -1,0 +1,176 @@
+//
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import AWSPinpointAnalyticsPlugin
+import XCTest
+
+class AnalyticsUserProfilePinpointTests: XCTestCase {
+
+    /// Given: A AnalyticsUserProfile
+    /// When: AnalyticsUserProfile.addPinpointEndpointCustomProperty(forKey) is invoked with a key and value
+    /// Then: The key is prefixed with a custom attribute prefix
+    ///      and the pair is included in AnalyticsUserProfile.endpointCustomProperties
+    ///      and the pair is not included in AnalyticsUserProfile.endpointUserProperties
+    func testAddPinpointEndpointCustomProperty_shouldAddPrefix() {
+        var userProfile = AnalyticsUserProfile()
+        userProfile.addPinpointEndpointCustomProperty("value", forKey: "key")
+
+        guard let properties = userProfile.properties else {
+            XCTFail("Properties should not be nil")
+            return
+        }
+
+        XCTAssertNil(properties["key"])
+        XCTAssertNotNil(properties["\(AnalyticsUserProfile.AWSPinpoint.Endpoint.customAttributePrefix)key"])
+        XCTAssertEqual(userProfile.endpointCustomProperties?.count, 1)
+        XCTAssertTrue(userProfile.endpointUserProperties?.isEmpty ?? false)
+    }
+
+    /// Given: A AnalyticsUserProfile
+    /// When: AnalyticsUserProfile.addPinpointEndpointProperties() is invoked with a dictionary containg pairs of keys and values
+    /// Then: Each key is prefixed with a custom attribute prefix
+    ///      and each pair is included in AnalyticsUserProfile.endpointCustomProperties
+    ///      and each pair is not included in AnalyticsUserProfile.endpointUserProperties
+    func testAddPinpointEndpointCustomProperties_shouldAddPrefixes() {
+        var userProfile = AnalyticsUserProfile()
+        let endpointProperties: AnalyticsProperties = [
+            "attributeKey": "string",
+            "metricKey": 2
+        ]
+        userProfile.addPinpointEndpointProperties(endpointProperties)
+
+        guard let properties = userProfile.properties else {
+            XCTFail("Properties should not be nil")
+            return
+        }
+
+        XCTAssertNil(properties["attributeKey"])
+        XCTAssertNil(properties["metricKey"])
+        XCTAssertNotNil(properties["\(AnalyticsUserProfile.AWSPinpoint.Endpoint.customAttributePrefix)attributeKey"])
+        XCTAssertNotNil(properties["\(AnalyticsUserProfile.AWSPinpoint.Endpoint.customAttributePrefix)metricKey"])
+        XCTAssertEqual(userProfile.endpointCustomProperties?.count, endpointProperties.count)
+        XCTAssertTrue(userProfile.endpointUserProperties?.isEmpty ?? false)
+    }
+
+    /// Given: A AnalyticsUserProfile
+    /// When: AnalyticsUserProfile.addPinpointEndpointUserProperty(forKey) is invoked with a key and value
+    /// Then: The key is prefixed with a custom attribute prefix
+    ///      and the pair is included in AnalyticsUserProfile.endpointUserProperties
+    ///      and the pair is not included in AnalyticsUserProfile.endpointCustomProperties
+    func testAddPinpointEndpointUserProperty_shouldAddPrefix() {
+        var userProfile = AnalyticsUserProfile()
+        userProfile.addPinpointEndpointUserProperty("value", forKey: "key")
+
+        guard let properties = userProfile.properties else {
+            XCTFail("Properties should not be nil")
+            return
+        }
+
+        XCTAssertNil(properties["key"])
+        XCTAssertNotNil(properties["\(AnalyticsUserProfile.AWSPinpoint.Endpoint.userAttributePrefix)key"])
+        XCTAssertEqual(userProfile.endpointUserProperties?.count, 1)
+        XCTAssertTrue(userProfile.endpointCustomProperties?.isEmpty ?? false)
+    }
+
+    /// Given: A AnalyticsUserProfile
+    /// When: AnalyticsUserProfile.addPinpointUserProperties() is invoked with a dictionary containg pairs of keys and values
+    /// Then: Each key is prefixed with a custom attribute prefix
+    ///      and each pair is included in AnalyticsUserProfile.endpointUserProperties, without any prefix
+    ///      and each pair is not included in AnalyticsUserProfile.endpointCustomProperties
+    func testAddPinpointEndpointUserProperties_shouldAddPrefixes() {
+        var userProfile = AnalyticsUserProfile()
+        userProfile.addPinpointUserProperties([
+            "attributeKey": "string",
+            "metricKey": 2
+        ])
+
+        guard let properties = userProfile.properties else {
+            XCTFail("Properties should not be nil")
+            return
+        }
+
+        XCTAssertNil(properties["attributeKey"])
+        XCTAssertNotNil(properties["\(AnalyticsUserProfile.AWSPinpoint.Endpoint.userAttributePrefix)attributeKey"])
+        XCTAssertNotNil(properties["\(AnalyticsUserProfile.AWSPinpoint.Endpoint.userAttributePrefix)metricKey"])
+        XCTAssertEqual(userProfile.endpointUserProperties?.count, 2)
+        XCTAssertTrue(userProfile.endpointCustomProperties?.isEmpty ?? false)
+    }
+
+    /// Given: A AnalyticsUserProfile is created with properties whose keys that don't include any prefix.
+    /// When: AnalyticsUserProfile.endpointCustomProperties is invoked
+    /// Then: The properties that were missing a prefix are included
+    func testProperties_withoutPrefix_shouldBeAddedToEndpointCustomProperties() {
+        let userProfile = AnalyticsUserProfile(properties: [
+            "key": "value",
+            "\(AnalyticsUserProfile.AWSPinpoint.Endpoint.userAttributePrefix)userKey1": "userValue1",
+        ])
+
+        XCTAssertEqual(userProfile.endpointCustomProperties?.count, 1)
+    }
+
+    /// Given: A AnalyticsUserProfile is created with properties whose keys have prefixes
+    /// When: AnalyticsUserProfile.endpointCustomProperties and AnalyticsUserProfile.endpointUserProperties are invoked
+    /// Then: The properties are filtered out accordingly to their keys prefix
+    func testEndpointCustomAndUserProperties_shouldFilterOutOtherProperties() {
+        let userProfile = AnalyticsUserProfile(properties: [
+            "\(AnalyticsUserProfile.AWSPinpoint.Endpoint.userAttributePrefix)userKey1": "userValue1",
+            "\(AnalyticsUserProfile.AWSPinpoint.Endpoint.userAttributePrefix)userKey2": "userValue2",
+            "\(AnalyticsUserProfile.AWSPinpoint.Endpoint.customAttributePrefix)endpointKey1": "endpointValue1",
+            "\(AnalyticsUserProfile.AWSPinpoint.Endpoint.customAttributePrefix)endpointKey2": 2,
+            "endpointKey3": "endpointValue3",
+        ])
+
+        guard let properties = userProfile.properties,
+              let endpointProperties = userProfile.endpointCustomProperties,
+              let userProperties = userProfile.endpointUserProperties else {
+            XCTFail("Properties should not be nil")
+            return
+        }
+
+        XCTAssertEqual(properties.count, 5)
+        XCTAssertEqual(userProperties.count, 2)
+        XCTAssertEqual(endpointProperties.count, 3)
+
+        XCTAssertFalse(userProperties.contains(where: {$0.key == "endpointKey3"}))
+        XCTAssertFalse(endpointProperties.contains(where: {$0.key == "userKey1"}))
+    }
+
+    /// Given: A AnalyticsUserProfile is created with properties whose keys have prefixes that are not recognized
+    /// When: AnalyticsUserProfile.endpointCustomProperties and AnalyticsUserProfile.endpointUserProperties are invoked
+    /// Then: The properties with unrecognized prefixes are included in endpointCustomProperties without modification
+    func testEndpointCustomAndUserProperties_withUnrecognizedPrefixes_shouldIncludeThemAsCustomProperties() {
+        let userProfile = AnalyticsUserProfile(properties: [
+            "\(AnalyticsUserProfile.AWSPinpoint.Endpoint.userAttributePrefix)userKey1": "userValue1",
+            "\(AnalyticsUserProfile.AWSPinpoint.Endpoint.customAttributePrefix)endpointKey1": "endpointValue1",
+            "unknownPrefix1::unknownKey1": "unknownValue1",
+            "unknownPrefix2::unknownKey2": "unknownValue2"
+        ])
+
+        guard let properties = userProfile.properties,
+              let endpointProperties = userProfile.endpointCustomProperties,
+              let userProperties = userProfile.endpointUserProperties else {
+            XCTFail("Properties should not be nil")
+            return
+        }
+
+        XCTAssertEqual(properties.count, 4)
+        XCTAssertEqual(userProperties.count, 1)
+        XCTAssertEqual(endpointProperties.count, 3)
+
+        XCTAssertFalse(userProperties.contains(where: {$0.key == "unknownPrefix1::unknownKey1"}))
+        XCTAssertFalse(userProperties.contains(where: {$0.key == "unknownPrefix2::unknownKey2"}))
+        XCTAssertFalse(userProperties.contains(where: {$0.key == "unknownKey1"}))
+        XCTAssertFalse(userProperties.contains(where: {$0.key == "unknownKey2"}))
+
+        XCTAssertTrue(endpointProperties.contains(where: {$0.key == "unknownPrefix1::unknownKey1"}))
+        XCTAssertTrue(endpointProperties.contains(where: {$0.key == "unknownPrefix2::unknownKey2"}))
+        XCTAssertFalse(endpointProperties.contains(where: {$0.key == "unknownKey1"}))
+        XCTAssertFalse(endpointProperties.contains(where: {$0.key == "unknownKey2"}))
+    }
+}


### PR DESCRIPTION
## Issue \#
https://github.com/aws-amplify/amplify-swift/issues/1416

## Description
Analytics' `identifyUser` lets you pass a `AnalyticsUserProfile` with additional information. 
`AnalyticsUserProfile` is a **`struct`** that has a `properties` dictionary, among other properties.

```swift
public struct AnalyticsUserProfile {
    /// Name of the user
    public var name: String?

    /// The user's email
    public var email: String?

    /// The plan for the user
    public var plan: String?

    /// Location data about the user
    public var location: Location?

    /// Properties of the user profile
    public var properties: AnalyticsProperties?
}
```

When mapping it to the **Pinpoint** models, we add those properties to the endpoint's `attributes` and `metrics`, which makes them show up in the Console as **Custom attributes**.
However, Pinpoint's endpoint also has a `user` property, which in turn has `attributes` of its own. These attributes then show up in the Console as **User attributes**.

![](https://user-images.githubusercontent.com/2077790/123826472-ccc09300-d8cd-11eb-9812-071dbd97d448.png)

----

With our current implementation, there is **no** way for our customers to set **User attributes**, as we only provide one `properties` dictionary in which to add attributes and metrics.

Since we want to keep the category API generic and service-agnostic, we can't really add an explicit distinction (e.g. a new dictionary called `userProperties` ). And because `AnalyticsUserProfile` is a struct, we can't subclass it either to create a Pinpoint-specific version of it (which is what Android ended up doing for their implementation).

Ideally we should define `AnalyticsUserProfile` as a protocol (as we do with `AnalyticsEvent`), and then provide a concrete Pinpoint implementation that can handle both type of attributes. But that right now would be a breaking change, and unfortunately we can't do it.

In the meantime, in order to support this I'm following the suggestion discussed in https://github.com/aws-amplify/amplify-swift/pull/1208, which is to add a custom prefix to the properties' keys so we can internally differentiate them that way. To maintain backwards compatibility, properties whose keys don't have a prefix are mapped to **Custom attributes**, just as before.

I've also extended `AnalyticsUserProfile` to add these methods that customers can just call and save them from having to manually prefix their keys:
- `addPinpointEndpointCustomProperty(_:forKey:)`
- `addPinpointEndpointUserProperty(_:forKey:)`
- `addPinpointEndpointCustomProperties(_:)`
- `addPinpointEndpointUserProperties(_:)`

I've defined the extension inside the `AWSPinpointAnalyticsPlugin` module, so the new methods only appear if the customer explicitly imports the module. This is not ideal, but I think it's a fair compromise until a future **v3** in which we can refactor `AnalyticsUserProfile` into a `protocol`.


## General Checklist
<!-- Check or cross out if not relevant -->

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required **- TBD**
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
