### PR TITLE
fix(api): Add User-Agent and intercept subscription connect request

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/SubscriptionConnectionFactory.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/SubscriptionConnectionFactory.swift
@@ -8,12 +8,14 @@
 import Amplify
 import AWSPluginsCore
 import AppSyncRealTimeClient
+import Foundation
 
 /// Protocol for the subscription factory
 protocol SubscriptionConnectionFactory {
 
     /// Get connection based on the connection type
     func getOrCreateConnection(for endpointConfig: AWSAPICategoryPluginConfiguration.EndpointConfig,
+                               urlRequest: URLRequest,
                                authService: AWSAuthServiceBehavior,
                                authType: AWSAuthorizationType?,
                                apiAuthProviderFactory: APIAuthProviderFactory) throws -> SubscriptionConnection

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Mocks/MockSubscription.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Mocks/MockSubscription.swift
@@ -10,8 +10,10 @@ import Amplify
 
 import AWSPluginsCore
 import AppSyncRealTimeClient
+import Foundation
 
 struct MockSubscriptionConnectionFactory: SubscriptionConnectionFactory {
+    
     typealias OnGetOrCreateConnection = (
         AWSAPICategoryPluginConfiguration.EndpointConfig,
         AWSAuthServiceBehavior,
@@ -27,6 +29,7 @@ struct MockSubscriptionConnectionFactory: SubscriptionConnectionFactory {
 
     func getOrCreateConnection(
         for endpointConfig: AWSAPICategoryPluginConfiguration.EndpointConfig,
+        urlRequest: URLRequest,
         authService: AWSAuthServiceBehavior,
         authType: AWSAuthorizationType?,
         apiAuthProviderFactory: APIAuthProviderFactory


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
Add User-Agent to the underlying URLRequest for subscriptions. This change depends on AppSyncRTClient 3.0.0 with https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/110

This change is in `v2` and will need another PR for `v1`. [AppSync SDK](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/) should also eventually consume AppSyncRTClient 3.0.0. 


## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
