### PR TITLE
chore: Fixing Xcode warnings related to Sendable conformance.

### DIFF
--- a/Amplify/Categories/API/Response/SubscriptionEvent.swift
+++ b/Amplify/Categories/API/Response/SubscriptionEvent.swift
@@ -6,7 +6,7 @@
 //
 
 /// Event for subscription
-public enum GraphQLSubscriptionEvent<T: Decodable> {
+public enum GraphQLSubscriptionEvent<T: Decodable & Sendable> {
     /// The subscription's connection state has changed.
     case connection(SubscriptionConnectionState)
 

--- a/Amplify/Categories/DataStore/Model/Temporal/DateTime.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/DateTime.swift
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if swift(<5.7)
+@preconcurrency import Foundation
+#else
 import Foundation
+#endif
 
 extension Temporal {
     /// `Temporal.DateTime` represents a `DateTime` with specific allowable formats.
@@ -14,7 +18,7 @@ extension Temporal {
     ///  * `.medium` => `yyyy-MM-dd'T'HH:mm:ss`
     ///  * `.long` => `yyyy-MM-dd'T'HH:mm:ssZZZZZ`
     ///  * `.full` => `yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ`
-    public struct DateTime: TemporalSpec {
+    public struct DateTime: TemporalSpec, Sendable {
         // Inherits documentation from `TemporalSpec`
         public let foundationDate: Foundation.Date
 

--- a/Amplify/Categories/DataStore/Subscribe/DataStoreQuerySnapshot.swift
+++ b/Amplify/Categories/DataStore/Subscribe/DataStoreQuerySnapshot.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// A snapshot of the items from DataStore, the changes since last snapshot, and whether this model has
 /// finished syncing and subscriptions are active
-public struct DataStoreQuerySnapshot<M: Model> {
+public struct DataStoreQuerySnapshot<M: Model & Sendable> {
 
     /// All model instances from the local store
     public let items: [M]

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
@@ -10,7 +10,7 @@ import Foundation
 import AWSPluginsCore
 import AppSyncRealTimeClient
 
-public class AWSGraphQLSubscriptionTaskRunner<R: Decodable>: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel {
+public class AWSGraphQLSubscriptionTaskRunner<R: Decodable & Sendable>: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel {
     public typealias Request = GraphQLOperationRequest<R>
     public typealias InProcess = GraphQLSubscriptionEvent<R>
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStoreObserveQueryOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStoreObserveQueryOperation.swift
@@ -39,7 +39,7 @@ class ObserveQueryRequest: AmplifyOperationRequest {
 ///
 /// This operation should perform its methods under the serial DispatchQueue `serialQueue` to ensure all its properties
 /// remain thread-safe.
-class ObserveQueryTaskRunner<M: Model>: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel, DataStoreObserveQueryOperation {
+class ObserveQueryTaskRunner<M: Model & Sendable>: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel, DataStoreObserveQueryOperation {
     typealias Request = ObserveQueryRequest
     typealias InProcess = DataStoreQuerySnapshot<M>
     var request: ObserveQueryRequest

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -434,7 +434,7 @@ class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
     }
 }
 
-class MockAWSGraphQLSubscriptionTaskRunner<R: Decodable>: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel {
+class MockAWSGraphQLSubscriptionTaskRunner<R: Decodable & Sendable>: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel {
     
     public typealias Request = GraphQLOperationRequest<R>
     public typealias InProcess = GraphQLSubscriptionEvent<R>

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -329,7 +329,7 @@ class ObserveQueryRequest: AmplifyOperationRequest {
     
 }
 
-class MockObserveQueryTaskRunner<M: Model>: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel {
+class MockObserveQueryTaskRunner<M: Model & Sendable>: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel {
 
     public typealias Request = ObserveQueryRequest
     public typealias InProcess = DataStoreQuerySnapshot<M>


### PR DESCRIPTION
## Description
Adding `Sendable` conformance to various DataStore/API models to suppress warnings.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
