### PR TITLE
chore(auth): Integration tests fail fast on failed assertions

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthDeleteUserTests/AuthDeleteUserTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthDeleteUserTests/AuthDeleteUserTests.swift
@@ -15,10 +15,12 @@ import AmplifyTestCommon
 class AuthDeleteUserTests: AWSAuthBaseTest {
 
     override func setUpWithError() throws {
+        continueAfterFailure = false
         try initializeAmplify()
     }
 
     override func tearDownWithError() throws {
+        _ = Amplify.Auth.signOut()
         Amplify.reset()
         sleep(2)
     }
@@ -50,10 +52,10 @@ class AuthDeleteUserTests: AWSAuthBaseTest {
             defer {
                 authSignedInSessionExpectation.fulfill()
             }
-            do {
-                let session = try result.get()
+            switch result {
+            case .success(let session):
                 XCTAssertTrue(session.isSignedIn, "Auth session should be signedIn")
-            } catch {
+            case .failure(let error):
                 XCTFail("Fetch auth session failed with error - \(error)")
             }
         }
@@ -66,7 +68,7 @@ class AuthDeleteUserTests: AWSAuthBaseTest {
             }
             switch result {
             case .success:
-                print("Success deleteUser")
+                break
             case .failure(let error):
                 XCTFail("deleteUser should not fail - \(error)")
             }
@@ -98,10 +100,10 @@ class AuthDeleteUserTests: AWSAuthBaseTest {
             defer {
                 authSignedOutSessionExpectation.fulfill()
             }
-            do {
-                let session = try result.get()
+            switch result {
+            case .success(let session):
                 XCTAssertFalse(session.isSignedIn, "Auth session should NOT be signedIn")
-            } catch {
+            case .failure(let error):
                 XCTFail("Fetch auth session failed with error - \(error)")
             }
         }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignInTests/AuthUsernamePasswordSignInTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignInTests/AuthUsernamePasswordSignInTests.swift
@@ -13,6 +13,7 @@ import AmplifyTestCommon
 class AuthUsernamePasswordSignInTests: AWSAuthBaseTest {
 
     override func setUpWithError() throws {
+        continueAfterFailure = false
         try initializeAmplify()
     }
 
@@ -37,7 +38,9 @@ class AuthUsernamePasswordSignInTests: AWSAuthBaseTest {
         let signUpExpectation = expectation(description: "SignUp operation should complete")
         AuthSignInHelper.signUpUser(username: username, password: password,
                                     email: email) { didSucceed, error in
-            signUpExpectation.fulfill()
+            defer {
+                signUpExpectation.fulfill()
+            }
             XCTAssertTrue(didSucceed, "Signup operation failed - \(String(describing: error))")
         }
         wait(for: [signUpExpectation], timeout: networkTimeout)
@@ -74,7 +77,9 @@ class AuthUsernamePasswordSignInTests: AWSAuthBaseTest {
         let signUpExpectation = expectation(description: "SignUp operation should complete")
         AuthSignInHelper.signUpUser(username: username, password: password,
                                     email: email) { didSucceed, error in
-            signUpExpectation.fulfill()
+            defer {
+                signUpExpectation.fulfill()
+            }
             XCTAssertTrue(didSucceed, "Signup operation failed - \(String(describing: error))")
         }
         wait(for: [signUpExpectation], timeout: networkTimeout)
@@ -114,7 +119,9 @@ class AuthUsernamePasswordSignInTests: AWSAuthBaseTest {
         let signUpExpectation = expectation(description: "SignUp operation should complete")
         AuthSignInHelper.signUpUser(username: username, password: password,
                                     email: email) { didSucceed, error in
-            signUpExpectation.fulfill()
+            defer {
+                signUpExpectation.fulfill()
+            }
             XCTAssertTrue(didSucceed, "Signup operation failed - \(String(describing: error))")
         }
         wait(for: [signUpExpectation], timeout: networkTimeout)
@@ -157,7 +164,9 @@ class AuthUsernamePasswordSignInTests: AWSAuthBaseTest {
         let signUpExpectation = expectation(description: "SignUp operation should complete")
         AuthSignInHelper.signUpUser(username: username, password: password,
                                     email: email) { didSucceed, error in
-            signUpExpectation.fulfill()
+            defer {
+                signUpExpectation.fulfill()
+            }
             XCTAssertTrue(didSucceed, "Signup operation failed - \(String(describing: error))")
         }
         wait(for: [signUpExpectation], timeout: networkTimeout)
@@ -230,7 +239,9 @@ class AuthUsernamePasswordSignInTests: AWSAuthBaseTest {
         let signUpExpectation = expectation(description: "SignUp operation should complete")
         AuthSignInHelper.signUpUser(username: username, password: password,
                                     email: email) { didSucceed, error in
-            signUpExpectation.fulfill()
+            defer {
+                signUpExpectation.fulfill()
+            }
             XCTAssertTrue(didSucceed, "Signup operation failed - \(String(describing: error))")
         }
         wait(for: [signUpExpectation], timeout: networkTimeout)
@@ -297,7 +308,9 @@ class AuthUsernamePasswordSignInTests: AWSAuthBaseTest {
         let firstSignInExpectation = expectation(description: "SignIn operation should complete")
         AuthSignInHelper.registerAndSignInUser(username: username, password: password,
                                                email: email) { didSucceed, error in
-            firstSignInExpectation.fulfill()
+            defer {
+                firstSignInExpectation.fulfill()
+            }
             XCTAssertTrue(didSucceed, "SignIn operation failed - \(String(describing: error))")
         }
         wait(for: [firstSignInExpectation], timeout: networkTimeout)
@@ -359,8 +372,10 @@ class AuthUsernamePasswordSignInTests: AWSAuthBaseTest {
         let operationExpectation = expectation(description: "Operation should not complete")
         operationExpectation.isInverted = true
         let operation = Amplify.Auth.signIn(username: username, password: password) { result in
+            defer {
+                operationExpectation.fulfill()
+            }
             XCTFail("Received result \(result)")
-            operationExpectation.fulfill()
         }
         XCTAssertNotNil(operation, "signIn operations should not be nil")
         operation.cancel()

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignOutTests/AuthSignOutTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthSignOutTests/AuthSignOutTests.swift
@@ -15,6 +15,7 @@ import AmplifyTestCommon
 class AuthSignedOutTests: AWSAuthBaseTest {
 
     override func setUpWithError() throws {
+        continueAfterFailure = false
         try initializeAmplify()
     }
 
@@ -39,7 +40,7 @@ class AuthSignedOutTests: AWSAuthBaseTest {
             }
             switch result {
             case .success:
-                print("Success signout")
+                break
             case .failure(let error):
                 XCTFail("SignOut should not fail - \(error)")
             }
@@ -65,7 +66,9 @@ class AuthSignedOutTests: AWSAuthBaseTest {
         AuthSignInHelper.registerAndSignInUser(username: username,
                                                password: password,
                                                email: email) { didSucceed, error in
-            signInExpectation.fulfill()
+            defer {
+                signInExpectation.fulfill()
+            }
             XCTAssertTrue(didSucceed, "SignIn operation failed - \(String(describing: error))")
         }
         wait(for: [signInExpectation], timeout: networkTimeout)
@@ -76,10 +79,10 @@ class AuthSignedOutTests: AWSAuthBaseTest {
             defer {
                 authSignedInSessionExpectation.fulfill()
             }
-            do {
-                let session = try result.get()
+            switch result {
+            case .success(let session):
                 XCTAssertTrue(session.isSignedIn, "Auth session should be signedin")
-            } catch {
+            case .failure(let error):
                 XCTFail("Fetch auth session failed with error - \(error)")
             }
         }
@@ -92,7 +95,7 @@ class AuthSignedOutTests: AWSAuthBaseTest {
             }
             switch result {
             case .success:
-                print("Success signout")
+                break
             case .failure(let error):
                 XCTFail("SignOut should not fail - \(error)")
             }
@@ -133,7 +136,9 @@ class AuthSignedOutTests: AWSAuthBaseTest {
         AuthSignInHelper.registerAndSignInUser(username: username,
                                                password: password,
                                                email: email) { didSucceed, error in
-            signInExpectation.fulfill()
+            defer {
+                signInExpectation.fulfill()
+            }
             XCTAssertTrue(didSucceed, "SignIn operation failed - \(String(describing: error))")
         }
         wait(for: [signInExpectation], timeout: networkTimeout)
@@ -145,10 +150,10 @@ class AuthSignedOutTests: AWSAuthBaseTest {
             defer {
                 authSignedInSessionExpectation.fulfill()
             }
-            do {
-                let session = try result.get()
+            switch result {
+            case .success(let session):
                 XCTAssertTrue(session.isSignedIn, "Auth session should be signedin")
-            } catch {
+            case .failure(let error):
                 XCTFail("Fetch auth session failed with error - \(error)")
             }
         }
@@ -161,7 +166,7 @@ class AuthSignedOutTests: AWSAuthBaseTest {
             }
             switch result {
             case .success:
-                print("Success signout")
+                break
             case .failure(let error):
                 XCTFail("SignOut should not fail - \(error)")
             }

--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthUserAttributesTests/AuthUserAttributesTests.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/AuthUserAttributesTests/AuthUserAttributesTests.swift
@@ -10,9 +10,11 @@ import XCTest
 import AWSCognitoAuthPlugin
 import AmplifyTestCommon
 
+// swiftlint:disable line_length
 class AuthUserAttributesTests: AWSAuthBaseTest {
 
     override func setUpWithError() throws {
+        continueAfterFailure = false
         try initializeAmplify()
     }
 
@@ -41,7 +43,9 @@ class AuthUserAttributesTests: AWSAuthBaseTest {
         AuthSignInHelper.registerAndSignInUser(username: username,
                                                password: password,
                                                email: email) { didSucceed, error in
-            signInExpectation.fulfill()
+            defer {
+                signInExpectation.fulfill()
+            }
             XCTAssertTrue(didSucceed, "SignIn operation failed - \(String(describing: error))")
         }
         wait(for: [signInExpectation], timeout: networkTimeout)
@@ -50,9 +54,12 @@ class AuthUserAttributesTests: AWSAuthBaseTest {
         let pluginOptions = AWSUpdateUserAttributeOptions(metadata: ["mydata": "myvalue"])
         let options = AuthUpdateUserAttributeRequest.Options(pluginOptions: pluginOptions)
         _ = Amplify.Auth.update(userAttribute: AuthUserAttribute(.email, value: email), options: options) { result in
+            defer {
+                updateExpectation.fulfill()
+            }
             switch result {
             case .success:
-                updateExpectation.fulfill()
+                break
             case .failure(let error):
                 XCTFail("Failed to update user attribute with \(error)")
             }
@@ -80,7 +87,9 @@ class AuthUserAttributesTests: AWSAuthBaseTest {
         AuthSignInHelper.registerAndSignInUser(username: username,
                                                password: password,
                                                email: email) { didSucceed, error in
-            signInExpectation.fulfill()
+            defer {
+                signInExpectation.fulfill()
+            }
             XCTAssertTrue(didSucceed, "SignIn operation failed - \(String(describing: error))")
         }
         wait(for: [signInExpectation], timeout: networkTimeout)
@@ -88,9 +97,12 @@ class AuthUserAttributesTests: AWSAuthBaseTest {
         let updateExpectation = expectation(description: "Update operation should complete")
 
         _ = Amplify.Auth.update(userAttribute: AuthUserAttribute(.email, value: email2)) { result in
+            defer {
+                updateExpectation.fulfill()
+            }
             switch result {
             case .success:
-                updateExpectation.fulfill()
+                break
             case .failure(let error):
                 XCTFail("Failed to update user attribute with \(error)")
             }
@@ -102,10 +114,12 @@ class AuthUserAttributesTests: AWSAuthBaseTest {
         let pluginOptions = AWSAttributeResendConfirmationCodeOptions(metadata: ["mydata": "myvalue"])
         let options = AuthAttributeResendConfirmationCodeRequest.Options(pluginOptions: pluginOptions)
         _ = Amplify.Auth.resendConfirmationCode(for: .email, options: options) { result in
+            defer {
+                resendExpectation.fulfill()
+            }
             switch result {
             case .success(let deliveryDetails):
                 print("Resend code send to - \(deliveryDetails)")
-                resendExpectation.fulfill()
             case .failure(let error):
                 print("Resend code failed with error \(error)")
             }


### PR DESCRIPTION
## Issue

https://github.com/aws-amplify/amplify-swift/issues/2705

## Description
<!-- Why is this change required? What problem does it solve? -->

Ensuring integration tests fail fast on assertions such as those for a successful sign-in. This helps reduce noise during investigations. Think of this as the unit test equivalent of an [andon cord](https://en.wikipedia.org/wiki/Andon_(manufacturing)).

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
