### PR TITLE
fix(auth): Remove static deviceMetaData in auth flow

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/InitiateAuthDeviceSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/InitiateAuthDeviceSRP.swift
@@ -39,7 +39,6 @@ struct InitiateAuthDeviceSRP: Action {
                 NHexValue: nHexValue,
                 gHexValue: gHexValue,
                 srpKeyPair: srpKeyPair,
-                deviceMetadata: deviceMetadata,
                 clientTimestamp: Date())
 
             let request = RespondToAuthChallengeInput.deviceSRP(

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/VerifyDevicePasswordSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/VerifyDevicePasswordSRP.swift
@@ -33,12 +33,15 @@ struct VerifyDevicePasswordSRP: Action {
             let secretBlock = try secretBlock(secretBlockString)
             let serverPublicB = try serverPublic(parameters)
 
-            guard case .metadata(let deviceData) = stateData.deviceMetadata else {
+            let deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
+                for: username,
+                with: environment)
+            guard
+                case .metadata(let deviceData) = deviceMetadata
+            else {
                 let authError = SignInError.service(error: SRPError.calculation)
                 logVerbose("\(#fileID) DevciceSRPSignInError \(authError)", environment: environment)
-                let event = SignInEvent(
-                    eventType: .throwPasswordVerifierError(authError)
-                )
+                let event = SignInEvent(eventType: .throwPasswordVerifierError(authError))
                 await dispatcher.send(event)
                 return
             }
@@ -58,6 +61,7 @@ struct VerifyDevicePasswordSRP: Action {
                 session: authResponse.session,
                 secretBlock: secretBlockString,
                 signature: signature,
+                deviceMetadata: deviceMetadata,
                 environment: userPoolEnv)
 
             let responseEvent = try await UserPoolSignInHelper.sendRespondToAuth(

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/InitiateAuthSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/InitiateAuthSRP.swift
@@ -50,7 +50,6 @@ struct InitiateAuthSRP: Action {
                 NHexValue: nHexValue,
                 gHexValue: gHexValue,
                 srpKeyPair: srpKeyPair,
-                deviceMetadata: deviceMetadata,
                 clientTimestamp: Date())
 
             let asfDeviceId = try await CognitoUserPoolASF.asfDeviceID(

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/VerifyPasswordSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/VerifyPasswordSRP.swift
@@ -41,6 +41,9 @@ struct VerifyPasswordSRP: Action {
             let secretBlock = try secretBlock(secretBlockString)
             let serverPublicB = try serverPublic(parameters)
 
+            let deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
+                for: username,
+                with: environment)
             let signature = try signature(userIdForSRP: userIdForSRP,
                                           saltHex: saltHex,
                                           secretBlock: secretBlock,
@@ -53,6 +56,7 @@ struct VerifyPasswordSRP: Action {
                 session: authResponse.session,
                 secretBlock: secretBlockString,
                 signature: signature,
+                deviceMetadata: deviceMetadata,
                 environment: userPoolEnv)
             let responseEvent = try await UserPoolSignInHelper.sendRespondToAuth(
                 request: request,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/SRPStateData.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/SRPStateData.swift
@@ -13,7 +13,6 @@ struct SRPStateData {
     let NHexValue: String
     let gHexValue: String
     let srpKeyPair: SRPKeys
-    let deviceMetadata: DeviceMetadata
     let clientTimestamp: Date
 
     init(
@@ -22,7 +21,6 @@ struct SRPStateData {
         NHexValue: String,
         gHexValue: String,
         srpKeyPair: SRPKeys,
-        deviceMetadata: DeviceMetadata,
         clientTimestamp: Date
     ) {
         self.username = username
@@ -30,7 +28,6 @@ struct SRPStateData {
         self.NHexValue = NHexValue
         self.gHexValue = gHexValue
         self.srpKeyPair = srpKeyPair
-        self.deviceMetadata = deviceMetadata
         self.clientTimestamp = clientTimestamp
     }
 
@@ -47,13 +44,12 @@ extension SRPStateData: CustomDebugDictionaryConvertible {
         [
             "username": username.masked(),
             "password": password.redacted(),
-            "NHexValue": NHexValue,
-            "gHexValue": gHexValue,
+            "NHexValue": NHexValue.masked(),
+            "gHexValue": gHexValue.masked(),
             "srpKeyPair": """
-                <privateKey \(srpKeyPair.privateKeyHexValue)>, \
-                <publicKey \(srpKeyPair.publicKeyHexValue)>
+                <privateKey \(srpKeyPair.privateKeyHexValue.masked())>, \
+                <publicKey \(srpKeyPair.publicKeyHexValue.masked())>
                 """,
-            "deviceMetadata": deviceMetadata,
             "clientTimestamp": clientTimestamp
         ]
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/RespondToAuthChallengeInput+Amplify.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/RespondToAuthChallengeInput+Amplify.swift
@@ -15,6 +15,7 @@ extension RespondToAuthChallengeInput {
                                  session: String?,
                                  secretBlock: String,
                                  signature: String,
+                                 deviceMetadata: DeviceMetadata,
                                  environment: UserPoolEnvironment) -> RespondToAuthChallengeInput {
         let dateStr = stateData.clientTimestamp.utcString
         let challengeResponses = [
@@ -28,7 +29,7 @@ extension RespondToAuthChallengeInput {
             challengeResponses: challengeResponses,
             session: session,
             clientMetadata: [:],
-            deviceMetadata: stateData.deviceMetadata,
+            deviceMetadata: deviceMetadata,
             environment: environment)
     }
 
@@ -56,6 +57,7 @@ extension RespondToAuthChallengeInput {
                                        session: String?,
                                        secretBlock: String,
                                        signature: String,
+                                       deviceMetadata: DeviceMetadata,
                                        environment: UserPoolEnvironment)
     -> RespondToAuthChallengeInput {
         let dateStr = stateData.clientTimestamp.utcString
@@ -70,7 +72,7 @@ extension RespondToAuthChallengeInput {
             challengeResponses: challengeResponses,
             session: session,
             clientMetadata: [:],
-            deviceMetadata: stateData.deviceMetadata,
+            deviceMetadata: deviceMetadata,
             environment: environment)
     }
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/SRPTestData.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/SRPTestData.swift
@@ -19,7 +19,6 @@ extension SRPStateData {
         NHexValue: "",
         gHexValue: "",
         srpKeyPair: SRPKeys(publicKeyHexValue: "", privateKeyHexValue: ""),
-        deviceMetadata: .noData,
         clientTimestamp: Date()
     )
 }
@@ -171,7 +170,6 @@ extension SRPStateData {
                 "98bab9079c01ab6acd0e75518d0cda640b9a1f011c9a7cefab68b6ddce666c874659" +
                 "8a502c0e6adef0722bac",
             privateKeyHexValue: "c142c2d2471fd53bca99c2fdec84e522adec8ee2dcda0d9fff9dbea52ac4a65f"),
-        deviceMetadata: .noData,
         clientTimestamp: Date(timeIntervalSinceReferenceDate: 656_187_908.969623)
     )
 }


### PR DESCRIPTION
## Issue \#
NA

## Description
DeviceMetaData is stored in keychain which are mapped to `username`. But the `username` value changes during the signIn flow, because in the username defined by Cognito is different from the one entered by user. For example in case of user alias if user entered a phone number as `username`, on `initiateAuth` will return a UUID as `username`. 

We should use this username to see if we have a mapping of deviceMetaData on the next step of authflow and should not keep a static deviceMetadata.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
