### PR TITLE
fix(auth): Device binding add retry incase of device not found

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInChallengeEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInChallengeEvent.swift
@@ -15,6 +15,8 @@ struct SignInChallengeEvent: StateMachineEvent {
 
         case verifyChallengeAnswer(ConfirmSignInEventData)
 
+        case retryVerifyChallengeAnswer(ConfirmSignInEventData)
+
         case verified
 
     }
@@ -28,6 +30,7 @@ struct SignInChallengeEvent: StateMachineEvent {
         case .verified: return "SignInChallengeEvent.verified"
         case .verifyChallengeAnswer: return "SignInChallengeEvent.verifyChallengeAnswer"
         case .waitForAnswer: return "SignInChallengeEvent.waitForAnswer"
+        case .retryVerifyChallengeAnswer: return "SignInChallengeEvent.retryVerifyChallengeAnswer"
         }
     }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInEvent.swift
@@ -74,7 +74,7 @@ struct SignInEvent: StateMachineEvent {
         case .throwAuthError: return "SignInEvent.throwAuthError"
         case .receivedChallenge: return "SignInEvent.receivedChallenge"
         case .verifySMSChallenge: return "SignInEvent.verifySMSChallenge"
-        case . retryRespondPasswordVerifier: return "SignInEvent.retryRespondPasswordVerifier"
+        case .retryRespondPasswordVerifier: return "SignInEvent.retryRespondPasswordVerifier"
         }
     }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInEvent.swift
@@ -29,6 +29,8 @@ struct SignInEvent: StateMachineEvent {
 
         case respondPasswordVerifier(SRPStateData, InitiateAuthOutputResponse)
 
+        case retryRespondPasswordVerifier(SRPStateData, InitiateAuthOutputResponse)
+
         case initiateDeviceSRP(Username, SignInResponseBehavior)
 
         case respondDeviceSRPChallenge(Username, SignInResponseBehavior)
@@ -72,6 +74,7 @@ struct SignInEvent: StateMachineEvent {
         case .throwAuthError: return "SignInEvent.throwAuthError"
         case .receivedChallenge: return "SignInEvent.receivedChallenge"
         case .verifySMSChallenge: return "SignInEvent.verifySMSChallenge"
+        case . retryRespondPasswordVerifier: return "SignInEvent.retryRespondPasswordVerifier"
         }
     }
 
@@ -104,7 +107,8 @@ extension SignInEvent.EventType: Equatable {
             (.cancelSRPSignIn, .cancelSRPSignIn),
             (.throwAuthError, .throwAuthError),
             (.receivedChallenge, .receivedChallenge),
-            (.verifySMSChallenge, .verifySMSChallenge):
+            (.verifySMSChallenge, .verifySMSChallenge),
+            (.retryRespondPasswordVerifier, .retryRespondPasswordVerifier):
             return true
         default: return false
         }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SRP/SRPSignInState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SRP/SRPSignInState+Resolver.swift
