### PR TITLE
Amplify.Auth v1: Fix asynchronous operations outlive unit tests

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin.xcodeproj/project.pbxproj
@@ -18,6 +18,10 @@
 		5653A9F22979B5F400AC6D82 /* AuthHubEventHandlerSignInApiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5653A9F12979B5F400AC6D82 /* AuthHubEventHandlerSignInApiTests.swift */; };
 		5653A9F42979BF7700AC6D82 /* AuthHubEventHandlerSignOutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5653A9F32979BF7700AC6D82 /* AuthHubEventHandlerSignOutTests.swift */; };
 		5653A9F62979C2FC00AC6D82 /* AuthHubEventHandlerUserDeletedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5653A9F52979C2FC00AC6D82 /* AuthHubEventHandlerUserDeletedTests.swift */; };
+		5653A9F8297AE40200AC6D82 /* AWSCognitoAuthPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5653A9F7297AE40200AC6D82 /* AWSCognitoAuthPluginTests.swift */; };
+		5653A9FA297B157900AC6D82 /* AWSCognitoAuthPluginUserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5653A9F9297B157900AC6D82 /* AWSCognitoAuthPluginUserDefaultsTests.swift */; };
+		5653A9FC297B1F8C00AC6D82 /* AuthenticationProviderAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5653A9FB297B1F8C00AC6D82 /* AuthenticationProviderAdapterTests.swift */; };
+		5653A9FE297B229600AC6D82 /* AuthorizationProviderAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5653A9FD297B229600AC6D82 /* AuthorizationProviderAdapterTests.swift */; };
 		5C33248B2772384600F2C47B /* AWSAuthDeleteUserOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C33248A2772384600F2C47B /* AWSAuthDeleteUserOperation.swift */; };
 		5C33248D27723D0800F2C47B /* AuthenticationProviderAdapter+DeleteUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C33248C27723D0800F2C47B /* AuthenticationProviderAdapter+DeleteUser.swift */; };
 		5CD3C21A277D275D007DB926 /* AuthDeleteUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD3C219277D275D007DB926 /* AuthDeleteUserTests.swift */; };
@@ -210,6 +214,10 @@
 		5653A9F12979B5F400AC6D82 /* AuthHubEventHandlerSignInApiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthHubEventHandlerSignInApiTests.swift; sourceTree = "<group>"; };
 		5653A9F32979BF7700AC6D82 /* AuthHubEventHandlerSignOutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthHubEventHandlerSignOutTests.swift; sourceTree = "<group>"; };
 		5653A9F52979C2FC00AC6D82 /* AuthHubEventHandlerUserDeletedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthHubEventHandlerUserDeletedTests.swift; sourceTree = "<group>"; };
+		5653A9F7297AE40200AC6D82 /* AWSCognitoAuthPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSCognitoAuthPluginTests.swift; sourceTree = "<group>"; };
+		5653A9F9297B157900AC6D82 /* AWSCognitoAuthPluginUserDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSCognitoAuthPluginUserDefaultsTests.swift; sourceTree = "<group>"; };
+		5653A9FB297B1F8C00AC6D82 /* AuthenticationProviderAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationProviderAdapterTests.swift; sourceTree = "<group>"; };
+		5653A9FD297B229600AC6D82 /* AuthorizationProviderAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationProviderAdapterTests.swift; sourceTree = "<group>"; };
 		5C33248A2772384600F2C47B /* AWSAuthDeleteUserOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSAuthDeleteUserOperation.swift; sourceTree = "<group>"; };
 		5C33248C27723D0800F2C47B /* AuthenticationProviderAdapter+DeleteUser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AuthenticationProviderAdapter+DeleteUser.swift"; sourceTree = "<group>"; };
 		5CD3C219277D275D007DB926 /* AuthDeleteUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthDeleteUserTests.swift; sourceTree = "<group>"; };
@@ -445,6 +453,7 @@
 				B4136E3D256D76960011210B /* AuthenticationProviderSignoutTests.swift */,
 				B4060294256C21BC00D23D50 /* AuthenticationProviderSignupTests.swift */,
 				B402C915257700610020B83B /* BaseAuthenticationProviderTest.swift */,
+				5653A9FB297B1F8C00AC6D82 /* AuthenticationProviderAdapterTests.swift */,
 			);
 			path = AuthenticationProviderTests;
 			sourceTree = "<group>";
@@ -542,6 +551,7 @@
 				B4136E5D256D7A690011210B /* AuthorizationProviderSessionSignInTests.swift */,
 				B4136E63256D7A740011210B /* AuthorizationProviderSessionSignoutTests.swift */,
 				B4D5411A256F2C8A00436E5C /* BaseAuthorizationProviderTest.swift */,
+				5653A9FD297B229600AC6D82 /* AuthorizationProviderAdapterTests.swift */,
 			);
 			path = AuthorizationProviderTests;
 			sourceTree = "<group>";
@@ -789,6 +799,7 @@
 				B43B4DD72565E803008F345D /* Mocks */,
 				B41D0FDC2475A3A10049D08D /* Utils */,
 				B41D0FE02475A3A10049D08D /* Info.plist */,
+				5653A9F7297AE40200AC6D82 /* AWSCognitoAuthPluginTests.swift */,
 			);
 			path = AWSCognitoAuthPluginTests;
 			sourceTree = "<group>";
