### PR TITLE
chore: remove amplify-data from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,1 @@
 * @aws-amplify/amplify-ios 
-
-# This covers
-# - Amplify/Categories/DataStore/**
-# - Amplify/Categories/API/**
-# - AmplifyPlugins/DataStore/**
-# - AmplifyPlugins/API/**
-# - AmplifyPlugins/Core/AWSPuginsCore/**
-# - AmplifyTests/CategoryTests/DataStore/**
-# - AmplifyTestCommon/Models
-**/DataStore/**  @aws-amplify/amplify-data @aws-amplify/amplify-ios
-**/API/**  @aws-amplify/amplify-data @aws-amplify/amplify-ios
-**/Core/**  @aws-amplify/amplify-data @aws-amplify/amplify-ios
-/AmplifyTestCommon/Models/** @aws-amplify/amplify-data @aws-amplify/amplify-ios
-/.circleci @aws-amplify/amplify-data @aws-amplify/amplify-ios
-/.github @aws-amplify/amplify-data @aws-amplify/amplify-ios


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

N/A

## Description
<!-- Why is this change required? What problem does it solve? -->

Remove amplify-data team from codeowners

## General Checklist
<!-- Check or cross out if not relevant -->

- ~[ ] Added new tests to cover change, if needed~
- ~[ ] Build succeeds with all target using Swift Package Manager~
- ~[ ] All unit tests pass~
- ~[ ] All integration tests pass~
- ~[ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~
- ~[ ] Documentation update for the change if required~
- ~[ ] PR title conforms to conventional commit style~
- ~[ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- ~[ ] If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
