### PR TITLE
fix: Add missing PropertyPath types double and int

### DIFF
--- a/.github/workflows/integ_test_api.yml
+++ b/.github/workflows/integ_test_api.yml
@@ -2,7 +2,7 @@ name: API Integration Tests
 on:
   workflow_dispatch:
   push:
-    branches: [data-dev-preview.github-workflows]
+    branches: [main]
 
 permissions:
     id-token: write

--- a/.github/workflows/integ_test_api.yml
+++ b/.github/workflows/integ_test_api.yml
@@ -2,7 +2,7 @@ name: API Integration Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [data-dev-preview.github-workflows]
 
 permissions:
     id-token: write

--- a/.github/workflows/integ_test_datastore.yml
+++ b/.github/workflows/integ_test_datastore.yml
@@ -2,7 +2,7 @@ name: DataStore Integration Tests
 on:
   workflow_dispatch:
   push:
-    branches: [data-dev-preview.github-workflows]
+    branches: [main]
 
 permissions:
     id-token: write

--- a/.github/workflows/integ_test_datastore.yml
+++ b/.github/workflows/integ_test_datastore.yml
@@ -2,7 +2,7 @@ name: DataStore Integration Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [data-dev-preview.github-workflows]
 
 permissions:
     id-token: write

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -2,7 +2,7 @@ name: DataStore TransformerV2 Tests
 on:
   workflow_dispatch:
   push:
-    branches: [data-dev-preview.github-workflows]
+    branches: [main]
 
 permissions:
     id-token: write

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -2,7 +2,7 @@ name: DataStore TransformerV2 Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [data-dev-preview.github-workflows]
 
 permissions:
     id-token: write

--- a/Amplify/Categories/DataStore/Model/PropertyPath.swift
+++ b/Amplify/Categories/DataStore/Model/PropertyPath.swift
@@ -123,4 +123,8 @@ open class ModelPath<ModelType: Model> : PropertyContainerPath {
     public func time(_ name: String) -> FieldPath<Temporal.Time> {
         FieldPath(name: name, parent: self)
     }
+    
+    public func int(_ name: String) -> FieldPath<Int> {
+        FieldPath(name: name, parent: self)
+    }
 }

--- a/Amplify/Categories/DataStore/Model/PropertyPath.swift
+++ b/Amplify/Categories/DataStore/Model/PropertyPath.swift
@@ -127,4 +127,8 @@ open class ModelPath<ModelType: Model> : PropertyContainerPath {
     public func int(_ name: String) -> FieldPath<Int> {
         FieldPath(name: name, parent: self)
     }
+    
+    public func double(_ name: String) -> FieldPath<Double> {
+        FieldPath(name: name, parent: self)
+    }
 }

--- a/Amplify/Core/Error/CoreError.swift
+++ b/Amplify/Core/Error/CoreError.swift
@@ -10,7 +10,7 @@ public enum CoreError {
 
     /// A related operation performed on `List` resulted in an error.
     case listOperation(ErrorDescription, RecoverySuggestion, Error? = nil)
-    
+
     /// A client side validation error occured.
     case clientValidation(ErrorDescription, RecoverySuggestion, Error? = nil)
 }

--- a/Amplify/Core/Error/CoreError.swift
+++ b/Amplify/Core/Error/CoreError.swift
@@ -10,7 +10,7 @@ public enum CoreError {
 
     /// A related operation performed on `List` resulted in an error.
     case listOperation(ErrorDescription, RecoverySuggestion, Error? = nil)
-
+    
     /// A client side validation error occured.
     case clientValidation(ErrorDescription, RecoverySuggestion, Error? = nil)
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
@@ -164,6 +164,16 @@
 		21908A79291D7631005021F7 /* Post8+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21908A74291D7631005021F7 /* Post8+Schema.swift */; };
 		21908A7A291D7631005021F7 /* Comment8+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21908A75291D7631005021F7 /* Comment8+Schema.swift */; };
 		219253C428BFEBE400820737 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 219253C328BFEBE200820737 /* XCTest.framework */; };
+		21BC111B2971ADA4000E189E /* UserSettings14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11122971ADA4000E189E /* UserSettings14+Schema.swift */; };
+		21BC111C2971ADA4000E189E /* Comment14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11132971ADA4000E189E /* Comment14.swift */; };
+		21BC111D2971ADA4000E189E /* UserSettings14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11142971ADA4000E189E /* UserSettings14.swift */; };
+		21BC111E2971ADA4000E189E /* User14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11152971ADA4000E189E /* User14+Schema.swift */; };
+		21BC111F2971ADA4000E189E /* User14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11162971ADA4000E189E /* User14.swift */; };
+		21BC11202971ADA4000E189E /* Comment14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11172971ADA4000E189E /* Comment14+Schema.swift */; };
+		21BC11212971ADA4000E189E /* Post14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11182971ADA4000E189E /* Post14+Schema.swift */; };
+		21BC11222971ADA4000E189E /* Post14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11192971ADA4000E189E /* Post14.swift */; };
+		21BC11232971ADA4000E189E /* PostStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC111A2971ADA4000E189E /* PostStatus.swift */; };
+		21BC11252971ADBD000E189E /* GraphQLLazyLoadUserPostCommentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11242971ADBD000E189E /* GraphQLLazyLoadUserPostCommentTests.swift */; };
 		21DFAEAE295F9F8C00B4A883 /* Person+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAEA8295F9F8C00B4A883 /* Person+Schema.swift */; };
 		21DFAEAF295F9F8C00B4A883 /* PhoneCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAEA9295F9F8C00B4A883 /* PhoneCall.swift */; };
 		21DFAEB0295F9F8C00B4A883 /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAEAA295F9F8C00B4A883 /* Person.swift */; };
@@ -463,6 +473,16 @@
 		21908A74291D7631005021F7 /* Post8+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post8+Schema.swift"; sourceTree = "<group>"; };
 		21908A75291D7631005021F7 /* Comment8+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Comment8+Schema.swift"; sourceTree = "<group>"; };
 		219253C328BFEBE200820737 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		21BC11122971ADA4000E189E /* UserSettings14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserSettings14+Schema.swift"; sourceTree = "<group>"; };
+		21BC11132971ADA4000E189E /* Comment14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment14.swift; sourceTree = "<group>"; };
+		21BC11142971ADA4000E189E /* UserSettings14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserSettings14.swift; sourceTree = "<group>"; };
+		21BC11152971ADA4000E189E /* User14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "User14+Schema.swift"; sourceTree = "<group>"; };
+		21BC11162971ADA4000E189E /* User14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User14.swift; sourceTree = "<group>"; };
+		21BC11172971ADA4000E189E /* Comment14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Comment14+Schema.swift"; sourceTree = "<group>"; };
+		21BC11182971ADA4000E189E /* Post14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post14+Schema.swift"; sourceTree = "<group>"; };
+		21BC11192971ADA4000E189E /* Post14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post14.swift; sourceTree = "<group>"; };
+		21BC111A2971ADA4000E189E /* PostStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostStatus.swift; sourceTree = "<group>"; };
+		21BC11242971ADBD000E189E /* GraphQLLazyLoadUserPostCommentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLLazyLoadUserPostCommentTests.swift; sourceTree = "<group>"; };
 		21D335B7289867FC00657B12 /* amplify-ios-staging */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-ios-staging"; path = ../../../..; sourceTree = "<group>"; };
 		21DFAEA8295F9F8C00B4A883 /* Person+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Person+Schema.swift"; sourceTree = "<group>"; };
 		21DFAEA9295F9F8C00B4A883 /* PhoneCall.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneCall.swift; sourceTree = "<group>"; };
@@ -883,6 +903,23 @@
 			path = LL12;
 			sourceTree = "<group>";
 		};
+		21BC11112971AD5F000E189E /* LL14 */ = {
+			isa = PBXGroup;
+			children = (
+				21BC11242971ADBD000E189E /* GraphQLLazyLoadUserPostCommentTests.swift */,
+				21BC11132971ADA4000E189E /* Comment14.swift */,
+				21BC11172971ADA4000E189E /* Comment14+Schema.swift */,
+				21BC11192971ADA4000E189E /* Post14.swift */,
+				21BC11182971ADA4000E189E /* Post14+Schema.swift */,
+				21BC111A2971ADA4000E189E /* PostStatus.swift */,
+				21BC11162971ADA4000E189E /* User14.swift */,
+				21BC11152971ADA4000E189E /* User14+Schema.swift */,
+				21BC11142971ADA4000E189E /* UserSettings14.swift */,
+				21BC11122971ADA4000E189E /* UserSettings14+Schema.swift */,
+			);
+			path = LL14;
+			sourceTree = "<group>";
+		};
 		21D335B6289867FC00657B12 /* Packages */ = {
 			isa = PBXGroup;
 			children = (
@@ -981,6 +1018,7 @@
 				219089E3291D6B20005021F7 /* LL11 */,
 				219089E4291D6B2A005021F7 /* LL12 */,
 				21DFAEA7295F9F4100B4A883 /* L13 */,
+				21BC11112971AD5F000E189E /* LL14 */,
 				21EA888328F9BD2D0000BA75 /* lazyload-schema.graphql */,
 				21EA888128F9BCD90000BA75 /* TestConfigHelper.swift */,
 				21EA887D28F9BCBB0000BA75 /* README.md */,
@@ -1760,6 +1798,7 @@
 				21908A48291D7608005021F7 /* Comment7.swift in Sources */,
 				21908A24291D75E4005021F7 /* Team2.swift in Sources */,
 				21908A0C291D75D6005021F7 /* GraphQLLazyLoadPostTagTests.swift in Sources */,
+				21BC11222971ADA4000E189E /* Post14.swift in Sources */,
 				21EA887628F9BC610000BA75 /* GraphQLLazyLoadBaseTest.swift in Sources */,
 				218D0195291AE3750068D133 /* Comment4V2+Schema.swift in Sources */,
 				21908A79291D7631005021F7 /* Post8+Schema.swift in Sources */,
@@ -1806,8 +1845,11 @@
 				21908A0D291D75D6005021F7 /* TagWithCompositeKey.swift in Sources */,
 				21FA8EF7295C9609009F6A07 /* GraphQLLazyLoadHasOneTests.swift in Sources */,
 				21908A6F291D762B005021F7 /* StrangeExplicitChild.swift in Sources */,
+				21BC111C2971ADA4000E189E /* Comment14.swift in Sources */,
 				21908A10291D75D6005021F7 /* PostWithTagsCompositeKey+Schema.swift in Sources */,
 				21908A63291D762B005021F7 /* HasOneParent+Schema.swift in Sources */,
+				21BC11252971ADBD000E189E /* GraphQLLazyLoadUserPostCommentTests.swift in Sources */,
+				21BC111D2971ADA4000E189E /* UserSettings14.swift in Sources */,
 				21908A35291D75F4005021F7 /* Team5.swift in Sources */,
 				21908A77291D7631005021F7 /* Comment8.swift in Sources */,
 				21FA8EFB295C9647009F6A07 /* GraphQLLazyLoadCompositePKTests.swift in Sources */,
@@ -1818,9 +1860,12 @@
 				21EA888228F9BCD90000BA75 /* TestConfigHelper.swift in Sources */,
 				21908A0E291D75D6005021F7 /* TagWithCompositeKey+Schema.swift in Sources */,
 				21908A6B291D762B005021F7 /* CompositePKParent+Schema.swift in Sources */,
+				21BC111F2971ADA4000E189E /* User14.swift in Sources */,
+				21BC111E2971ADA4000E189E /* User14+Schema.swift in Sources */,
 				219089F3291D75C3005021F7 /* Blog8V2.swift in Sources */,
 				21908A67291D762B005021F7 /* DefaultPKParent.swift in Sources */,
 				21DFAEB5295F9FA600B4A883 /* GraphQLLazyLoadPhoneCallTests.swift in Sources */,
+				21BC11232971ADA4000E189E /* PostStatus.swift in Sources */,
 				21908A42291D75FE005021F7 /* Team6+Schema.swift in Sources */,
 				21FA8EF9295C962E009F6A07 /* GraphQLLazyLoadDefaultPKTests.swift in Sources */,
 				21908A2C291D75EB005021F7 /* Comment4+Schema.swift in Sources */,
@@ -1829,6 +1874,7 @@
 				21908A69291D762B005021F7 /* HasOneParent.swift in Sources */,
 				21908A4C291D7608005021F7 /* Comment7+Schema.swift in Sources */,
 				21DFAEAF295F9F8C00B4A883 /* PhoneCall.swift in Sources */,
+				21BC111B2971ADA4000E189E /* UserSettings14+Schema.swift in Sources */,
 				21908A2B291D75EB005021F7 /* GraphQLLazyLoadPostComment4Tests.swift in Sources */,
 				21908A65291D762B005021F7 /* ChildSansBelongsTo+Schema.swift in Sources */,
 				21DFAEB0295F9F8C00B4A883 /* Person.swift in Sources */,
@@ -1836,6 +1882,8 @@
 				21908A02291D75CE005021F7 /* CommentWithCompositeKey+Schema.swift in Sources */,
 				21EA887E28F9BCC10000BA75 /* AsyncTesting.swift in Sources */,
 				219089EF291D75C3005021F7 /* MyCustomModel8+Schema.swift in Sources */,
+				21BC11202971ADA4000E189E /* Comment14+Schema.swift in Sources */,
+				21BC11212971ADA4000E189E /* Post14+Schema.swift in Sources */,
 				21908A21291D75E4005021F7 /* GraphQLLazyLoadProjectTeam2Tests.swift in Sources */,
 				219089FE291D75CE005021F7 /* GraphQLLazyLoadPostCommentWithCompositeKeyTests.swift in Sources */,
 				21908A76291D7631005021F7 /* GraphQLLazyLoadPostComment8Tests.swift in Sources */,

--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
@@ -164,6 +164,19 @@
 		21908A79291D7631005021F7 /* Post8+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21908A74291D7631005021F7 /* Post8+Schema.swift */; };
 		21908A7A291D7631005021F7 /* Comment8+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21908A75291D7631005021F7 /* Comment8+Schema.swift */; };
 		219253C428BFEBE400820737 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 219253C328BFEBE200820737 /* XCTest.framework */; };
+		21AB5C3A29819A4000CCA482 /* EnumTestModel+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C2D29819A3F00CCA482 /* EnumTestModel+Schema.swift */; };
+		21AB5C3B29819A4000CCA482 /* NestedTypeTestModel+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C2E29819A3F00CCA482 /* NestedTypeTestModel+Schema.swift */; };
+		21AB5C3C29819A4000CCA482 /* ListIntContainer+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C2F29819A3F00CCA482 /* ListIntContainer+Schema.swift */; };
+		21AB5C3D29819A4000CCA482 /* ListStringContainer+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C3029819A3F00CCA482 /* ListStringContainer+Schema.swift */; };
+		21AB5C3E29819A4000CCA482 /* NestedTypeTestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C3129819A3F00CCA482 /* NestedTypeTestModel.swift */; };
+		21AB5C3F29819A4000CCA482 /* TestEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C3229819A3F00CCA482 /* TestEnum.swift */; };
+		21AB5C4029819A4000CCA482 /* ListIntContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C3329819A4000CCA482 /* ListIntContainer.swift */; };
+		21AB5C4129819A4000CCA482 /* EnumTestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C3429819A4000CCA482 /* EnumTestModel.swift */; };
+		21AB5C4229819A4000CCA482 /* Nested.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C3529819A4000CCA482 /* Nested.swift */; };
+		21AB5C4329819A4000CCA482 /* ScalarContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C3629819A4000CCA482 /* ScalarContainer.swift */; };
+		21AB5C4429819A4000CCA482 /* ScalarContainer+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C3729819A4000CCA482 /* ScalarContainer+Schema.swift */; };
+		21AB5C4529819A4000CCA482 /* Nested+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C3829819A4000CCA482 /* Nested+Schema.swift */; };
+		21AB5C4629819A4000CCA482 /* ListStringContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C3929819A4000CCA482 /* ListStringContainer.swift */; };
 		21BC111B2971ADA4000E189E /* UserSettings14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11122971ADA4000E189E /* UserSettings14+Schema.swift */; };
 		21BC111C2971ADA4000E189E /* Comment14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11132971ADA4000E189E /* Comment14.swift */; };
 		21BC111D2971ADA4000E189E /* UserSettings14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11142971ADA4000E189E /* UserSettings14.swift */; };
