### PR TITLE
fix(auth): Pass deviceMetadata in RespondToAuthChallenge for signIn challenges

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/VerifyPasswordSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/VerifyPasswordSRP.swift
@@ -26,14 +26,16 @@ struct VerifyPasswordSRP: Action {
 
         logVerbose("\(#fileID) Starting execution", environment: environment)
 
+        let inputUsername = stateData.username
+        var username = inputUsername
+        var deviceMetadata = DeviceMetadata.noData
         do {
             let srpEnv = try environment.srpEnvironment()
             let userPoolEnv = try environment.userPoolEnvironment()
             let srpClient = try SRPSignInHelper.srpClient(srpEnv)
             let parameters = try challengeParameters()
 
-            let inputUsername = stateData.username
-            let username = parameters["USERNAME"] ?? inputUsername
+            username = parameters["USERNAME"] ?? inputUsername
             let userIdForSRP = parameters["USER_ID_FOR_SRP"] ?? inputUsername
 
             let saltHex = try saltHex(parameters)
@@ -41,7 +43,7 @@ struct VerifyPasswordSRP: Action {
             let secretBlock = try secretBlock(secretBlockString)
             let serverPublicB = try serverPublic(parameters)
 
-            let deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
+            deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
                 for: username,
                 with: environment)
             let signature = try signature(userIdForSRP: userIdForSRP,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/VerifySignInChallenge.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/VerifySignInChallenge.swift
@@ -21,6 +21,8 @@ struct VerifySignInChallenge: Action {
 
     func execute(withDispatcher dispatcher: EventDispatcher, environment: Environment) async {
         logVerbose("\(#fileID) Starting execution", environment: environment)
+        let username = challenge.username
+        var deviceMetadata = DeviceMetadata.noData
 
         do {
             let userpoolEnv = try environment.userPoolEnvironment()
@@ -28,6 +30,10 @@ struct VerifySignInChallenge: Action {
             let session = challenge.session
             let challengeType = challenge.challenge
             let responseKey = try challenge.getChallengeKey()
+
+            deviceMetadata = await DeviceMetadataHelper.getDeviceMetadata(
+                            for: username,
+                            with: environment)
 
             let input = RespondToAuthChallengeInput.verifyChallenge(
                 username: username,
@@ -37,6 +43,7 @@ struct VerifySignInChallenge: Action {
                 answer: confirmSignEventData.answer,
                 clientMetadata: confirmSignEventData.metadata,
                 attributes: confirmSignEventData.attributes,
+                deviceMetadata: deviceMetadata,
                 environment: userpoolEnv)
 
             let responseEvent = try await UserPoolSignInHelper.sendRespondToAuth(

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/RespondToAuthChallengeInput+Amplify.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/RespondToAuthChallengeInput+Amplify.swift
@@ -84,6 +84,7 @@ extension RespondToAuthChallengeInput {
         answer: String,
         clientMetadata: [String: String]?,
         attributes: [String: String],
+        deviceMetadata: DeviceMetadata,
         environment: UserPoolEnvironment) -> RespondToAuthChallengeInput {
 
             var challengeResponses = [
@@ -101,7 +102,7 @@ extension RespondToAuthChallengeInput {
                 challengeResponses: challengeResponses,
                 session: session,
                 clientMetadata: clientMetadata ?? [:],
-                deviceMetadata: .noData,
+                deviceMetadata: deviceMetadata,
                 environment: environment)
         }
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/VerifySignInChallenge/VerifySignInChallengeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/VerifySignInChallenge/VerifySignInChallengeTests.swift
@@ -1,0 +1,319 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+import XCTest
+import AWSCognitoIdentityProvider
+@testable import AWSPluginsTestCommon
+@testable import AWSCognitoAuthPlugin
+
+class VerifySignInChallengeTests: XCTestCase {
+
+    typealias CognitoFactory = BasicSRPAuthEnvironment.CognitoUserPoolFactory
+
+    let mockRespondAuthChallenge = RespondToAuthChallenge(challenge: .smsMfa,
+                                                          username: "usernameMock",
+                                                          session: "mockSession",
+                                                          parameters: [:])
+    let mockConfirmEvent = ConfirmSignInEventData(answer: "1233",
+                                              attributes: [:],
+                                              metadata: [:])
+
+    /// Test if valid input are given the service call is made
+    ///
+    /// - Given: VerifySignInChallenge action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input
+    /// - Then:
+    ///    - Cognito client should invoke the api `respondToAuthChallengeCallback`
+    ///
+    func testInitiateVerifyChallenge() async {
+        let verifyPasswordInvoked = expectation(
+            description: "verifyChallengeInvoked"
+        )
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    verifyPasswordInvoked.fulfill()
+                    return RespondToAuthChallengeOutputResponse()
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+        let action = VerifySignInChallenge(challenge: mockRespondAuthChallenge,
+                                           confirmSignEventData: mockConfirmEvent,
+                                           signInMethod: .apiBased(.userSRP))
+
+        await action.execute(
+            withDispatcher: MockDispatcher { _ in },
+            environment: environment
+        )
+
+        await waitForExpectations(timeout: 0.1)
+    }
+
+    /// Test empty response is returned by Cognito proper error is thrown
+    ///
+    /// - Given: VerifySignInChallenge action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input and mock empty response from service
+    /// - Then:
+    ///    - Should send an event with proper error
+    ///
+    func testVerifyChallengeWithEmptyResponse() async {
+
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    return RespondToAuthChallengeOutputResponse()
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+
+        let action = VerifySignInChallenge(challenge: mockRespondAuthChallenge,
+                                           confirmSignEventData: mockConfirmEvent,
+                                           signInMethod: .apiBased(.userSRP))
+
+        let passwordVerifierError = expectation(description: "passwordVerifierError")
+
+        let dispatcher = MockDispatcher { event in
+            defer { passwordVerifierError.fulfill() }
+
+            guard let event = event as? SignInEvent else {
+                XCTFail("Expected event to be SignInEvent but got \(event)")
+                return
+            }
+
+            guard case let .throwAuthError(error) = event.eventType,
+                  case .invalidServiceResponse = error
+            else {
+                      XCTFail("Should receive invalid service response")
+                      return
+                  }
+
+        }
+
+        await action.execute(withDispatcher: dispatcher, environment: environment)
+        await waitForExpectations(timeout: 0.1)
+    }
+
+    /// Test  successful response from the VerifySignInChallenge
+    ///
+    /// - Given: VerifySignInChallenge action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input
+    /// - Then:
+    ///    - Should send an event with the result
+    ///
+    func testSuccessfulRespondToAuthChallengePropagatesSuccess() async {
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    return RespondToAuthChallengeOutputResponse.testData()
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+
+        let action = VerifySignInChallenge(challenge: mockRespondAuthChallenge,
+                                           confirmSignEventData: mockConfirmEvent,
+                                           signInMethod: .apiBased(.userSRP))
+
+        let verifyChallengeComplete = expectation(description: "verifyChallengeComplete")
+
+        let dispatcher = MockDispatcher { event in
+            guard let event = event as? SignInEvent else {
+                XCTFail("Expected event to be SignInEvent but got \(event)")
+                return
+            }
+
+            if case let .finalizeSignIn(signedInData) = event.eventType {
+                XCTAssertNotNil(signedInData)
+                verifyChallengeComplete.fulfill()
+            }
+        }
+
+        await action.execute(withDispatcher: dispatcher, environment: environment)
+        await waitForExpectations(timeout: 0.1)
+    }
+
+    /// Test  successful response from the VerifySignInChallenge
+    ///
+    /// - Given: VerifySignInChallenge action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input and mock error from service
+    /// - Then:
+    ///    - Should send an event with service error
+    ///
+    func testRespondToAuthChallengePropagatesError() async {
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    throw try RespondToAuthChallengeOutputError(httpResponse: MockHttpResponse.ok)
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+
+        let action = VerifySignInChallenge(challenge: mockRespondAuthChallenge,
+                                           confirmSignEventData: mockConfirmEvent,
+                                           signInMethod: .apiBased(.userSRP))
+
+        let passwordVerifierError = expectation(
+            description: "passwordVerifierError")
+
+        let dispatcher = MockDispatcher { event in
+            defer { passwordVerifierError.fulfill() }
+
+            guard let event = event as? SignInEvent else {
+                XCTFail("Expected event to be SignInEvent but got \(event)")
+                return
+            }
+
+            guard case let .throwAuthError(error) = event.eventType,
+                  case .service = error
+            else {
+                      XCTFail("Should receive invalid service response")
+                      return
+                  }
+        }
+
+        await action.execute(withDispatcher: dispatcher, environment: environment)
+        await waitForExpectations(timeout: 0.1)
+    }
+
+//    /// Test verify password retry on device not found
+//    ///
+//    /// - Given: VerifySignInChallenge action with mocked cognito client and configuration
+//    /// - When:
+//    ///    - I invoke the action with valid input and mock empty device not found error from Cognito
+//    /// - Then:
+//    ///    - Should send an event with retryVerifyChallengeAnswer
+//    ///
+//    func testPasswordVerifierWithDeviceNotFound() async {
+//
+//        let identityProviderFactory: CognitoFactory = {
+//            MockIdentityProvider(
+//                mockRespondToAuthChallengeResponse: { _ in
+//                    throw RespondToAuthChallengeOutputError.resourceNotFoundException(
+//                        ResourceNotFoundException()
+//                    )
+//                })
+//        }
+//
+//        let environment = Defaults.makeDefaultAuthEnvironment(
+//            userPoolFactory: identityProviderFactory)
+//
+//        let action = VerifySignInChallenge(challenge: mockRespondAuthChallenge,
+//                                           confirmSignEventData: mockConfirmEvent,
+//                                           signInMethod: .apiBased(.userSRP))
+//        let passwordVerifierError = expectation(description: "passwordVerifierError")
+//
+//        let dispatcher = MockDispatcher { event in
+//            defer { passwordVerifierError.fulfill() }
+//
+//            guard let event = event as? SignInChallengeEvent else {
+//                XCTFail("Expected event to be SignInEvent but got \(event)")
+//                return
+//            }
+//
+//            guard case .retryVerifyChallengeAnswer = event.eventType
+//            else {
+//                XCTFail("Should receive retryRespondPasswordVerifier")
+//                return
+//            }
+//        }
+//
+//        await action.execute(withDispatcher: dispatcher, environment: environment)
+//        await waitForExpectations(timeout: 0.1)
+//    }
+
+    /// Test  successful response from the VerifySignInChallenge for confirmDevice
+    ///
+    /// - Given: VerifySignInChallenge action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input and mock new device
+    /// - Then:
+    ///    - Should send an event confirmDevice
+    ///
+    func testRespondToAuthChallengeWithConfirmDevice() async {
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    return RespondToAuthChallengeOutputResponse.testDataWithNewDevice()
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+
+        let action = VerifySignInChallenge(challenge: mockRespondAuthChallenge,
+                                           confirmSignEventData: mockConfirmEvent,
+                                           signInMethod: .apiBased(.userSRP))
+
+        let verifyChallengeComplete = expectation(description: "verifyChallengeComplete")
+
+        let dispatcher = MockDispatcher { event in
+            guard let event = event as? SignInEvent else {
+                XCTFail("Expected event to be SignInEvent but got \(event)")
+                return
+            }
+
+            if case .confirmDevice(let signedInData) = event.eventType {
+                XCTAssertNotNil(signedInData)
+                verifyChallengeComplete.fulfill()
+            }
+        }
+
+        await action.execute(withDispatcher: dispatcher, environment: environment)
+        await waitForExpectations(timeout: 0.1)
+    }
+
+    /// Test  successful response from the VerifySignInChallenge for verify device
+    ///
+    /// - Given: VerifySignInChallenge action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input and mock new device
+    /// - Then:
+    ///    - Should send an event initiateDeviceSRP
+    ///
+    func testRespondToAuthChallengeWithVerifyDevice() async {
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    return RespondToAuthChallengeOutputResponse.testDataWithVerifyDevice()
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+
+        let action = VerifySignInChallenge(challenge: mockRespondAuthChallenge,
+                                           confirmSignEventData: mockConfirmEvent,
+                                           signInMethod: .apiBased(.userSRP))
+
+        let verifyChallengeComplete = expectation(description: "verifyChallengeComplete")
+
+        let dispatcher = MockDispatcher { event in
+            guard let event = event as? SignInEvent else {
+                XCTFail("Expected event to be SignInEvent but got \(event)")
+                return
+            }
+
+            if case .initiateDeviceSRP(_, let response) = event.eventType {
+                XCTAssertNotNil(response)
+                verifyChallengeComplete.fulfill()
+            }
+        }
+
+        await action.execute(withDispatcher: dispatcher, environment: environment)
+        await waitForExpectations(timeout: 0.1)
+    }
+}

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/SRPTestData.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/SRPTestData.swift
@@ -83,6 +83,30 @@ extension RespondToAuthChallengeOutputResponse {
             challengeParameters: [:],
             session: "session")
     }
+
+    static func testDataWithNewDevice() -> RespondToAuthChallengeOutputResponse {
+        let result = CognitoIdentityProviderClientTypes.AuthenticationResultType(
+            accessToken: Defaults.validAccessToken,
+            expiresIn: 3_600,
+            idToken: "idTokenXXX",
+            newDeviceMetadata: .init(deviceGroupKey: "mockGroupKey", deviceKey: "mockKey"),
+            refreshToken: "refreshTokenXXX",
+            tokenType: "Bearer")
+
+        return RespondToAuthChallengeOutputResponse(
+            authenticationResult: result,
+            challengeName: .none,
+            challengeParameters: [:],
+            session: "session")
+    }
+
+    static func testDataWithVerifyDevice() -> RespondToAuthChallengeOutputResponse {
+        return RespondToAuthChallengeOutputResponse(
+            authenticationResult: nil,
+            challengeName: .deviceSrpAuth,
+            challengeParameters: [:],
+            session: "session")
+    }
 }
 
 extension RespondToAuthChallenge {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
- Pass deviceMetadata in RespondToAuthChallenge for signIn challenges, this value was only passed for SRP flow. PR changes that and deviceMetaData is passed for MFA challenge and other related flows.
- Some code cleanup which are used by the next PR - https://github.com/aws-amplify/amplify-swift/pull/2699

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
