### PR TITLE
fix(storage) Storage.uploadFile exits early on access denied

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadFileOperation.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadFileOperation.swift
@@ -84,6 +84,17 @@ class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation<
             return
         }
 
+        // This check was added because, at the time of this writing, AWS SDK
+        // failed silently on access denied.
+        if FileManager.default.fileExists(atPath: request.local.path) {
+            guard FileManager.default.isReadableFile(atPath: request.local.path) else {
+                dispatch(StorageError.accessDenied("Access to local file denied: \(request.local.path)",
+                                                   "Please ensure that \(request.local) is readable"))
+                finish()
+                return
+            }
+        }
+
         let uploadSize: UInt64
         do {
             uploadSize = try StorageRequestUtils.getSize(request.local)

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests2.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests2.swift
@@ -1,0 +1,74 @@
+////
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSPluginsTestCommon
+@testable import AWSS3StoragePlugin
+@testable import AWSPluginsCore
+
+import AWSS3
+import XCTest
+
+final class AWSS3StorageUploadFileOperationTests2: AWSS3StorageOperationTestBase {
+    
+    override func setUp() {
+        super.setUp()
+        self.continueAfterFailure = false
+    }
+
+    /// - Given: A file with no read permissions from the user
+    /// - When: An attempt is made to upload it
+    /// - Then: An accessDenied error is returned before attempting proceed further
+    func testAccessDenied() throws {
+        let path = NSTemporaryDirectory().appending(UUID().uuidString)
+        FileManager.default.createFile(atPath: path,
+                                       contents: Data(UUID().uuidString.utf8),
+                                       attributes: [FileAttributeKey.posixPermissions: 000])
+        defer {
+            try? FileManager.default.removeItem(atPath: path)
+        }
+
+        let url = URL(fileURLWithPath: path)
+        let key = (path as NSString).lastPathComponent
+        let options = StorageUploadFileRequest.Options(accessLevel: .protected)
+        let request = StorageUploadFileRequest(key: key, local: url, options: options)
+
+        let progressExpectation = expectation(description: "progress")
+        progressExpectation.isInverted = true
+        let progressListner: ProgressListener = { _ in progressExpectation.fulfill() }
+
+        let resultExpectation = expectation(description: "result")
+        let resultListener: StorageUploadFileOperation.ResultListener = { result in
+            defer {
+                resultExpectation.fulfill()
+            }
+            switch result {
+            case .failure(let error):
+                guard case .accessDenied(let description, let recommendation, _) = error else {
+                    XCTFail("Should have failed with validation error")
+                    return
+                }
+                XCTAssertEqual(description, "Access to local file denied: \(path)")
+                XCTAssertEqual(recommendation, "Please ensure that \(url) is readable")
+            case .success:
+                XCTFail("Expecting an error but got success")
+            }
+        }
+
+        let operation = AWSS3StorageUploadFileOperation(request,
+                                                        storageConfiguration: testStorageConfiguration,
+                                                        storageService: mockStorageService,
+                                                        authService: mockAuthService,
+                                                        progressListener: progressListner,
+                                                        resultListener: resultListener)
+        operation.start()
+
+        wait(for: [progressExpectation, resultExpectation], timeout: 1)
+        XCTAssertTrue(operation.isFinished)
+    }
+}


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

https://github.com/aws-amplify/amplify-swift/issues/2355

## Description
<!-- Why is this change required? What problem does it solve? -->

v2 fix for https://github.com/aws-amplify/amplify-swift/issues/2355 where upload will do an early return if the file represented by the given URL is inaccessible.

The v1 counterpart PR can be found [here](https://github.com/aws-amplify/amplify-swift/pull/2655).

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

![Screenshot 2023-01-27 at 2 05 36 PM](https://user-images.githubusercontent.com/1117904/215187267-85684a7d-9a84-42e8-9b4a-63367541d092.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