@@ -102,6 +102,13 @@ extension SRPSignInState {
             byApplying signInEvent: SignInEvent)
         -> StateResolution<SRPSignInState> {
             switch signInEvent.eventType {
+            case .retryRespondPasswordVerifier(let srpStateData, let authResponse):
+                let action = VerifyPasswordSRP(stateData: srpStateData,
+                                               authResponse: authResponse)
+                return StateResolution(
+                    newState: SRPSignInState.respondingPasswordVerifier(srpStateData),
+                    actions: [action]
+                )
             case .finalizeSignIn(let signedInData):
                 return .init(newState: .signedIn(signedInData),
                              actions: [SignInComplete(signedInData: signedInData)])

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SignIn/SignInChallengeState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SignIn/SignInChallengeState+Resolver.swift
@@ -42,6 +42,17 @@ extension SignInChallengeState {
 
             case .verifying(let challenge, let signInMethod, _):
 
+                if case .retryVerifyChallengeAnswer(let answerEventData) = event.isChallengeEvent {
+                    let action = VerifySignInChallenge(
+                        challenge: challenge,
+                        confirmSignEventData: answerEventData,
+                        signInMethod: signInMethod)
+                    return .init(
+                        newState: .verifying(challenge, signInMethod, answerEventData.answer),
+                        actions: [action]
+                    )
+                }
+
                 if case .finalizeSignIn(let signedInData) = event.isSignInEvent {
                     return .init(newState: .verified,
                                  actions: [SignInComplete(signedInData: signedInData)])

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/DeviceMetadataHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/DeviceMetadataHelper.swift
@@ -45,8 +45,4 @@ struct DeviceMetadataHelper {
                 logger?.error("Unable to remove device metadata with error: \(error)")
             }
         }
-<<<<<<< HEAD
-=======
-
->>>>>>> 1ac16570 (fix(auth): Device binding to use the right username for mapping)
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/DeviceMetadataHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/DeviceMetadataHelper.swift
@@ -45,4 +45,8 @@ struct DeviceMetadataHelper {
                 logger?.error("Unable to remove device metadata with error: \(error)")
             }
         }
+<<<<<<< HEAD
+=======
+
+>>>>>>> 1ac16570 (fix(auth): Device binding to use the right username for mapping)
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/UserPoolSignInHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/UserPoolSignInHelper.swift
@@ -69,16 +69,12 @@ struct UserPoolSignInHelper {
         environment: UserPoolEnvironment) async throws -> StateMachineEvent {
 
             let client = try environment.cognitoUserPoolFactory()
-
-            do {
-                let response = try await client.respondToAuthChallenge(input: request)
-                let event = try self.parseResponse(response, for: username, signInMethod: signInMethod)
-                return event
-            } catch {
-                let authError = SignInError.service(error: error)
-                return SignInEvent(eventType: .throwAuthError(authError))
-            }
+            let response = try await client.respondToAuthChallenge(input: request)
+            let event = try self.parseResponse(response, for: username, signInMethod: signInMethod)
+            return event
         }
+
+
 
     static func parseResponse(
         _ response: SignInResponseBehavior,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyPasswordSRPTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyPasswordSRPTests.swift
@@ -419,52 +419,52 @@ class VerifyPasswordSRPTests: XCTestCase {
         await waitForExpectations(timeout: 0.1)
     }
 
-//    /// Test verify password retry on device not found
-//    ///
-//    /// - Given: VerifyPasswordSRP action with mocked cognito client and configuration
-//    /// - When:
-//    ///    - I invoke the action with valid input and mock empty device not found error from Cognito
-//    /// - Then:
-//    ///    - Should send an event with retryRespondPasswordVerifier
-//    ///
-//    func testPasswordVerifierWithDeviceNotFound() async {
-//
-//        let identityProviderFactory: CognitoFactory = {
-//            MockIdentityProvider(
-//                mockRespondToAuthChallengeResponse: { _ in
-//                    throw RespondToAuthChallengeOutputError.resourceNotFoundException(
-//                        ResourceNotFoundException()
-//                    )
-//                })
-//        }
-//
-//        let environment = Defaults.makeDefaultAuthEnvironment(
-//            userPoolFactory: identityProviderFactory)
-//
-//        let data = InitiateAuthOutputResponse.validTestData
-//        let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
-//                                       authResponse: data)
-//
-//        let passwordVerifierError = expectation(description: "passwordVerifierError")
-//
-//        let dispatcher = MockDispatcher { event in
-//            defer { passwordVerifierError.fulfill() }
-//
-//            guard let event = event as? SignInEvent else {
-//                XCTFail("Expected event to be SignInEvent but got \(event)")
-//                return
-//            }
-//
-//            guard case .retryRespondPasswordVerifier = event.eventType
-//            else {
-//                XCTFail("Should receive retryRespondPasswordVerifier")
-//                return
-//            }
-//        }
-//
-//        await action.execute(withDispatcher: dispatcher, environment: environment)
-//        await waitForExpectations(timeout: 0.1)
-//    }
+    /// Test verify password retry on device not found
+    ///
+    /// - Given: VerifyPasswordSRP action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input and mock empty device not found error from Cognito
+    /// - Then:
+    ///    - Should send an event with retryRespondPasswordVerifier
+    ///
+    func testPasswordVerifierWithDeviceNotFound() async {
+
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    throw RespondToAuthChallengeOutputError.resourceNotFoundException(
+                        ResourceNotFoundException()
+                    )
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+
+        let data = InitiateAuthOutputResponse.validTestData
+        let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
+                                       authResponse: data)
+
+        let passwordVerifierError = expectation(description: "passwordVerifierError")
+
+        let dispatcher = MockDispatcher { event in
+            defer { passwordVerifierError.fulfill() }
+
+            guard let event = event as? SignInEvent else {
+                XCTFail("Expected event to be SignInEvent but got \(event)")
+                return
+            }
+
+            guard case .retryRespondPasswordVerifier = event.eventType
+            else {
+                XCTFail("Should receive retryRespondPasswordVerifier")
+                return
+            }
+        }
+
+        await action.execute(withDispatcher: dispatcher, environment: environment)
+        await waitForExpectations(timeout: 0.1)
+    }
 
     /// Test  successful response from the VerifyPasswordSRP for confirmDevice
     ///

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/VerifySignInChallenge/VerifySignInChallengeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/VerifySignInChallenge/VerifySignInChallengeTests.swift
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
+
 import XCTest
 import AWSCognitoIdentityProvider
 @testable import AWSPluginsTestCommon
@@ -189,51 +190,51 @@ class VerifySignInChallengeTests: XCTestCase {
         await waitForExpectations(timeout: 0.1)
     }
 
-//    /// Test verify password retry on device not found
-//    ///
-//    /// - Given: VerifySignInChallenge action with mocked cognito client and configuration
-//    /// - When:
-//    ///    - I invoke the action with valid input and mock empty device not found error from Cognito
-//    /// - Then:
-//    ///    - Should send an event with retryVerifyChallengeAnswer
-//    ///
-//    func testPasswordVerifierWithDeviceNotFound() async {
-//
-//        let identityProviderFactory: CognitoFactory = {
-//            MockIdentityProvider(
-//                mockRespondToAuthChallengeResponse: { _ in
-//                    throw RespondToAuthChallengeOutputError.resourceNotFoundException(
-//                        ResourceNotFoundException()
-//                    )
-//                })
-//        }
-//
-//        let environment = Defaults.makeDefaultAuthEnvironment(
-//            userPoolFactory: identityProviderFactory)
-//
-//        let action = VerifySignInChallenge(challenge: mockRespondAuthChallenge,
-//                                           confirmSignEventData: mockConfirmEvent,
-//                                           signInMethod: .apiBased(.userSRP))
-//        let passwordVerifierError = expectation(description: "passwordVerifierError")
-//
-//        let dispatcher = MockDispatcher { event in
-//            defer { passwordVerifierError.fulfill() }
-//
-//            guard let event = event as? SignInChallengeEvent else {
-//                XCTFail("Expected event to be SignInEvent but got \(event)")
-//                return
-//            }
-//
-//            guard case .retryVerifyChallengeAnswer = event.eventType
-//            else {
-//                XCTFail("Should receive retryRespondPasswordVerifier")
-//                return
-//            }
-//        }
-//
-//        await action.execute(withDispatcher: dispatcher, environment: environment)
-//        await waitForExpectations(timeout: 0.1)
-//    }
+    /// Test verify password retry on device not found
+    ///
+    /// - Given: VerifySignInChallenge action with mocked cognito client and configuration
+    /// - When:
+    ///    - I invoke the action with valid input and mock empty device not found error from Cognito
+    /// - Then:
+    ///    - Should send an event with retryVerifyChallengeAnswer
+    ///
+    func testPasswordVerifierWithDeviceNotFound() async {
+
+        let identityProviderFactory: CognitoFactory = {
+            MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    throw RespondToAuthChallengeOutputError.resourceNotFoundException(
+                        ResourceNotFoundException()
+                    )
+                })
+        }
+
+        let environment = Defaults.makeDefaultAuthEnvironment(
+            userPoolFactory: identityProviderFactory)
+
+        let action = VerifySignInChallenge(challenge: mockRespondAuthChallenge,
+                                           confirmSignEventData: mockConfirmEvent,
+                                           signInMethod: .apiBased(.userSRP))
+        let passwordVerifierError = expectation(description: "passwordVerifierError")
+
+        let dispatcher = MockDispatcher { event in
+            defer { passwordVerifierError.fulfill() }
+
+            guard let event = event as? SignInChallengeEvent else {
+                XCTFail("Expected event to be SignInEvent but got \(event)")
+                return
+            }
+
+            guard case .retryVerifyChallengeAnswer = event.eventType
+            else {
+                XCTFail("Should receive retryRespondPasswordVerifier")
+                return
+            }
+        }
+
+        await action.execute(withDispatcher: dispatcher, environment: environment)
+        await waitForExpectations(timeout: 0.1)
+    }
 
     /// Test  successful response from the VerifySignInChallenge for confirmDevice
     ///

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthConfirmSignInTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthConfirmSignInTaskTests.swift
@@ -599,39 +599,7 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             XCTFail("Should not return error \(error)")
         }
     }
