### PR TITLE
chore(auth): Add more verbose logging for easier debugging

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthChangePasswordTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthChangePasswordTask.swift
@@ -10,7 +10,7 @@ import Amplify
 import AWSPluginsCore
 import AWSCognitoIdentityProvider
 
-class AWSAuthChangePasswordTask: AuthChangePasswordTask {
+class AWSAuthChangePasswordTask: AuthChangePasswordTask, DefaultLogger {
     typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
 
     private let request: AuthChangePasswordRequest
@@ -33,10 +33,12 @@ class AWSAuthChangePasswordTask: AuthChangePasswordTask {
     }
 
     func execute() async throws {
+        log.verbose("Starting execution")
         do {
             await taskHelper.didStateMachineConfigured()
             let accessToken = try await taskHelper.getAccessToken()
             try await changePassword(with: accessToken)
+            log.verbose("Received success")
         } catch let error as ChangePasswordOutputError {
             throw error.authError
         } catch let error {
@@ -46,7 +48,9 @@ class AWSAuthChangePasswordTask: AuthChangePasswordTask {
 
     func changePassword(with accessToken: String) async throws {
         let userPoolService = try userPoolFactory()
-        let input = ChangePasswordInput(accessToken: accessToken, previousPassword: request.oldPassword, proposedPassword: request.newPassword)
+        let input = ChangePasswordInput(accessToken: accessToken,
+                                        previousPassword: request.oldPassword,
+                                        proposedPassword: request.newPassword)
         _ = try await userPoolService.changePassword(input: input)
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthClearFederationToIdentityPoolTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthClearFederationToIdentityPoolTask.swift
@@ -18,7 +18,8 @@ public extension HubPayload.EventName.Auth {
     static let clearedFederationToIdentityPoolAPI = "Auth.federationToIdentityPoolCleared"
 }
 
-public class AWSAuthClearFederationToIdentityPoolTask: AuthClearFederationToIdentityPoolTask {
+public class AWSAuthClearFederationToIdentityPoolTask: AuthClearFederationToIdentityPoolTask,
+                                                       DefaultLogger {
     private let authStateMachine: AuthStateMachine
     private let clearFederationHelper: ClearFederationOperationHelper
     private let taskHelper: AWSAuthTaskHelper
@@ -34,7 +35,10 @@ public class AWSAuthClearFederationToIdentityPoolTask: AuthClearFederationToIden
     }
 
     public func execute() async throws {
+        log.verbose("Starting execution")
         await taskHelper.didStateMachineConfigured()
-        return try await clearFederationHelper.clearFederation(authStateMachine)
+        try await clearFederationHelper.clearFederation(authStateMachine)
+        log.verbose("Cleared federation")
+        return
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmResetPasswordTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmResetPasswordTask.swift
@@ -11,7 +11,7 @@ import AWSPluginsCore
 import ClientRuntime
 import AWSCognitoIdentityProvider
 
-class AWSAuthConfirmResetPasswordTask: AuthConfirmResetPasswordTask {
+class AWSAuthConfirmResetPasswordTask: AuthConfirmResetPasswordTask, DefaultLogger {
     private let request: AuthConfirmResetPasswordRequest
     private let environment: AuthEnvironment
     private let authConfiguration: AuthConfiguration
@@ -27,10 +27,12 @@ class AWSAuthConfirmResetPasswordTask: AuthConfirmResetPasswordTask {
     }
 
     func execute() async throws {
+        log.verbose("Starting execution")
         if let validationError = request.hasError() {
             throw validationError
         }
         do {
+            
             try await confirmResetPassword()
         } catch let error as ConfirmForgotPasswordOutputError {
             throw error.authError

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignUpTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignUpTask.swift
@@ -9,7 +9,7 @@ import Foundation
 import Amplify
 import AWSCognitoIdentityProvider
 
-class AWSAuthConfirmSignUpTask: AuthConfirmSignUpTask {
+class AWSAuthConfirmSignUpTask: AuthConfirmSignUpTask, DefaultLogger {
 
     private let request: AuthConfirmSignUpRequest
     private let authEnvironment: AuthEnvironment
@@ -24,10 +24,10 @@ class AWSAuthConfirmSignUpTask: AuthConfirmSignUpTask {
     }
 
     func execute() async throws -> AuthSignUpResult {
+        log.verbose("Starting execution")
         try request.hasError()
         let userPoolEnvironment = authEnvironment.userPoolEnvironment
         do {
-
             let metadata = (request.options.pluginOptions as? AWSAuthConfirmSignUpOptions)?.metadata
             let client = try userPoolEnvironment.cognitoUserPoolFactory()
             let input = ConfirmSignUpInput(username: request.username,
@@ -35,6 +35,7 @@ class AWSAuthConfirmSignUpTask: AuthConfirmSignUpTask {
                                            clientMetadata: metadata,
                                            environment: userPoolEnvironment)
             _ = try await client.confirmSignUp(input: input)
+            log.verbose("Received success")
             return AuthSignUpResult(.done)
         } catch let error as AuthError {
             throw error

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFederateToIdentityPoolTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFederateToIdentityPoolTask.swift
@@ -17,7 +17,7 @@ public extension HubPayload.EventName.Auth {
     static let federateToIdentityPoolAPI = "Auth.federatedToIdentityPool"
 }
 
-public class AWSAuthFederateToIdentityPoolTask: AuthFederateToIdentityPoolTask {
+public class AWSAuthFederateToIdentityPoolTask: AuthFederateToIdentityPoolTask, DefaultLogger {
 
     private let request: AuthFederateToIdentityPoolRequest
     private let authStateMachine: AuthStateMachine
@@ -34,6 +34,7 @@ public class AWSAuthFederateToIdentityPoolTask: AuthFederateToIdentityPoolTask {
     }
 
     public func execute() async throws -> FederateToIdentityPoolResult {
+        log.verbose("Starting execution")
         await taskHelper.didStateMachineConfigured()
         let state = await authStateMachine.currentState
         guard case .configured(let authNState, let authZState) = state  else {
@@ -55,6 +56,7 @@ public class AWSAuthFederateToIdentityPoolTask: AuthFederateToIdentityPoolTask {
 
         await sendStartFederatingToIdentityPoolEvent()
         let stateSequences = await authStateMachine.listen()
+        log.verbose("Waiting for federation to complete")
         for await state in stateSequences {
             guard  case .configured(let authNState, let authZState) = state else {
                 continue

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFetchSessionTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFetchSessionTask.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Amplify
 
-class AWSAuthFetchSessionTask: AuthFetchSessionTask {
+class AWSAuthFetchSessionTask: AuthFetchSessionTask, DefaultLogger {
     private let request: AuthFetchSessionRequest
     private let authStateMachine: AuthStateMachine
     private let fetchAuthSessionHelper: FetchAuthSessionOperationHelper
@@ -26,6 +26,7 @@ class AWSAuthFetchSessionTask: AuthFetchSessionTask {
     }
 
     func execute() async throws -> AuthSession {
+        log.verbose("Starting execution")
         await taskHelper.didStateMachineConfigured()
         let doesNeedForceRefresh = request.options.forceRefresh
         return try await fetchAuthSessionHelper.fetch(authStateMachine,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResendSignUpCodeTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResendSignUpCodeTask.swift
@@ -11,7 +11,7 @@ import AWSPluginsCore
 import ClientRuntime
 import AWSCognitoIdentityProvider
 
-class AWSAuthResendSignUpCodeTask: AuthResendSignUpCodeTask {
+class AWSAuthResendSignUpCodeTask: AuthResendSignUpCodeTask, DefaultLogger {
     private let request: AuthResendSignUpCodeRequest
     private let environment: AuthEnvironment
     private let authConfiguration: AuthConfiguration
@@ -27,12 +27,15 @@ class AWSAuthResendSignUpCodeTask: AuthResendSignUpCodeTask {
     }
 
     func execute() async throws -> AuthCodeDeliveryDetails {
+        log.verbose("Starting execution")
         if let validationError = request.hasError() {
             throw validationError
         }
 
         do {
-            return try await resendSignUpCode()
+            let details = try await resendSignUpCode()
+            log.verbose("Received result")
+            return details
         } catch let error as ResendConfirmationCodeOutputError {
             throw error.authError
         } catch let error as SdkError<ResendConfirmationCodeOutputError> {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResetPasswordTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResetPasswordTask.swift
@@ -11,7 +11,8 @@ import AWSPluginsCore
 import ClientRuntime
 import AWSCognitoIdentityProvider
 
-class AWSAuthResetPasswordTask: AuthResetPasswordTask {
+class AWSAuthResetPasswordTask: AuthResetPasswordTask, DefaultLogger {
+
     private let request: AuthResetPasswordRequest
     private let environment: AuthEnvironment
     private let authConfiguration: AuthConfiguration
@@ -27,11 +28,14 @@ class AWSAuthResetPasswordTask: AuthResetPasswordTask {
     }
 
     func execute() async throws -> AuthResetPasswordResult {
+        log.verbose("Starting execution")
         if let validationError = request.hasError() {
             throw validationError
         }
         do {
-            return try await resetPassword()
+            let result = try await resetPassword()
+            log.verbose("Received result")
+            return result
         } catch let error as ForgotPasswordOutputError {
             throw error.authError
         } catch let error as SdkError<ForgotPasswordOutputError> {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignUpTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignUpTask.swift
@@ -9,7 +9,7 @@ import Foundation
 import AWSCognitoIdentityProvider
 import Amplify
 
-class AWSAuthSignUpTask: AuthSignUpTask {
+class AWSAuthSignUpTask: AuthSignUpTask, DefaultLogger {
 
     private let request: AuthSignUpRequest
 
@@ -25,6 +25,7 @@ class AWSAuthSignUpTask: AuthSignUpTask {
     }
 
     func execute() async throws -> AuthSignUpResult {
+        log.verbose("Starting execution")
         let userPoolEnvironment = authEnvironment.userPoolEnvironment
         try request.hasError()
 
@@ -49,6 +50,7 @@ class AWSAuthSignUpTask: AuthSignUpTask {
                                     environment: userPoolEnvironment)
 
             let response = try await client.signUp(input: input)
+            log.verbose("Received result")
             return response.authResponse
         } catch let error as AuthError {
             throw error

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthWebUISignInTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthWebUISignInTask.swift
@@ -8,7 +8,7 @@ import Foundation
 import Amplify
 import AWSPluginsCore
 
-class AWSAuthWebUISignInTask: AuthWebUISignInTask {
+class AWSAuthWebUISignInTask: AuthWebUISignInTask, DefaultLogger {
 
     private let helper: HostedUISignInHelper
     private let request: AuthWebUISignInRequest
@@ -31,10 +31,11 @@ class AWSAuthWebUISignInTask: AuthWebUISignInTask {
     }
 
     func execute() async throws -> AuthSignInResult {
-
+        log.verbose("Starting execution")
         do {
             await taskHelper.didStateMachineConfigured()
             let result = try await helper.initiateSignIn()
+            log.verbose("Received result")
             return result
         } catch let autherror as AuthErrorConvertible {
             throw autherror.authError

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/Helpers/AWSAuthTaskHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/Helpers/AWSAuthTaskHelper.swift
@@ -10,7 +10,7 @@ import Amplify
 import AWSPluginsCore
 import AWSCognitoIdentityProvider
 
-class AWSAuthTaskHelper {
+class AWSAuthTaskHelper: DefaultLogger {
 
     private let authStateMachine: AuthStateMachine
     private let fetchAuthSessionHelper: FetchAuthSessionOperationHelper
@@ -21,9 +21,13 @@ class AWSAuthTaskHelper {
     }
 
     func didStateMachineConfigured() async {
+        log.verbose("Check if authstate configured")
         let stateSequences = await authStateMachine.listen()
         for await state in stateSequences {
-            if case .configured = state { return }
+            if case .configured = state {
+                log.verbose("Auth state configured")
+                return
+            }
         }
     }
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
Adds more logs in verbose for easier debugging. Example of logs:

```
2023-01-27 13:38:18.432817-0800 AmplifyAuthSample[48850:3388855] [AWSAuthSignInTask] Starting execution
2023-01-27 13:38:18.433187-0800 AmplifyAuthSample[48850:3388855] [AWSAuthTaskHelper] Check if authstate configured
2023-01-27 13:38:18.433271-0800 AmplifyAuthSample[48850:3388855] [AWSAuthTaskHelper] Auth state configured
2023-01-27 13:38:18.433389-0800 AmplifyAuthSample[48850:3388855] [AWSAuthSignInTask] Validating current state
2023-01-27 13:38:18.433786-0800 AmplifyAuthSample[48850:3388855] [AWSAuthSignInTask] Signing with customWithSRP
2023-01-27 13:38:18.433846-0800 AmplifyAuthSample[48850:3388855] [AWSAuthSignInTask] Sending signIn event
2023-01-27 13:38:18.434026-0800 AmplifyAuthSample[48850:3388855] [AWSAuthSignInTask] Waiting for signin to complete
2023-01-27 13:38:18.434731-0800 AmplifyAuthSample[48850:3388855] [UserPoolSignInHelper] Checking next step for: notStarted
```

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
