### PR TITLE
chore(auth): Ensure AWSAuthBaseTest subclasses setup fail if initializeAmplify fails

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AWSAuthBaseTest.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AWSAuthBaseTest.swift
@@ -18,21 +18,11 @@ class AWSAuthBaseTest: XCTestCase {
 
     let amplifyConfigurationFile = "testconfiguration/AWSCognitoAuthPluginIntegrationTests-amplifyconfiguration"
 
-    func initializeAmplifyWithError() throws {
+    func initializeAmplify() throws {
         let configuration = try TestConfigHelper.retrieveAmplifyConfiguration(
             forResource: amplifyConfigurationFile)
         let authPlugin = AWSCognitoAuthPlugin()
         try Amplify.add(plugin: authPlugin)
         try Amplify.configure(configuration)
-    }
-
-    func initializeAmplify() {
-        do {
-            try initializeAmplifyWithError()
-            print("Amplify configured with auth plugin")
-        } catch {
-            print(error)
-            XCTFail("Failed to initialize Amplify with \(error)")
-        }
     }
 }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthDeleteUserTests/AuthDeleteUserTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthDeleteUserTests/AuthDeleteUserTests.swift
@@ -14,13 +14,11 @@ import AmplifyTestCommon
 
 class AuthDeleteUserTests: AWSAuthBaseTest {
 
-    override func setUp() {
-        super.setUp()
-        initializeAmplify()
+    override func setUpWithError() throws {
+        try initializeAmplify()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
         Amplify.reset()
         sleep(2)
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthDeviceTests/AuthDeviceOperationTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthDeviceTests/AuthDeviceOperationTests.swift
@@ -17,13 +17,11 @@ import AWSMobileClientXCF
 
 class AuthDeviceOperationTests: AWSAuthBaseTest {
 
-    override func setUp() {
-        super.setUp()
-        initializeAmplify()
+    override func setUpWithError() throws {
+        try initializeAmplify()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
         Amplify.reset()
         sleep(2)
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSessionTests/SignedInAuthSessionTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSessionTests/SignedInAuthSessionTests.swift
@@ -15,7 +15,7 @@ import AmplifyTestCommon
 class SignedInAuthSessionTests: AWSAuthBaseTest {
 
     override func setUpWithError() throws {
-        try initializeAmplifyWithError()
+        try initializeAmplify()
         AuthSessionHelper.clearKeychain()
     }
 

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSessionTests/SignedOutAuthSessionTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSessionTests/SignedOutAuthSessionTests.swift
@@ -12,13 +12,11 @@ import AWSPluginsCore
 
 class SignedOutAuthSessionTests: AWSAuthBaseTest {
 
-    override func setUp() {
-        super.setUp()
-        initializeAmplify()
+    override func setUpWithError() throws {
+        try initializeAmplify()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
         Amplify.reset()
         sleep(2)
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignInTests/AuthUsernamePasswordSignInTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignInTests/AuthUsernamePasswordSignInTests.swift
@@ -12,13 +12,11 @@ import AmplifyTestCommon
 
 class AuthUsernamePasswordSignInTests: AWSAuthBaseTest {
 
-    override func setUp() {
-        super.setUp()
-        initializeAmplify()
+    override func setUpWithError() throws {
+        try initializeAmplify()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
         Amplify.reset()
         sleep(2)
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignOutTests/AuthSignOutTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignOutTests/AuthSignOutTests.swift
@@ -14,13 +14,11 @@ import AmplifyTestCommon
 
 class AuthSignedOutTests: AWSAuthBaseTest {
 
-    override func setUp() {
-        super.setUp()
-        initializeAmplify()
+    override func setUpWithError() throws {
+        try initializeAmplify()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
         Amplify.reset()
         sleep(2)
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthConfirmSignUpTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthConfirmSignUpTests.swift
@@ -11,13 +11,11 @@ import AWSCognitoAuthPlugin
 
 class AuthConfirmSignUpTests: AWSAuthBaseTest {
 
-    override func setUp() {
-        super.setUp()
-        initializeAmplify()
+    override func setUpWithError() throws {
+        try initializeAmplify()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
         Amplify.reset()
         sleep(2)
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthResendSignUpCodeTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthResendSignUpCodeTests.swift
@@ -11,13 +11,11 @@ import AWSCognitoAuthPlugin
 
 class AuthResendSignUpCodeTests: AWSAuthBaseTest {
 
-    override func setUp() {
-        super.setUp()
-        initializeAmplify()
+    override func setUpWithError() throws {
+        try initializeAmplify()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
         Amplify.reset()
         sleep(2)
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthSignUpTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignUpTests/AuthSignUpTests.swift
@@ -12,13 +12,11 @@ import AmplifyTestCommon
 
 class AuthSignUpTests: AWSAuthBaseTest {
 
-    override func setUp() {
-        super.setUp()
-        initializeAmplify()
+    override func setUpWithError() throws {
+        try initializeAmplify()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
         Amplify.reset()
         sleep(2)
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthUserAttributesTests/AuthUserAttributesTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthUserAttributesTests/AuthUserAttributesTests.swift
@@ -12,13 +12,11 @@ import AmplifyTestCommon
 
 class AuthUserAttributesTests: AWSAuthBaseTest {
 
-    override func setUp() {
-        super.setUp()
-        initializeAmplify()
+    override func setUpWithError() throws {
+        try initializeAmplify()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
         Amplify.reset()
         sleep(2)
     }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthUserTests/AuthUserTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthUserTests/AuthUserTests.swift
@@ -12,13 +12,11 @@ import AmplifyTestCommon
 
 class AuthUserTests: AWSAuthBaseTest {
 
-    override func setUp() {
-        super.setUp()
-        initializeAmplify()
+    override func setUpWithError() throws {
+        try initializeAmplify()
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDownWithError() throws {
         Amplify.reset()
         sleep(2)
     }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

https://github.com/aws-amplify/amplify-swift/issues/2695

## Description
<!-- Why is this change required? What problem does it solve? -->

This fix ensures AWSAuthBaseTest subclasses setup fail if `initializeAmplify()` fails.

## General Checklist
<!-- Check or cross out if not relevant -->

~~- [ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
~~- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~~
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
