### PR TITLE
chore(auth): Adds device helper method to clear devicemeta data info

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/RefreshAuthorizationSession/UserPool/RefreshUserPoolTokens.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/RefreshAuthorizationSession/UserPool/RefreshUserPoolTokens.swift
@@ -34,8 +34,8 @@ struct RefreshUserPoolTokens: Action {
             let existingTokens = existingSignedIndata.cognitoUserPoolTokens
 
             let deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
-                for: environment,
-                with: existingSignedIndata.username)
+                for: existingSignedIndata.username,
+                with: environment)
 
             let asfDeviceId = try await CognitoUserPoolASF.asfDeviceID(
                 for: existingSignedIndata.username,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/InitiateAuthDeviceSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/InitiateAuthDeviceSRP.swift
@@ -30,8 +30,8 @@ struct InitiateAuthDeviceSRP: Action {
 
             // Get device metadata
             let deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
-                for: environment,
-                with: username)
+                for: username,
+                with: environment)
 
             let srpStateData = SRPStateData(
                 username: username,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/IntializeSignInFlow.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/IntializeSignInFlow.swift
@@ -34,8 +34,8 @@ struct InitializeSignInFlow: Action {
         var deviceMetadata = DeviceMetadata.noData
         if let username = signInEventData.username {
             deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
-                for: environment,
-                with: username)
+                for: username,
+                with: environment)
         }
 
         let event: SignInEvent

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/DeviceMetadataHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/DeviceMetadataHelper.swift
@@ -10,12 +10,13 @@ import AWSPluginsCore
 struct DeviceMetadataHelper {
 
     static func getDeviceMetadata(
-        for environment: Environment,
-        with username: String) async -> DeviceMetadata {
+        for username: String,
+        with environment: Environment) async -> DeviceMetadata {
             let credentialStoreClient = (environment as? AuthEnvironment)?.credentialsClient
             do {
-                let data = try await credentialStoreClient?.fetchData(type: .deviceMetadata(username: username))
-
+                let data = try await credentialStoreClient?.fetchData(
+                    type: .deviceMetadata(username: username)
+                )
                 if case .deviceMetadata(let fetchedMetadata, _) = data {
                     return fetchedMetadata
                 }
@@ -31,4 +32,17 @@ struct DeviceMetadataHelper {
             return .noData
         }
 
+    static func removeDeviceMetaData(
+        of username: String,
+        environment: Environment) async {
+            let credentialStoreClient = (environment as? AuthEnvironment)?.credentialsClient
+            do {
+                try await credentialStoreClient?.deleteData(
+                    type: .deviceMetadata(username: username)
+                )
+            } catch {
+                let logger = (environment as? LoggerProvider)?.logger
+                logger?.error("Unable to fetch device metadata with error: \(error)")
+            }
+        }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/DeviceMetadataHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/DeviceMetadataHelper.swift
@@ -42,7 +42,7 @@ struct DeviceMetadataHelper {
                 )
             } catch {
                 let logger = (environment as? LoggerProvider)?.logger
-                logger?.error("Unable to fetch device metadata with error: \(error)")
+                logger?.error("Unable to remove device metadata with error: \(error)")
             }
         }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/DeviceMetadataHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/DeviceMetadataHelper.swift
@@ -34,7 +34,7 @@ struct DeviceMetadataHelper {
 
     static func removeDeviceMetaData(
         of username: String,
-        environment: Environment) async {
+        with environment: Environment) async {
             let credentialStoreClient = (environment as? AuthEnvironment)?.credentialsClient
             do {
                 try await credentialStoreClient?.deleteData(

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/DeviceMetadataHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/DeviceMetadataHelper.swift
@@ -33,7 +33,7 @@ struct DeviceMetadataHelper {
         }
 
     static func removeDeviceMetaData(
-        of username: String,
+        for username: String,
         with environment: Environment) async {
             let credentialStoreClient = (environment as? AuthEnvironment)?.credentialsClient
             do {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthForgetDeviceTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthForgetDeviceTask.swift
@@ -62,8 +62,8 @@ class AWSAuthForgetDeviceTask: AuthForgetDeviceTask {
         let userPoolService = try environment.cognitoUserPoolFactory()
         guard let device = request.device else {
             let deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
-                for: environment,
-                with: username)
+                for: username,
+                with: environment)
             if case .metadata(let data) = deviceMetadata {
                 let input = ForgetDeviceInput(accessToken: accessToken, deviceKey: data.deviceKey)
                 _ = try await userPoolService.forgetDevice(input: input)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthRememberDeviceTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthRememberDeviceTask.swift
@@ -60,8 +60,8 @@ class AWSAuthRememberDeviceTask: AuthRememberDeviceTask {
     private func rememberDevice(with accessToken: String, username: String) async throws {
         let userPoolService = try environment.cognitoUserPoolFactory()
         let deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
-            for: environment,
-            with: username)
+            for: username,
+            with: environment)
         if case .metadata(let data) = deviceMetadata {
             let input = UpdateDeviceStatusInput(accessToken: accessToken,
                                                 deviceKey: data.deviceKey,


### PR DESCRIPTION
## Issue \#
NA

## Description
- Adds a method to clear devicemetadata from keychain, this will be used for device meta data cleanup during signIn.
- Change the `getDeviceMetaData` property to accurately say that it is fetching deviceMetaData for a user. 


## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