@@ -473,6 +486,19 @@
 		21908A74291D7631005021F7 /* Post8+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post8+Schema.swift"; sourceTree = "<group>"; };
 		21908A75291D7631005021F7 /* Comment8+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Comment8+Schema.swift"; sourceTree = "<group>"; };
 		219253C328BFEBE200820737 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		21AB5C2D29819A3F00CCA482 /* EnumTestModel+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "EnumTestModel+Schema.swift"; sourceTree = "<group>"; };
+		21AB5C2E29819A3F00CCA482 /* NestedTypeTestModel+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NestedTypeTestModel+Schema.swift"; sourceTree = "<group>"; };
+		21AB5C2F29819A3F00CCA482 /* ListIntContainer+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ListIntContainer+Schema.swift"; sourceTree = "<group>"; };
+		21AB5C3029819A3F00CCA482 /* ListStringContainer+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ListStringContainer+Schema.swift"; sourceTree = "<group>"; };
+		21AB5C3129819A3F00CCA482 /* NestedTypeTestModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestedTypeTestModel.swift; sourceTree = "<group>"; };
+		21AB5C3229819A3F00CCA482 /* TestEnum.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEnum.swift; sourceTree = "<group>"; };
+		21AB5C3329819A4000CCA482 /* ListIntContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListIntContainer.swift; sourceTree = "<group>"; };
+		21AB5C3429819A4000CCA482 /* EnumTestModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumTestModel.swift; sourceTree = "<group>"; };
+		21AB5C3529819A4000CCA482 /* Nested.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Nested.swift; sourceTree = "<group>"; };
+		21AB5C3629819A4000CCA482 /* ScalarContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScalarContainer.swift; sourceTree = "<group>"; };
+		21AB5C3729819A4000CCA482 /* ScalarContainer+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ScalarContainer+Schema.swift"; sourceTree = "<group>"; };
+		21AB5C3829819A4000CCA482 /* Nested+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Nested+Schema.swift"; sourceTree = "<group>"; };
+		21AB5C3929819A4000CCA482 /* ListStringContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListStringContainer.swift; sourceTree = "<group>"; };
 		21BC11122971ADA4000E189E /* UserSettings14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserSettings14+Schema.swift"; sourceTree = "<group>"; };
 		21BC11132971ADA4000E189E /* Comment14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment14.swift; sourceTree = "<group>"; };
 		21BC11142971ADA4000E189E /* UserSettings14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserSettings14.swift; sourceTree = "<group>"; };
@@ -903,6 +929,26 @@
 			path = LL12;
 			sourceTree = "<group>";
 		};
+		21AB5C2C298199E200CCA482 /* LL15 */ = {
+			isa = PBXGroup;
+			children = (
+				21AB5C3429819A4000CCA482 /* EnumTestModel.swift */,
+				21AB5C2D29819A3F00CCA482 /* EnumTestModel+Schema.swift */,
+				21AB5C3329819A4000CCA482 /* ListIntContainer.swift */,
+				21AB5C2F29819A3F00CCA482 /* ListIntContainer+Schema.swift */,
+				21AB5C3929819A4000CCA482 /* ListStringContainer.swift */,
+				21AB5C3029819A3F00CCA482 /* ListStringContainer+Schema.swift */,
+				21AB5C3529819A4000CCA482 /* Nested.swift */,
+				21AB5C3829819A4000CCA482 /* Nested+Schema.swift */,
+				21AB5C3129819A3F00CCA482 /* NestedTypeTestModel.swift */,
+				21AB5C2E29819A3F00CCA482 /* NestedTypeTestModel+Schema.swift */,
+				21AB5C3629819A4000CCA482 /* ScalarContainer.swift */,
+				21AB5C3729819A4000CCA482 /* ScalarContainer+Schema.swift */,
+				21AB5C3229819A3F00CCA482 /* TestEnum.swift */,
+			);
+			path = LL15;
+			sourceTree = "<group>";
+		};
 		21BC11112971AD5F000E189E /* LL14 */ = {
 			isa = PBXGroup;
 			children = (
@@ -1019,6 +1065,7 @@
 				219089E4291D6B2A005021F7 /* LL12 */,
 				21DFAEA7295F9F4100B4A883 /* L13 */,
 				21BC11112971AD5F000E189E /* LL14 */,
+				21AB5C2C298199E200CCA482 /* LL15 */,
 				21EA888328F9BD2D0000BA75 /* lazyload-schema.graphql */,
 				21EA888128F9BCD90000BA75 /* TestConfigHelper.swift */,
 				21EA887D28F9BCBB0000BA75 /* README.md */,
@@ -1802,6 +1849,7 @@
 				21EA887628F9BC610000BA75 /* GraphQLLazyLoadBaseTest.swift in Sources */,
 				218D0195291AE3750068D133 /* Comment4V2+Schema.swift in Sources */,
 				21908A79291D7631005021F7 /* Post8+Schema.swift in Sources */,
+				21AB5C4229819A4000CCA482 /* Nested.swift in Sources */,
 				2136C8B32926A509002CC005 /* GraphQLLazyLoadBlogPostComment8V2Tests.swift in Sources */,
 				21908A6D291D762B005021F7 /* CompositePKChild.swift in Sources */,
 				21908A41291D75FE005021F7 /* GraphQLLazyLoadProjectTeam6Tests.swift in Sources */,
@@ -1831,6 +1879,7 @@
 				21908A16291D75DD005021F7 /* Project1.swift in Sources */,
 				21908A6C291D762B005021F7 /* CompositePKChild+Schema.swift in Sources */,
 				21908A0F291D75D6005021F7 /* PostWithTagsCompositeKey.swift in Sources */,
+				21AB5C3C29819A4000CCA482 /* ListIntContainer+Schema.swift in Sources */,
 				21908A3E291D75FE005021F7 /* Project6+Schema.swift in Sources */,
 				21908A40291D75FE005021F7 /* Team6.swift in Sources */,
 				219089FF291D75CE005021F7 /* PostWithCompositeKey.swift in Sources */,
@@ -1839,30 +1888,39 @@
 				21908A00291D75CE005021F7 /* PostWithCompositeKey+Schema.swift in Sources */,
 				21908A7A291D7631005021F7 /* Comment8+Schema.swift in Sources */,
 				21908A6A291D762B005021F7 /* ChildSansBelongsTo.swift in Sources */,
+				21AB5C3D29819A4000CCA482 /* ListStringContainer+Schema.swift in Sources */,
 				219089F2291D75C3005021F7 /* Post8V2+Schema.swift in Sources */,
 				21908A22291D75E4005021F7 /* Team2+Schema.swift in Sources */,
 				21DFAEB3295F9F8C00B4A883 /* Transcript+Schema.swift in Sources */,
 				21908A0D291D75D6005021F7 /* TagWithCompositeKey.swift in Sources */,
 				21FA8EF7295C9609009F6A07 /* GraphQLLazyLoadHasOneTests.swift in Sources */,
 				21908A6F291D762B005021F7 /* StrangeExplicitChild.swift in Sources */,
+				21AB5C3A29819A4000CCA482 /* EnumTestModel+Schema.swift in Sources */,
 				21BC111C2971ADA4000E189E /* Comment14.swift in Sources */,
 				21908A10291D75D6005021F7 /* PostWithTagsCompositeKey+Schema.swift in Sources */,
+				21AB5C3F29819A4000CCA482 /* TestEnum.swift in Sources */,
 				21908A63291D762B005021F7 /* HasOneParent+Schema.swift in Sources */,
 				21BC11252971ADBD000E189E /* GraphQLLazyLoadUserPostCommentTests.swift in Sources */,
 				21BC111D2971ADA4000E189E /* UserSettings14.swift in Sources */,
 				21908A35291D75F4005021F7 /* Team5.swift in Sources */,
 				21908A77291D7631005021F7 /* Comment8.swift in Sources */,
+				21AB5C4129819A4000CCA482 /* EnumTestModel.swift in Sources */,
+				21AB5C4429819A4000CCA482 /* ScalarContainer+Schema.swift in Sources */,
 				21FA8EFB295C9647009F6A07 /* GraphQLLazyLoadCompositePKTests.swift in Sources */,
 				21908A4A291D7608005021F7 /* Post7.swift in Sources */,
 				21908A68291D762B005021F7 /* CompositePKParent.swift in Sources */,
+				21AB5C4329819A4000CCA482 /* ScalarContainer.swift in Sources */,
 				219089F5291D75C3005021F7 /* Post8V2.swift in Sources */,
 				21908A2E291D75EB005021F7 /* Post4.swift in Sources */,
+				21AB5C3B29819A4000CCA482 /* NestedTypeTestModel+Schema.swift in Sources */,
 				21EA888228F9BCD90000BA75 /* TestConfigHelper.swift in Sources */,
+				21AB5C4029819A4000CCA482 /* ListIntContainer.swift in Sources */,
 				21908A0E291D75D6005021F7 /* TagWithCompositeKey+Schema.swift in Sources */,
 				21908A6B291D762B005021F7 /* CompositePKParent+Schema.swift in Sources */,
 				21BC111F2971ADA4000E189E /* User14.swift in Sources */,
 				21BC111E2971ADA4000E189E /* User14+Schema.swift in Sources */,
 				219089F3291D75C3005021F7 /* Blog8V2.swift in Sources */,
+				21AB5C4529819A4000CCA482 /* Nested+Schema.swift in Sources */,
 				21908A67291D762B005021F7 /* DefaultPKParent.swift in Sources */,
 				21DFAEB5295F9FA600B4A883 /* GraphQLLazyLoadPhoneCallTests.swift in Sources */,
 				21BC11232971ADA4000E189E /* PostStatus.swift in Sources */,
@@ -1875,6 +1933,7 @@
 				21908A4C291D7608005021F7 /* Comment7+Schema.swift in Sources */,
 				21DFAEAF295F9F8C00B4A883 /* PhoneCall.swift in Sources */,
 				21BC111B2971ADA4000E189E /* UserSettings14+Schema.swift in Sources */,
+				21AB5C4629819A4000CCA482 /* ListStringContainer.swift in Sources */,
 				21908A2B291D75EB005021F7 /* GraphQLLazyLoadPostComment4Tests.swift in Sources */,
 				21908A65291D762B005021F7 /* ChildSansBelongsTo+Schema.swift in Sources */,
 				21DFAEB0295F9F8C00B4A883 /* Person.swift in Sources */,
@@ -1891,6 +1950,7 @@
 				21908A49291D7608005021F7 /* GraphQLLazyLoadPostComment7Tests.swift in Sources */,
 				21908A2D291D75EB005021F7 /* Post4+Schema.swift in Sources */,
 				218D0196291AE3750068D133 /* Post4V2+Schema.swift in Sources */,
+				21AB5C3E29819A4000CCA482 /* NestedTypeTestModel.swift in Sources */,
 				21DFAEB2295F9F8C00B4A883 /* PhoneCall+Schema.swift in Sources */,
 				21908A64291D762B005021F7 /* ImplicitChild+Schema.swift in Sources */,
 				21908A34291D75F4005021F7 /* Project5+Schema.swift in Sources */,

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/Comment14+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/Comment14+Schema.swift
@@ -1,0 +1,69 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Comment14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case content
+    case post
+    case author
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let comment14 = Comment14.keys
+    
+    model.authRules = [
+      rule(allow: .public, operations: [.create, .update, .delete, .read])
+    ]
+    
+    model.pluralName = "Comment14s"
+    
+    model.attributes(
+      .primaryKey(fields: [comment14.id])
+    )
+    
+    model.fields(
+      .field(comment14.id, is: .required, ofType: .string),
+      .field(comment14.content, is: .optional, ofType: .string),
+      .belongsTo(comment14.post, is: .optional, ofType: Post14.self, targetNames: ["post14CommentsId"]),
+      .belongsTo(comment14.author, is: .required, ofType: User14.self, targetNames: ["user14CommentsId"]),
+      .field(comment14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(comment14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Comment14> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Comment14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == Comment14 {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var content: FieldPath<String>   {
+      string("content") 
+    }
+  public var post: ModelPath<Post14>   {
+      Post14.Path(name: "post", parent: self) 
+    }
+  public var author: ModelPath<User14>   {
+      User14.Path(name: "author", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/Comment14.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/Comment14.swift
@@ -1,0 +1,71 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Comment14: Model {
+  public let id: String
+  public var content: String?
+  internal var _post: LazyReference<Post14>
+  public var post: Post14?   {
+      get async throws { 
+        try await _post.get()
+      } 
+    }
+  internal var _author: LazyReference<User14>
+  public var author: User14   {
+      get async throws { 
+        try await _author.require()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      content: String? = nil,
+      post: Post14? = nil,
+      author: User14) {
+    self.init(id: id,
+      content: content,
+      post: post,
+      author: author,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      content: String? = nil,
+      post: Post14? = nil,
+      author: User14,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.content = content
+      self._post = LazyReference(post)
+      self._author = LazyReference(author)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setPost(_ post: Post14? = nil) {
+    self._post = LazyReference(post)
+  }
+  public mutating func setAuthor(_ author: User14) {
+    self._author = LazyReference(author)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      content = try? values.decode(String?.self, forKey: .content)
+      _post = try values.decodeIfPresent(LazyReference<Post14>.self, forKey: .post) ?? LazyReference(identifiers: nil)
+      _author = try values.decodeIfPresent(LazyReference<User14>.self, forKey: .author) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(content, forKey: .content)
+      try container.encode(_post, forKey: .post)
+      try container.encode(_author, forKey: .author)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/GraphQLLazyLoadUserPostCommentTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/GraphQLLazyLoadUserPostCommentTests.swift
@@ -51,21 +51,63 @@ final class GraphQLLazyLoadUserPostCommentTests: GraphQLLazyLoadBaseTest {
         try await mutate(.create(comment))
     }
     
-    func testQueryComment() async throws {
+    /// LazyLoad from queried models
+    ///
+    /// - Given: Created models
+    /// - When:
+    ///    - Querying for models
+    /// - Then:
+    ///    - Traversing from the models to its connected models are successful
+    ///
+    func testLazyLoad() async throws {
         await setup(withModels: UserPostCommentModels())
         let user = User(username: "name")
         let savedUser = try await mutate(.create(user))
+        let userSettings = UserSettings(language: "en-us", user: savedUser)
+        try await mutate(.create(userSettings))
         let post = Post(title: "title", rating: 1, status: .active, author: savedUser)
         let savedPost = try await mutate(.create(post))
         let comment = Comment(content: "content", post: savedPost, author: savedUser)
-        let savedComment = try await mutate(.create(comment))
+        try await mutate(.create(comment))
         
-        let response = try await Amplify.API.query(request: .get(Comment.self, byId: comment.id))
-        guard case .success(let queriedComment) = response,
-              let queriedComment = queriedComment else {
-            return
-        }
-        XCTAssertEqual(queriedComment.id, savedComment.id)
+        // Traverse from User
+        let queriedUser = try await query(for: user)!
+        try await queriedUser.posts?.fetch()
+        XCTAssertEqual(queriedUser.posts?.count, 1)
+        try await queriedUser.comments?.fetch()
+        XCTAssertEqual(queriedUser.comments?.count, 1)
+        // Cannot traverse from User to settings
+        //let queriedUserSettings = try await queriedUser.settings
+        //XCTAssertNotNil(queriedUserSettings)
+        
+        // Traverse from UserSettings
+        let queriedSettings = try await query(for: userSettings)!
+        let queriedSettingsUser = try await queriedSettings.user
+        XCTAssertEqual(queriedSettingsUser.id, user.id)
+
+        // Traverse from Post
+        let queriedPost = try await query(for: post)!
+        try await queriedPost.comments?.fetch()
+        XCTAssertEqual(queriedPost.comments?.count, 1)
+        let queriedPostUser = try await queriedPost.author
+        XCTAssertEqual(queriedPostUser.id, user.id)
+
+        // Traverse from Comment
+        let queriedComment = try await query(for: comment)!
+        let queriedCommentPost = try await queriedComment.post
+        XCTAssertEqual(queriedCommentPost?.id, post.id)
+        let queriedCommentUser = try await queriedComment.author
+        XCTAssertEqual(queriedCommentUser.id, user.id)
+
+        // Clean up - delete the saved models
+        try await mutate(.delete(comment))
+        try await assertModelDoesNotExist(comment)
+        try await mutate(.delete(post))
+        try await assertModelDoesNotExist(post)
+        try await mutate(.delete(userSettings))
+        try await assertModelDoesNotExist(userSettings)
+        try await mutate(.delete(user))
+        try await assertModelDoesNotExist(user)
     }
 }
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/GraphQLLazyLoadUserPostCommentTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/GraphQLLazyLoadUserPostCommentTests.swift
@@ -1,0 +1,87 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Combine
+import XCTest
+
+@testable import Amplify
+
+final class GraphQLLazyLoadUserPostCommentTests: GraphQLLazyLoadBaseTest {
+
+    func testConfigure() async throws {
+        await setup(withModels: UserPostCommentModels(), logLevel: .verbose)
+    }
+
+    func testSaveUser() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        try await mutate(.create(user))
+    }
+    
+    func testSaveUserSettings() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        let savedUser = try await mutate(.create(user))
+        
+        let userSettings = UserSettings(language: "en-us", user: savedUser)
+        try await mutate(.create(userSettings))
+    }
+    
+    func testSavePost() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        let savedUser = try await mutate(.create(user))
+        let post = Post(title: "title", rating: 1, status: .active, author: savedUser)
+        try await mutate(.create(post))
+    }
+    
+    func testSaveComment() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        let savedUser = try await mutate(.create(user))
+        let post = Post(title: "title", rating: 1, status: .active, author: savedUser)
+        let savedPost = try await mutate(.create(post))
+        
+        let comment = Comment(content: "content", post: savedPost, author: savedUser)
+        try await mutate(.create(comment))
+    }
+    
+    func testQueryComment() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        let savedUser = try await mutate(.create(user))
+        let post = Post(title: "title", rating: 1, status: .active, author: savedUser)
+        let savedPost = try await mutate(.create(post))
+        let comment = Comment(content: "content", post: savedPost, author: savedUser)
+        let savedComment = try await mutate(.create(comment))
+        
+        let response = try await Amplify.API.query(request: .get(Comment.self, byId: comment.id))
+        guard case .success(let queriedComment) = response,
+              let queriedComment = queriedComment else {
+            return
+        }
+        XCTAssertEqual(queriedComment.id, savedComment.id)
+    }
+}
+
+extension GraphQLLazyLoadUserPostCommentTests {
+    typealias User = User14
+    typealias Post = Post14
+    typealias Comment = Comment14
+    typealias UserSettings = UserSettings14
+    
+    struct UserPostCommentModels: AmplifyModelRegistration {
+        public let version: String = "version"
+        func registerModels(registry: ModelRegistry.Type) {
+            ModelRegistry.register(modelType: User14.self)
+            ModelRegistry.register(modelType: Post14.self)
+            ModelRegistry.register(modelType: Comment14.self)
+            ModelRegistry.register(modelType: UserSettings14.self)
+        }
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/Post14+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/Post14+Schema.swift
@@ -1,0 +1,76 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case title
+    case rating
+    case status
+    case comments
+    case author
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post14 = Post14.keys
+    
+    model.authRules = [
+      rule(allow: .public, operations: [.create, .update, .delete, .read])
+    ]
+    
+    model.pluralName = "Post14s"
+    
+    model.attributes(
+      .primaryKey(fields: [post14.id])
+    )
+    
+    model.fields(
+      .field(post14.id, is: .required, ofType: .string),
+      .field(post14.title, is: .required, ofType: .string),
+      .field(post14.rating, is: .required, ofType: .int),
+      .field(post14.status, is: .required, ofType: .enum(type: PostStatus.self)),
+      .hasMany(post14.comments, is: .optional, ofType: Comment14.self, associatedWith: Comment14.keys.post),
+      .belongsTo(post14.author, is: .required, ofType: User14.self, targetNames: ["user14PostsId"]),
+      .field(post14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Post14> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Post14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == Post14 {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var title: FieldPath<String>   {
+      string("title") 
+    }
+  public var rating: FieldPath<Int>   {
+      int("rating") 
+    }
+  public var comments: ModelPath<Comment14>   {
+      Comment14.Path(name: "comments", isCollection: true, parent: self) 
+    }
+  public var author: ModelPath<User14>   {
+      User14.Path(name: "author", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/Post14.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/Post14.swift
@@ -1,0 +1,77 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post14: Model {
+  public let id: String
+  public var title: String
+  public var rating: Int
+  public var status: PostStatus
+  public var comments: List<Comment14>?
+  internal var _author: LazyReference<User14>
+  public var author: User14   {
+      get async throws { 
+        try await _author.require()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      title: String,
+      rating: Int,
+      status: PostStatus,
+      comments: List<Comment14>? = [],
+      author: User14) {
+    self.init(id: id,
+      title: title,
+      rating: rating,
+      status: status,
+      comments: comments,
+      author: author,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      title: String,
+      rating: Int,
+      status: PostStatus,
+      comments: List<Comment14>? = [],
+      author: User14,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.title = title
+      self.rating = rating
+      self.status = status
+      self.comments = comments
+      self._author = LazyReference(author)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setAuthor(_ author: User14) {
+    self._author = LazyReference(author)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      title = try values.decode(String.self, forKey: .title)
+      rating = try values.decode(Int.self, forKey: .rating)
+      status = try values.decode(PostStatus.self, forKey: .status)
+      comments = try values.decodeIfPresent(List<Comment14>?.self, forKey: .comments) ?? .init()
+      _author = try values.decodeIfPresent(LazyReference<User14>.self, forKey: .author) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(title, forKey: .title)
+      try container.encode(rating, forKey: .rating)
+      try container.encode(status, forKey: .status)
+      try container.encode(comments, forKey: .comments)
+      try container.encode(_author, forKey: .author)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/PostStatus.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/PostStatus.swift
@@ -1,0 +1,8 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public enum PostStatus: String, EnumPersistable {
+  case active = "ACTIVE"
+  case inactive = "INACTIVE"
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/User14+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/User14+Schema.swift
@@ -1,0 +1,79 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension User14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case username
+    case posts
+    case comments
+    case settings
+    case createdAt
+    case updatedAt
+    case user14SettingsId
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let user14 = User14.keys
+    
+    model.authRules = [
+      rule(allow: .public, operations: [.create, .update, .delete, .read])
+    ]
+    
+    model.pluralName = "User14s"
+    
+    model.attributes(
+      .primaryKey(fields: [user14.id])
+    )
+    
+    model.fields(
+      .field(user14.id, is: .required, ofType: .string),
+      .field(user14.username, is: .required, ofType: .string),
+      .hasMany(user14.posts, is: .optional, ofType: Post14.self, associatedWith: Post14.keys.author),
+      .hasMany(user14.comments, is: .optional, ofType: Comment14.self, associatedWith: Comment14.keys.author),
+      .hasOne(user14.settings, is: .optional, ofType: UserSettings14.self, associatedWith: UserSettings14.keys.user, targetNames: ["user14SettingsId"]),
+      .field(user14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(user14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(user14.user14SettingsId, is: .optional, ofType: .string)
+    )
+    }
+    public class Path: ModelPath<User14> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension User14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == User14 {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var username: FieldPath<String>   {
+      string("username") 
+    }
+  public var posts: ModelPath<Post14>   {
+      Post14.Path(name: "posts", isCollection: true, parent: self) 
+    }
+  public var comments: ModelPath<Comment14>   {
+      Comment14.Path(name: "comments", isCollection: true, parent: self) 
+    }
+  public var settings: ModelPath<UserSettings14>   {
+      UserSettings14.Path(name: "settings", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+  public var user14SettingsId: FieldPath<String>   {
+      string("user14SettingsId") 
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/User14.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/User14.swift
@@ -1,0 +1,77 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct User14: Model {
+  public let id: String
+  public var username: String
+  public var posts: List<Post14>?
+  public var comments: List<Comment14>?
+  internal var _settings: LazyReference<UserSettings14>
+  public var settings: UserSettings14?   {
+      get async throws { 
+        try await _settings.get()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  public var user14SettingsId: String?
+  
+  public init(id: String = UUID().uuidString,
+      username: String,
+      posts: List<Post14>? = [],
+      comments: List<Comment14>? = [],
+      settings: UserSettings14? = nil,
+      user14SettingsId: String? = nil) {
+    self.init(id: id,
+      username: username,
+      posts: posts,
+      comments: comments,
+      settings: settings,
+      createdAt: nil,
+      updatedAt: nil,
+      user14SettingsId: user14SettingsId)
+  }
+  internal init(id: String = UUID().uuidString,
+      username: String,
+      posts: List<Post14>? = [],
+      comments: List<Comment14>? = [],
+      settings: UserSettings14? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil,
+      user14SettingsId: String? = nil) {
+      self.id = id
+      self.username = username
+      self.posts = posts
+      self.comments = comments
+      self._settings = LazyReference(settings)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+      self.user14SettingsId = user14SettingsId
+  }
+  public mutating func setSettings(_ settings: UserSettings14? = nil) {
+    self._settings = LazyReference(settings)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      username = try values.decode(String.self, forKey: .username)
+      posts = try values.decodeIfPresent(List<Post14>?.self, forKey: .posts) ?? .init()
+      comments = try values.decodeIfPresent(List<Comment14>?.self, forKey: .comments) ?? .init()
+      _settings = try values.decodeIfPresent(LazyReference<UserSettings14>.self, forKey: .settings) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+      user14SettingsId = try? values.decode(String?.self, forKey: .user14SettingsId)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(username, forKey: .username)
+      try container.encode(posts, forKey: .posts)
+      try container.encode(comments, forKey: .comments)
+      try container.encode(_settings, forKey: .settings)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+      try container.encode(user14SettingsId, forKey: .user14SettingsId)
+  }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/UserSettings14+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/UserSettings14+Schema.swift
@@ -1,0 +1,64 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension UserSettings14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case language
+    case user
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let userSettings14 = UserSettings14.keys
+    
+    model.authRules = [
+      rule(allow: .public, operations: [.create, .update, .delete, .read])
+    ]
+    
+    model.pluralName = "UserSettings14s"
+    
+    model.attributes(
+      .primaryKey(fields: [userSettings14.id])
+    )
+    
+    model.fields(
+      .field(userSettings14.id, is: .required, ofType: .string),
+      .field(userSettings14.language, is: .optional, ofType: .string),
+      .belongsTo(userSettings14.user, is: .required, ofType: User14.self, targetNames: ["userSettings14UserId"]),
+      .field(userSettings14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(userSettings14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<UserSettings14> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension UserSettings14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == UserSettings14 {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var language: FieldPath<String>   {
+      string("language") 
+    }
+  public var user: ModelPath<User14>   {
+      User14.Path(name: "user", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/UserSettings14.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL14/UserSettings14.swift
@@ -1,0 +1,56 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct UserSettings14: Model {
+  public let id: String
+  public var language: String?
+  internal var _user: LazyReference<User14>
+  public var user: User14   {
+      get async throws { 
+        try await _user.require()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      language: String? = nil,
+      user: User14) {
+    self.init(id: id,
+      language: language,
+      user: user,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      language: String? = nil,
+      user: User14,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.language = language
+      self._user = LazyReference(user)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setUser(_ user: User14) {
+    self._user = LazyReference(user)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      language = try? values.decode(String?.self, forKey: .language)
+      _user = try values.decodeIfPresent(LazyReference<User14>.self, forKey: .user) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(language, forKey: .language)
+      try container.encode(_user, forKey: .user)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/EnumTestModel+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/EnumTestModel+Schema.swift
@@ -1,0 +1,62 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension EnumTestModel {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case enumVal
+    case nullableEnumVal
+    case enumList
+    case enumNullableList
+    case nullableEnumList
+    case nullableEnumNullableList
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let enumTestModel = EnumTestModel.keys
+    
+    model.pluralName = "EnumTestModels"
+    
+    model.attributes(
+      .primaryKey(fields: [enumTestModel.id])
+    )
+    
+    model.fields(
+      .field(enumTestModel.id, is: .required, ofType: .string),
+      .field(enumTestModel.enumVal, is: .required, ofType: .enum(type: TestEnum.self)),
+      .field(enumTestModel.nullableEnumVal, is: .optional, ofType: .enum(type: TestEnum.self)),
+      .field(enumTestModel.enumList, is: .required, ofType: .embeddedCollection(of: TestEnum.self)),
+      .field(enumTestModel.enumNullableList, is: .optional, ofType: .embeddedCollection(of: TestEnum.self)),
+      .field(enumTestModel.nullableEnumList, is: .required, ofType: .embeddedCollection(of: TestEnum.self)),
+      .field(enumTestModel.nullableEnumNullableList, is: .optional, ofType: .embeddedCollection(of: TestEnum.self)),
+      .field(enumTestModel.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(enumTestModel.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<EnumTestModel> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension EnumTestModel: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == EnumTestModel {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/EnumTestModel.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/EnumTestModel.swift
@@ -1,0 +1,52 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct EnumTestModel: Model {
+  public let id: String
+  public var enumVal: TestEnum
+  public var nullableEnumVal: TestEnum?
+  public var enumList: [TestEnum]
+  public var enumNullableList: [TestEnum]?
+  public var nullableEnumList: [TestEnum?]
+  public var nullableEnumNullableList: [TestEnum?]?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      enumVal: TestEnum,
+      nullableEnumVal: TestEnum? = nil,
+      enumList: [TestEnum] = [],
+      enumNullableList: [TestEnum]? = nil,
+      nullableEnumList: [TestEnum?] = [],
+      nullableEnumNullableList: [TestEnum?]? = nil) {
+    self.init(id: id,
+      enumVal: enumVal,
+      nullableEnumVal: nullableEnumVal,
+      enumList: enumList,
+      enumNullableList: enumNullableList,
+      nullableEnumList: nullableEnumList,
+      nullableEnumNullableList: nullableEnumNullableList,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      enumVal: TestEnum,
+      nullableEnumVal: TestEnum? = nil,
+      enumList: [TestEnum] = [],
+      enumNullableList: [TestEnum]? = nil,
+      nullableEnumList: [TestEnum?] = [],
+      nullableEnumNullableList: [TestEnum?]? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.enumVal = enumVal
+      self.nullableEnumVal = nullableEnumVal
+      self.enumList = enumList
+      self.enumNullableList = enumNullableList
+      self.nullableEnumList = nullableEnumList
+      self.nullableEnumNullableList = nullableEnumNullableList
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/ListIntContainer+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/ListIntContainer+Schema.swift
@@ -1,0 +1,80 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension ListIntContainer {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case test
+    case nullableInt
+    case intList
+    case intNullableList
+    case nullableIntList
+    case nullableIntNullableList
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let listIntContainer = ListIntContainer.keys
+    
+    model.pluralName = "ListIntContainers"
+    
+    model.attributes(
+      .primaryKey(fields: [listIntContainer.id])
+    )
+    
+    model.fields(
+      .field(listIntContainer.id, is: .required, ofType: .string),
+      .field(listIntContainer.test, is: .required, ofType: .int),
+      .field(listIntContainer.nullableInt, is: .optional, ofType: .int),
+      .field(listIntContainer.intList, is: .required, ofType: .embeddedCollection(of: Int.self)),
+      .field(listIntContainer.intNullableList, is: .optional, ofType: .embeddedCollection(of: Int.self)),
+      .field(listIntContainer.nullableIntList, is: .required, ofType: .embeddedCollection(of: Int.self)),
+      .field(listIntContainer.nullableIntNullableList, is: .optional, ofType: .embeddedCollection(of: Int.self)),
+      .field(listIntContainer.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(listIntContainer.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<ListIntContainer> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension ListIntContainer: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == ListIntContainer {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var test: FieldPath<Int>   {
+      int("test") 
+    }
+  public var nullableInt: FieldPath<Int>   {
+      int("nullableInt") 
+    }
+  public var intList: FieldPath<Int>   {
+      int("intList") 
+    }
+  public var intNullableList: FieldPath<Int>   {
+      int("intNullableList") 
+    }
+  public var nullableIntList: FieldPath<Int>   {
+      int("nullableIntList") 
+    }
+  public var nullableIntNullableList: FieldPath<Int>   {
+      int("nullableIntNullableList") 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/ListIntContainer.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/ListIntContainer.swift
@@ -1,0 +1,52 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct ListIntContainer: Model {
+  public let id: String
+  public var test: Int
+  public var nullableInt: Int?
+  public var intList: [Int]
+  public var intNullableList: [Int]?
+  public var nullableIntList: [Int?]
+  public var nullableIntNullableList: [Int?]?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      test: Int,
+      nullableInt: Int? = nil,
+      intList: [Int] = [],
+      intNullableList: [Int]? = nil,
+      nullableIntList: [Int?] = [],
+      nullableIntNullableList: [Int?]? = nil) {
+    self.init(id: id,
+      test: test,
+      nullableInt: nullableInt,
+      intList: intList,
+      intNullableList: intNullableList,
+      nullableIntList: nullableIntList,
+      nullableIntNullableList: nullableIntNullableList,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      test: Int,
+      nullableInt: Int? = nil,
+      intList: [Int] = [],
+      intNullableList: [Int]? = nil,
+      nullableIntList: [Int?] = [],
+      nullableIntNullableList: [Int?]? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.test = test
+      self.nullableInt = nullableInt
+      self.intList = intList
+      self.intNullableList = intNullableList
+      self.nullableIntList = nullableIntList
+      self.nullableIntNullableList = nullableIntNullableList
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/ListStringContainer+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/ListStringContainer+Schema.swift
@@ -1,0 +1,80 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension ListStringContainer {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case test
+    case nullableString
+    case stringList
+    case stringNullableList
+    case nullableStringList
+    case nullableStringNullableList
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let listStringContainer = ListStringContainer.keys
+    
+    model.pluralName = "ListStringContainers"
+    
+    model.attributes(
+      .primaryKey(fields: [listStringContainer.id])
+    )
+    
+    model.fields(
+      .field(listStringContainer.id, is: .required, ofType: .string),
+      .field(listStringContainer.test, is: .required, ofType: .string),
+      .field(listStringContainer.nullableString, is: .optional, ofType: .string),
+      .field(listStringContainer.stringList, is: .required, ofType: .embeddedCollection(of: String.self)),
+      .field(listStringContainer.stringNullableList, is: .optional, ofType: .embeddedCollection(of: String.self)),
+      .field(listStringContainer.nullableStringList, is: .required, ofType: .embeddedCollection(of: String.self)),
+      .field(listStringContainer.nullableStringNullableList, is: .optional, ofType: .embeddedCollection(of: String.self)),
+      .field(listStringContainer.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(listStringContainer.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<ListStringContainer> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension ListStringContainer: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == ListStringContainer {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var test: FieldPath<String>   {
+      string("test") 
+    }
+  public var nullableString: FieldPath<String>   {
+      string("nullableString") 
+    }
+  public var stringList: FieldPath<String>   {
+      string("stringList") 
+    }
+  public var stringNullableList: FieldPath<String>   {
+      string("stringNullableList") 
+    }
+  public var nullableStringList: FieldPath<String>   {
+      string("nullableStringList") 
+    }
+  public var nullableStringNullableList: FieldPath<String>   {
+      string("nullableStringNullableList") 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/ListStringContainer.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/ListStringContainer.swift
@@ -1,0 +1,52 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct ListStringContainer: Model {
+  public let id: String
+  public var test: String
+  public var nullableString: String?
+  public var stringList: [String]
+  public var stringNullableList: [String]?
+  public var nullableStringList: [String?]
+  public var nullableStringNullableList: [String?]?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      test: String,
+      nullableString: String? = nil,
+      stringList: [String] = [],
+      stringNullableList: [String]? = nil,
+      nullableStringList: [String?] = [],
+      nullableStringNullableList: [String?]? = nil) {
+    self.init(id: id,
+      test: test,
+      nullableString: nullableString,
+      stringList: stringList,
+      stringNullableList: stringNullableList,
+      nullableStringList: nullableStringList,
+      nullableStringNullableList: nullableStringNullableList,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      test: String,
+      nullableString: String? = nil,
+      stringList: [String] = [],
+      stringNullableList: [String]? = nil,
+      nullableStringList: [String?] = [],
+      nullableStringNullableList: [String?]? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.test = test
+      self.nullableString = nullableString
+      self.stringList = stringList
+      self.stringNullableList = stringNullableList
+      self.nullableStringList = nullableStringList
+      self.nullableStringNullableList = nullableStringNullableList
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/Nested+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/Nested+Schema.swift
@@ -1,0 +1,25 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Nested {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case valueOne
+    case valueTwo
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let nested = Nested.keys
+    
+    model.pluralName = "Nesteds"
+    
+    model.fields(
+      .field(nested.valueOne, is: .optional, ofType: .int),
+      .field(nested.valueTwo, is: .optional, ofType: .string)
+    )
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/Nested.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/Nested.swift
@@ -1,0 +1,8 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Nested: Embeddable {
+  var valueOne: Int?
+  var valueTwo: String?
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/NestedTypeTestModel+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/NestedTypeTestModel+Schema.swift
@@ -1,0 +1,62 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension NestedTypeTestModel {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case nestedVal
+    case nullableNestedVal
+    case nestedList
+    case nestedNullableList
+    case nullableNestedList
+    case nullableNestedNullableList
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let nestedTypeTestModel = NestedTypeTestModel.keys
+    
+    model.pluralName = "NestedTypeTestModels"
+    
+    model.attributes(
+      .primaryKey(fields: [nestedTypeTestModel.id])
+    )
+    
+    model.fields(
+      .field(nestedTypeTestModel.id, is: .required, ofType: .string),
+      .field(nestedTypeTestModel.nestedVal, is: .required, ofType: .embedded(type: Nested.self)),
+      .field(nestedTypeTestModel.nullableNestedVal, is: .optional, ofType: .embedded(type: Nested.self)),
+      .field(nestedTypeTestModel.nestedList, is: .required, ofType: .embeddedCollection(of: Nested.self)),
+      .field(nestedTypeTestModel.nestedNullableList, is: .optional, ofType: .embeddedCollection(of: Nested.self)),
+      .field(nestedTypeTestModel.nullableNestedList, is: .required, ofType: .embeddedCollection(of: Nested.self)),
+      .field(nestedTypeTestModel.nullableNestedNullableList, is: .optional, ofType: .embeddedCollection(of: Nested.self)),
+      .field(nestedTypeTestModel.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(nestedTypeTestModel.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<NestedTypeTestModel> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension NestedTypeTestModel: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == NestedTypeTestModel {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/NestedTypeTestModel.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/NestedTypeTestModel.swift
@@ -1,0 +1,52 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct NestedTypeTestModel: Model {
+  public let id: String
+  public var nestedVal: Nested
+  public var nullableNestedVal: Nested?
+  public var nestedList: [Nested]
+  public var nestedNullableList: [Nested]?
+  public var nullableNestedList: [Nested?]
+  public var nullableNestedNullableList: [Nested?]?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      nestedVal: Nested,
+      nullableNestedVal: Nested? = nil,
+      nestedList: [Nested] = [],
+      nestedNullableList: [Nested]? = nil,
+      nullableNestedList: [Nested?] = [],
+      nullableNestedNullableList: [Nested?]? = nil) {
+    self.init(id: id,
+      nestedVal: nestedVal,
+      nullableNestedVal: nullableNestedVal,
+      nestedList: nestedList,
+      nestedNullableList: nestedNullableList,
+      nullableNestedList: nullableNestedList,
+      nullableNestedNullableList: nullableNestedNullableList,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      nestedVal: Nested,
+      nullableNestedVal: Nested? = nil,
+      nestedList: [Nested] = [],
+      nestedNullableList: [Nested]? = nil,
+      nullableNestedList: [Nested?] = [],
+      nullableNestedNullableList: [Nested?]? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.nestedVal = nestedVal
+      self.nullableNestedVal = nullableNestedVal
+      self.nestedList = nestedList
+      self.nestedNullableList = nestedNullableList
+      self.nullableNestedList = nullableNestedList
+      self.nullableNestedNullableList = nullableNestedNullableList
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/ScalarContainer+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/ScalarContainer+Schema.swift
@@ -1,0 +1,115 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension ScalarContainer {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case myString
+    case myInt
+    case myDouble
+    case myBool
+    case myDate
+    case myTime
+    case myDateTime
+    case myTimeStamp
+    case myEmail
+    case myJSON
+    case myPhone
+    case myURL
+    case myIPAddress
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let scalarContainer = ScalarContainer.keys
+    
+    model.pluralName = "ScalarContainers"
+    
+    model.attributes(
+      .primaryKey(fields: [scalarContainer.id])
+    )
+    
+    model.fields(
+      .field(scalarContainer.id, is: .required, ofType: .string),
+      .field(scalarContainer.myString, is: .optional, ofType: .string),
+      .field(scalarContainer.myInt, is: .optional, ofType: .int),
+      .field(scalarContainer.myDouble, is: .optional, ofType: .double),
+      .field(scalarContainer.myBool, is: .optional, ofType: .bool),
+      .field(scalarContainer.myDate, is: .optional, ofType: .date),
+      .field(scalarContainer.myTime, is: .optional, ofType: .time),
+      .field(scalarContainer.myDateTime, is: .optional, ofType: .dateTime),
+      .field(scalarContainer.myTimeStamp, is: .optional, ofType: .int),
+      .field(scalarContainer.myEmail, is: .optional, ofType: .string),
+      .field(scalarContainer.myJSON, is: .optional, ofType: .string),
+      .field(scalarContainer.myPhone, is: .optional, ofType: .string),
+      .field(scalarContainer.myURL, is: .optional, ofType: .string),
+      .field(scalarContainer.myIPAddress, is: .optional, ofType: .string),
+      .field(scalarContainer.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(scalarContainer.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<ScalarContainer> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension ScalarContainer: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == ScalarContainer {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var myString: FieldPath<String>   {
+      string("myString") 
+    }
+  public var myInt: FieldPath<Int>   {
+      int("myInt") 
+    }
+  public var myDouble: FieldPath<Double>   {
+      double("myDouble") 
+    }
+  public var myBool: FieldPath<Bool>   {
+      bool("myBool") 
+    }
+  public var myDate: FieldPath<Temporal.Date>   {
+      date("myDate") 
+    }
+  public var myTime: FieldPath<Temporal.Time>   {
+      time("myTime") 
+    }
+  public var myDateTime: FieldPath<Temporal.DateTime>   {
+      datetime("myDateTime") 
+    }
+  public var myTimeStamp: FieldPath<Int>   {
+      int("myTimeStamp") 
+    }
+  public var myEmail: FieldPath<String>   {
+      string("myEmail") 
+    }
+  public var myJSON: FieldPath<String>   {
+      string("myJSON") 
+    }
+  public var myPhone: FieldPath<String>   {
+      string("myPhone") 
+    }
+  public var myURL: FieldPath<String>   {
+      string("myURL") 
+    }
+  public var myIPAddress: FieldPath<String>   {
+      string("myIPAddress") 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/ScalarContainer.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/ScalarContainer.swift
@@ -1,0 +1,87 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct ScalarContainer: Model {
+  public let id: String
+  public var myString: String?
+  public var myInt: Int?
+  public var myDouble: Double?
+  public var myBool: Bool?
+  public var myDate: Temporal.Date?
+  public var myTime: Temporal.Time?
+  public var myDateTime: Temporal.DateTime?
+  public var myTimeStamp: Int?
+  public var myEmail: String?
+  public var myJSON: String?
+  public var myPhone: String?
+  public var myURL: String?
+  public var myIPAddress: String?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      myString: String? = nil,
+      myInt: Int? = nil,
+      myDouble: Double? = nil,
+      myBool: Bool? = nil,
+      myDate: Temporal.Date? = nil,
+      myTime: Temporal.Time? = nil,
+      myDateTime: Temporal.DateTime? = nil,
+      myTimeStamp: Int? = nil,
+      myEmail: String? = nil,
+      myJSON: String? = nil,
+      myPhone: String? = nil,
+      myURL: String? = nil,
+      myIPAddress: String? = nil) {
+    self.init(id: id,
+      myString: myString,
+      myInt: myInt,
+      myDouble: myDouble,
+      myBool: myBool,
+      myDate: myDate,
+      myTime: myTime,
+      myDateTime: myDateTime,
+      myTimeStamp: myTimeStamp,
+      myEmail: myEmail,
+      myJSON: myJSON,
+      myPhone: myPhone,
+      myURL: myURL,
+      myIPAddress: myIPAddress,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      myString: String? = nil,
+      myInt: Int? = nil,
+      myDouble: Double? = nil,
+      myBool: Bool? = nil,
+      myDate: Temporal.Date? = nil,
+      myTime: Temporal.Time? = nil,
+      myDateTime: Temporal.DateTime? = nil,
+      myTimeStamp: Int? = nil,
+      myEmail: String? = nil,
+      myJSON: String? = nil,
+      myPhone: String? = nil,
+      myURL: String? = nil,
+      myIPAddress: String? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.myString = myString
+      self.myInt = myInt
+      self.myDouble = myDouble
+      self.myBool = myBool
+      self.myDate = myDate
+      self.myTime = myTime
+      self.myDateTime = myDateTime
+      self.myTimeStamp = myTimeStamp
+      self.myEmail = myEmail
+      self.myJSON = myJSON
+      self.myPhone = myPhone
+      self.myURL = myURL
+      self.myIPAddress = myIPAddress
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/TestEnum.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL15/TestEnum.swift
@@ -1,0 +1,8 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public enum TestEnum: String, EnumPersistable {
+  case valueOne = "VALUE_ONE"
+  case valueTwo = "VALUE_TWO"
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/lazyload-schema.graphql
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/lazyload-schema.graphql
@@ -283,3 +283,40 @@ type Transcript @model {
   language: String
   phoneCall: PhoneCall @belongsTo
 }
+
+# LL.14
+
+enum PostStatus {
+  ACTIVE
+  INACTIVE
+}
+
+type User14 @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  username: String!
+  posts: [Post14] @hasMany
+  comments: [Comment14] @hasMany
+  settings: UserSettings14 @hasOne
+}
+
+type UserSettings14 @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  language: String
+  user: User14! @belongsTo
+}
+
+type Post14 @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  title: String!
+  rating: Int!
+  status: PostStatus!
+  comments: [Comment14] @hasMany
+  author: User14! @belongsTo
+}
+
+type Comment14 @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  content: String
+  post: Post14 @belongsTo
+  author: User14! @belongsTo
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/lazyload-schema.graphql
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/lazyload-schema.graphql
@@ -320,3 +320,72 @@ type Comment14 @model @auth(rules: [{allow: public}]) {
   post: Post14 @belongsTo
   author: User14! @belongsTo
 }
+
+## LL.15
+
+type ScalarContainer @model {
+   id: ID!
+   myString: String
+   myInt: Int
+   myDouble: Float
+   myBool: Boolean
+   myDate: AWSDate
+   myTime: AWSTime
+   myDateTime: AWSDateTime
+   myTimeStamp: AWSTimestamp
+   myEmail: AWSEmail
+   myJSON: AWSJSON
+   myPhone: AWSPhone
+   myURL: AWSURL
+   myIPAddress: AWSIPAddress
+}
+
+type ListIntContainer @model {
+  id: ID!
+  test: Int!
+  nullableInt: Int
+  intList: [Int!]!
+  intNullableList: [Int!]
+  nullableIntList: [Int]!
+  nullableIntNullableList: [Int]
+}
+
+type ListStringContainer @model {
+  id: ID!
+  test: String!
+  nullableString: String
+  stringList: [String!]!
+  stringNullableList: [String!]
+  nullableStringList: [String]!
+  nullableStringNullableList: [String]
+}
+
+type EnumTestModel @model {
+  id: ID!
+  enumVal: TestEnum!
+  nullableEnumVal: TestEnum
+  enumList: [TestEnum!]!
+  enumNullableList: [TestEnum!]
+  nullableEnumList: [TestEnum]!
+  nullableEnumNullableList: [TestEnum]
+}
+
+enum TestEnum {
+  VALUE_ONE
+  VALUE_TWO
+}
+
+type NestedTypeTestModel @model {
+  id: ID!
+  nestedVal: Nested!
+  nullableNestedVal: Nested
+  nestedList: [Nested!]!
+  nestedNullableList: [Nested!]
+  nullableNestedList: [Nested]!
+  nullableNestedNullableList: [Nested]
+}
+
+type Nested {
+  valueOne: Int
+  valueTwo: String
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/AWSDataStoreLazyLoadUserPostCommentTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/AWSDataStoreLazyLoadUserPostCommentTests.swift
@@ -47,9 +47,64 @@ final class AWSDataStoreLazyLoadUserPostCommentTests: AWSDataStoreLazyLoadBaseTe
         let savedUser = try await saveAndWaitForSync(user)
         let post = Post(title: "title", rating: 1, status: .active, author: savedUser)
         let savedPost = try await saveAndWaitForSync(post)
-        
         let comment = Comment(content: "content", post: savedPost, author: savedUser)
         try await saveAndWaitForSync(comment)
+    }
+    
+    /// LazyLoad from queried models
+    ///
+    /// - Given: Saved and synced models
+    /// - When:
+    ///    - Querying for models
+    /// - Then:
+    ///    - Traversing from the models to its connected models are successful
+    ///
+    func testLazyLoad() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        let savedUser = try await saveAndWaitForSync(user)
+        let userSettings = UserSettings(language: "en-us", user: savedUser)
+        try await saveAndWaitForSync(userSettings)
+        let post = Post(title: "title", rating: 1, status: .active, author: savedUser)
+        let savedPost = try await saveAndWaitForSync(post)
+        let comment = Comment(content: "content", post: savedPost, author: savedUser)
+        try await saveAndWaitForSync(comment)
+        
+        // Traverse from User
+        let queriedUser = try await query(for: user)
+        try await queriedUser.posts?.fetch()
+        XCTAssertEqual(queriedUser.posts?.count, 1)
+        try await queriedUser.comments?.fetch()
+        XCTAssertEqual(queriedUser.comments?.count, 1)
+        // Cannot traverse from User to settings
+        //let queriedUserSettings = try await queriedUser.settings
+        //XCTAssertNotNil(queriedUserSettings)
+        
+        // Traverse from UserSettings
+        let queriedSettings = try await query(for: userSettings)
+        let queriedSettingsUser = try await queriedSettings.user
+        XCTAssertEqual(queriedSettingsUser.id, user.id)
+        
+        // Traverse from Post
+        let queriedPost = try await query(for: post)
+        try await queriedPost.comments?.fetch()
+        XCTAssertEqual(queriedPost.comments?.count, 1)
+        let queriedPostUser = try await queriedPost.author
+        XCTAssertEqual(queriedPostUser.id, user.id)
+        
+        // Traverse from Comment
+        let queriedComment = try await query(for: comment)
+        let queriedCommentPost = try await queriedComment.post
+        XCTAssertEqual(queriedCommentPost?.id, post.id)
+        let queriedCommentUser = try await queriedComment.author
+        XCTAssertEqual(queriedCommentUser.id, user.id)
+        
+        // Clean up - delete the saved models
+        try await deleteAndWaitForSync(user)
+        try await assertModelDoesNotExist(comment)
+        try await assertModelDoesNotExist(post)
+        try await assertModelDoesNotExist(userSettings)
+        try await assertModelDoesNotExist(user)
     }
 }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/AWSDataStoreLazyLoadUserPostCommentTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/AWSDataStoreLazyLoadUserPostCommentTests.swift
@@ -1,0 +1,72 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Combine
+import XCTest
+
+@testable import Amplify
+
+final class AWSDataStoreLazyLoadUserPostCommentTests: AWSDataStoreLazyLoadBaseTest {
+
+    func testStart() async throws {
+        await setup(withModels: UserPostCommentModels())
+        try await startAndWaitForReady()
+    }
+
+    func testSaveUser() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        try await saveAndWaitForSync(user)
+    }
+    
+    func testSaveUserSettings() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        let savedUser = try await saveAndWaitForSync(user)
+        
+        let userSettings = UserSettings(language: "en-us", user: savedUser)
+        try await saveAndWaitForSync(userSettings)
+    }
+    
+    func testSavePost() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        let savedUser = try await saveAndWaitForSync(user)
+        let post = Post(title: "title", rating: 1, status: .active, author: savedUser)
+        try await saveAndWaitForSync(post)
+    }
+    
+    func testSaveComment() async throws {
+        await setup(withModels: UserPostCommentModels())
+        let user = User(username: "name")
+        let savedUser = try await saveAndWaitForSync(user)
+        let post = Post(title: "title", rating: 1, status: .active, author: savedUser)
+        let savedPost = try await saveAndWaitForSync(post)
+        
+        let comment = Comment(content: "content", post: savedPost, author: savedUser)
+        try await saveAndWaitForSync(comment)
+    }
+}
+
+
+extension AWSDataStoreLazyLoadUserPostCommentTests {
+    typealias User = User14
+    typealias Post = Post14
+    typealias Comment = Comment14
+    typealias UserSettings = UserSettings14
+    
+    struct UserPostCommentModels: AmplifyModelRegistration {
+        public let version: String = "version"
+        func registerModels(registry: ModelRegistry.Type) {
+            ModelRegistry.register(modelType: User14.self)
+            ModelRegistry.register(modelType: Post14.self)
+            ModelRegistry.register(modelType: Comment14.self)
+            ModelRegistry.register(modelType: UserSettings14.self)
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/Comment14+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/Comment14+Schema.swift
@@ -1,0 +1,69 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Comment14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case content
+    case post
+    case author
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let comment14 = Comment14.keys
+    
+    model.authRules = [
+      rule(allow: .public, operations: [.create, .update, .delete, .read])
+    ]
+    
+    model.pluralName = "Comment14s"
+    
+    model.attributes(
+      .primaryKey(fields: [comment14.id])
+    )
+    
+    model.fields(
+      .field(comment14.id, is: .required, ofType: .string),
+      .field(comment14.content, is: .optional, ofType: .string),
+      .belongsTo(comment14.post, is: .optional, ofType: Post14.self, targetNames: ["post14CommentsId"]),
+      .belongsTo(comment14.author, is: .required, ofType: User14.self, targetNames: ["user14CommentsId"]),
+      .field(comment14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(comment14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Comment14> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Comment14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == Comment14 {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var content: FieldPath<String>   {
+      string("content") 
+    }
+  public var post: ModelPath<Post14>   {
+      Post14.Path(name: "post", parent: self) 
+    }
+  public var author: ModelPath<User14>   {
+      User14.Path(name: "author", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/Comment14.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/Comment14.swift
@@ -1,0 +1,71 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Comment14: Model {
+  public let id: String
+  public var content: String?
+  internal var _post: LazyReference<Post14>
+  public var post: Post14?   {
+      get async throws { 
+        try await _post.get()
+      } 
+    }
+  internal var _author: LazyReference<User14>
+  public var author: User14   {
+      get async throws { 
+        try await _author.require()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      content: String? = nil,
+      post: Post14? = nil,
+      author: User14) {
+    self.init(id: id,
+      content: content,
+      post: post,
+      author: author,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      content: String? = nil,
+      post: Post14? = nil,
+      author: User14,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.content = content
+      self._post = LazyReference(post)
+      self._author = LazyReference(author)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setPost(_ post: Post14? = nil) {
+    self._post = LazyReference(post)
+  }
+  public mutating func setAuthor(_ author: User14) {
+    self._author = LazyReference(author)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      content = try? values.decode(String?.self, forKey: .content)
+      _post = try values.decodeIfPresent(LazyReference<Post14>.self, forKey: .post) ?? LazyReference(identifiers: nil)
+      _author = try values.decodeIfPresent(LazyReference<User14>.self, forKey: .author) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(content, forKey: .content)
+      try container.encode(_post, forKey: .post)
+      try container.encode(_author, forKey: .author)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/Post14+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/Post14+Schema.swift
@@ -1,0 +1,76 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case title
+    case rating
+    case status
+    case comments
+    case author
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post14 = Post14.keys
+    
+    model.authRules = [
+      rule(allow: .public, operations: [.create, .update, .delete, .read])
+    ]
+    
+    model.pluralName = "Post14s"
+    
+    model.attributes(
+      .primaryKey(fields: [post14.id])
+    )
+    
+    model.fields(
+      .field(post14.id, is: .required, ofType: .string),
+      .field(post14.title, is: .required, ofType: .string),
+      .field(post14.rating, is: .required, ofType: .int),
+      .field(post14.status, is: .required, ofType: .enum(type: PostStatus.self)),
+      .hasMany(post14.comments, is: .optional, ofType: Comment14.self, associatedWith: Comment14.keys.post),
+      .belongsTo(post14.author, is: .required, ofType: User14.self, targetNames: ["user14PostsId"]),
+      .field(post14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<Post14> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension Post14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == Post14 {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var title: FieldPath<String>   {
+      string("title") 
+    }
+  public var rating: FieldPath<Int>   {
+      int("rating") 
+    }
+  public var comments: ModelPath<Comment14>   {
+      Comment14.Path(name: "comments", isCollection: true, parent: self) 
+    }
+  public var author: ModelPath<User14>   {
+      User14.Path(name: "author", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/Post14.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/Post14.swift
@@ -1,0 +1,77 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post14: Model {
+  public let id: String
+  public var title: String
+  public var rating: Int
+  public var status: PostStatus
+  public var comments: List<Comment14>?
+  internal var _author: LazyReference<User14>
+  public var author: User14   {
+      get async throws { 
+        try await _author.require()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      title: String,
+      rating: Int,
+      status: PostStatus,
+      comments: List<Comment14>? = [],
+      author: User14) {
+    self.init(id: id,
+      title: title,
+      rating: rating,
+      status: status,
+      comments: comments,
+      author: author,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      title: String,
+      rating: Int,
+      status: PostStatus,
+      comments: List<Comment14>? = [],
+      author: User14,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.title = title
+      self.rating = rating
+      self.status = status
+      self.comments = comments
+      self._author = LazyReference(author)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setAuthor(_ author: User14) {
+    self._author = LazyReference(author)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      title = try values.decode(String.self, forKey: .title)
+      rating = try values.decode(Int.self, forKey: .rating)
+      status = try values.decode(PostStatus.self, forKey: .status)
+      comments = try values.decodeIfPresent(List<Comment14>?.self, forKey: .comments) ?? .init()
+      _author = try values.decodeIfPresent(LazyReference<User14>.self, forKey: .author) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(title, forKey: .title)
+      try container.encode(rating, forKey: .rating)
+      try container.encode(status, forKey: .status)
+      try container.encode(comments, forKey: .comments)
+      try container.encode(_author, forKey: .author)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/PostStatus.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/PostStatus.swift
@@ -1,0 +1,8 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public enum PostStatus: String, EnumPersistable {
+  case active = "ACTIVE"
+  case inactive = "INACTIVE"
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/User14+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/User14+Schema.swift
@@ -1,0 +1,79 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension User14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case username
+    case posts
+    case comments
+    case settings
+    case createdAt
+    case updatedAt
+    case user14SettingsId
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let user14 = User14.keys
+    
+    model.authRules = [
+      rule(allow: .public, operations: [.create, .update, .delete, .read])
+    ]
+    
+    model.pluralName = "User14s"
+    
+    model.attributes(
+      .primaryKey(fields: [user14.id])
+    )
+    
+    model.fields(
+      .field(user14.id, is: .required, ofType: .string),
+      .field(user14.username, is: .required, ofType: .string),
+      .hasMany(user14.posts, is: .optional, ofType: Post14.self, associatedWith: Post14.keys.author),
+      .hasMany(user14.comments, is: .optional, ofType: Comment14.self, associatedWith: Comment14.keys.author),
+      .hasOne(user14.settings, is: .optional, ofType: UserSettings14.self, associatedWith: UserSettings14.keys.user, targetNames: ["user14SettingsId"]),
+      .field(user14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(user14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(user14.user14SettingsId, is: .optional, ofType: .string)
+    )
+    }
+    public class Path: ModelPath<User14> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension User14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == User14 {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var username: FieldPath<String>   {
+      string("username") 
+    }
+  public var posts: ModelPath<Post14>   {
+      Post14.Path(name: "posts", isCollection: true, parent: self) 
+    }
+  public var comments: ModelPath<Comment14>   {
+      Comment14.Path(name: "comments", isCollection: true, parent: self) 
+    }
+  public var settings: ModelPath<UserSettings14>   {
+      UserSettings14.Path(name: "settings", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+  public var user14SettingsId: FieldPath<String>   {
+      string("user14SettingsId") 
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/User14.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/User14.swift
@@ -1,0 +1,77 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct User14: Model {
+  public let id: String
+  public var username: String
+  public var posts: List<Post14>?
+  public var comments: List<Comment14>?
+  internal var _settings: LazyReference<UserSettings14>
+  public var settings: UserSettings14?   {
+      get async throws { 
+        try await _settings.get()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  public var user14SettingsId: String?
+  
+  public init(id: String = UUID().uuidString,
+      username: String,
+      posts: List<Post14>? = [],
+      comments: List<Comment14>? = [],
+      settings: UserSettings14? = nil,
+      user14SettingsId: String? = nil) {
+    self.init(id: id,
+      username: username,
+      posts: posts,
+      comments: comments,
+      settings: settings,
+      createdAt: nil,
+      updatedAt: nil,
+      user14SettingsId: user14SettingsId)
+  }
+  internal init(id: String = UUID().uuidString,
+      username: String,
+      posts: List<Post14>? = [],
+      comments: List<Comment14>? = [],
+      settings: UserSettings14? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil,
+      user14SettingsId: String? = nil) {
+      self.id = id
+      self.username = username
+      self.posts = posts
+      self.comments = comments
+      self._settings = LazyReference(settings)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+      self.user14SettingsId = user14SettingsId
+  }
+  public mutating func setSettings(_ settings: UserSettings14? = nil) {
+    self._settings = LazyReference(settings)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      username = try values.decode(String.self, forKey: .username)
+      posts = try values.decodeIfPresent(List<Post14>?.self, forKey: .posts) ?? .init()
+      comments = try values.decodeIfPresent(List<Comment14>?.self, forKey: .comments) ?? .init()
+      _settings = try values.decodeIfPresent(LazyReference<UserSettings14>.self, forKey: .settings) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+      user14SettingsId = try? values.decode(String?.self, forKey: .user14SettingsId)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(username, forKey: .username)
+      try container.encode(posts, forKey: .posts)
+      try container.encode(comments, forKey: .comments)
+      try container.encode(_settings, forKey: .settings)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+      try container.encode(user14SettingsId, forKey: .user14SettingsId)
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/UserSettings14+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/UserSettings14+Schema.swift
@@ -1,0 +1,64 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension UserSettings14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case language
+    case user
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let userSettings14 = UserSettings14.keys
+    
+    model.authRules = [
+      rule(allow: .public, operations: [.create, .update, .delete, .read])
+    ]
+    
+    model.pluralName = "UserSettings14s"
+    
+    model.attributes(
+      .primaryKey(fields: [userSettings14.id])
+    )
+    
+    model.fields(
+      .field(userSettings14.id, is: .required, ofType: .string),
+      .field(userSettings14.language, is: .optional, ofType: .string),
+      .belongsTo(userSettings14.user, is: .required, ofType: User14.self, targetNames: ["userSettings14UserId"]),
+      .field(userSettings14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(userSettings14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<UserSettings14> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension UserSettings14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == UserSettings14 {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var language: FieldPath<String>   {
+      string("language") 
+    }
+  public var user: ModelPath<User14>   {
+      User14.Path(name: "user", parent: self) 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/UserSettings14.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/UserSettings14.swift
@@ -1,0 +1,56 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct UserSettings14: Model {
+  public let id: String
+  public var language: String?
+  internal var _user: LazyReference<User14>
+  public var user: User14   {
+      get async throws { 
+        try await _user.require()
+      } 
+    }
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      language: String? = nil,
+      user: User14) {
+    self.init(id: id,
+      language: language,
+      user: user,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      language: String? = nil,
+      user: User14,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.language = language
+      self._user = LazyReference(user)
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+  public mutating func setUser(_ user: User14) {
+    self._user = LazyReference(user)
+  }
+  public init(from decoder: Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(String.self, forKey: .id)
+      language = try? values.decode(String?.self, forKey: .language)
+      _user = try values.decodeIfPresent(LazyReference<User14>.self, forKey: .user) ?? LazyReference(identifiers: nil)
+      createdAt = try? values.decode(Temporal.DateTime?.self, forKey: .createdAt)
+      updatedAt = try? values.decode(Temporal.DateTime?.self, forKey: .updatedAt)
+  }
+  public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(language, forKey: .language)
+      try container.encode(_user, forKey: .user)
+      try container.encode(createdAt, forKey: .createdAt)
+      try container.encode(updatedAt, forKey: .updatedAt)
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/EnumTestModel+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/EnumTestModel+Schema.swift
@@ -1,0 +1,62 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension EnumTestModel {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case enumVal
+    case nullableEnumVal
+    case enumList
+    case enumNullableList
+    case nullableEnumList
+    case nullableEnumNullableList
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let enumTestModel = EnumTestModel.keys
+    
+    model.pluralName = "EnumTestModels"
+    
+    model.attributes(
+      .primaryKey(fields: [enumTestModel.id])
+    )
+    
+    model.fields(
+      .field(enumTestModel.id, is: .required, ofType: .string),
+      .field(enumTestModel.enumVal, is: .required, ofType: .enum(type: TestEnum.self)),
+      .field(enumTestModel.nullableEnumVal, is: .optional, ofType: .enum(type: TestEnum.self)),
+      .field(enumTestModel.enumList, is: .required, ofType: .embeddedCollection(of: TestEnum.self)),
+      .field(enumTestModel.enumNullableList, is: .optional, ofType: .embeddedCollection(of: TestEnum.self)),
+      .field(enumTestModel.nullableEnumList, is: .required, ofType: .embeddedCollection(of: TestEnum.self)),
+      .field(enumTestModel.nullableEnumNullableList, is: .optional, ofType: .embeddedCollection(of: TestEnum.self)),
+      .field(enumTestModel.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(enumTestModel.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<EnumTestModel> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension EnumTestModel: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == EnumTestModel {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/EnumTestModel.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/EnumTestModel.swift
@@ -1,0 +1,52 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct EnumTestModel: Model {
+  public let id: String
+  public var enumVal: TestEnum
+  public var nullableEnumVal: TestEnum?
+  public var enumList: [TestEnum]
+  public var enumNullableList: [TestEnum]?
+  public var nullableEnumList: [TestEnum?]
+  public var nullableEnumNullableList: [TestEnum?]?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      enumVal: TestEnum,
+      nullableEnumVal: TestEnum? = nil,
+      enumList: [TestEnum] = [],
+      enumNullableList: [TestEnum]? = nil,
+      nullableEnumList: [TestEnum?] = [],
+      nullableEnumNullableList: [TestEnum?]? = nil) {
+    self.init(id: id,
+      enumVal: enumVal,
+      nullableEnumVal: nullableEnumVal,
+      enumList: enumList,
+      enumNullableList: enumNullableList,
+      nullableEnumList: nullableEnumList,
+      nullableEnumNullableList: nullableEnumNullableList,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      enumVal: TestEnum,
+      nullableEnumVal: TestEnum? = nil,
+      enumList: [TestEnum] = [],
+      enumNullableList: [TestEnum]? = nil,
+      nullableEnumList: [TestEnum?] = [],
+      nullableEnumNullableList: [TestEnum?]? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.enumVal = enumVal
+      self.nullableEnumVal = nullableEnumVal
+      self.enumList = enumList
+      self.enumNullableList = enumNullableList
+      self.nullableEnumList = nullableEnumList
+      self.nullableEnumNullableList = nullableEnumNullableList
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/ListIntContainer+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/ListIntContainer+Schema.swift
@@ -1,0 +1,80 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension ListIntContainer {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case test
+    case nullableInt
+    case intList
+    case intNullableList
+    case nullableIntList
+    case nullableIntNullableList
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let listIntContainer = ListIntContainer.keys
+    
+    model.pluralName = "ListIntContainers"
+    
+    model.attributes(
+      .primaryKey(fields: [listIntContainer.id])
+    )
+    
+    model.fields(
+      .field(listIntContainer.id, is: .required, ofType: .string),
+      .field(listIntContainer.test, is: .required, ofType: .int),
+      .field(listIntContainer.nullableInt, is: .optional, ofType: .int),
+      .field(listIntContainer.intList, is: .required, ofType: .embeddedCollection(of: Int.self)),
+      .field(listIntContainer.intNullableList, is: .optional, ofType: .embeddedCollection(of: Int.self)),
+      .field(listIntContainer.nullableIntList, is: .required, ofType: .embeddedCollection(of: Int.self)),
+      .field(listIntContainer.nullableIntNullableList, is: .optional, ofType: .embeddedCollection(of: Int.self)),
+      .field(listIntContainer.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(listIntContainer.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<ListIntContainer> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension ListIntContainer: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == ListIntContainer {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var test: FieldPath<Int>   {
+      int("test") 
+    }
+  public var nullableInt: FieldPath<Int>   {
+      int("nullableInt") 
+    }
+  public var intList: FieldPath<Int>   {
+      int("intList") 
+    }
+  public var intNullableList: FieldPath<Int>   {
+      int("intNullableList") 
+    }
+  public var nullableIntList: FieldPath<Int>   {
+      int("nullableIntList") 
+    }
+  public var nullableIntNullableList: FieldPath<Int>   {
+      int("nullableIntNullableList") 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/ListIntContainer.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/ListIntContainer.swift
@@ -1,0 +1,52 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct ListIntContainer: Model {
+  public let id: String
+  public var test: Int
+  public var nullableInt: Int?
+  public var intList: [Int]
+  public var intNullableList: [Int]?
+  public var nullableIntList: [Int?]
+  public var nullableIntNullableList: [Int?]?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      test: Int,
+      nullableInt: Int? = nil,
+      intList: [Int] = [],
+      intNullableList: [Int]? = nil,
+      nullableIntList: [Int?] = [],
+      nullableIntNullableList: [Int?]? = nil) {
+    self.init(id: id,
+      test: test,
+      nullableInt: nullableInt,
+      intList: intList,
+      intNullableList: intNullableList,
+      nullableIntList: nullableIntList,
+      nullableIntNullableList: nullableIntNullableList,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      test: Int,
+      nullableInt: Int? = nil,
+      intList: [Int] = [],
+      intNullableList: [Int]? = nil,
+      nullableIntList: [Int?] = [],
+      nullableIntNullableList: [Int?]? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.test = test
+      self.nullableInt = nullableInt
+      self.intList = intList
+      self.intNullableList = intNullableList
+      self.nullableIntList = nullableIntList
+      self.nullableIntNullableList = nullableIntNullableList
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/ListStringContainer+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/ListStringContainer+Schema.swift
@@ -1,0 +1,80 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension ListStringContainer {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case test
+    case nullableString
+    case stringList
+    case stringNullableList
+    case nullableStringList
+    case nullableStringNullableList
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let listStringContainer = ListStringContainer.keys
+    
+    model.pluralName = "ListStringContainers"
+    
+    model.attributes(
+      .primaryKey(fields: [listStringContainer.id])
+    )
+    
+    model.fields(
+      .field(listStringContainer.id, is: .required, ofType: .string),
+      .field(listStringContainer.test, is: .required, ofType: .string),
+      .field(listStringContainer.nullableString, is: .optional, ofType: .string),
+      .field(listStringContainer.stringList, is: .required, ofType: .embeddedCollection(of: String.self)),
+      .field(listStringContainer.stringNullableList, is: .optional, ofType: .embeddedCollection(of: String.self)),
+      .field(listStringContainer.nullableStringList, is: .required, ofType: .embeddedCollection(of: String.self)),
+      .field(listStringContainer.nullableStringNullableList, is: .optional, ofType: .embeddedCollection(of: String.self)),
+      .field(listStringContainer.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(listStringContainer.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<ListStringContainer> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension ListStringContainer: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == ListStringContainer {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var test: FieldPath<String>   {
+      string("test") 
+    }
+  public var nullableString: FieldPath<String>   {
+      string("nullableString") 
+    }
+  public var stringList: FieldPath<String>   {
+      string("stringList") 
+    }
+  public var stringNullableList: FieldPath<String>   {
+      string("stringNullableList") 
+    }
+  public var nullableStringList: FieldPath<String>   {
+      string("nullableStringList") 
+    }
+  public var nullableStringNullableList: FieldPath<String>   {
+      string("nullableStringNullableList") 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/ListStringContainer.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/ListStringContainer.swift
@@ -1,0 +1,52 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct ListStringContainer: Model {
+  public let id: String
+  public var test: String
+  public var nullableString: String?
+  public var stringList: [String]
+  public var stringNullableList: [String]?
+  public var nullableStringList: [String?]
+  public var nullableStringNullableList: [String?]?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      test: String,
+      nullableString: String? = nil,
+      stringList: [String] = [],
+      stringNullableList: [String]? = nil,
+      nullableStringList: [String?] = [],
+      nullableStringNullableList: [String?]? = nil) {
+    self.init(id: id,
+      test: test,
+      nullableString: nullableString,
+      stringList: stringList,
+      stringNullableList: stringNullableList,
+      nullableStringList: nullableStringList,
+      nullableStringNullableList: nullableStringNullableList,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      test: String,
+      nullableString: String? = nil,
+      stringList: [String] = [],
+      stringNullableList: [String]? = nil,
+      nullableStringList: [String?] = [],
+      nullableStringNullableList: [String?]? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.test = test
+      self.nullableString = nullableString
+      self.stringList = stringList
+      self.stringNullableList = stringNullableList
+      self.nullableStringList = nullableStringList
+      self.nullableStringNullableList = nullableStringNullableList
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/Nested+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/Nested+Schema.swift
@@ -1,0 +1,25 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Nested {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case valueOne
+    case valueTwo
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let nested = Nested.keys
+    
+    model.pluralName = "Nesteds"
+    
+    model.fields(
+      .field(nested.valueOne, is: .optional, ofType: .int),
+      .field(nested.valueTwo, is: .optional, ofType: .string)
+    )
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/Nested.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/Nested.swift
@@ -1,0 +1,8 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Nested: Embeddable {
+  var valueOne: Int?
+  var valueTwo: String?
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/NestedTypeTestModel+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/NestedTypeTestModel+Schema.swift
@@ -1,0 +1,62 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension NestedTypeTestModel {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case nestedVal
+    case nullableNestedVal
+    case nestedList
+    case nestedNullableList
+    case nullableNestedList
+    case nullableNestedNullableList
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let nestedTypeTestModel = NestedTypeTestModel.keys
+    
+    model.pluralName = "NestedTypeTestModels"
+    
+    model.attributes(
+      .primaryKey(fields: [nestedTypeTestModel.id])
+    )
+    
+    model.fields(
+      .field(nestedTypeTestModel.id, is: .required, ofType: .string),
+      .field(nestedTypeTestModel.nestedVal, is: .required, ofType: .embedded(type: Nested.self)),
+      .field(nestedTypeTestModel.nullableNestedVal, is: .optional, ofType: .embedded(type: Nested.self)),
+      .field(nestedTypeTestModel.nestedList, is: .required, ofType: .embeddedCollection(of: Nested.self)),
+      .field(nestedTypeTestModel.nestedNullableList, is: .optional, ofType: .embeddedCollection(of: Nested.self)),
+      .field(nestedTypeTestModel.nullableNestedList, is: .required, ofType: .embeddedCollection(of: Nested.self)),
+      .field(nestedTypeTestModel.nullableNestedNullableList, is: .optional, ofType: .embeddedCollection(of: Nested.self)),
+      .field(nestedTypeTestModel.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(nestedTypeTestModel.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<NestedTypeTestModel> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension NestedTypeTestModel: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == NestedTypeTestModel {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/NestedTypeTestModel.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/NestedTypeTestModel.swift
@@ -1,0 +1,52 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct NestedTypeTestModel: Model {
+  public let id: String
+  public var nestedVal: Nested
+  public var nullableNestedVal: Nested?
+  public var nestedList: [Nested]
+  public var nestedNullableList: [Nested]?
+  public var nullableNestedList: [Nested?]
+  public var nullableNestedNullableList: [Nested?]?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      nestedVal: Nested,
+      nullableNestedVal: Nested? = nil,
+      nestedList: [Nested] = [],
+      nestedNullableList: [Nested]? = nil,
+      nullableNestedList: [Nested?] = [],
+      nullableNestedNullableList: [Nested?]? = nil) {
+    self.init(id: id,
+      nestedVal: nestedVal,
+      nullableNestedVal: nullableNestedVal,
+      nestedList: nestedList,
+      nestedNullableList: nestedNullableList,
+      nullableNestedList: nullableNestedList,
+      nullableNestedNullableList: nullableNestedNullableList,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      nestedVal: Nested,
+      nullableNestedVal: Nested? = nil,
+      nestedList: [Nested] = [],
+      nestedNullableList: [Nested]? = nil,
+      nullableNestedList: [Nested?] = [],
+      nullableNestedNullableList: [Nested?]? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.nestedVal = nestedVal
+      self.nullableNestedVal = nullableNestedVal
+      self.nestedList = nestedList
+      self.nestedNullableList = nestedNullableList
+      self.nullableNestedList = nullableNestedList
+      self.nullableNestedNullableList = nullableNestedNullableList
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/ScalarContainer+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/ScalarContainer+Schema.swift
@@ -1,0 +1,115 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension ScalarContainer {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case myString
+    case myInt
+    case myDouble
+    case myBool
+    case myDate
+    case myTime
+    case myDateTime
+    case myTimeStamp
+    case myEmail
+    case myJSON
+    case myPhone
+    case myURL
+    case myIPAddress
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let scalarContainer = ScalarContainer.keys
+    
+    model.pluralName = "ScalarContainers"
+    
+    model.attributes(
+      .primaryKey(fields: [scalarContainer.id])
+    )
+    
+    model.fields(
+      .field(scalarContainer.id, is: .required, ofType: .string),
+      .field(scalarContainer.myString, is: .optional, ofType: .string),
+      .field(scalarContainer.myInt, is: .optional, ofType: .int),
+      .field(scalarContainer.myDouble, is: .optional, ofType: .double),
+      .field(scalarContainer.myBool, is: .optional, ofType: .bool),
+      .field(scalarContainer.myDate, is: .optional, ofType: .date),
+      .field(scalarContainer.myTime, is: .optional, ofType: .time),
+      .field(scalarContainer.myDateTime, is: .optional, ofType: .dateTime),
+      .field(scalarContainer.myTimeStamp, is: .optional, ofType: .int),
+      .field(scalarContainer.myEmail, is: .optional, ofType: .string),
+      .field(scalarContainer.myJSON, is: .optional, ofType: .string),
+      .field(scalarContainer.myPhone, is: .optional, ofType: .string),
+      .field(scalarContainer.myURL, is: .optional, ofType: .string),
+      .field(scalarContainer.myIPAddress, is: .optional, ofType: .string),
+      .field(scalarContainer.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(scalarContainer.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+    public class Path: ModelPath<ScalarContainer> { }
+    
+    public static var rootPath: PropertyContainerPath? { Path() }
+}
+
+extension ScalarContainer: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}
+extension ModelPath where ModelType == ScalarContainer {
+  public var id: FieldPath<String>   {
+      string("id") 
+    }
+  public var myString: FieldPath<String>   {
+      string("myString") 
+    }
+  public var myInt: FieldPath<Int>   {
+      int("myInt") 
+    }
+  public var myDouble: FieldPath<Double>   {
+      double("myDouble") 
+    }
+  public var myBool: FieldPath<Bool>   {
+      bool("myBool") 
+    }
+  public var myDate: FieldPath<Temporal.Date>   {
+      date("myDate") 
+    }
+  public var myTime: FieldPath<Temporal.Time>   {
+      time("myTime") 
+    }
+  public var myDateTime: FieldPath<Temporal.DateTime>   {
+      datetime("myDateTime") 
+    }
+  public var myTimeStamp: FieldPath<Int>   {
+      int("myTimeStamp") 
+    }
+  public var myEmail: FieldPath<String>   {
+      string("myEmail") 
+    }
+  public var myJSON: FieldPath<String>   {
+      string("myJSON") 
+    }
+  public var myPhone: FieldPath<String>   {
+      string("myPhone") 
+    }
+  public var myURL: FieldPath<String>   {
+      string("myURL") 
+    }
+  public var myIPAddress: FieldPath<String>   {
+      string("myIPAddress") 
+    }
+  public var createdAt: FieldPath<Temporal.DateTime>   {
+      datetime("createdAt") 
+    }
+  public var updatedAt: FieldPath<Temporal.DateTime>   {
+      datetime("updatedAt") 
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/ScalarContainer.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/ScalarContainer.swift
@@ -1,0 +1,87 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct ScalarContainer: Model {
+  public let id: String
+  public var myString: String?
+  public var myInt: Int?
+  public var myDouble: Double?
+  public var myBool: Bool?
+  public var myDate: Temporal.Date?
+  public var myTime: Temporal.Time?
+  public var myDateTime: Temporal.DateTime?
+  public var myTimeStamp: Int?
+  public var myEmail: String?
+  public var myJSON: String?
+  public var myPhone: String?
+  public var myURL: String?
+  public var myIPAddress: String?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      myString: String? = nil,
+      myInt: Int? = nil,
+      myDouble: Double? = nil,
+      myBool: Bool? = nil,
+      myDate: Temporal.Date? = nil,
+      myTime: Temporal.Time? = nil,
+      myDateTime: Temporal.DateTime? = nil,
+      myTimeStamp: Int? = nil,
+      myEmail: String? = nil,
+      myJSON: String? = nil,
+      myPhone: String? = nil,
+      myURL: String? = nil,
+      myIPAddress: String? = nil) {
+    self.init(id: id,
+      myString: myString,
+      myInt: myInt,
+      myDouble: myDouble,
+      myBool: myBool,
+      myDate: myDate,
+      myTime: myTime,
+      myDateTime: myDateTime,
+      myTimeStamp: myTimeStamp,
+      myEmail: myEmail,
+      myJSON: myJSON,
+      myPhone: myPhone,
+      myURL: myURL,
+      myIPAddress: myIPAddress,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      myString: String? = nil,
+      myInt: Int? = nil,
+      myDouble: Double? = nil,
+      myBool: Bool? = nil,
+      myDate: Temporal.Date? = nil,
+      myTime: Temporal.Time? = nil,
+      myDateTime: Temporal.DateTime? = nil,
+      myTimeStamp: Int? = nil,
+      myEmail: String? = nil,
+      myJSON: String? = nil,
+      myPhone: String? = nil,
+      myURL: String? = nil,
+      myIPAddress: String? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.myString = myString
+      self.myInt = myInt
+      self.myDouble = myDouble
+      self.myBool = myBool
+      self.myDate = myDate
+      self.myTime = myTime
+      self.myDateTime = myDateTime
+      self.myTimeStamp = myTimeStamp
+      self.myEmail = myEmail
+      self.myJSON = myJSON
+      self.myPhone = myPhone
+      self.myURL = myURL
+      self.myIPAddress = myIPAddress
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/TestEnum.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL15/TestEnum.swift
@@ -1,0 +1,8 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public enum TestEnum: String, EnumPersistable {
+  case valueOne = "VALUE_ONE"
+  case valueTwo = "VALUE_TWO"
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/lazyload-schema.graphql
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/lazyload-schema.graphql
@@ -283,3 +283,40 @@ type Transcript @model {
   language: String
   phoneCall: PhoneCall @belongsTo
 }
+
+# LL.14
+
+enum PostStatus {
+  ACTIVE
+  INACTIVE
+}
+
+type User14 @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  username: String!
+  posts: [Post14] @hasMany
+  comments: [Comment14] @hasMany
+  settings: UserSettings14 @hasOne
+}
+
+type UserSettings14 @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  language: String
+  user: User14! @belongsTo
+}
+
+type Post14 @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  title: String!
+  rating: Int!
+  status: PostStatus!
+  comments: [Comment14] @hasMany
+  author: User14! @belongsTo
+}
+
+type Comment14 @model @auth(rules: [{allow: public}]) {
+  id: ID!
+  content: String
+  post: Post14 @belongsTo
+  author: User14! @belongsTo
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/lazyload-schema.graphql
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/lazyload-schema.graphql
@@ -320,3 +320,72 @@ type Comment14 @model @auth(rules: [{allow: public}]) {
   post: Post14 @belongsTo
   author: User14! @belongsTo
 }
+
+## LL.15
+
+type ScalarContainer @model {
+   id: ID!
+   myString: String
+   myInt: Int
+   myDouble: Float
+   myBool: Boolean
+   myDate: AWSDate
+   myTime: AWSTime
+   myDateTime: AWSDateTime
+   myTimeStamp: AWSTimestamp
+   myEmail: AWSEmail
+   myJSON: AWSJSON
+   myPhone: AWSPhone
+   myURL: AWSURL
+   myIPAddress: AWSIPAddress
+}
+
+type ListIntContainer @model {
+  id: ID!
+  test: Int!
+  nullableInt: Int
+  intList: [Int!]!
+  intNullableList: [Int!]
+  nullableIntList: [Int]!
+  nullableIntNullableList: [Int]
+}
+
+type ListStringContainer @model {
+  id: ID!
+  test: String!
+  nullableString: String
+  stringList: [String!]!
+  stringNullableList: [String!]
+  nullableStringList: [String]!
+  nullableStringNullableList: [String]
+}
+
+type EnumTestModel @model {
+  id: ID!
+  enumVal: TestEnum!
+  nullableEnumVal: TestEnum
+  enumList: [TestEnum!]!
+  enumNullableList: [TestEnum!]
+  nullableEnumList: [TestEnum]!
+  nullableEnumNullableList: [TestEnum]
+}
+
+enum TestEnum {
+  VALUE_ONE
+  VALUE_TWO
+}
+
+type NestedTypeTestModel @model {
+  id: ID!
+  nestedVal: Nested!
+  nullableNestedVal: Nested
+  nestedList: [Nested!]!
+  nestedNullableList: [Nested!]
+  nullableNestedList: [Nested]!
+  nullableNestedNullableList: [Nested]
+}
+
+type Nested {
+  valueOne: Int
+  valueTwo: String
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
@@ -497,6 +497,16 @@
 		21BC10CF296DDB4B000E189E /* Post4V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10CB296DDB4B000E189E /* Post4V2.swift */; };
 		21BC10D0296DDB4B000E189E /* Post4V2+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10CC296DDB4B000E189E /* Post4V2+Schema.swift */; };
 		21BC10D2296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10D1296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift */; };
+		21BC11062971A82A000E189E /* PostStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10FD2971A82A000E189E /* PostStatus.swift */; };
+		21BC11072971A82A000E189E /* Post14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10FE2971A82A000E189E /* Post14.swift */; };
+		21BC11082971A82A000E189E /* User14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10FF2971A82A000E189E /* User14.swift */; };
+		21BC11092971A82A000E189E /* UserSettings14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11002971A82A000E189E /* UserSettings14.swift */; };
+		21BC110A2971A82A000E189E /* Comment14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11012971A82A000E189E /* Comment14+Schema.swift */; };
+		21BC110B2971A82A000E189E /* Comment14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11022971A82A000E189E /* Comment14.swift */; };
+		21BC110C2971A82A000E189E /* Post14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11032971A82A000E189E /* Post14+Schema.swift */; };
+		21BC110D2971A82A000E189E /* User14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11042971A82A000E189E /* User14+Schema.swift */; };
+		21BC110E2971A82A000E189E /* UserSettings14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC11052971A82A000E189E /* UserSettings14+Schema.swift */; };
+		21BC11102971A87F000E189E /* AWSDataStoreLazyLoadUserPostCommentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC110F2971A87F000E189E /* AWSDataStoreLazyLoadUserPostCommentTests.swift */; };
 		21C3C4C1293FD9BD009194A0 /* AWSDataStoreLazyLoadDefaultPKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C3C4C0293FD9BD009194A0 /* AWSDataStoreLazyLoadDefaultPKTests.swift */; };
 		21C3C4C3293FD9FF009194A0 /* AWSDataStoreLazyLoadHasOneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C3C4C2293FD9FF009194A0 /* AWSDataStoreLazyLoadHasOneTests.swift */; };
 		21C3C4C5293FDA12009194A0 /* AWSDataStoreLazyLoadCompositePKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C3C4C4293FDA12009194A0 /* AWSDataStoreLazyLoadCompositePKTests.swift */; };
@@ -507,6 +517,11 @@
 		21DFAEA3295F4E8600B4A883 /* PhoneCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAE9D295F4E8600B4A883 /* PhoneCall.swift */; };
 		21DFAEA4295F4E8600B4A883 /* Transcript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAE9E295F4E8600B4A883 /* Transcript.swift */; };
 		21DFAEA6295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAEA5295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift */; };
+		21BC10CD296DDB4B000E189E /* Comment4V2+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10C9296DDB4B000E189E /* Comment4V2+Schema.swift */; };
+		21BC10CE296DDB4B000E189E /* Comment4V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10CA296DDB4B000E189E /* Comment4V2.swift */; };
+		21BC10CF296DDB4B000E189E /* Post4V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10CB296DDB4B000E189E /* Post4V2.swift */; };
+		21BC10D0296DDB4B000E189E /* Post4V2+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10CC296DDB4B000E189E /* Post4V2+Schema.swift */; };
+		21BC10D2296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10D1296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift */; };
 		681DFE8328E746C10000C36A /* AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8028E746C10000C36A /* AsyncTesting.swift */; };
 		681DFE8428E746C10000C36A /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8128E746C10000C36A /* AsyncExpectation.swift */; };
 		681DFE8528E746C10000C36A /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8228E746C10000C36A /* XCTestCase+AsyncTesting.swift */; };
@@ -712,6 +727,7 @@
 		211F5093296DD4C30040EB62 /* AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift; sourceTree = "<group>"; };
 		213848292947ACCF00BBA647 /* AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift; sourceTree = "<group>"; };
 		2138482B2947F89C00BBA647 /* AWSDataStoreLazyLoadingBlogPostCmment8V2SnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadingBlogPostCmment8V2SnapshotTests.swift; sourceTree = "<group>"; };
+		211F5093296DD4C30040EB62 /* AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift; sourceTree = "<group>"; };
 		213DBB6128A4172000B30280 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		213DBB6228A5743200B30280 /* ModelImplicitDefaultPk+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ModelImplicitDefaultPk+Schema.swift"; sourceTree = "<group>"; };
 		213DBB6328A5743200B30280 /* ModelImplicitDefaultPk.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelImplicitDefaultPk.swift; sourceTree = "<group>"; };
@@ -1229,6 +1245,16 @@
 		21BC10CB296DDB4B000E189E /* Post4V2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post4V2.swift; sourceTree = "<group>"; };
 		21BC10CC296DDB4B000E189E /* Post4V2+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post4V2+Schema.swift"; sourceTree = "<group>"; };
 		21BC10D1296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStorePrimaryKeyPostComment4V2Test.swift; sourceTree = "<group>"; };
+		21BC10FD2971A82A000E189E /* PostStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostStatus.swift; sourceTree = "<group>"; };
+		21BC10FE2971A82A000E189E /* Post14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post14.swift; sourceTree = "<group>"; };
+		21BC10FF2971A82A000E189E /* User14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User14.swift; sourceTree = "<group>"; };
+		21BC11002971A82A000E189E /* UserSettings14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserSettings14.swift; sourceTree = "<group>"; };
+		21BC11012971A82A000E189E /* Comment14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Comment14+Schema.swift"; sourceTree = "<group>"; };
+		21BC11022971A82A000E189E /* Comment14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment14.swift; sourceTree = "<group>"; };
+		21BC11032971A82A000E189E /* Post14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post14+Schema.swift"; sourceTree = "<group>"; };
+		21BC11042971A82A000E189E /* User14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "User14+Schema.swift"; sourceTree = "<group>"; };
+		21BC11052971A82A000E189E /* UserSettings14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserSettings14+Schema.swift"; sourceTree = "<group>"; };
+		21BC110F2971A87F000E189E /* AWSDataStoreLazyLoadUserPostCommentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadUserPostCommentTests.swift; sourceTree = "<group>"; };
 		21C3C4C0293FD9BD009194A0 /* AWSDataStoreLazyLoadDefaultPKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadDefaultPKTests.swift; sourceTree = "<group>"; };
 		21C3C4C2293FD9FF009194A0 /* AWSDataStoreLazyLoadHasOneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadHasOneTests.swift; sourceTree = "<group>"; };
 		21C3C4C4293FDA12009194A0 /* AWSDataStoreLazyLoadCompositePKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadCompositePKTests.swift; sourceTree = "<group>"; };
@@ -1239,6 +1265,11 @@
 		21DFAE9D295F4E8600B4A883 /* PhoneCall.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneCall.swift; sourceTree = "<group>"; };
 		21DFAE9E295F4E8600B4A883 /* Transcript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transcript.swift; sourceTree = "<group>"; };
 		21DFAEA5295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadPhoneCallTests.swift; sourceTree = "<group>"; };
+		21BC10C9296DDB4B000E189E /* Comment4V2+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Comment4V2+Schema.swift"; sourceTree = "<group>"; };
+		21BC10CA296DDB4B000E189E /* Comment4V2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment4V2.swift; sourceTree = "<group>"; };
+		21BC10CB296DDB4B000E189E /* Post4V2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post4V2.swift; sourceTree = "<group>"; };
+		21BC10CC296DDB4B000E189E /* Post4V2+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post4V2+Schema.swift"; sourceTree = "<group>"; };
+		21BC10D1296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStorePrimaryKeyPostComment4V2Test.swift; sourceTree = "<group>"; };
 		681DFE8028E746C10000C36A /* AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncTesting.swift; sourceTree = "<group>"; };
 		681DFE8128E746C10000C36A /* AsyncExpectation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncExpectation.swift; sourceTree = "<group>"; };
 		681DFE8228E746C10000C36A /* XCTestCase+AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AsyncTesting.swift"; sourceTree = "<group>"; };
@@ -1565,6 +1596,7 @@
 				21801D472902E0FD00FFA37E /* LL11 */,
 				21801D4B29097CAB00FFA37E /* LL12 */,
 				21DFAE98295F4E4C00B4A883 /* LL13 */,
+				21BC10FC2971A7DE000E189E /* LL14 */,
 			);
 			path = AWSDataStorePluginLazyLoadTests;
 			sourceTree = "<group>";
@@ -2516,6 +2548,23 @@
 			path = 10;
 			sourceTree = "<group>";
 		};
+		21BC10FC2971A7DE000E189E /* LL14 */ = {
+			isa = PBXGroup;
+			children = (
+				21BC110F2971A87F000E189E /* AWSDataStoreLazyLoadUserPostCommentTests.swift */,
+				21BC11022971A82A000E189E /* Comment14.swift */,
+				21BC11012971A82A000E189E /* Comment14+Schema.swift */,
+				21BC10FE2971A82A000E189E /* Post14.swift */,
+				21BC11032971A82A000E189E /* Post14+Schema.swift */,
+				21BC10FD2971A82A000E189E /* PostStatus.swift */,
+				21BC10FF2971A82A000E189E /* User14.swift */,
+				21BC11042971A82A000E189E /* User14+Schema.swift */,
+				21BC11002971A82A000E189E /* UserSettings14.swift */,
+				21BC11052971A82A000E189E /* UserSettings14+Schema.swift */,
+			);
+			path = LL14;
+			sourceTree = "<group>";
+		};
 		21C3C4BD293FD84C009194A0 /* HasOneParentChild */ = {
 			isa = PBXGroup;
 			children = (
@@ -2570,6 +2619,18 @@
 				21DFAE9B295F4E8500B4A883 /* Transcript+Schema.swift */,
 			);
 			path = LL13;
+			sourceTree = "<group>";
+		};
+		21BC10C8296DDB2B000E189E /* 10 */ = {
+			isa = PBXGroup;
+			children = (
+				21BC10D1296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift */,
+				21BC10CA296DDB4B000E189E /* Comment4V2.swift */,
+				21BC10C9296DDB4B000E189E /* Comment4V2+Schema.swift */,
+				21BC10CB296DDB4B000E189E /* Post4V2.swift */,
+				21BC10CC296DDB4B000E189E /* Post4V2+Schema.swift */,
+			);
+			path = 10;
 			sourceTree = "<group>";
 		};
 		681DFE7F28E746C10000C36A /* AsyncTesting */ = {
@@ -3445,11 +3506,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21BC11082971A82A000E189E /* User14.swift in Sources */,
 				21801CE328F9A86800FFA37E /* Project6.swift in Sources */,
 				21801CE628F9A86800FFA37E /* TagWithCompositeKey+Schema.swift in Sources */,
 				21801D2F29006DA900FFA37E /* Team1.swift in Sources */,
+				21BC11102971A87F000E189E /* AWSDataStoreLazyLoadUserPostCommentTests.swift in Sources */,
 				21801D6529097D5800FFA37E /* DefaultPKParent+Schema.swift in Sources */,
 				21801CE728F9A86800FFA37E /* Project2.swift in Sources */,
+				21BC110D2971A82A000E189E /* User14+Schema.swift in Sources */,
+				21BC110E2971A82A000E189E /* UserSettings14+Schema.swift in Sources */,
 				217AA7C32909EF050042CD5D /* AWSDataStoreLazyLoadPostComment8Tests.swift in Sources */,
 				21801D6A29097D5800FFA37E /* ChildSansBelongsTo+Schema.swift in Sources */,
 				21619C1129480AA100E0900F /* AWSDataStoreLazyLoadProjectTeam1SnapshotTests.swift in Sources */,
@@ -3458,6 +3523,7 @@
 				21801CFB28F9A86800FFA37E /* Team2+Schema.swift in Sources */,
 				21801D6F29097D5800FFA37E /* ChildSansBelongsTo.swift in Sources */,
 				21801D6B29097D5800FFA37E /* HasOneParent.swift in Sources */,
+				21BC110B2971A82A000E189E /* Comment14.swift in Sources */,
 				21801D0328F9A86800FFA37E /* Post7+Schema.swift in Sources */,
 				21801D3329006DB500FFA37E /* Team5.swift in Sources */,
 				21801CEF28F9A86800FFA37E /* Blog8V2+Schema.swift in Sources */,
@@ -3465,6 +3531,7 @@
 				21801D3629006DC200FFA37E /* Project5+Schema.swift in Sources */,
 				21801D6229097D5800FFA37E /* CompositePKChild.swift in Sources */,
 				21801CE028F9A86800FFA37E /* Post8V2.swift in Sources */,
+				21BC11062971A82A000E189E /* PostStatus.swift in Sources */,
 				21801D3E2900A10600FFA37E /* AWSDataStoreLazyLoadProjectTeam1Tests.swift in Sources */,
 				21801C7D28F9A22900FFA37E /* AWSDataStoreLazyLoadBaseTest.swift in Sources */,
 				21DFAEA6295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift in Sources */,
@@ -3472,11 +3539,13 @@
 				217AA7BF2909C6330042CD5D /* AWSDataStoreLazyLoadProjectTeam6Tests.swift in Sources */,
 				21DFAEA1295F4E8600B4A883 /* Transcript+Schema.swift in Sources */,
 				21DFAE9F295F4E8600B4A883 /* Person.swift in Sources */,
+				21BC11072971A82A000E189E /* Post14.swift in Sources */,
 				21801D0228F9A86800FFA37E /* Comment8+Schema.swift in Sources */,
 				21801D5F29097D5800FFA37E /* HasOneChild+Schema.swift in Sources */,
 				21801CFC28F9A86800FFA37E /* Comment4V2+Schema.swift in Sources */,
 				21801CEC28F9A86800FFA37E /* Team6+Schema.swift in Sources */,
 				21AB5C2A297AE56D00CCA482 /* AWSDataStoreLazyLoadPostTagSnapshotTests.swift in Sources */,
+				21BC110C2971A82A000E189E /* Post14+Schema.swift in Sources */,
 				21801CEA28F9A86800FFA37E /* Comment8.swift in Sources */,
 				21801D6329097D5800FFA37E /* StrangeExplicitChild+Schema.swift in Sources */,
 				21801C8728F9A38000FFA37E /* TestConfigHelper.swift in Sources */,
@@ -3487,6 +3556,7 @@
 				21801CE828F9A86800FFA37E /* Comment4V2.swift in Sources */,
 				21DFAEA2295F4E8600B4A883 /* Person+Schema.swift in Sources */,
 				21C3C4C1293FD9BD009194A0 /* AWSDataStoreLazyLoadDefaultPKTests.swift in Sources */,
+				21BC11092971A82A000E189E /* UserSettings14.swift in Sources */,
 				21801CD528F9A86800FFA37E /* CommentWithCompositeKey+Schema.swift in Sources */,
 				217AA7BD2909C1D00042CD5D /* AWSDataStoreLazyLoadProjectTeam5Tests.swift in Sources */,
 				21801CED28F9A86800FFA37E /* Post4.swift in Sources */,
@@ -3512,6 +3582,7 @@
 				21801D2A29006DA300FFA37E /* Project1.swift in Sources */,
 				2138482A2947ACCF00BBA647 /* AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift in Sources */,
 				21801CF128F9A86800FFA37E /* Project2+Schema.swift in Sources */,
+				21BC110A2971A82A000E189E /* Comment14+Schema.swift in Sources */,
 				21C3C4C5293FDA12009194A0 /* AWSDataStoreLazyLoadCompositePKTests.swift in Sources */,
 				21801D0428F9A86800FFA37E /* MyNestedModel8.swift in Sources */,
 				21C3C4C3293FD9FF009194A0 /* AWSDataStoreLazyLoadHasOneTests.swift in Sources */,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
@@ -248,6 +248,19 @@
 		219B518528E3A4B00080EDCC /* DataStoreConnectionOptionalAssociations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BBFA00289BFE3400B32A39 /* DataStoreConnectionOptionalAssociations.swift */; };
 		219B518628E3A7150080EDCC /* DataStoreHubEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BBF9EE289BFE3400B32A39 /* DataStoreHubEvent.swift */; };
 		21AB5C2A297AE56D00CCA482 /* AWSDataStoreLazyLoadPostTagSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C29297AE56D00CCA482 /* AWSDataStoreLazyLoadPostTagSnapshotTests.swift */; };
+		21AB5C5529819BF100CCA482 /* Nested.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C4829819BF000CCA482 /* Nested.swift */; };
+		21AB5C5629819BF100CCA482 /* NestedTypeTestModel+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C4929819BF000CCA482 /* NestedTypeTestModel+Schema.swift */; };
+		21AB5C5729819BF100CCA482 /* Nested+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C4A29819BF100CCA482 /* Nested+Schema.swift */; };
+		21AB5C5829819BF100CCA482 /* EnumTestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C4B29819BF100CCA482 /* EnumTestModel.swift */; };
+		21AB5C5929819BF100CCA482 /* ListStringContainer+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C4C29819BF100CCA482 /* ListStringContainer+Schema.swift */; };
+		21AB5C5A29819BF100CCA482 /* TestEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C4D29819BF100CCA482 /* TestEnum.swift */; };
+		21AB5C5B29819BF100CCA482 /* NestedTypeTestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C4E29819BF100CCA482 /* NestedTypeTestModel.swift */; };
+		21AB5C5C29819BF100CCA482 /* ListIntContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C4F29819BF100CCA482 /* ListIntContainer.swift */; };
+		21AB5C5D29819BF100CCA482 /* ListStringContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C5029819BF100CCA482 /* ListStringContainer.swift */; };
+		21AB5C5E29819BF100CCA482 /* ScalarContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C5129819BF100CCA482 /* ScalarContainer.swift */; };
+		21AB5C5F29819BF100CCA482 /* EnumTestModel+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C5229819BF100CCA482 /* EnumTestModel+Schema.swift */; };
+		21AB5C6029819BF100CCA482 /* ListIntContainer+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C5329819BF100CCA482 /* ListIntContainer+Schema.swift */; };
+		21AB5C6129819BF100CCA482 /* ScalarContainer+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C5429819BF100CCA482 /* ScalarContainer+Schema.swift */; };
 		21BBFB4A289BFF9400B32A39 /* AWSDataStorePluginConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BBF9F2289BFE3400B32A39 /* AWSDataStorePluginConfigurationTests.swift */; };
 		21BBFB4B289BFFA000B32A39 /* DataStoreConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BBF9F1289BFE3400B32A39 /* DataStoreConfigurationTests.swift */; };
 		21BBFB4C289BFFA300B32A39 /* DataStoreConsecutiveUpdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BBFA16289BFE3400B32A39 /* DataStoreConsecutiveUpdatesTests.swift */; };
@@ -517,11 +530,6 @@
 		21DFAEA3295F4E8600B4A883 /* PhoneCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAE9D295F4E8600B4A883 /* PhoneCall.swift */; };
 		21DFAEA4295F4E8600B4A883 /* Transcript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAE9E295F4E8600B4A883 /* Transcript.swift */; };
 		21DFAEA6295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAEA5295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift */; };
-		21BC10CD296DDB4B000E189E /* Comment4V2+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10C9296DDB4B000E189E /* Comment4V2+Schema.swift */; };
-		21BC10CE296DDB4B000E189E /* Comment4V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10CA296DDB4B000E189E /* Comment4V2.swift */; };
-		21BC10CF296DDB4B000E189E /* Post4V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10CB296DDB4B000E189E /* Post4V2.swift */; };
-		21BC10D0296DDB4B000E189E /* Post4V2+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10CC296DDB4B000E189E /* Post4V2+Schema.swift */; };
-		21BC10D2296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC10D1296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift */; };
 		681DFE8328E746C10000C36A /* AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8028E746C10000C36A /* AsyncTesting.swift */; };
 		681DFE8428E746C10000C36A /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8128E746C10000C36A /* AsyncExpectation.swift */; };
 		681DFE8528E746C10000C36A /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8228E746C10000C36A /* XCTestCase+AsyncTesting.swift */; };
@@ -727,7 +735,6 @@
 		211F5093296DD4C30040EB62 /* AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift; sourceTree = "<group>"; };
 		213848292947ACCF00BBA647 /* AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift; sourceTree = "<group>"; };
 		2138482B2947F89C00BBA647 /* AWSDataStoreLazyLoadingBlogPostCmment8V2SnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadingBlogPostCmment8V2SnapshotTests.swift; sourceTree = "<group>"; };
-		211F5093296DD4C30040EB62 /* AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift; sourceTree = "<group>"; };
 		213DBB6128A4172000B30280 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		213DBB6228A5743200B30280 /* ModelImplicitDefaultPk+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ModelImplicitDefaultPk+Schema.swift"; sourceTree = "<group>"; };
 		213DBB6328A5743200B30280 /* ModelImplicitDefaultPk.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelImplicitDefaultPk.swift; sourceTree = "<group>"; };
@@ -885,6 +892,19 @@
 		21977D84289C1633005B49D6 /* primarykey_schema.graphql */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = primarykey_schema.graphql; sourceTree = "<group>"; };
 		21977DBE289C1719005B49D6 /* TestConfigHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestConfigHelper.swift; sourceTree = "<group>"; };
 		21AB5C29297AE56D00CCA482 /* AWSDataStoreLazyLoadPostTagSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadPostTagSnapshotTests.swift; sourceTree = "<group>"; };
+		21AB5C4829819BF000CCA482 /* Nested.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Nested.swift; sourceTree = "<group>"; };
+		21AB5C4929819BF000CCA482 /* NestedTypeTestModel+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NestedTypeTestModel+Schema.swift"; sourceTree = "<group>"; };
+		21AB5C4A29819BF100CCA482 /* Nested+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Nested+Schema.swift"; sourceTree = "<group>"; };
+		21AB5C4B29819BF100CCA482 /* EnumTestModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumTestModel.swift; sourceTree = "<group>"; };
+		21AB5C4C29819BF100CCA482 /* ListStringContainer+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ListStringContainer+Schema.swift"; sourceTree = "<group>"; };
+		21AB5C4D29819BF100CCA482 /* TestEnum.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEnum.swift; sourceTree = "<group>"; };
+		21AB5C4E29819BF100CCA482 /* NestedTypeTestModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestedTypeTestModel.swift; sourceTree = "<group>"; };
+		21AB5C4F29819BF100CCA482 /* ListIntContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListIntContainer.swift; sourceTree = "<group>"; };
+		21AB5C5029819BF100CCA482 /* ListStringContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListStringContainer.swift; sourceTree = "<group>"; };
+		21AB5C5129819BF100CCA482 /* ScalarContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScalarContainer.swift; sourceTree = "<group>"; };
+		21AB5C5229819BF100CCA482 /* EnumTestModel+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "EnumTestModel+Schema.swift"; sourceTree = "<group>"; };
+		21AB5C5329819BF100CCA482 /* ListIntContainer+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ListIntContainer+Schema.swift"; sourceTree = "<group>"; };
+		21AB5C5429819BF100CCA482 /* ScalarContainer+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ScalarContainer+Schema.swift"; sourceTree = "<group>"; };
 		21BBF9E6289BFE3400B32A39 /* DataStoreCustomPrimaryKeyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataStoreCustomPrimaryKeyTests.swift; sourceTree = "<group>"; };
 		21BBF9E8289BFE3400B32A39 /* TestModelRegistration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestModelRegistration.swift; sourceTree = "<group>"; };
 		21BBF9E9289BFE3400B32A39 /* SyncEngineIntegrationTestBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncEngineIntegrationTestBase.swift; sourceTree = "<group>"; };
@@ -1265,11 +1285,6 @@
 		21DFAE9D295F4E8600B4A883 /* PhoneCall.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneCall.swift; sourceTree = "<group>"; };
 		21DFAE9E295F4E8600B4A883 /* Transcript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transcript.swift; sourceTree = "<group>"; };
 		21DFAEA5295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadPhoneCallTests.swift; sourceTree = "<group>"; };
-		21BC10C9296DDB4B000E189E /* Comment4V2+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Comment4V2+Schema.swift"; sourceTree = "<group>"; };
-		21BC10CA296DDB4B000E189E /* Comment4V2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment4V2.swift; sourceTree = "<group>"; };
-		21BC10CB296DDB4B000E189E /* Post4V2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post4V2.swift; sourceTree = "<group>"; };
-		21BC10CC296DDB4B000E189E /* Post4V2+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post4V2+Schema.swift"; sourceTree = "<group>"; };
-		21BC10D1296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStorePrimaryKeyPostComment4V2Test.swift; sourceTree = "<group>"; };
 		681DFE8028E746C10000C36A /* AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncTesting.swift; sourceTree = "<group>"; };
 		681DFE8128E746C10000C36A /* AsyncExpectation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncExpectation.swift; sourceTree = "<group>"; };
 		681DFE8228E746C10000C36A /* XCTestCase+AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AsyncTesting.swift"; sourceTree = "<group>"; };
@@ -1597,6 +1612,7 @@
 				21801D4B29097CAB00FFA37E /* LL12 */,
 				21DFAE98295F4E4C00B4A883 /* LL13 */,
 				21BC10FC2971A7DE000E189E /* LL14 */,
+				21AB5C4729819BD900CCA482 /* LL15 */,
 			);
 			path = AWSDataStorePluginLazyLoadTests;
 			sourceTree = "<group>";
@@ -1832,6 +1848,26 @@
 				21977DBE289C1719005B49D6 /* TestConfigHelper.swift */,
 			);
 			path = Base;
+			sourceTree = "<group>";
+		};
+		21AB5C4729819BD900CCA482 /* LL15 */ = {
+			isa = PBXGroup;
+			children = (
+				21AB5C4B29819BF100CCA482 /* EnumTestModel.swift */,
+				21AB5C5229819BF100CCA482 /* EnumTestModel+Schema.swift */,
+				21AB5C4F29819BF100CCA482 /* ListIntContainer.swift */,
+				21AB5C5329819BF100CCA482 /* ListIntContainer+Schema.swift */,
+				21AB5C5029819BF100CCA482 /* ListStringContainer.swift */,
+				21AB5C4C29819BF100CCA482 /* ListStringContainer+Schema.swift */,
+				21AB5C4829819BF000CCA482 /* Nested.swift */,
+				21AB5C4A29819BF100CCA482 /* Nested+Schema.swift */,
+				21AB5C4E29819BF100CCA482 /* NestedTypeTestModel.swift */,
+				21AB5C4929819BF000CCA482 /* NestedTypeTestModel+Schema.swift */,
+				21AB5C5129819BF100CCA482 /* ScalarContainer.swift */,
+				21AB5C5429819BF100CCA482 /* ScalarContainer+Schema.swift */,
+				21AB5C4D29819BF100CCA482 /* TestEnum.swift */,
+			);
+			path = LL15;
 			sourceTree = "<group>";
 		};
 		21BBF9E7289BFE3400B32A39 /* TestSupport */ = {
@@ -2619,18 +2655,6 @@
 				21DFAE9B295F4E8500B4A883 /* Transcript+Schema.swift */,
 			);
 			path = LL13;
-			sourceTree = "<group>";
-		};
-		21BC10C8296DDB2B000E189E /* 10 */ = {
-			isa = PBXGroup;
-			children = (
-				21BC10D1296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift */,
-				21BC10CA296DDB4B000E189E /* Comment4V2.swift */,
-				21BC10C9296DDB4B000E189E /* Comment4V2+Schema.swift */,
-				21BC10CB296DDB4B000E189E /* Post4V2.swift */,
-				21BC10CC296DDB4B000E189E /* Post4V2+Schema.swift */,
-			);
-			path = 10;
 			sourceTree = "<group>";
 		};
 		681DFE7F28E746C10000C36A /* AsyncTesting */ = {
@@ -3512,10 +3536,13 @@
 				21801D2F29006DA900FFA37E /* Team1.swift in Sources */,
 				21BC11102971A87F000E189E /* AWSDataStoreLazyLoadUserPostCommentTests.swift in Sources */,
 				21801D6529097D5800FFA37E /* DefaultPKParent+Schema.swift in Sources */,
+				21AB5C5929819BF100CCA482 /* ListStringContainer+Schema.swift in Sources */,
 				21801CE728F9A86800FFA37E /* Project2.swift in Sources */,
 				21BC110D2971A82A000E189E /* User14+Schema.swift in Sources */,
 				21BC110E2971A82A000E189E /* UserSettings14+Schema.swift in Sources */,
 				217AA7C32909EF050042CD5D /* AWSDataStoreLazyLoadPostComment8Tests.swift in Sources */,
+				21AB5C6029819BF100CCA482 /* ListIntContainer+Schema.swift in Sources */,
+				21AB5C5E29819BF100CCA482 /* ScalarContainer.swift in Sources */,
 				21801D6A29097D5800FFA37E /* ChildSansBelongsTo+Schema.swift in Sources */,
 				21619C1129480AA100E0900F /* AWSDataStoreLazyLoadProjectTeam1SnapshotTests.swift in Sources */,
 				21801CF728F9A86800FFA37E /* Post8V2+Schema.swift in Sources */,
@@ -3531,6 +3558,7 @@
 				21801D3629006DC200FFA37E /* Project5+Schema.swift in Sources */,
 				21801D6229097D5800FFA37E /* CompositePKChild.swift in Sources */,
 				21801CE028F9A86800FFA37E /* Post8V2.swift in Sources */,
+				21AB5C5D29819BF100CCA482 /* ListStringContainer.swift in Sources */,
 				21BC11062971A82A000E189E /* PostStatus.swift in Sources */,
 				21801D3E2900A10600FFA37E /* AWSDataStoreLazyLoadProjectTeam1Tests.swift in Sources */,
 				21801C7D28F9A22900FFA37E /* AWSDataStoreLazyLoadBaseTest.swift in Sources */,
@@ -3539,8 +3567,10 @@
 				217AA7BF2909C6330042CD5D /* AWSDataStoreLazyLoadProjectTeam6Tests.swift in Sources */,
 				21DFAEA1295F4E8600B4A883 /* Transcript+Schema.swift in Sources */,
 				21DFAE9F295F4E8600B4A883 /* Person.swift in Sources */,
+				21AB5C5729819BF100CCA482 /* Nested+Schema.swift in Sources */,
 				21BC11072971A82A000E189E /* Post14.swift in Sources */,
 				21801D0228F9A86800FFA37E /* Comment8+Schema.swift in Sources */,
+				21AB5C6129819BF100CCA482 /* ScalarContainer+Schema.swift in Sources */,
 				21801D5F29097D5800FFA37E /* HasOneChild+Schema.swift in Sources */,
 				21801CFC28F9A86800FFA37E /* Comment4V2+Schema.swift in Sources */,
 				21801CEC28F9A86800FFA37E /* Team6+Schema.swift in Sources */,
@@ -3555,10 +3585,13 @@
 				21801D5E29097D5800FFA37E /* StrangeExplicitChild.swift in Sources */,
 				21801CE828F9A86800FFA37E /* Comment4V2.swift in Sources */,
 				21DFAEA2295F4E8600B4A883 /* Person+Schema.swift in Sources */,
+				21AB5C5F29819BF100CCA482 /* EnumTestModel+Schema.swift in Sources */,
 				21C3C4C1293FD9BD009194A0 /* AWSDataStoreLazyLoadDefaultPKTests.swift in Sources */,
 				21BC11092971A82A000E189E /* UserSettings14.swift in Sources */,
 				21801CD528F9A86800FFA37E /* CommentWithCompositeKey+Schema.swift in Sources */,
+				21AB5C5629819BF100CCA482 /* NestedTypeTestModel+Schema.swift in Sources */,
 				217AA7BD2909C1D00042CD5D /* AWSDataStoreLazyLoadProjectTeam5Tests.swift in Sources */,
+				21AB5C5A29819BF100CCA482 /* TestEnum.swift in Sources */,
 				21801CED28F9A86800FFA37E /* Post4.swift in Sources */,
 				21801CF228F9A86800FFA37E /* Post4V2+Schema.swift in Sources */,
 				21801CFA28F9A86800FFA37E /* TagWithCompositeKey.swift in Sources */,
@@ -3567,6 +3600,7 @@
 				21801CF328F9A86800FFA37E /* Project6+Schema.swift in Sources */,
 				21801CD728F9A86800FFA37E /* CommentWithCompositeKey.swift in Sources */,
 				21801CFE28F9A86800FFA37E /* Comment8V2.swift in Sources */,
+				21AB5C5C29819BF100CCA482 /* ListIntContainer.swift in Sources */,
 				21801CD928F9A86800FFA37E /* Post8.swift in Sources */,
 				2138482C2947F89C00BBA647 /* AWSDataStoreLazyLoadingBlogPostCmment8V2SnapshotTests.swift in Sources */,
 				21801CDD28F9A86800FFA37E /* Comment8V2+Schema.swift in Sources */,
@@ -3580,6 +3614,7 @@
 				21801D0728F9B11800FFA37E /* AsyncTesting.swift in Sources */,
 				21DFAEA0295F4E8600B4A883 /* PhoneCall+Schema.swift in Sources */,
 				21801D2A29006DA300FFA37E /* Project1.swift in Sources */,
+				21AB5C5529819BF100CCA482 /* Nested.swift in Sources */,
 				2138482A2947ACCF00BBA647 /* AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift in Sources */,
 				21801CF128F9A86800FFA37E /* Project2+Schema.swift in Sources */,
 				21BC110A2971A82A000E189E /* Comment14+Schema.swift in Sources */,
@@ -3608,12 +3643,14 @@
 				21801D6929097D5800FFA37E /* CompositePKParent.swift in Sources */,
 				21801D2528FDA5E700FFA37E /* AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests.swift in Sources */,
 				210EB5EC294796C40060C185 /* AWSDataStoreLazyLoadPostComment4V2SnapshotTests.swift in Sources */,
+				21AB5C5829819BF100CCA482 /* EnumTestModel.swift in Sources */,
 				21801CDE28F9A86800FFA37E /* Post4+Schema.swift in Sources */,
 				21801D4A2906CF3B00FFA37E /* AWSDataStoreLazyLoadPostTagTests.swift in Sources */,
 				21801D6829097D5800FFA37E /* DefaultPKChild.swift in Sources */,
 				21801CDA28F9A86800FFA37E /* PostWithTagsCompositeKey.swift in Sources */,
 				21801D0928F9B11E00FFA37E /* XCTestCase+AsyncTesting.swift in Sources */,
 				21801D7129097E9400FFA37E /* AWSDataStoreLazyLoadProjectTeam2Tests.swift in Sources */,
+				21AB5C5B29819BF100CCA482 /* NestedTypeTestModel.swift in Sources */,
 				21DFAEA3295F4E8600B4A883 /* PhoneCall.swift in Sources */,
 				21801CF428F9A86800FFA37E /* Post7.swift in Sources */,
 				21DFAEA4295F4E8600B4A883 /* Transcript.swift in Sources */,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -12,7 +12,7 @@
     {
       "identity" : "aws-crt-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/awslabs/aws-crt-swift.git",
+      "location" : "https://github.com/awslabs/aws-crt-swift",
       "state" : {
         "revision" : "afe23a2a2f6cf78e6d8803d7c9e0c8e6f50b6915",
         "version" : "0.4.0"
@@ -48,7 +48,7 @@
     {
       "identity" : "smithy-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/awslabs/smithy-swift.git",
+      "location" : "https://github.com/awslabs/smithy-swift",
       "state" : {
         "revision" : "f59ed07c29d4e03f91ea8324edf7a2486bd86a9c",
         "version" : "0.6.0"


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
Add missing `int` and `double` to the PropertyPath. This PR also adds two sets of models (LL14 and LL15) to the lazy loading schema and have been used to update the shared backend provisioning. The two schemas, each has a use case that utilizes the missing property path method `int` and `double`.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