-    
-    /// Test a confirmSignIn call with ResourceNotFoundException response from service
-    ///
-    /// - Given: an auth plugin with mocked service. Mocked service should mock a
-    ///   ResourceNotFoundException response
-    ///
-    /// - When:
-    ///    - I invoke confirmSignIn with a valid confirmation code
-    /// - Then:
-    ///    - I should get a .service error with .resourceNotFound as underlyingError
-    ///
-    func testConfirmSignInWithResourceNotFoundException() async {
-        
-        self.mockIdentityProvider = MockIdentityProvider(
-            mockRespondToAuthChallengeResponse: { _ in
-                throw RespondToAuthChallengeOutputError.resourceNotFoundException(
-                    .init(message: "Exception"))
-            })
-        
-        do {
-            _ = try await plugin.confirmSignIn(challengeResponse: "code")
-            XCTFail("Should return an error if the result from service is invalid")
-        } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
-                XCTFail("Should produce service error instead of \(error)")
-                return
-            }
-            guard case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
-                XCTFail("Underlying error should be resourceNotFound \(error)")
-                return
-            }
-        }
-    }
+
     
     /// Test a confirmSignIn call with SoftwareTokenMFANotFoundException response from service
     ///


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
Add logic to retry the respondToAuthChallenge in case device not found was received.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
