### PR TITLE
fix: add granular read ops enum

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/Schema/AuthRule.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/AuthRule.swift
@@ -22,6 +22,12 @@ public enum ModelOperation {
     case update
     case delete
     case read
+    // granular read access
+    case `get`
+    case list 
+    case sync 
+    case listen 
+    case search
 }
 
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-flutter/issues/2526
## Description
<!-- Why is this change required? What problem does it solve? -->
Add granular read operation enums in model auth operation rule
Refer https://docs.amplify.aws/cli/graphql/authorization-rules/#how-it-works
## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
