### PR TITLE
fix(auth): Restore non-normalized keychain namespace in AuthSessionHe…

### DIFF
--- a/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/Support/AuthSessionHelper.swift
+++ b/AmplifyPlugins/Auth/AWSCognitoAuthPluginIntegrationTests/Support/AuthSessionHelper.swift
@@ -25,7 +25,14 @@ struct AuthSessionHelper {
         // Please note that the clientId + username namespace combination is
         // normalized by converting it to a lower-case string somewhere upstream
         // of the AWSUICKeyChainStore. So, the same is done below.
-        let namespace = "\(clientId).\(username)".lowercased()
+        let namespace = "\(clientId).\(username)"
+        invalidateSession(keychain: keychain, namespace: namespace)
+
+        let namespaceNormalized = namespace.lowercased()
+        invalidateSession(keychain: keychain, namespace: namespaceNormalized)
+    }
+
+    private static func invalidateSession(keychain: AWSUICKeyChainStore, namespace: String) {
         let expirationKey = "\(namespace).tokenExpiration"
         let refreshTokenKey = "\(namespace).refreshToken"
 


### PR DESCRIPTION
## Description
<!-- Why is this change required? What problem does it solve? -->

We're seeing the `SignedInAuthSessionTests` integration test fail in CICD but not on developer machines. This likely because of [a change that was made to normalize the namespace used by AuthSessionHelper.swift](https://github.com/aws-amplify/amplify-swift/pull/2693/files#diff-ae2ad98c306bf7f0bca2ab3d2cc6fd49abe79fc356324fc86f2785748269dbd6) when invalidation a user's session. So, this change puts the old non-normalized namespace back into play.

See: https://github.com/aws-amplify/amplify-swift/pull/2693/files

Working locally:

![Screenshot 2023-01-26 at 4 25 47 PM](https://user-images.githubusercontent.com/1117904/214964673-80912b77-aa41-4793-83e2-a0960df4f0f0.png)

## General Checklist

<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