@@ -797,6 +808,7 @@
 			isa = PBXGroup;
 			children = (
 				B41D0FDD2475A3A10049D08D /* AuthUserAttributeKeyTests.swift */,
+				5653A9F9297B157900AC6D82 /* AWSCognitoAuthPluginUserDefaultsTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1535,8 +1547,10 @@
 			files = (
 				B4136E1A256D73D80011210B /* AuthenticationProviderSigninTests.swift in Sources */,
 				B4136E32256D76640011210B /* AuthenticationProviderSigninWithWebUITests.swift in Sources */,
+				5653A9FC297B1F8C00AC6D82 /* AuthenticationProviderAdapterTests.swift in Sources */,
 				FA1C817D25868C46006160E9 /* AWSCognitoAuthPluginAmplifyVersionableTests.swift in Sources */,
 				B4136E9A256D7B700011210B /* AuthDeviceRememberDeviceTests.swift in Sources */,
+				5653A9FA297B157900AC6D82 /* AWSCognitoAuthPluginUserDefaultsTests.swift in Sources */,
 				B4136E4E256D79710011210B /* AuthenticationProviderConfirmResetPasswordTests.swift in Sources */,
 				B43B4DE32565E8D7008F345D /* MockAuthorizationProviderBehavior.swift in Sources */,
 				5653A9F22979B5F400AC6D82 /* AuthHubEventHandlerSignInApiTests.swift in Sources */,
@@ -1549,6 +1563,7 @@
 				B43B4E1A2565FBFE008F345D /* AWSCognitoAuthDeviceBehaviorTests.swift in Sources */,
 				B43B4E032565E95E008F345D /* MockAuthDeviceServiceBehavior.swift in Sources */,
 				B4136E6C256D7AF30011210B /* UserBehaviorFetchAttributeTests.swift in Sources */,
+				5653A9F8297AE40200AC6D82 /* AWSCognitoAuthPluginTests.swift in Sources */,
 				B4D5411B256F2C8A00436E5C /* BaseAuthorizationProviderTest.swift in Sources */,
 				B43B4E102565EA64008F345D /* AWSCognitoAuthClientBehaviorTests.swift in Sources */,
 				B4136E2C256D764B0011210B /* AuthenticationProviderResendSignupCodeTests.swift in Sources */,
@@ -1569,6 +1584,7 @@
 				5653A9F62979C2FC00AC6D82 /* AuthHubEventHandlerUserDeletedTests.swift in Sources */,
 				5653A9F42979BF7700AC6D82 /* AuthHubEventHandlerSignOutTests.swift in Sources */,
 				B4060295256C21BC00D23D50 /* AuthenticationProviderSignupTests.swift in Sources */,
+				5653A9FE297B229600AC6D82 /* AuthorizationProviderAdapterTests.swift in Sources */,
 				B41D0FE22475A3A10049D08D /* AuthUserAttributeKeyTests.swift in Sources */,
 				5653A9EC2979B42100AC6D82 /* MockAuthSession.swift in Sources */,
 				B4136E26256D76300011210B /* AuthenticationProviderConfirmSigninTests.swift in Sources */,

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AWSCognitoAuthPluginUserDefaults.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPlugin/Support/Utils/AWSCognitoAuthPluginUserDefaults.swift
@@ -11,11 +11,13 @@ struct AWSCognitoAuthPluginUserDefaults: AWSCognitoAuthPluginUserDefaultsBehavio
 
     private let preferPrivateSessionKey = "AWSCognitoAuthPluginUserDefaults.privateSessionKey"
 
+    var defaults: UserDefaults = .standard
+
     func storePreferredBrowserSession(privateSessionPrefered: Bool) {
-        UserDefaults.standard.setValue(privateSessionPrefered, forKey: preferPrivateSessionKey)
+        defaults.setValue(privateSessionPrefered, forKey: preferPrivateSessionKey)
     }
 
     func isPrivateSessionPreferred() -> Bool {
-        return UserDefaults.standard.bool(forKey: preferPrivateSessionKey)
+        return defaults.bool(forKey: preferPrivateSessionKey)
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AWSCognitoAuthPluginTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AWSCognitoAuthPluginTests.swift
@@ -1,0 +1,38 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+@testable import AWSCognitoAuthPlugin
+@testable import AWSMobileClient
+
+final class AWSCognitoAuthPluginTests: XCTestCase {
+
+    var systemUnderTest: AWSCognitoAuthPlugin!
+    var authorizationProvider: MockAuthorizationProviderBehavior!
+
+    override func setUpWithError() throws {
+        authorizationProvider = MockAuthorizationProviderBehavior()
+        systemUnderTest = AWSCognitoAuthPlugin()
+        systemUnderTest.authorizationProvider = authorizationProvider
+    }
+
+    override func tearDownWithError() throws {
+        systemUnderTest = nil
+    }
+
+    /// - Given: A plugin configured with an authorization provider
+    /// - When: An invalidateCachedTemporaryCredentials message is sent to the plugin
+    /// - Then: The message is propagated to the authorization provider
+    func testInvalidateCachedTemporaryCredentials() throws {
+        systemUnderTest.invalidateCachedTemporaryCredentials()
+        XCTAssertEqual(authorizationProvider.interactions, [
+            "invalidateCachedTemporaryCredentials()"
+        ])
+    }
+
+}

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderAdapterTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthenticationProviderTests/AuthenticationProviderAdapterTests.swift
@@ -1,0 +1,51 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AWSCognitoAuthPlugin
+import XCTest
+
+final class AuthenticationProviderAdapterTests: XCTestCase {
+
+    var systemUnderTest: AuthenticationProviderAdapter!
+    var mobileClient: MockAWSMobileClient!
+    var authUserDefaults: AWSCognitoAuthPluginUserDefaults!
+
+    override func setUpWithError() throws {
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: #file))
+        userDefaults.removePersistentDomain(forName: #file)
+
+        mobileClient = MockAWSMobileClient()
+        authUserDefaults = AWSCognitoAuthPluginUserDefaults(defaults: userDefaults)
+        systemUnderTest = AuthenticationProviderAdapter(awsMobileClient: mobileClient,
+                                                        userdefaults: authUserDefaults)
+    }
+
+    override func tearDownWithError() throws {
+        mobileClient = nil
+        authUserDefaults = nil
+        systemUnderTest = nil
+    }
+
+    /// - Given: A newly-initialized adapter
+    /// - When: The current user is requested
+    /// - Then: It builds its result from the underlying mobile client's username and userSub
+    func testGetCurrentUser() throws {
+        let username = UUID().uuidString
+        mobileClient.username = username
+
+        let userSub = UUID().uuidString
+        mobileClient.userSub = userSub
+
+        let user = try XCTUnwrap(systemUnderTest.getCurrentUser())
+        XCTAssertEqual(user.username, username)
+        XCTAssertEqual(user.username, username)
+        XCTAssertEqual(mobileClient.interactions, [
+            "getUsername()",
+            "getUserSub()"
+        ])
+    }
+}

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthorizationProviderTests/AuthorizationProviderAdapterTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/AuthorizationProviderTests/AuthorizationProviderAdapterTests.swift
@@ -1,0 +1,123 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+@testable import AWSCognitoAuthPlugin
+import AWSCore
+import XCTest
+
+final class AuthorizationProviderAdapterTests: XCTestCase {
+
+    var systemUnderTest: AuthorizationProviderAdapter!
+    var mobileClient: MockAWSMobileClient!
+
+    override func setUpWithError() throws {
+        mobileClient = MockAWSMobileClient()
+        mobileClient.awsCredentialsMockResult = .success(AWSCredentials(accessKey: UUID().uuidString,
+                                                                        secretKey: UUID().uuidString,
+                                                                        sessionKey: UUID().uuidString,
+                                                                        expiration: Date.distantFuture))
+        systemUnderTest = AuthorizationProviderAdapter(awsMobileClient: mobileClient)
+    }
+
+    override func tearDownWithError() throws {
+        mobileClient = nil
+        systemUnderTest = nil
+    }
+
+    /// - Given: A newly initialized adapter
+    /// - When: No other direct interaction has taken place
+    /// - Then: The mobile client has received an "addUserStateListener" message
+    func testInitializationSideEffects() throws {
+        XCTAssertEqual(mobileClient.interactions, ["addUserStateListener(_:_:)"])
+    }
+
+    /// - Given: A mobile client user state of "guest"
+    /// - When: A fetchSession message is sent to the adapter
+    /// - Then: The credentials and identity are requested from the mobile client
+    func testFetchSessionForGuest() throws {
+        mobileClient.mockCurrentUserState = .guest
+
+        let request = AuthFetchSessionRequest(options: .init())
+        let fetchSessionExpectation = expectation(description: "fetchSession")
+        systemUnderTest.fetchSession(request: request) { result in
+            switch result {
+            case .success:
+                fetchSessionExpectation.fulfill()
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+        wait(for: [fetchSessionExpectation], timeout: 1.0)
+        XCTAssertEqual(mobileClient.interactions, [
+            "addUserStateListener(_:_:)",
+            "getCurrentUserState()",
+            "getAWSCredentials(_:)",
+            "getIdentityId()"
+        ])
+    }
+
+    /// - Given: A mobile client user state of "signedIn"
+    /// - When: A fetchSession message is sent to the adapter
+    /// - Then: The session's tokens are requested from the mobile client
+    func testFetchSessionForSignedIn() throws {
+        mobileClient.mockCurrentUserState = .signedIn
+
+        let request = AuthFetchSessionRequest(options: .init())
+        let fetchSessionExpectation = expectation(description: "fetchSession")
+        systemUnderTest.fetchSession(request: request) { result in
+            switch result {
+            case .success:
+                fetchSessionExpectation.fulfill()
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+        wait(for: [fetchSessionExpectation], timeout: 1.0)
+        XCTAssertEqual(mobileClient.interactions, [
+            "addUserStateListener(_:_:)",
+            "getCurrentUserState()",
+            "getTokens(_:)"
+        ])
+    }
+
+    /// - Given: A mobile client user state of "signedOut"
+    /// - When: A fetchSession message is sent to the adapter
+    /// - Then: The credentials and identity are requested from the mobile client
+    func testFetchSessionForSignedOut() throws {
+        mobileClient.mockCurrentUserState = .signedOut
+
+        let request = AuthFetchSessionRequest(options: .init())
+        let fetchSessionExpectation = expectation(description: "fetchSession")
+        systemUnderTest.fetchSession(request: request) { result in
+            switch result {
+            case .success:
+                fetchSessionExpectation.fulfill()
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+        wait(for: [fetchSessionExpectation], timeout: 1.0)
+        XCTAssertEqual(mobileClient.interactions, [
+            "addUserStateListener(_:_:)",
+            "getCurrentUserState()",
+            "getAWSCredentials(_:)",
+            "getIdentityId()"
+        ])
+    }
+
+    /// - Given: Newly initialized adapter
+    /// - When: It receives a "invalidateCachedTemporaryCredentials" message
+    /// - Then: The "invalidateCachedTemporaryCredentials" is propagated to the mobile client
+    func testInvalidateCachedTemporaryCredentials() throws {
+        systemUnderTest.invalidateCachedTemporaryCredentials()
+        XCTAssertEqual(mobileClient.interactions, [
+            "addUserStateListener(_:_:)",
+            "invalidateCachedTemporaryCredentials()"
+        ])
+    }
+}

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ClientBehaviorAPITests/AWSCognitoAuthClientBehaviorTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ClientBehaviorAPITests/AWSCognitoAuthClientBehaviorTests.swift
@@ -8,22 +8,41 @@
 import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
+import Combine
 
-class AWSCognitoAuthClientBehaviorTests: XCTestCase {
+// swiftlint:disable file_length type_body_length
+final class AWSCognitoAuthClientBehaviorTests: XCTestCase {
 
     var plugin: AWSCognitoAuthPlugin!
+    var authenticationProvider: MockAuthenticationProviderBehavior!
+    var authorizationProvider: MockAuthorizationProviderBehavior!
+    var userService: MockAuthUserServiceBehavior!
+    var deviceService: MockAuthDeviceServiceBehavior!
+    var hubEventHandler: MockAuthHubEventBehavior!
 
-    override func setUp() {
+    override func setUpWithError() throws {
+        authenticationProvider = MockAuthenticationProviderBehavior()
+        authorizationProvider = MockAuthorizationProviderBehavior()
+        userService = MockAuthUserServiceBehavior()
+        deviceService = MockAuthDeviceServiceBehavior()
+        hubEventHandler = MockAuthHubEventBehavior()
         plugin = AWSCognitoAuthPlugin()
-        plugin.configure(authenticationProvider: MockAuthenticationProviderBehavior(),
-                         authorizationProvider: MockAuthorizationProviderBehavior(),
-                         userService: MockAuthUserServiceBehavior(),
-                         deviceService: MockAuthDeviceServiceBehavior(),
-                         hubEventHandler: MockAuthHubEventBehavior())
+        plugin.configure(authenticationProvider: authenticationProvider,
+                         authorizationProvider: authorizationProvider,
+                         userService: userService,
+                         deviceService: deviceService,
+                         hubEventHandler: hubEventHandler)
+        try Amplify.configure(AmplifyConfiguration())
     }
 
-    override func tearDown() {
+    override func tearDownWithError() throws {
         Amplify.reset()
+        authenticationProvider = nil
+        authorizationProvider = nil
+        userService = nil
+        deviceService = nil
+        hubEventHandler = nil
+        plugin = nil
     }
 
     /// Test signup operation can be invoked
@@ -41,6 +60,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
         let options = AuthSignUpRequest.Options(userAttributes: [emailAttribute], pluginOptions: pluginOptions)
         let operation = plugin.signUp(username: "userName", password: "password", options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["signUp(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test signup operation can be invoked without options
@@ -54,6 +81,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
     func testSignUpRequestWithoutOptions() {
         let operation = plugin.signUp(username: "userName", password: "password")
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["signUp(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test confirmSignup operation can be invoked
@@ -70,6 +105,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
         let options = AuthConfirmSignUpRequest.Options(pluginOptions: pluginOptions)
         let operation = plugin.confirmSignUp(for: "username", confirmationCode: "code", options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["confirmSignUp(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test confirmSignup operation can be invoked without options
@@ -83,6 +126,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
     func testConfirmSignUpRequestWithoutOptions() {
         let operation = plugin.confirmSignUp(for: "username", confirmationCode: "code")
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["confirmSignUp(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test resendSignUpCode operation can be invoked
@@ -98,6 +149,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
         let options = AuthResendSignUpCodeRequest.Options(pluginOptions: pluginOptions)
         let operation = plugin.resendSignUpCode(for: "username", options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["resendSignUpCode(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test resendSignUpCode operation can be invoked without options
@@ -111,6 +170,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
     func testResendSignupCodeRequestWithoutOptions() {
         let operation = plugin.resendSignUpCode(for: "username")
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["resendSignUpCode(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test signIn operation can be invoked
@@ -127,6 +194,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
         let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
         let operation = plugin.signIn(username: "username", password: "password", options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["signIn(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test signIn operation can be invoked without options
@@ -140,6 +215,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
     func testSigninRequestWithoutOptions() {
         let operation = plugin.signIn(username: "username", password: "password")
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["signIn(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test signInWithWebUI operation can be invoked
@@ -160,6 +243,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
                                                      pluginOptions: pluginOptions)
         let operation = plugin.signInWithWebUI(presentationAnchor: UIWindow(), options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["signInWithWebUI(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test signInWithWebUI operation can be invoked without options
@@ -173,6 +264,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
     func testSigninWithWebUIRequestWithoutOptions() {
         let operation = plugin.signInWithWebUI(presentationAnchor: UIWindow())
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["signInWithWebUI(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test signInWithWebUI operation can be invoked
@@ -193,6 +292,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
                                                      pluginOptions: pluginOptions)
         let operation = plugin.signInWithWebUI(for: .amazon, presentationAnchor: UIWindow(), options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["signInWithWebUI(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test signInWithWebUI operation can be invoked without options
@@ -206,6 +313,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
     func testSigninWithSocialWebUIRequestWithoutOptions() {
         let operation = plugin.signInWithWebUI(for: .amazon, presentationAnchor: UIWindow())
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["signInWithWebUI(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test confirmSignIn operation can be invoked
@@ -223,6 +338,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
         let options = AuthConfirmSignInRequest.Options(pluginOptions: pluginOptions)
         let operation = plugin.confirmSignIn(challengeResponse: "reponse", options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["confirmSignIn(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test confirmSignIn operation can be invoked without options
@@ -236,6 +359,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
     func testConfirmSigninRequestWithoutOptions() {
         let operation = plugin.confirmSignIn(challengeResponse: "reponse")
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["confirmSignIn(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test signOut operation can be invoked
@@ -250,6 +381,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
         let options = AuthSignOutRequest.Options(globalSignOut: true)
         let operation = plugin.signOut(options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["signOut(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test signOut operation can be invoked without options
@@ -263,6 +402,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
     func testSignoutRequestWithoutOptions() {
         let operation = plugin.signOut()
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["signOut(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test fetchAuthSession operation can be invoked
@@ -277,6 +424,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
         let options = AuthFetchSessionRequest.Options()
         let operation = plugin.fetchAuthSession(options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, [])
+        XCTAssertEqual(authorizationProvider.interactions, ["fetchSession(request:completionHandler:)"])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test fetchAuthSession operation can be invoked without options
@@ -290,6 +445,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
     func testfetchAuthSessionWithoutOptions() {
         let operation = plugin.fetchAuthSession()
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, [])
+        XCTAssertEqual(authorizationProvider.interactions, ["fetchSession(request:completionHandler:)"])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test resetPassword operation can be invoked
@@ -305,6 +468,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
         let options = AuthResetPasswordRequest.Options(pluginOptions: pluginOptions)
         let operation = plugin.resetPassword(for: "username", options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["resetPassword(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test resetPassword operation can be invoked without options
@@ -318,6 +489,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
     func testResetPasswordRequestWithoutOptions() {
         let operation = plugin.resetPassword(for: "username")
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["resetPassword(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test confirmResetPassword operation can be invoked
@@ -336,6 +515,14 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
                                                     confirmationCode: "code",
                                                     options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["confirmResetPassword(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test confirmResetPassword operation can be invoked without options
@@ -346,8 +533,16 @@ class AWSCognitoAuthClientBehaviorTests: XCTestCase {
     /// - Then:
     ///    - I should get a valid operation object
     ///
-    func testConfirmResetPasswordRequestWithoutOptions() {
+    func testConfirmResetPasswordRequestWithoutOptions() throws {
         let operation = plugin.confirmResetPassword(for: "username", with: "password", confirmationCode: "code")
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, ["confirmResetPassword(request:completionHandler:)"])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, [])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ClientBehaviorAPITests/AWSCognitoAuthUserBehaviorTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/ClientBehaviorAPITests/AWSCognitoAuthUserBehaviorTests.swift
@@ -14,54 +14,81 @@ import XCTest
 class AWSCognitoAuthUserBehaviorTests: XCTestCase {
 
     var plugin: AWSCognitoAuthPlugin!
+    var authenticationProvider: MockAuthenticationProviderBehavior!
+    var authorizationProvider: MockAuthorizationProviderBehavior!
+    var userService: MockAuthUserServiceBehavior!
+    var deviceService: MockAuthDeviceServiceBehavior!
+    var hubEventHandler: MockAuthHubEventBehavior!
 
-    override func setUp() {
+    override func setUpWithError() throws {
+        authenticationProvider = MockAuthenticationProviderBehavior()
+        authorizationProvider = MockAuthorizationProviderBehavior()
+        userService = MockAuthUserServiceBehavior()
+        deviceService = MockAuthDeviceServiceBehavior()
+        hubEventHandler = MockAuthHubEventBehavior()
         plugin = AWSCognitoAuthPlugin()
-        plugin.configure(authenticationProvider: MockAuthenticationProviderBehavior(),
-                         authorizationProvider: MockAuthorizationProviderBehavior(),
-                         userService: MockAuthUserServiceBehavior(),
-                         deviceService: MockAuthDeviceServiceBehavior(),
-                         hubEventHandler: MockAuthHubEventBehavior())
+        plugin.configure(authenticationProvider: authenticationProvider,
+                         authorizationProvider: authorizationProvider,
+                         userService: userService,
+                         deviceService: deviceService,
+                         hubEventHandler: hubEventHandler)
+        try Amplify.configure(AmplifyConfiguration())
     }
 
     override func tearDown() {
         Amplify.reset()
+        authenticationProvider = nil
+        authorizationProvider = nil
+        userService = nil
+        deviceService = nil
+        hubEventHandler = nil
+        plugin = nil
     }
 
     /// Test fetchUserAttributes operation can be invoked
     ///
     /// - Given: Given a configured auth plugin
-    /// - When:
-    ///    - I call fetchUserAttributes operation
-    /// - Then:
-    ///    - I should get a valid operation object
+    /// - When: It receives a `fetchUserAttributes` message with options
+    /// - Then: The operation is delegated to the user service's `fetchAttributes(request:completionHandler:)` method
     ///
     func testFetchUserAttributesRequest() {
         let options = AuthFetchUserAttributesRequest.Options()
         let operation = plugin.fetchUserAttributes(options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, [])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, ["fetchAttributes(request:completionHandler:)"])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test fetchDevices operation can be invoked without options
     ///
     /// - Given: Given a configured auth plugin
-    /// - When:
-    ///    - I call fetchDevices operation
-    /// - Then:
-    ///    - I should get a valid operation object
+    /// - When: It receives a `fetchUserAttributes` message without any options
+    /// - Then: The operation is delegated to the user service's `fetchAttributes(request:completionHandler:)` method
     ///
     func testFetchUserAttributesRequestWithoutOptions() {
         let operation = plugin.fetchUserAttributes()
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, [])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, ["fetchAttributes(request:completionHandler:)"])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test update(userAttribute:) operation can be invoked
     ///
     /// - Given: Given a configured auth plugin
-    /// - When:
-    ///    - I call update(userAttribute:) operation
-    /// - Then:
-    ///    - I should get a valid operation object
+    /// - When: It receives an `update(userAttribute:)` message with an email attribute and options
+    /// - Then: The operation is delegated to the user service's `updateAttribute(request:completionHandler:)` (singular) method
     ///
     func testUpdateUserAttributeRequest() {
         let emailAttribute = AuthUserAttribute(.email, value: "email")
@@ -69,29 +96,41 @@ class AWSCognitoAuthUserBehaviorTests: XCTestCase {
         let options = AuthUpdateUserAttributeRequest.Options(pluginOptions: pluginOptions)
         let operation = plugin.update(userAttribute: emailAttribute, options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, [])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, ["updateAttribute(request:completionHandler:)"])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test update(userAttribute:) operation can be invoked without options
     ///
     /// - Given: Given a configured auth plugin
-    /// - When:
-    ///    - I call update(userAttribute:) operation
-    /// - Then:
-    ///    - I should get a valid operation object
+    /// - When: It receives an `update(userAttribute:)` message with an email attribute and without options
+    /// - Then: The operation is delegated to the user service's `updateAttribute(request:completionHandler:)` (singular) method
     ///
     func testUpdateUserAttributeRequestWithoutOptions() {
         let emailAttribute = AuthUserAttribute(.email, value: "email")
         let operation = plugin.update(userAttribute: emailAttribute)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, [])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, ["updateAttribute(request:completionHandler:)"])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test update(userAttributes:) operation can be invoked
     ///
     /// - Given: Given a configured auth plugin
-    /// - When:
-    ///    - I call update(userAttributes:) operation
-    /// - Then:
-    ///    - I should get a valid operation object
+    /// - When: It receives an `update(userAttribute:)` message with email and phone number attributes and options
+    /// - Then: The operation is delegated to the user service's `updateAttributes(request:completionHandler:)` (plural) method
     ///
     func testUpdateUserAttributesRequest() {
         let emailAttribute = AuthUserAttribute(.email, value: "email")
@@ -100,102 +139,152 @@ class AWSCognitoAuthUserBehaviorTests: XCTestCase {
         let options = AuthUpdateUserAttributesRequest.Options(pluginOptions: pluginOptions)
         let operation = plugin.update(userAttributes: [emailAttribute, phoneAttribute], options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, [])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, ["updateAttributes(request:completionHandler:)"])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test update(userAttributes:) operation can be invoked without options
     ///
     /// - Given: Given a configured auth plugin
-    /// - When:
-    ///    - I call update(userAttributes:) operation
-    /// - Then:
-    ///    - I should get a valid operation object
+    /// - When: It receives an `update(userAttribute:)` message with email and phone number attributes and no options
+    /// - Then: The operation is delegated to the user service's `updateAttributes(request:completionHandler:)` (plural) method
     ///
     func testUpdateUserAttributesRequestWithoutOptions() {
         let emailAttribute = AuthUserAttribute(.email, value: "email")
         let phoneAttribute = AuthUserAttribute(.phoneNumber, value: "123213")
         let operation = plugin.update(userAttributes: [emailAttribute, phoneAttribute])
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, [])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, ["updateAttributes(request:completionHandler:)"])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test resendConfirmationCode(for:) operation can be invoked
     ///
     /// - Given: Given a configured auth plugin
-    /// - When:
-    ///    - I call resendConfirmationCode(for:)  operation
-    /// - Then:
-    ///    - I should get a valid operation object
+    /// - When: It receives an `resendConfirmationCode(for:)` message with options
+    /// - Then: The operation is delegated to the user service's `resendAttributeConfirmationCode(request:completionHandler:)` method
     ///
     func testResendConfirmationCodeAttributeRequest() {
         let pluginOptions = AWSAttributeResendConfirmationCodeOptions(metadata: ["key": "value"])
         let options = AuthAttributeResendConfirmationCodeRequest.Options(pluginOptions: pluginOptions)
         let operation = plugin.resendConfirmationCode(for: .email, options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, [])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, ["resendAttributeConfirmationCode(request:completionHandler:)"])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test resendConfirmationCode(for:)  operation can be invoked without options
     ///
     /// - Given: Given a configured auth plugin
-    /// - When:
-    ///    - I call resendConfirmationCode(for:)  operation
-    /// - Then:
-    ///    - I should get a valid operation object
+    /// - When: It receives an `resendConfirmationCode(for:)` message without any options
+    /// - Then: The operation is delegated to the user service's `resendAttributeConfirmationCode(request:completionHandler:)` method
     ///
     func testResendConfirmationCodeAttributeRequestWithoutOptions() {
         let operation = plugin.resendConfirmationCode(for: .email)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, [])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, ["resendAttributeConfirmationCode(request:completionHandler:)"])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test confirm(userAttribute: ) operation can be invoked
     ///
     /// - Given: Given a configured auth plugin
-    /// - When:
-    ///    - I call confirm(userAttribute: )  operation
-    /// - Then:
-    ///    - I should get a valid operation object
+    /// - When: It receives a `confirm(userAttribute:)` message with options
+    /// - Then: The operation is delegated to the user service's `confirmAttribute(request:completionHandler:)` method
     ///
     func testConfirmUserAttributeRequest() {
         let options = AuthConfirmUserAttributeRequest.Options()
         let operation = plugin.confirm(userAttribute: .email, confirmationCode: "code", options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, [])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, ["confirmAttribute(request:completionHandler:)"])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test confirm(userAttribute: )  operation can be invoked without options
     ///
     /// - Given: Given a configured auth plugin
-    /// - When:
-    ///    - I call confirm(userAttribute: ) operation
-    /// - Then:
-    ///    - I should get a valid operation object
+    /// - When: It receives a `confirm(userAttribute:)` message without any options
+    /// - Then: The operation is delegated to the user service's `confirmAttribute(request:completionHandler:)` method
     ///
     func testConfirmUserAttributeRequestWithoutOptions() {
         let operation = plugin.confirm(userAttribute: .email, confirmationCode: "code")
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, [])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, ["confirmAttribute(request:completionHandler:)"])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test update(oldPassword:to: ) operation can be invoked
     ///
     /// - Given: Given a configured auth plugin
-    /// - When:
-    ///    - I call update(oldPassword:to: ) operation
-    /// - Then:
-    ///    - I should get a valid operation object
+    /// - When: It receives an `update(oldPassword:to:)` message with options
+    /// - Then: The operation is delegated to the user service's `changePassword(request:completionHandler:)` method
     ///
     func testUpdatePasswordRequest() {
         let options = AuthChangePasswordRequest.Options(metadata: ["key": "value"])
         let operation = plugin.update(oldPassword: "oldpwd", to: "newpwd", options: options)
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, [])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, ["changePassword(request:completionHandler:)"])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 
     /// Test update(oldPassword:to: )  operation can be invoked without options
     ///
     /// - Given: Given a configured auth plugin
-    /// - When:
-    ///    - I call update(oldPassword:to: ) operation
-    /// - Then:
-    ///    - I should get a valid operation object
+    /// - When: It receives an `update(oldPassword:to:)` message with options
+    /// - Then: The operation is delegated to the user service's `changePassword(request:completionHandler:)` method
     ///
     func testUpdatePasswordRequestWithoutOptions() {
         let operation = plugin.update(oldPassword: "oldpwd", to: "newpwd")
         XCTAssertNotNil(operation)
+
+        operation.waitUntilFinished()
+
+        XCTAssertEqual(authenticationProvider.interactions, [])
+        XCTAssertEqual(authorizationProvider.interactions, [])
+        XCTAssertEqual(userService.interactions, ["changePassword(request:completionHandler:)"])
+        XCTAssertEqual(deviceService.interactions, [])
+        XCTAssertEqual(hubEventHandler.interactions, [])
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAWSMobileClient.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAWSMobileClient.swift
@@ -9,10 +9,8 @@
 import AWSMobileClient
 
 class MockAWSMobileClient: AWSMobileClientBehavior {
-    func signOut(uiwindow: UIWindow, options: SignOutOptions, completionHandler: @escaping ((Error?) -> Void)) {
 
-    }
-
+    var interactions: [String] = []
 
     var signupMockResult: Result<SignUpResult, Error>?
     var confirmSignUpMockResult: Result<SignUpResult, Error>?
@@ -34,7 +32,7 @@ class MockAWSMobileClient: AWSMobileClientBehavior {
     var forgotPasswordMockResult: Result<ForgotPasswordResult, Error>?
     var confirmForgotPasswordMockResult: Result<ForgotPasswordResult, Error>?
 
-    var getIdentityIdMockResult: AWSTask<NSString>?
+    var getIdentityIdMockResult: AWSTask<NSString> = AWSTask(result: UUID().uuidString as NSString)
     var tokensMockResult: Result<Tokens, Error>?
     var awsCredentialsMockResult: Result<AWSCredentials, Error>?
     var getCurrentUserStateMockResult: UserState?
@@ -47,7 +45,11 @@ class MockAWSMobileClient: AWSMobileClientBehavior {
     var mockCurrentUserState: UserState = .unknown
 
     func initialize() throws {
-        fatalError()
+        interactions.append(#function)
+    }
+
+    func signOut(uiwindow: UIWindow, options: SignOutOptions, completionHandler: @escaping ((Error?) -> Void)) {
+        interactions.append(#function)
     }
 
     func signUp(username: String,
@@ -56,6 +58,7 @@ class MockAWSMobileClient: AWSMobileClientBehavior {
                 validationData: [String: String],
                 clientMetaData: [String: String],
                 completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
+        interactions.append(#function)
         prepareResult(mockResult: signupMockResult, completionHandler: completionHandler)
     }
 
@@ -63,12 +66,14 @@ class MockAWSMobileClient: AWSMobileClientBehavior {
                        confirmationCode: String,
                        clientMetaData: [String: String],
                        completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
+        interactions.append(#function)
         prepareResult(mockResult: confirmSignUpMockResult, completionHandler: completionHandler)
     }
 
     func resendSignUpCode(username: String,
                           clientMetaData: [String: String],
                           completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
+        interactions.append(#function)
         prepareResult(mockResult: resendSignUpCodeMockResult, completionHandler: completionHandler)
     }
 
@@ -77,6 +82,7 @@ class MockAWSMobileClient: AWSMobileClientBehavior {
                 validationData: [String: String]?,
                 clientMetaData: [String: String],
                 completionHandler: @escaping ((SignInResult?, Error?) -> Void)) {
+        interactions.append(#function)
         prepareResult(mockResult: signInMockResult, completionHandler: completionHandler)
     }
 
@@ -84,6 +90,7 @@ class MockAWSMobileClient: AWSMobileClientBehavior {
                          token: String,
                          federatedSignInOptions: FederatedSignInOptions,
                          completionHandler: @escaping ((UserState?, Error?) -> Void)) {
+        interactions.append(#function)
         prepareResult(mockResult: federatedSignInMockResult, completionHandler: completionHandler)
     }
 
@@ -91,12 +98,14 @@ class MockAWSMobileClient: AWSMobileClientBehavior {
                     signInUIOptions: SignInUIOptions,
                     hostedUIOptions: HostedUIOptions?,
                     _ completionHandler: @escaping (UserState?, Error?) -> Void) {
+        interactions.append(#function)
         prepareResult(mockResult: showSignInMockResult, completionHandler: completionHandler)
     }
 
     func showSignIn(uiwindow: UIWindow,
                     hostedUIOptions: HostedUIOptions,
                     _ completionHandler: @escaping (UserState?, Error?) -> Void) {
+        interactions.append(#function)
         prepareResult(mockResult: showSignInMockResult, completionHandler: completionHandler)
     }
 
@@ -104,61 +113,76 @@ class MockAWSMobileClient: AWSMobileClientBehavior {
                        userAttributes: [String: String],
                        clientMetaData: [String: String],
                        completionHandler: @escaping ((SignInResult?, Error?) -> Void)) {
+        interactions.append(#function)
         prepareResult(mockResult: confirmSignInMockResult, completionHandler: completionHandler)
     }
 
     func signOut(options: SignOutOptions,
                  completionHandler: @escaping ((Error?) -> Void)) {
+        interactions.append(#function)
        completionHandler(signOutMockError)
     }
 
     func signOutLocally() {
-        // Do nothing
+        interactions.append(#function)
     }
 
     func deleteUser(completionHandler: @escaping ((Error?) -> Void)) {
+        interactions.append(#function)
        completionHandler(deleteUserMockError)
     }
 
+    var username: String?
+
     func getUsername() -> String? {
-        fatalError()
+        interactions.append(#function)
+        return username
     }
 
+    var userSub: String?
+
     func getUserSub() -> String? {
-        fatalError()
+        interactions.append(#function)
+        return userSub
     }
 
     func verifyUserAttribute(attributeName: String,
                              clientMetaData: [String: String],
                              completionHandler: @escaping ((UserCodeDeliveryDetails?, Error?) -> Void)) {
+        interactions.append(#function)
         prepareResult(mockResult: verifyUserAttributeMockResult, completionHandler: completionHandler)
     }
 
     func updateUserAttributes(attributeMap: [String: String],
                               clientMetaData: [String: String],
                               completionHandler: @escaping (([UserCodeDeliveryDetails]?, Error?) -> Void)) {
+        interactions.append(#function)
         prepareResult(mockResult: updateUserAttributesMockResult, completionHandler: completionHandler)
     }
 
     func getUserAttributes(completionHandler: @escaping (([String: String]?, Error?) -> Void)) {
+        interactions.append(#function)
         prepareResult(mockResult: getUserAttributeMockResult, completionHandler: completionHandler)
     }
 
     func confirmUpdateUserAttributes(attributeName: String,
                                      code: String,
                                      completionHandler: @escaping ((Error?) -> Void)) {
+        interactions.append(#function)
         completionHandler(confirmUserAttributeMockResult)
     }
 
     func changePassword(currentPassword: String,
                         proposedPassword: String,
                         completionHandler: @escaping ((Error?) -> Void)) {
+        interactions.append(#function)
         completionHandler(changePasswordMockResult)
     }
 
     func forgotPassword(username: String,
                         clientMetaData: [String: String],
                         completionHandler: @escaping ((ForgotPasswordResult?, Error?) -> Void)) {
+        interactions.append(#function)
         prepareResult(mockResult: forgotPasswordMockResult, completionHandler: completionHandler)
     }
 
@@ -167,60 +191,70 @@ class MockAWSMobileClient: AWSMobileClientBehavior {
                                confirmationCode: String,
                                clientMetaData: [String: String],
                                completionHandler: @escaping ((ForgotPasswordResult?, Error?) -> Void)) {
+        interactions.append(#function)
         prepareResult(mockResult: confirmForgotPasswordMockResult, completionHandler: completionHandler)
     }
 
     func getIdentityId() -> AWSTask<NSString> {
-        return getIdentityIdMockResult!
+        interactions.append(#function)
+        return getIdentityIdMockResult
     }
 
     func getTokens(_ completionHandler: @escaping (Tokens?, Error?) -> Void) {
+        interactions.append(#function)
         prepareResult(mockResult: tokensMockResult, completionHandler: completionHandler)
     }
 
     func getAWSCredentials(_ completionHandler: @escaping (AWSCredentials?, Error?) -> Void) {
+        interactions.append(#function)
         prepareResult(mockResult: awsCredentialsMockResult, completionHandler: completionHandler)
     }
 
     func getCurrentUserState() -> UserState {
+        interactions.append(#function)
         return mockCurrentUserState
     }
 
     func listDevices(completionHandler: @escaping ((ListDevicesResult?, Error?) -> Void)) {
+        interactions.append(#function)
         prepareResult(mockResult: listDevicesMockResult, completionHandler: completionHandler)
     }
 
     func updateDeviceStatus(remembered: Bool,
                             completionHandler: @escaping ((UpdateDeviceStatusResult?, Error?) -> Void)) {
+        interactions.append(#function)
         prepareResult(mockResult: rememberDeviceMockResult, completionHandler: completionHandler)
     }
 
     func getDevice(_ completionHandler: @escaping ((Device?, Error?) -> Void)) {
-        fatalError()
+        interactions.append(#function)
+        completionHandler(nil, nil)
     }
 
     func forgetDevice(deviceId: String, completionHandler: @escaping ((Error?) -> Void)) {
+        interactions.append(#function)
         completionHandler(forgetDeviceMockResult)
     }
 
     func forgetCurrentDevice(_ completionHandler: @escaping ((Error?) -> Void)) {
+        interactions.append(#function)
         completionHandler(forgetCurrentDeviceMockResult)
     }
 
     func invalidateCachedTemporaryCredentials() {
-        fatalError()
+        interactions.append(#function)
     }
 
     func addUserStateListener(_ object: AnyObject, _ callback: @escaping UserStateChangeCallback) {
-
+        interactions.append(#function)
     }
 
     func removeUserStateListener(_ object: AnyObject) {
-        fatalError()
+        interactions.append(#function)
     }
 
     func releaseSignInWait() {
-        fatalError()
+        interactions.append(#function)
     }
 
     func prepareResult<R, E>(mockResult: Result<R, E>?,

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthDeviceServiceBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthDeviceServiceBehavior.swift
@@ -10,19 +10,38 @@ import Amplify
 
 class MockAuthDeviceServiceBehavior: AuthDeviceServiceBehavior {
 
+    var interactions: [String] = []
+
+    // swiftlint:disable line_length
+    var fetchDevicesHandler: (AuthFetchDevicesRequest, (Result<[AuthDevice], AuthError>) -> Void) -> Void = { _, completion in
+        completion(.success([]))
+    }
+
     func fetchDevices(request: AuthFetchDevicesRequest,
                       completionHandler: @escaping (Result<[AuthDevice], AuthError>) -> Void) {
-        // Incomplete implementation
+        interactions.append(#function)
+        fetchDevicesHandler(request, completionHandler)
+    }
+
+    var forgetDeviceHandler: (AuthForgetDeviceRequest, (Result<Void, AuthError>) -> Void) -> Void = { _, completion in
+        completion(.success(()))
     }
 
     func forgetDevice(request: AuthForgetDeviceRequest,
                       completionHandler: @escaping (Result<Void, AuthError>) -> Void) {
-        // Incomplete implementation
+        interactions.append(#function)
+        forgetDeviceHandler(request, completionHandler)
+    }
+
+    // swiftlint:disable line_length
+    var rememberDeviceHandler: (AuthRememberDeviceRequest, (Result<Void, AuthError>) -> Void) -> Void = { _, completion in
+        completion(.success(()))
     }
 
     func rememberDevice(request: AuthRememberDeviceRequest,
                         completionHandler: @escaping (Result<Void, AuthError>) -> Void) {
-        // Incomplete implementation
+        interactions.append(#function)
+        rememberDeviceHandler(request, completionHandler)
     }
 
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthHubEventBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthHubEventBehavior.swift
@@ -9,19 +9,22 @@ import Amplify
 @testable import AWSCognitoAuthPlugin
 
 class MockAuthHubEventBehavior: AuthHubEventBehavior {
+
+    var interactions: [String] = []
+
     func sendUserSignedInEvent() {
-        // Incomplete implementation
+        interactions.append(#function)
     }
 
     func sendUserSignedOutEvent() {
-        // Incomplete implementation
+        interactions.append(#function)
     }
 
     func sendUserDeletedEvent() {
-        // Incomplete implementation
+        interactions.append(#function)
     }
 
     func sendSessionExpiredEvent() {
-        // Incomplete implementation
+        interactions.append(#function)
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthUserServiceBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthUserServiceBehavior.swift
@@ -9,35 +9,76 @@ import Amplify
 @testable import AWSCognitoAuthPlugin
 
 class MockAuthUserServiceBehavior: AuthUserServiceBehavior {
+
+    var interactions: [String] = []
+
+    // swiftlint:disable line_length
+    var fetchAttributesHandler: (AuthFetchUserAttributesRequest, FetchUserAttributesCompletion) -> Void = { _, completion in
+        completion(.success([]))
+    }
+
     func fetchAttributes(request: AuthFetchUserAttributesRequest,
                          completionHandler: @escaping FetchUserAttributesCompletion) {
-        // Incomplete implementation
+        interactions.append(#function)
+        fetchAttributesHandler(request, completionHandler)
+    }
+
+    // swiftlint:disable line_length
+    var updateAttributeHandler: (AuthUpdateUserAttributeRequest, UpdateUserAttributeCompletion) -> Void = { _, completion in
+        completion(.success(AuthUpdateAttributeResult(isUpdated: true, nextStep: .done)))
     }
 
     func updateAttribute(request: AuthUpdateUserAttributeRequest,
                          completionHandler: @escaping UpdateUserAttributeCompletion) {
-        // Incomplete implementation
+        interactions.append(#function)
+        updateAttributeHandler(request, completionHandler)
+    }
+
+    // swiftlint:disable line_length
+    var updateAttributesHandler: (AuthUpdateUserAttributesRequest, UpdateUserAttributesCompletion) -> Void = { request, completion in
+        let resultAsArray = request.userAttributes.map { attribute in
+            return (attribute.key, AuthUpdateAttributeResult(isUpdated: true, nextStep: .done))
+        }
+        let resultAsDictionary = Dictionary(resultAsArray, uniquingKeysWith: { key, _ in key })
+        completion(.success(resultAsDictionary))
     }
 
     func updateAttributes(request: AuthUpdateUserAttributesRequest,
                           completionHandler: @escaping UpdateUserAttributesCompletion) {
-        // Incomplete implementation
+        interactions.append(#function)
+        updateAttributesHandler(request, completionHandler)
+    }
+
+    // swiftlint:disable line_length
+    var resendAttributeConfirmationCodeHandler: (AuthAttributeResendConfirmationCodeRequest, ResendAttributeConfirmationCodeCompletion) -> Void = { _, completion in
+        completion(.success(AuthCodeDeliveryDetails(destination: .email("user@example.com"))))
     }
 
     func resendAttributeConfirmationCode(request: AuthAttributeResendConfirmationCodeRequest,
                                          completionHandler: @escaping ResendAttributeConfirmationCodeCompletion) {
-        // Incomplete implementation
+        interactions.append(#function)
+        resendAttributeConfirmationCodeHandler(request, completionHandler)
+    }
+
+    // swiftlint:disable line_length
+    var confirmAttributeHandler: (AuthConfirmUserAttributeRequest, ConfirmAttributeCompletion) -> Void = { _, completion in
+        completion(.success(()))
     }
 
     func confirmAttribute(request: AuthConfirmUserAttributeRequest,
                           completionHandler: @escaping ConfirmAttributeCompletion) {
-        // Incomplete implementation
+        interactions.append(#function)
+        confirmAttributeHandler(request, completionHandler)
+    }
+
+    // swiftlint:disable line_length
+    var changePasswordHandler: (AuthChangePasswordRequest, ChangePasswordCompletion) -> Void = { _, completion in
+        completion(.success(()))
     }
 
     func changePassword(request: AuthChangePasswordRequest,
                         completionHandler: @escaping ChangePasswordCompletion) {
-        // Incomplete implementation
+        interactions.append(#function)
+        changePasswordHandler(request, completionHandler)
     }
-
-
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthenticationProviderBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthenticationProviderBehavior.swift
@@ -10,58 +10,118 @@ import Amplify
 
 class MockAuthenticationProviderBehavior: AuthenticationProviderBehavior {
 
+    var interactions: [String] = []
+
+    var signUpHandler: (AuthSignUpRequest, (Result<AuthSignUpResult, AuthError>) -> Void) -> Void = { _, completion in
+        completion(.success(AuthSignUpResult(.done)))
+    }
+
     func signUp(request: AuthSignUpRequest,
                 completionHandler: @escaping (Result<AuthSignUpResult, AuthError>) -> Void) {
-        // Incomplete implementation
+        interactions.append(#function)
+        signUpHandler(request, completionHandler)
+    }
+
+    // swiftlint:disable line_length
+    var confirmSignUpHandler: (AuthConfirmSignUpRequest, (Result<AuthSignUpResult, AuthError>) -> Void) -> Void = { _, completion in
+        completion(.success(AuthSignUpResult(.done)))
     }
 
     func confirmSignUp(request: AuthConfirmSignUpRequest,
                        completionHandler: @escaping (Result<AuthSignUpResult, AuthError>) -> Void) {
-        // Incomplete implementation
+        interactions.append(#function)
+        confirmSignUpHandler(request, completionHandler)
+    }
+
+    // swiftlint:disable line_length
+    var resendSignUpCodeHandler: (AuthResendSignUpCodeRequest, (Result<AuthCodeDeliveryDetails, AuthError>) -> Void) -> Void = { _, completion in
+        completion(.success(AuthCodeDeliveryDetails(destination: .email("user@example.com"))))
     }
 
     func resendSignUpCode(request: AuthResendSignUpCodeRequest,
                           completionHandler: @escaping (Result<AuthCodeDeliveryDetails, AuthError>) -> Void) {
-        // Incomplete implementation
+        interactions.append(#function)
+        resendSignUpCodeHandler(request, completionHandler)
+    }
+
+    var signInHandler: (AuthSignInRequest, (Result<AuthSignInResult, AuthError>) -> Void) -> Void = { _, completion in
+        completion(.success(AuthSignInResult(nextStep: .done)))
     }
 
     func signIn(request: AuthSignInRequest,
                 completionHandler: @escaping (Result<AuthSignInResult, AuthError>) -> Void) {
-        // Incomplete implementation
+        interactions.append(#function)
+        signInHandler(request, completionHandler)
+    }
+
+    // swiftlint:disable line_length
+    var signInWithWebUIHandler: (AuthWebUISignInRequest, (Result<AuthSignInResult, AuthError>) -> Void) -> Void = { _, completion in
+        completion(.success(AuthSignInResult(nextStep: .done)))
     }
 
     func signInWithWebUI(request: AuthWebUISignInRequest,
                          completionHandler: @escaping (Result<AuthSignInResult, AuthError>) -> Void) {
-        // Incomplete implementation
+        interactions.append(#function)
+        signInWithWebUIHandler(request, completionHandler)
+    }
+
+    // swiftlint:disable line_length
+    var confirmSignInHandler: (AuthConfirmSignInRequest, (Result<AuthSignInResult, AuthError>) -> Void) -> Void = { _, completion in
+        completion(.success(AuthSignInResult(nextStep: .done)))
     }
 
     func confirmSignIn(request: AuthConfirmSignInRequest,
                        completionHandler: @escaping (Result<AuthSignInResult, AuthError>) -> Void) {
-        // Incomplete implementation
+        interactions.append(#function)
+        confirmSignInHandler(request, completionHandler)
+    }
+
+    var signOutHandler: (AuthSignOutRequest, (Result<Void, AuthError>) -> Void) -> Void = { _, completion in
+        completion(.success(()))
     }
 
     func signOut(request: AuthSignOutRequest,
                  completionHandler: @escaping (Result<Void, AuthError>) -> Void) {
-        // Incomplete implementation
+        interactions.append(#function)
+        signOutHandler(request, completionHandler)
+    }
+
+    var deleteUserHandler: (AuthDeleteUserRequest, (Result<Void, AuthError>) -> Void) -> Void = { _, completion in
+        completion(.success(()))
     }
 
     func deleteUser(request: AuthDeleteUserRequest,
                     completionHandler: @escaping (Result<Void, AuthError>) -> Void) {
-        // Incomplete implementation
+        interactions.append(#function)
+        deleteUserHandler(request, completionHandler)
     }
 
-    func getCurrentUser() -> AuthUser? {
-        fatalError()
+    var authUser: AuthUser?
 
+    func getCurrentUser() -> AuthUser? {
+        interactions.append(#function)
+        return authUser
+    }
+
+    // swiftlint:disable line_length
+    var resetPasswordHandler: (AuthResetPasswordRequest, (Result<AuthResetPasswordResult, AuthError>) -> Void) -> Void = { _, completion in
+        completion(.success(AuthResetPasswordResult(isPasswordReset: true, nextStep: .done)))
     }
 
     func resetPassword(request: AuthResetPasswordRequest,
                        completionHandler: @escaping (Result<AuthResetPasswordResult, AuthError>) -> Void) {
-        // Incomplete implementation
+        interactions.append(#function)
+        resetPasswordHandler(request, completionHandler)
+    }
+
+    // swiftlint:disable line_length
+    var confirmResetPasswordHandler: (AuthConfirmResetPasswordRequest, (Result<Void, AuthError>) -> Void) -> Void = { _, completion in
+        completion(.success(()))
     }
 
     func confirmResetPassword(request: AuthConfirmResetPasswordRequest,
                               completionHandler: @escaping (Result<Void, AuthError>) -> Void) {
-        // Incomplete implementation
+        interactions.append(#function)
+        confirmResetPasswordHandler(request, completionHandler)
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthorizationProviderBehavior.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Mocks/MockAuthorizationProviderBehavior.swift
@@ -9,12 +9,21 @@ import Amplify
 @testable import AWSCognitoAuthPlugin
 
 class MockAuthorizationProviderBehavior: AuthorizationProviderBehavior {
+
+    var interactions: [String] = []
+
+    // swiftlint:disable line_length
+    var fetchSessionHandler: (AuthFetchSessionRequest, (Result<AuthSession, AuthError>) -> Void) -> Void = { _, completion in
+        completion(.success(MockAuthSession(isSignedIn: true, tokens: .success(MockAuthCognitoTokens()))))
+    }
+
     func fetchSession(request: AuthFetchSessionRequest,
                       completionHandler: @escaping (Result<AuthSession, AuthError>) -> Void) {
-        // Incomplete implementation
+        interactions.append(#function)
+        fetchSessionHandler(request, completionHandler)
     }
 
     func invalidateCachedTemporaryCredentials() {
-        // Incomplete implementation
+        interactions.append(#function)
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Utils/AWSCognitoAuthPluginUserDefaultsTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginTests/Utils/AWSCognitoAuthPluginUserDefaultsTests.swift
@@ -1,0 +1,43 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AWSCognitoAuthPlugin
+import XCTest
+
+final class AWSCognitoAuthPluginUserDefaultsTests: XCTestCase {
+
+    var systemUnderTest: AWSCognitoAuthPluginUserDefaults!
+    var userDefaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        userDefaults = UserDefaults(suiteName: #file)
+        userDefaults.removePersistentDomain(forName: #file)
+        systemUnderTest = AWSCognitoAuthPluginUserDefaults()
+        systemUnderTest.defaults = userDefaults
+    }
+
+    override func tearDownWithError() throws {
+        userDefaults = nil
+        systemUnderTest = nil
+    }
+
+    /// - Given: A newly-initialized defaults container
+    /// - When: Its privateSessionPreferred value is changed
+    /// - Then: This change is propagated to the underlying defaults
+    func testPreferPrivateSession() throws {
+        let defaultValue = systemUnderTest.isPrivateSessionPreferred()
+        XCTAssertEqual(defaultValue, false)
+
+        let customValue = !defaultValue
+        systemUnderTest.storePreferredBrowserSession(privateSessionPrefered: customValue)
+
+        let updatedValue = systemUnderTest.isPrivateSessionPreferred()
+        XCTAssertEqual(updatedValue, customValue)
+
+        XCTAssertEqual(updatedValue, userDefaults.bool(forKey: "AWSCognitoAuthPluginUserDefaults.privateSessionKey"))
+    }
+}


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

https://github.com/aws-amplify/amplify-swift/issues/2685

## Description
<!-- Why is this change required? What problem does it solve? -->

This commit ensures that auth unit tests wait for operations they create complete. There are also a few minor additional unit tests for low-hanging fruit.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
~~- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
