### PR TITLE
fix(auth): Unblock fetchAuthSession call during a signIn flow

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/AuthorizationState.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/AuthorizationState.swift
@@ -13,8 +13,6 @@ enum AuthorizationState: State {
 
     case configured
 
-    case signingIn
-
     case signingOut(AmplifyCredentials?)
 
     case clearingFederation
@@ -47,8 +45,6 @@ extension AuthorizationState {
             return "AuthorizationState.notConfigured"
         case .configured:
             return "AuthorizationState.configured"
-        case .signingIn:
-            return "AuthorizationState.signingIn"
         case .signingOut:
             return "AuthorizationState.signingOut"
         case .federatingToIdentityPool:

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/DebugInfo/AuthorizationState+Debug.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/DebugInfo/AuthorizationState+Debug.swift
@@ -14,7 +14,6 @@ extension AuthorizationState: CustomDebugDictionaryConvertible {
         switch self {
         case .notConfigured,
                 .configured,
-                .signingIn,
                 .signingOut,
                 .clearingFederation,
                 .deletingUser:

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/CodableStates/AuthorizationState+Codable.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/CodableStates/AuthorizationState+Codable.swift
@@ -82,8 +82,6 @@ extension AuthorizationState: Codable {
 
         } else if type == "AuthorizationState.Configured" {
             self = .configured
-        } else if type == "AuthorizationState.SigningIn" {
-            self = .signingIn
         } else {
             fatalError("Decoding not supported")
         }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestResources/states/SigningIn_SigningIn.json
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestResources/states/SigningIn_SigningIn.json
@@ -19,6 +19,6 @@
         }
     },
     "AuthorizationState": {
-        "type": "AuthorizationState.SigningIn"
+        "type": "AuthorizationState.Configured"
     }
 }


### PR DESCRIPTION
## Issue \#
https://github.com/aws-amplify/amplify-swift/issues/2608

## Description
Current implementation of the auth state machine blocks any fetch Auth session call to be invoked if there is a signIn is in progress. This causes issue if we want to call fetchAuthSession when the library is waiting for user input for confirm signIn. This PR unblocks the fetchAuthSession api during signIn invocation. 

Note that this does not interfere in a signIn flow because only one api will be executing at a time in the auth plugin.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
