### PR TITLE
chore(auth): Fix SignedInAuthSessionTests

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AWSAuthBaseTest.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AWSAuthBaseTest.swift
@@ -18,13 +18,17 @@ class AWSAuthBaseTest: XCTestCase {
 
     let amplifyConfigurationFile = "testconfiguration/AWSCognitoAuthPluginIntegrationTests-amplifyconfiguration"
 
+    func initializeAmplifyWithError() throws {
+        let configuration = try TestConfigHelper.retrieveAmplifyConfiguration(
+            forResource: amplifyConfigurationFile)
+        let authPlugin = AWSCognitoAuthPlugin()
+        try Amplify.add(plugin: authPlugin)
+        try Amplify.configure(configuration)
+    }
+
     func initializeAmplify() {
         do {
-            let configuration = try TestConfigHelper.retrieveAmplifyConfiguration(
-                forResource: amplifyConfigurationFile)
-            let authPlugin = AWSCognitoAuthPlugin()
-            try Amplify.add(plugin: authPlugin)
-            try Amplify.configure(configuration)
+            try initializeAmplifyWithError()
             print("Amplify configured with auth plugin")
         } catch {
             print(error)

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSessionTests/SignedInAuthSessionTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSessionTests/SignedInAuthSessionTests.swift
@@ -14,14 +14,13 @@ import AmplifyTestCommon
 
 class SignedInAuthSessionTests: AWSAuthBaseTest {
 
-    override func setUp() {
-        super.setUp()
-        initializeAmplify()
+    override func setUpWithError() throws {
+        try initializeAmplifyWithError()
         AuthSessionHelper.clearKeychain()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
+        _ = Amplify.Auth.signOut()
         Amplify.reset()
         sleep(2)
         AuthSessionHelper.clearKeychain()
@@ -41,21 +40,21 @@ class SignedInAuthSessionTests: AWSAuthBaseTest {
         let signInExpectation = expectation(description: "SignIn operation should complete")
         AuthSignInHelper.registerAndSignInUser(username: username, password: password,
                                                email: email) { didSucceed, error in
-            signInExpectation.fulfill()
+            if didSucceed {
+                signInExpectation.fulfill()
+            }
             XCTAssertTrue(didSucceed, "SignIn operation failed - \(String(describing: error))")
         }
         wait(for: [signInExpectation], timeout: networkTimeout)
 
         let authSessionExpectation = expectation(description: "Received event result from fetchAuth")
         _ = Amplify.Auth.fetchAuthSession { result in
-            defer {
-                authSessionExpectation.fulfill()
-            }
             switch result {
+            case .failure(let error):
+                XCTFail("Unable to fetch session: \(error)")
             case .success(let session):
                 XCTAssertTrue(session.isSignedIn, "Session state should be signed In")
-            case .failure(let error):
-                XCTFail("Should not receive error \(error)")
+                authSessionExpectation.fulfill()
             }
         }
         wait(for: [authSessionExpectation], timeout: networkTimeout)
@@ -69,52 +68,64 @@ class SignedInAuthSessionTests: AWSAuthBaseTest {
     /// - Then:
     ///    - I should get the signedin state as true but with token result as sessionExpired
     ///
-    func testSessionExpired() {
+    func testSessionExpired() throws {
         let username = "integTest\(UUID().uuidString)"
         let password = "P123@\(UUID().uuidString)"
         let signInExpectation = expectation(description: "SignIn operation should complete")
         AuthSignInHelper.registerAndSignInUser(username: username, password: password,
                                                email: email) { didSucceed, error in
-            signInExpectation.fulfill()
+            if didSucceed {
+                signInExpectation.fulfill()
+            }
             XCTAssertTrue(didSucceed, "SignIn operation failed - \(String(describing: error))")
         }
         wait(for: [signInExpectation], timeout: networkTimeout)
 
-        let authSessionExpectation = expectation(description: "Received event result from fetchAuth")
+        let originalSessionExpectation = expectation(description: "Received event result from fetchAuth")
+        var originalSession: AuthSession?
         _ = Amplify.Auth.fetchAuthSession { result in
-            defer {
-                authSessionExpectation.fulfill()
-            }
-
-            do {
-                let authSession = try result.get() as? AuthCognitoTokensProvider
-                _ = try authSession?.getCognitoTokens().get()
-            } catch {
-                XCTFail("Should not receive error \(error)")
+            switch result {
+            case .failure(let error):
+                XCTFail("Unable to retreive session \(error)")
+            case .success(let session):
+                XCTAssertTrue(session.isSignedIn)
+                originalSession = session
+                originalSessionExpectation.fulfill()
             }
         }
-        wait(for: [authSessionExpectation], timeout: networkTimeout)
+        wait(for: [originalSessionExpectation], timeout: networkTimeout)
+
+        let originalTokenProvider = try XCTUnwrap(originalSession as? AuthCognitoTokensProvider)
+        _ = try originalTokenProvider.getCognitoTokens().get()
 
         // Manually invalidate the tokens and then try to fetch the session.
         AuthSessionHelper.invalidateSession(username: username)
-        let authSessionExpiredExpectation = expectation(description: "Received event result from fetchAuth")
+        let postExpirationExpectation = expectation(description: "Received event result from fetchAuth")
+        var postExpirationSession: AuthSession?
         _ = Amplify.Auth.fetchAuthSession { result in
-            defer {
-                authSessionExpiredExpectation.fulfill()
-            }
-
-            do {
-                let authSession = try result.get() as? AuthCognitoTokensProvider
-                _ = try authSession?.getCognitoTokens().get()
-                XCTFail("Should not receive a valid token")
-            } catch {
-                guard let authError = error as? AuthError,
-                      case .sessionExpired = authError else {
-                    XCTFail("Should receive a session expired error")
-                    return
-                }
+            switch result {
+            case .failure(let error):
+                XCTFail("Unable to retreive session \(error)")
+            case .success(let session):
+                XCTAssertTrue(session.isSignedIn)
+                postExpirationSession = session
+                postExpirationExpectation.fulfill()
             }
         }
-        wait(for: [authSessionExpiredExpectation], timeout: networkTimeout)
+        wait(for: [postExpirationExpectation], timeout: networkTimeout)
+
+        let postExpirationTokenProvider = try XCTUnwrap(postExpirationSession as? AuthCognitoTokensProvider)
+        let tokenResult = postExpirationTokenProvider.getCognitoTokens()
+        switch tokenResult {
+        case .failure(let error):
+            switch error {
+            case .sessionExpired:
+                break
+            default:
+                XCTFail("Unexpected error case: \(error)")
+            }
+        case .success(let tokens):
+            XCTFail("Unexpected tokens: \(String(describing: tokens).prefix(64))")
+        }
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/README.md
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/README.md
@@ -1,10 +1,13 @@
 #  AWSCognitoAuthPlugin Integration tests
 
-The following steps demonstrate how to setup the integration tests for auth plugin. 
+The following steps demonstrate how to setup the integration tests for the auth plugin. 
 
 ## CLI setup
 
-The integration test require auth configured with AWS Cognito User Pool and AWS Cognito Identity Pool. 
+The integration tests require auth configured with AWS Cognito User Pool and
+AWS Cognito Identity Pool. So, the first time you attempt to run the
+integration tests, you may have to do the following from the (directory
+containing the xcodeproj)[../]:
 
 ```
 amplify add auth

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/Support/AuthSessionHelper.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/Support/AuthSessionHelper.swift
@@ -20,7 +20,12 @@ struct AuthSessionHelper {
     static func invalidateSession(username: String) {
         let bundleID = Bundle.main.bundleIdentifier
         let keychain = AWSUICKeyChainStore(service: "\(bundleID!).\(AWSCognitoIdentityUserPool.self)")
-        let namespace = "\(AWSMobileClient.default().userPoolClient!.userPoolConfiguration.clientId).\(username)"
+        let clientId = AWSMobileClient.default().userPoolClient!.userPoolConfiguration.clientId
+
+        // Please note that the clientId + username namespace combination is
+        // normalized by converting it to a lower-case string somewhere upstream
+        // of the AWSUICKeyChainStore. So, the same is done below.
+        let namespace = "\(clientId).\(username)".lowercased()
         let expirationKey = "\(namespace).tokenExpiration"
         let refreshTokenKey = "\(namespace).refreshToken"
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/2692

## Description
<!-- Why is this change required? What problem does it solve? -->
This SignedInAuthSessionTests fix ensures that:

1. The assertions made in SignedInAuthSessionTests fail as early as possible.
2. AuthSessionHelper normalizes its namespace before performing operations on the keychain dictionary.

![Screenshot 2023-01-25 at 2 02 00 PM](https://user-images.githubusercontent.com/1117904/214678934-3790abcb-eb45-431b-bca5-d511edce01a5.png)


## General Checklist
<!-- Check or cross out if not relevant -->

~~- [ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
~~- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
