### PR TITLE
fix: CPK uni-directional has-many lazy list load

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/ModelListProvider.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelListProvider.swift
@@ -25,10 +25,10 @@ public enum ModelListProviderState<Element: Model> {
     /// If the list represents an association between two models, the `associatedIdentifiers` will
     /// hold the information necessary to query the associated elements (e.g. comments of a post)
     ///
-    /// The associatedField represents the field to which the owner of the `List` is linked to.
+    /// The associatedFields represents the field to which the owner of the `List` is linked to.
     /// For example, if `Post.comments` is associated with `Comment.post` the `List<Comment>`
     /// of `Post` will have a reference to the `post` field in `Comment`.
-    case notLoaded(associatedIdentifiers: [String], associatedField: String)
+    case notLoaded(associatedIdentifiers: [String], associatedFields: [String])
     case loaded([Element])
 }
 

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
@@ -87,7 +87,7 @@ import Foundation
 /// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
 ///   directly by host applications. The behavior of this may change without warning.
 public enum ModelAssociation {
-    case hasMany(associatedFieldName: String?, targetNames: [String] = [])
+    case hasMany(associatedFieldName: String?, associatedFieldNames: [String] = [])
     case hasOne(associatedFieldName: String?, targetNames: [String])
     case belongsTo(associatedFieldName: String?, targetNames: [String])
 
@@ -98,8 +98,8 @@ public enum ModelAssociation {
         return .belongsTo(associatedFieldName: nil, targetNames: targetNames)
     }
     
-    public static func hasMany(associatedWith: CodingKey?, targetNames: [String] = []) -> ModelAssociation {
-        return .hasMany(associatedFieldName: associatedWith?.stringValue, targetNames: targetNames)
+    public static func hasMany(associatedWith: CodingKey? = nil, associatedWithFields: [CodingKey] = []) -> ModelAssociation {
+        return .hasMany(associatedFieldName: associatedWith?.stringValue, associatedFieldNames: associatedWithFields.map { $0.stringValue })
     }
 
     @available(*, deprecated, message: "Use hasOne(associatedWith:targetNames:)")
@@ -267,14 +267,14 @@ extension ModelField {
     ///   breaking change.
     public var associatedFieldNames: [String] {
         switch association {
-        case .belongsTo(let associatedKey, let targetNames),
-                .hasOne(let associatedKey, let targetNames),
-                .hasMany(let associatedKey, let targetNames):
-            if targetNames.isEmpty, let associatedKey = associatedKey {
+        case .belongsTo(let associatedKey, let associatedKeys),
+                .hasOne(let associatedKey, let associatedKeys),
+                .hasMany(let associatedKey, let associatedKeys):
+            if associatedKeys.isEmpty, let associatedKey = associatedKey {
                 return [associatedKey]
             }
             
-            return targetNames
+            return associatedKeys
         case .none:
             return []
         }

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
@@ -98,8 +98,8 @@ public enum ModelAssociation {
         return .belongsTo(associatedFieldName: nil, targetNames: targetNames)
     }
     
-    public static func hasMany(associatedWith: CodingKey? = nil, associatedWithFields: [CodingKey] = []) -> ModelAssociation {
-        return .hasMany(associatedFieldName: associatedWith?.stringValue, associatedFieldNames: associatedWithFields.map { $0.stringValue })
+    public static func hasMany(associatedWith: CodingKey? = nil, associatedFields: [CodingKey] = []) -> ModelAssociation {
+        return .hasMany(associatedFieldName: associatedWith?.stringValue, associatedFieldNames: associatedFields.map { $0.stringValue })
     }
 
     @available(*, deprecated, message: "Use hasOne(associatedWith:targetNames:)")

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -233,13 +233,24 @@ public enum ModelFieldDefinition {
                                is nullability: ModelFieldNullability = .required,
                                isReadOnly: Bool = false,
                                ofType type: Model.Type,
-                               associatedWith associatedKey: CodingKey,
-                               targetNames: [String] = []) -> ModelFieldDefinition {
+                               associatedWith associatedKey: CodingKey) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
                       isReadOnly: isReadOnly,
                       ofType: .collection(of: type),
-                      association: .hasMany(associatedWith: associatedKey, targetNames: targetNames))
+                      association: .hasMany(associatedWith: associatedKey))
+    }
+    
+    public static func hasMany(_ key: CodingKey,
+                               is nullability: ModelFieldNullability = .required,
+                               isReadOnly: Bool = false,
+                               ofType type: Model.Type,
+                               associatedWithFields associatedKeys: [CodingKey]) -> ModelFieldDefinition {
+        return .field(key,
+                      is: nullability,
+                      isReadOnly: isReadOnly,
+                      ofType: .collection(of: type),
+                      association: .hasMany(associatedWith: associatedKeys.first ?? nil, associatedWithFields: associatedKeys))
     }
 
     public static func hasOne(_ key: CodingKey,

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -233,12 +233,13 @@ public enum ModelFieldDefinition {
                                is nullability: ModelFieldNullability = .required,
                                isReadOnly: Bool = false,
                                ofType type: Model.Type,
-                               associatedWith associatedKey: CodingKey) -> ModelFieldDefinition {
+                               associatedWith associatedKey: CodingKey,
+                               targetNames: [String] = []) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
                       isReadOnly: isReadOnly,
                       ofType: .collection(of: type),
-                      association: .hasMany(associatedWith: associatedKey))
+                      association: .hasMany(associatedWith: associatedKey, targetNames: targetNames))
     }
 
     public static func hasOne(_ key: CodingKey,

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -245,12 +245,12 @@ public enum ModelFieldDefinition {
                                is nullability: ModelFieldNullability = .required,
                                isReadOnly: Bool = false,
                                ofType type: Model.Type,
-                               associatedWithFields associatedKeys: [CodingKey]) -> ModelFieldDefinition {
+                               associatedFields associatedKeys: [CodingKey]) -> ModelFieldDefinition {
         return .field(key,
                       is: nullability,
                       isReadOnly: isReadOnly,
                       ofType: .collection(of: type),
-                      association: .hasMany(associatedWith: associatedKeys.first ?? nil, associatedWithFields: associatedKeys))
+                      association: .hasMany(associatedWith: associatedKeys.first ?? nil, associatedFields: associatedKeys))
     }
 
     public static func hasOne(_ key: CodingKey,

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListDecoder.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListDecoder.swift
@@ -16,7 +16,7 @@ public struct AppSyncListDecoder: ModelListDecoder {
     /// Metadata that contains information about an associated parent object.
     struct Metadata: Codable {
         let appSyncAssociatedIdentifiers: [String]
-        let appSyncAssociatedField: String
+        let appSyncAssociatedFields: [String]
         let apiName: String?
     }
     

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListProvider.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListProvider.swift
@@ -115,7 +115,6 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
             var queryPredicates: [QueryPredicateOperation] = []
             
             let columnNames = columnNames(fields: associatedFields, Element.schema)
-            print("####### columnNames for \(associatedFields) \(columnNames) ")
             let predicateValues = zip(columnNames, associatedIdentifiers)
             for (identifierName, identifierValue) in predicateValues {
                 queryPredicates.append(QueryPredicateOperation(field: identifierName,

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListProvider.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListProvider.swift
@@ -22,11 +22,11 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
         /// If the list represents an association between two models, the `associatedIdentifiers` will
         /// hold the information necessary to query the associated elements (e.g. comments of a post)
         ///
-        /// The associatedField represents the field to which the owner of the `List` is linked to.
+        /// The associatedFields represents the field to which the owner of the `List` is linked to.
         /// For example, if `Post.comments` is associated with `Comment.post` the `List<Comment>`
         /// of `Post` will have a reference to the `post` field in `Comment`.
         case notLoaded(associatedIdentifiers: [String],
-                       associatedField: String)
+                       associatedFields: [String])
 
         /// If the list is retrieved directly, this state holds the underlying data, nextToken used to create
         /// the subsequent GraphQL request, and previous filter used to create the loaded list
@@ -58,7 +58,7 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
 
     convenience init(metadata: AppSyncListDecoder.Metadata) {
         self.init(associatedIdentifiers: metadata.appSyncAssociatedIdentifiers,
-                  associatedField: metadata.appSyncAssociatedField,
+                  associatedFields: metadata.appSyncAssociatedFields,
                   apiName: metadata.apiName)
     }
 
@@ -76,9 +76,9 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
     }
 
     // Internal initializer for testing
-    init(associatedIdentifiers: [String], associatedField: String, apiName: String? = nil) {
+    init(associatedIdentifiers: [String], associatedFields: [String], apiName: String? = nil) {
         self.loadedState = .notLoaded(associatedIdentifiers: associatedIdentifiers,
-                                      associatedField: associatedField)
+                                      associatedFields: associatedFields)
         self.apiName = apiName
     }
 
@@ -86,8 +86,8 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
 
     public func getState() -> ModelListProviderState<Element> {
         switch loadedState {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
-            return .notLoaded(associatedIdentifiers: associatedIdentifiers, associatedField: associatedField)
+        case .notLoaded(let associatedIdentifiers, let associatedFields):
+            return .notLoaded(associatedIdentifiers: associatedIdentifiers, associatedFields: associatedFields)
         case .loaded(let elements, _, _):
             return .loaded(elements)
         }
@@ -97,22 +97,25 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
         switch loadedState {
         case .loaded(let elements, _, _):
             return elements
-        case .notLoaded(let associatedIdentifiers, let associatedField):
-            return try await load(associatedIdentifiers: associatedIdentifiers, associatedField: associatedField)
+        case .notLoaded(let associatedIdentifiers, let associatedFields):
+            return try await load(associatedIdentifiers: associatedIdentifiers, associatedFields: associatedFields)
         }
     }
     
     //// Internal `load` to perform the retrieval of the first page and storing it in memory
     func load(associatedIdentifiers: [String],
-              associatedField: String) async throws -> [Element] {
+              associatedFields: [String]) async throws -> [Element] {
         let filter: GraphQLFilter
-        if associatedIdentifiers.count == 1, let associatedId = associatedIdentifiers.first {
+        if associatedIdentifiers.count == 1,
+            let associatedId = associatedIdentifiers.first,
+            let associatedField = associatedFields.first {
             let predicate: QueryPredicate = field(associatedField) == associatedId
             filter = predicate.graphQLFilter(for: Element.schema)
         } else {
             var queryPredicates: [QueryPredicateOperation] = []
-            let columnNames = columnNames(field: associatedField, Element.schema)
             
+            let columnNames = columnNames(fields: associatedFields, Element.schema)
+            print("####### columnNames for \(associatedFields) \(columnNames) ")
             let predicateValues = zip(columnNames, associatedIdentifiers)
             for (identifierName, identifierValue) in predicateValues {
                 queryPredicates.append(QueryPredicateOperation(field: identifierName,
@@ -220,10 +223,10 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
     
     public func encode(to encoder: Encoder) throws {
         switch loadedState {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
+        case .notLoaded(let associatedIdentifiers, let associatedFields):
             let metadata = AppSyncListDecoder.Metadata.init(
                 appSyncAssociatedIdentifiers: associatedIdentifiers,
-                appSyncAssociatedField: associatedField,
+                appSyncAssociatedFields: associatedFields,
                 apiName: apiName)
             var container = encoder.singleValueContainer()
             try container.encode(metadata)
@@ -241,9 +244,14 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
     // MARK: - Helpers
     
     /// Retrieve the column names for the specified field `field` for this schema.
-    func columnNames(field: String, _ modelSchema: ModelSchema) -> [String] {
-        guard let modelField = modelSchema.field(withName: field) else {
-            return [field]
+    func columnNames(fields: [String], _ modelSchema: ModelSchema) -> [String] {
+        // Associated field names have already been resolved from the parent model's has-many targetNames
+        if fields.count > 1 {
+            return fields
+        }
+        // Resolve the ModelField of the field reference
+        guard let field = fields.first, let modelField = modelSchema.field(withName: field) else {
+            return fields
         }
         let defaultFieldName = modelSchema.name.camelCased() + field.pascalCased() + "Id"
         switch modelField.association {
@@ -254,7 +262,7 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
             }
             return targetNames
         default:
-            return [field]
+            return fields
         }
     }
     

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncModelMetadata.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncModelMetadata.swift
@@ -113,10 +113,9 @@ public struct AppSyncModelMetadataUtils {
                 // Scenario: Has-many items array is missing.
                 // Store the association data (parent's identifier and field name)
                 // This allows the list to perform lazy loading of child items using parent identifier as the predicate
-                if let associatedField = modelField.associatedField,
-                   modelJSON[modelField.name] == nil {
+                if modelJSON[modelField.name] == nil {
                     let appSyncModelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: identifiers,
-                                                                           appSyncAssociatedField: associatedField.name,
+                                                                           appSyncAssociatedFields: modelField.associatedFieldNames,
                                                                            apiName: apiName)
                     if let serializedMetadata = try? encoder.encode(appSyncModelMetadata),
                        let metadataJSON = try? decoder.decode(JSONValue.self, from: serializedMetadata) {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/GraphQLLazyLoadBaseTest.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/GraphQLLazyLoadBaseTest.swift
@@ -133,18 +133,18 @@ class GraphQLLazyLoadBaseTest: XCTestCase {
     }
     
     enum AssertListState {
-        case isNotLoaded(associatedIdentifiers: [String], associatedField: String)
+        case isNotLoaded(associatedIdentifiers: [String], associatedFields: [String])
         case isLoaded(count: Int)
     }
     
     func assertList<M: Model>(_ list: List<M>, state: AssertListState) {
         switch state {
-        case .isNotLoaded(let expectedAssociatedIdentifiers, let expectedAssociatedField):
-            if case .notLoaded(let associatedIdentifiers, let associatedField) = list.listProvider.getState() {
+        case .isNotLoaded(let expectedAssociatedIdentifiers, let expectedAssociatedFields):
+            if case .notLoaded(let associatedIdentifiers, let associatedFields) = list.listProvider.getState() {
                 XCTAssertEqual(associatedIdentifiers, expectedAssociatedIdentifiers)
-                XCTAssertEqual(associatedField, expectedAssociatedField)
+                XCTAssertEqual(associatedFields, expectedAssociatedFields)
             } else {
-                XCTFail("It should be not loaded with expected associatedId \(expectedAssociatedIdentifiers) associatedField \(expectedAssociatedField)")
+                XCTFail("It should be not loaded with expected associatedIds \(expectedAssociatedIdentifiers) associatedFields \(expectedAssociatedFields)")
             }
         case .isLoaded(let count):
             if case .loaded(let loadedList) = list.listProvider.getState() {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL1/GraphQLLazyLoadPostComment4V2Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL1/GraphQLLazyLoadPostComment4V2Tests.swift
@@ -39,7 +39,7 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
         
         // The loaded post should have comments that are also not loaded
         let comments = loadedPost.comments!
-        assertList(comments, state: .isNotLoaded(associatedIdentifiers: [createdPost.id], associatedField: "post"))
+        assertList(comments, state: .isNotLoaded(associatedIdentifiers: [createdPost.id], associatedFields: ["post"]))
         // load the comments
         try await comments.fetch()
         assertList(comments, state: .isLoaded(count: 1))
@@ -60,7 +60,7 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
         XCTAssertEqual(loadedPost.id, post.id)
         // The loaded post should have comments that are not loaded
         let comments = loadedPost.comments!
-        assertList(comments, state: .isNotLoaded(associatedIdentifiers: [post.id], associatedField: "post"))
+        assertList(comments, state: .isNotLoaded(associatedIdentifiers: [post.id], associatedFields: ["post"]))
         // load the comments
         try await comments.fetch()
         assertList(comments, state: .isLoaded(count: 1))
@@ -175,7 +175,7 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
         _ = try await mutate(.create(comment))
         let queriedPost = try await query(.get(Post.self, byId: post.id))!
         let comments = queriedPost.comments!
-        assertList(comments, state: .isNotLoaded(associatedIdentifiers: [post.id], associatedField: "post"))
+        assertList(comments, state: .isNotLoaded(associatedIdentifiers: [post.id], associatedFields: ["post"]))
         try await comments.fetch()
         assertList(comments, state: .isLoaded(count: 1))
         assertLazyReference(comments.first!._post, state: .notLoaded(identifiers: [.init(name: "id", value: post.id)]))
@@ -217,7 +217,7 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
         let queriedPosts = try await listQuery(.list(Post.self, where: Post.keys.id == post.id))
         assertList(queriedPosts, state: .isLoaded(count: 1))
         assertList(queriedPosts.first!.comments!,
-                   state: .isNotLoaded(associatedIdentifiers: [post.id], associatedField: "post"))
+                   state: .isNotLoaded(associatedIdentifiers: [post.id], associatedFields: ["post"]))
         
         let queriedComments = try await listQuery(.list(Comment.self, where: Comment.keys.id == comment.id))
         assertList(queriedComments, state: .isLoaded(count: 1))
@@ -394,7 +394,7 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
                         switch result {
                         case .success(let createdPost):
                             log.verbose("Successfully got createdPost from subscription: \(createdPost)")
-                            assertList(createdPost.comments!, state: .isNotLoaded(associatedIdentifiers: [post.id], associatedField: "post"))
+                            assertList(createdPost.comments!, state: .isNotLoaded(associatedIdentifiers: [post.id], associatedFields: ["post"]))
                             await onCreatedPost.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL10/GraphQLLazyLoadPostComment7Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL10/GraphQLLazyLoadPostComment7Tests.swift
@@ -41,7 +41,7 @@ final class GraphQLLazyLoadPostComment7Tests: GraphQLLazyLoadBaseTest {
         
         let comments = loadedPost.comments!
         // The loaded post should have comments that are also not loaded
-        assertList(comments, state: .isNotLoaded(associatedIdentifiers: [createdPost.postId, createdPost.title], associatedField: "post"))
+        assertList(comments, state: .isNotLoaded(associatedIdentifiers: [createdPost.postId, createdPost.title], associatedFields: ["post"]))
         // load the comments
         try await comments.fetch()
         assertList(comments, state: .isLoaded(count: 1))
@@ -63,7 +63,7 @@ final class GraphQLLazyLoadPostComment7Tests: GraphQLLazyLoadBaseTest {
         XCTAssertEqual(loadedPost.postId, post.postId)
         // The loaded post should have comments that are not loaded
         let comments = loadedPost.comments!
-        assertList(comments, state: .isNotLoaded(associatedIdentifiers: [createdPost.postId, createdPost.title], associatedField: "post"))
+        assertList(comments, state: .isNotLoaded(associatedIdentifiers: [createdPost.postId, createdPost.title], associatedFields: ["post"]))
         // load the comments
         try await comments.fetch()
         assertList(comments, state: .isLoaded(count: 1))
@@ -97,7 +97,7 @@ final class GraphQLLazyLoadPostComment7Tests: GraphQLLazyLoadBaseTest {
         let queriedPosts = try await listQuery(.list(Post.self, where: Post.keys.postId == post.postId))
         assertList(queriedPosts, state: .isLoaded(count: 1))
         assertList(queriedPosts.first!.comments!,
-                   state: .isNotLoaded(associatedIdentifiers: [post.postId, post.title], associatedField: "post"))
+                   state: .isNotLoaded(associatedIdentifiers: [post.postId, post.title], associatedFields: ["post"]))
         
         let queriedComments = try await listQuery(.list(Comment.self, where: Comment.keys.commentId == comment.commentId))
         assertList(queriedComments, state: .isLoaded(count: 1))
@@ -142,7 +142,7 @@ final class GraphQLLazyLoadPostComment7Tests: GraphQLLazyLoadBaseTest {
             return
         }
         assertList(comments, state: .isNotLoaded(associatedIdentifiers: [post.postId, post.title],
-                                                 associatedField: "post"))
+                                                 associatedFields: ["post"]))
         try await comments.fetch()
         assertList(comments, state: .isLoaded(count: 1))
         guard let comment = comments.first else {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL11/GraphQLLazyLoadPostComment8Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL11/GraphQLLazyLoadPostComment8Tests.swift
@@ -61,7 +61,7 @@ final class GraphQLLazyLoadPostComment8Tests: GraphQLLazyLoadBaseTest {
             return
         }
         assertList(comments, state: .isNotLoaded(associatedIdentifiers: [post.postId, post.title],
-                                                 associatedField: "postId"))
+                                                 associatedFields: ["postId", "postTitle"]))
         try await comments.fetch()
         assertList(comments, state: .isLoaded(count: 1))
         guard let comment = comments.first else {
@@ -85,7 +85,7 @@ final class GraphQLLazyLoadPostComment8Tests: GraphQLLazyLoadBaseTest {
         let queriedPosts = try await listQuery(.list(Post.self, where: Post.keys.postId == post.postId))
         assertList(queriedPosts, state: .isLoaded(count: 1))
         assertList(queriedPosts.first!.comments!,
-                   state: .isNotLoaded(associatedIdentifiers: [post.postId, post.title], associatedField: "postId"))
+                   state: .isNotLoaded(associatedIdentifiers: [post.postId, post.title], associatedFields: ["postId", "postTitle"]))
         
         let queriedComments = try await listQuery(.list(Comment.self, where: Comment.keys.commentId == comment.commentId))
         assertList(queriedComments, state: .isLoaded(count: 1))

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL11/Post8+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL11/Post8+Schema.swift
@@ -28,7 +28,7 @@ extension Post8 {
     model.fields(
       .field(post8.postId, is: .required, ofType: .string),
       .field(post8.title, is: .required, ofType: .string),
-      .hasMany(post8.comments, is: .optional, ofType: Comment8.self, associatedWith: Comment8.keys.postId),
+      .hasMany(post8.comments, is: .optional, ofType: Comment8.self, associatedWith: Comment8.keys.postId, targetNames: ["postId", "postTitle"]),
       .field(post8.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(post8.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL11/Post8+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL11/Post8+Schema.swift
@@ -28,7 +28,7 @@ extension Post8 {
     model.fields(
       .field(post8.postId, is: .required, ofType: .string),
       .field(post8.title, is: .required, ofType: .string),
-      .hasMany(post8.comments, is: .optional, ofType: Comment8.self, associatedWithFields: [Comment8.keys.postId, Comment8.keys.postTitle]),
+      .hasMany(post8.comments, is: .optional, ofType: Comment8.self, associatedFields: [Comment8.keys.postId, Comment8.keys.postTitle]),
       .field(post8.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(post8.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL11/Post8+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL11/Post8+Schema.swift
@@ -28,7 +28,7 @@ extension Post8 {
     model.fields(
       .field(post8.postId, is: .required, ofType: .string),
       .field(post8.title, is: .required, ofType: .string),
-      .hasMany(post8.comments, is: .optional, ofType: Comment8.self, associatedWith: Comment8.keys.postId, targetNames: ["postId", "postTitle"]),
+      .hasMany(post8.comments, is: .optional, ofType: Comment8.self, associatedWithFields: [Comment8.keys.postId, Comment8.keys.postTitle]),
       .field(post8.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(post8.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/CompositePK/GraphQLLazyLoadCompositePKTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/CompositePK/GraphQLLazyLoadCompositePKTests.swift
@@ -118,19 +118,19 @@ final class GraphQLLazyLoadCompositePKTests: GraphQLLazyLoadBaseTest {
                                                                            content: savedParent.content)))!
         assertList(queriedParent.children!, state: .isNotLoaded(associatedIdentifiers: [queriedParent.customId,
                                                                                         queriedParent.content],
-                                                                associatedField: "parent"))
+                                                                associatedFields: ["parent"]))
         try await queriedParent.children?.fetch()
         assertList(queriedParent.children!, state: .isLoaded(count: 1))
         
         assertList(queriedParent.implicitChildren!, state: .isNotLoaded(associatedIdentifiers: [queriedParent.customId,
                                                                                                 queriedParent.content],
-                                                                        associatedField: "parent"))
+                                                                        associatedFields: ["parent"]))
         try await queriedParent.implicitChildren?.fetch()
         assertList(queriedParent.implicitChildren!, state: .isLoaded(count: 1))
         
         assertList(queriedParent.strangeChildren!, state: .isNotLoaded(associatedIdentifiers: [queriedParent.customId,
                                                                                                queriedParent.content],
-                                                                       associatedField: "parent"))
+                                                                       associatedFields: ["parent"]))
         try await queriedParent.strangeChildren?.fetch()
         assertList(queriedParent.strangeChildren!, state: .isLoaded(count: 1))
         
@@ -153,7 +153,7 @@ final class GraphQLLazyLoadCompositePKTests: GraphQLLazyLoadBaseTest {
          */
         assertList(queriedParent.childrenSansBelongsTo!, state: .isNotLoaded(associatedIdentifiers: [queriedParent.customId,
                                                                                                      queriedParent.content],
-                                                                             associatedField: "compositePKParentChildrenSansBelongsToCustomId"))
+                                                                             associatedFields: ["compositePKParentChildrenSansBelongsToCustomId"]))
         try await queriedParent.childrenSansBelongsTo?.fetch()
         assertList(queriedParent.childrenSansBelongsTo!, state: .isLoaded(count: 1))
         

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/DefaultPK/GraphQLLazyLoadDefaultPKTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/DefaultPK/GraphQLLazyLoadDefaultPKTests.swift
@@ -74,7 +74,7 @@ final class GraphQLLazyLoadDefaultPKTests: GraphQLLazyLoadBaseTest {
         
         let queriedParent = try await query(.get(DefaultPKParent.self, byId: savedParent.id))!
         assertList(queriedParent.children!, state: .isNotLoaded(associatedIdentifiers: [queriedParent.id],
-                                                                associatedField: "parent"))
+                                                                associatedFields: ["parent"]))
         try await queriedParent.children?.fetch()
         assertList(queriedParent.children!, state: .isLoaded(count: 1))
         

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL2/GraphQLLazyLoadBlogPostComment8V2Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL2/GraphQLLazyLoadBlogPostComment8V2Tests.swift
@@ -19,7 +19,7 @@ final class GraphQLLazyLoadBlogPostComment8V2Tests: GraphQLLazyLoadBaseTest {
         let blog = Blog(name: "name")
         let createdBlog = try await mutate(.create(blog))
         let queriedBlog = try await query(for: createdBlog)!
-        assertList(queriedBlog.posts!, state: .isNotLoaded(associatedIdentifiers: [blog.id], associatedField: "blog"))
+        assertList(queriedBlog.posts!, state: .isNotLoaded(associatedIdentifiers: [blog.id], associatedFields: ["blog"]))
         try await queriedBlog.posts?.fetch()
         assertList(queriedBlog.posts!, state: .isLoaded(count: 0))
     }
@@ -29,7 +29,7 @@ final class GraphQLLazyLoadBlogPostComment8V2Tests: GraphQLLazyLoadBaseTest {
         let post = Post(name: "name", randomId: "randomId")
         let createdPost = try await mutate(.create(post))
         let queriedPost = try await query(for: createdPost)!
-        assertList(queriedPost.comments!, state: .isNotLoaded(associatedIdentifiers: [post.id], associatedField: "post"))
+        assertList(queriedPost.comments!, state: .isNotLoaded(associatedIdentifiers: [post.id], associatedFields: ["post"]))
         try await queriedPost.comments?.fetch()
         assertList(queriedPost.comments!, state: .isLoaded(count: 0))
         
@@ -44,7 +44,7 @@ final class GraphQLLazyLoadBlogPostComment8V2Tests: GraphQLLazyLoadBaseTest {
         let createdPost = try await mutate(.create(post))
         
         // the blog can load the posts
-        assertList(createdBlog.posts!, state: .isNotLoaded(associatedIdentifiers: [blog.id], associatedField: "blog"))
+        assertList(createdBlog.posts!, state: .isNotLoaded(associatedIdentifiers: [blog.id], associatedFields: ["blog"]))
         try await createdBlog.posts?.fetch()
         assertList(createdBlog.posts!, state: .isLoaded(count: 1))
         assertLazyReference(createdBlog.posts!.first!._blog, state: .notLoaded(identifiers: [.init(name: "id", value: blog.id)]))
@@ -53,7 +53,7 @@ final class GraphQLLazyLoadBlogPostComment8V2Tests: GraphQLLazyLoadBaseTest {
         assertLazyReference(createdPost._blog, state: .notLoaded(identifiers: [.init(name: "id", value: blog.id)]))
         let loadedBlog = try await createdPost.blog!
         assertLazyReference(createdPost._blog, state: .loaded(model: loadedBlog))
-        assertList(loadedBlog.posts!, state: .isNotLoaded(associatedIdentifiers: [blog.id], associatedField: "blog"))
+        assertList(loadedBlog.posts!, state: .isNotLoaded(associatedIdentifiers: [blog.id], associatedFields: ["blog"]))
     }
     
     func testSaveComment() async throws {
@@ -73,10 +73,10 @@ final class GraphQLLazyLoadBlogPostComment8V2Tests: GraphQLLazyLoadBaseTest {
         // the comment can load the post
         assertLazyReference(createdComment._post, state: .notLoaded(identifiers: [.init(name: "id", value: post.id)]))
         let loadedPost = try await createdComment.post!
-        assertList(loadedPost.comments!, state: .isNotLoaded(associatedIdentifiers: [post.id], associatedField: "post"))
+        assertList(loadedPost.comments!, state: .isNotLoaded(associatedIdentifiers: [post.id], associatedFields: ["post"]))
         
         // the post can load the comment
-        assertList(createdPost.comments!, state: .isNotLoaded(associatedIdentifiers: [post.id], associatedField: "post"))
+        assertList(createdPost.comments!, state: .isNotLoaded(associatedIdentifiers: [post.id], associatedFields: ["post"]))
         try await createdPost.comments?.fetch()
         assertList(createdPost.comments!, state: .isLoaded(count: 1))
     }
@@ -95,13 +95,13 @@ final class GraphQLLazyLoadBlogPostComment8V2Tests: GraphQLLazyLoadBaseTest {
         let loadedPost = try await createdComment.post!
         assertLazyReference(loadedPost._blog, state: .notLoaded(identifiers: [.init(name: "id", value: blog.id)]))
         let loadedBlog = try await loadedPost.blog!
-        assertList(loadedBlog.posts!, state: .isNotLoaded(associatedIdentifiers: [blog.id], associatedField: "blog"))
+        assertList(loadedBlog.posts!, state: .isNotLoaded(associatedIdentifiers: [blog.id], associatedFields: ["blog"]))
         
         // the blog can load the post and load the comment
-        assertList(createdBlog.posts!, state: .isNotLoaded(associatedIdentifiers: [createdBlog.id], associatedField: "blog"))
+        assertList(createdBlog.posts!, state: .isNotLoaded(associatedIdentifiers: [createdBlog.id], associatedFields: ["blog"]))
         try await createdBlog.posts?.fetch()
         let loadedPost2 = createdBlog.posts!.first!
-        assertList(loadedPost2.comments!, state: .isNotLoaded(associatedIdentifiers: [loadedPost2.id], associatedField: "post"))
+        assertList(loadedPost2.comments!, state: .isNotLoaded(associatedIdentifiers: [loadedPost2.id], associatedFields: ["post"]))
         try await loadedPost2.comments?.fetch()
         assertLazyReference(loadedPost2.comments!.first!._post, state: .notLoaded(identifiers: [.init(name: "id", value: post.id)]))
     }
@@ -179,12 +179,12 @@ final class GraphQLLazyLoadBlogPostComment8V2Tests: GraphQLLazyLoadBaseTest {
         let queriedBlogs = try await listQuery(.list(Blog.self, where: Blog.keys.id == blog.id))
         assertList(queriedBlogs, state: .isLoaded(count: 1))
         assertList(queriedBlogs.first!.posts!,
-                   state: .isNotLoaded(associatedIdentifiers: [blog.id], associatedField: "blog"))
+                   state: .isNotLoaded(associatedIdentifiers: [blog.id], associatedFields: ["blog"]))
         
         let queriedPosts = try await listQuery(.list(Post.self, where: Post.keys.id == post.id))
         assertList(queriedPosts, state: .isLoaded(count: 1))
         assertList(queriedPosts.first!.comments!,
-                   state: .isNotLoaded(associatedIdentifiers: [post.id], associatedField: "post"))
+                   state: .isNotLoaded(associatedIdentifiers: [post.id], associatedFields: ["post"]))
         
         let queriedComments = try await listQuery(.list(Comment.self, where: Comment.keys.id == comment.id))
         assertList(queriedComments, state: .isLoaded(count: 1))

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL3/GraphQLLazyLoadPostCommentWithCompositeKeyTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL3/GraphQLLazyLoadPostCommentWithCompositeKeyTests.swift
@@ -41,7 +41,7 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
         // The loaded post should have comments that are also not loaded
         let comments = loadedPost.comments!
         assertList(comments, state: .isNotLoaded(associatedIdentifiers: [post.id, post.title],
-                                                 associatedField: "post"))
+                                                 associatedFields: ["post"]))
         try await comments.fetch()
         assertList(comments, state: .isLoaded(count: 1))
         assertLazyReference(comments.first!._post, state: .notLoaded(identifiers: [.init(name: "id", value: createdPost.id),
@@ -62,7 +62,7 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
         // The loaded post should have comments that are not loaded
         let comments = loadedPost.comments!
         assertList(comments, state: .isNotLoaded(associatedIdentifiers: [post.id, post.title],
-                                                 associatedField: "post"))
+                                                 associatedFields: ["post"]))
         // load the comments
         try await comments.fetch()
         assertList(comments, state: .isLoaded(count: 1))
@@ -131,7 +131,7 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
         _ = try await mutate(.create(comment))
         let queriedPost = try await query(.get(Post.self, byIdentifier: .identifier(id: post.id, title: post.title)))!
         let comments = queriedPost.comments!
-        assertList(comments, state: .isNotLoaded(associatedIdentifiers: [post.id, post.title], associatedField: "post"))
+        assertList(comments, state: .isNotLoaded(associatedIdentifiers: [post.id, post.title], associatedFields: ["post"]))
         try await comments.fetch()
         assertList(comments, state: .isLoaded(count: 1))
         assertLazyReference(comments.first!._post, state: .notLoaded(identifiers: [.init(name: "id", value: post.id),
@@ -178,7 +178,7 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
         let queriedPosts = try await listQuery(.list(Post.self, where: Post.keys.id == post.id))
         assertList(queriedPosts, state: .isLoaded(count: 1))
         assertList(queriedPosts.first!.comments!,
-                   state: .isNotLoaded(associatedIdentifiers: [post.id, post.title], associatedField: "post"))
+                   state: .isNotLoaded(associatedIdentifiers: [post.id, post.title], associatedFields: ["post"]))
         
         let queriedComments = try await listQuery(.list(Comment.self, where: Comment.keys.id == comment.id))
         assertList(queriedComments, state: .isLoaded(count: 1))
@@ -372,7 +372,7 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
                         switch result {
                         case .success(let createdPost):
                             log.verbose("Successfully got createdPost from subscription: \(createdPost)")
-                            assertList(createdPost.comments!, state: .isNotLoaded(associatedIdentifiers: [post.id, post.title], associatedField: "post"))
+                            assertList(createdPost.comments!, state: .isNotLoaded(associatedIdentifiers: [post.id, post.title], associatedFields: ["post"]))
                             await onCreatedPost.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL4/GraphQLLazyLoadPostTagTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL4/GraphQLLazyLoadPostTagTests.swift
@@ -65,7 +65,7 @@ final class GraphQLLazyLoadPostTagTests: GraphQLLazyLoadBaseTest {
             return
         }
         assertList(postTags, state: .isNotLoaded(associatedIdentifiers: [post.postId, post.title],
-                                                 associatedField: "postWithTagsCompositeKey"))
+                                                 associatedFields: ["postWithTagsCompositeKey"]))
         try await postTags.fetch()
         assertList(postTags, state: .isLoaded(count: 1))
     }
@@ -77,7 +77,7 @@ final class GraphQLLazyLoadPostTagTests: GraphQLLazyLoadBaseTest {
             return
         }
         assertList(postTags, state: .isNotLoaded(associatedIdentifiers: [tag.id, tag.name],
-                                                 associatedField: "tagWithCompositeKey"))
+                                                 associatedFields: ["tagWithCompositeKey"]))
         try await postTags.fetch()
         assertList(postTags, state: .isLoaded(count: 1))
     }
@@ -161,12 +161,12 @@ final class GraphQLLazyLoadPostTagTests: GraphQLLazyLoadBaseTest {
         let queriedPosts = try await listQuery(.list(Post.self, where: Post.keys.postId == post.postId))
         assertList(queriedPosts, state: .isLoaded(count: 1))
         assertList(queriedPosts.first!.tags!,
-                   state: .isNotLoaded(associatedIdentifiers: [post.postId, post.title], associatedField: "postWithTagsCompositeKey"))
+                   state: .isNotLoaded(associatedIdentifiers: [post.postId, post.title], associatedFields: ["postWithTagsCompositeKey"]))
         
         let queriedTags = try await listQuery(.list(Tag.self, where: Tag.keys.id == tag.id))
         assertList(queriedTags, state: .isLoaded(count: 1))
         assertList(queriedTags.first!.posts!,
-                   state: .isNotLoaded(associatedIdentifiers: [tag.id, tag.name], associatedField: "tagWithCompositeKey"))
+                   state: .isNotLoaded(associatedIdentifiers: [tag.id, tag.name], associatedFields: ["tagWithCompositeKey"]))
         
         let queriedPostTags = try await listQuery(.list(PostTag.self, where: PostTag.keys.id == postTag.id))
         assertList(queriedPostTags, state: .isLoaded(count: 1))
@@ -216,7 +216,7 @@ final class GraphQLLazyLoadPostTagTests: GraphQLLazyLoadBaseTest {
             return
         }
         assertList(postTags, state: .isNotLoaded(associatedIdentifiers: [post.postId, post.title],
-                                                 associatedField: "postWithTagsCompositeKey"))
+                                                 associatedFields: ["postWithTagsCompositeKey"]))
         try await postTags.fetch()
         assertList(postTags, state: .isLoaded(count: 0))
     }
@@ -227,7 +227,7 @@ final class GraphQLLazyLoadPostTagTests: GraphQLLazyLoadBaseTest {
             return
         }
         assertList(postTags, state: .isNotLoaded(associatedIdentifiers: [tag.id, tag.name],
-                                                 associatedField: "tagWithCompositeKey"))
+                                                 associatedFields: ["tagWithCompositeKey"]))
         try await postTags.fetch()
         assertList(postTags, state: .isLoaded(count: 0))
     }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL7/Post4+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL7/Post4+Schema.swift
@@ -28,7 +28,7 @@ extension Post4 {
     model.fields(
       .field(post4.postId, is: .required, ofType: .string),
       .field(post4.title, is: .required, ofType: .string),
-      .hasMany(post4.comments, is: .optional, ofType: Comment4.self, associatedWith: Comment4.keys.post4CommentsPostId, targetNames: ["post4CommentsPostId", "post4CommentsTitle"]),
+      .hasMany(post4.comments, is: .optional, ofType: Comment4.self, associatedWithFields: [Comment4.keys.post4CommentsPostId, Comment4.keys.post4CommentsTitle]),
       .field(post4.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(post4.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL7/Post4+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL7/Post4+Schema.swift
@@ -28,7 +28,7 @@ extension Post4 {
     model.fields(
       .field(post4.postId, is: .required, ofType: .string),
       .field(post4.title, is: .required, ofType: .string),
-      .hasMany(post4.comments, is: .optional, ofType: Comment4.self, associatedWith: Comment4.keys.post4CommentsPostId),
+      .hasMany(post4.comments, is: .optional, ofType: Comment4.self, associatedWith: Comment4.keys.post4CommentsPostId, targetNames: ["post4CommentsPostId", "post4CommentsTitle"]),
       .field(post4.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(post4.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL7/Post4+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL7/Post4+Schema.swift
@@ -28,7 +28,7 @@ extension Post4 {
     model.fields(
       .field(post4.postId, is: .required, ofType: .string),
       .field(post4.title, is: .required, ofType: .string),
-      .hasMany(post4.comments, is: .optional, ofType: Comment4.self, associatedWithFields: [Comment4.keys.post4CommentsPostId, Comment4.keys.post4CommentsTitle]),
+      .hasMany(post4.comments, is: .optional, ofType: Comment4.self, associatedFields: [Comment4.keys.post4CommentsPostId, Comment4.keys.post4CommentsTitle]),
       .field(post4.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(post4.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListDecoderTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListDecoderTests.swift
@@ -78,7 +78,7 @@ class AppSyncListDecoderTests: XCTestCase {
 
     func testShouldDecodeFromModelMetadata() throws {
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
-                                                        appSyncAssociatedField: "post",
+                                                        appSyncAssociatedFields: ["post"],
                                                         apiName: "apiName")
         let data = try encoder.encode(modelMetadata)
         let harness = try decoder.decode(AppSyncListDecoderHarness<Comment4>.self, from: data)
@@ -87,12 +87,12 @@ class AppSyncListDecoderTests: XCTestCase {
             XCTFail("Could get AppSyncListProvider")
             return
         }
-        guard case .notLoaded(let associatedIdentifiers, let associatedField) = provider.getState() else {
+        guard case .notLoaded(let associatedIdentifiers, let associatedFields) = provider.getState() else {
             XCTFail("Should be in not loaded state")
             return
         }
         XCTAssertEqual(associatedIdentifiers, ["postId"])
-        XCTAssertEqual(associatedField, "post")
+        XCTAssertEqual(associatedFields, ["post"])
     }
 
     func testShouldDecodeFromAWSAppSyncListResponse() throws {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListProviderPaginationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListProviderPaginationTests.swift
@@ -35,7 +35,7 @@ extension AppSyncListProviderTests {
     
     func testNotLoadedStateHasNextPageFalse() {
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
-                                                        appSyncAssociatedField: "post",
+                                                        appSyncAssociatedFields: ["post"],
                                                         apiName: "apiName")
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded = provider.loadedState else {
@@ -137,7 +137,7 @@ extension AppSyncListProviderTests {
     
     func testNotLoadedStateGetNextPageFailure() async {
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
-                                                        appSyncAssociatedField: "post",
+                                                        appSyncAssociatedFields: ["post"],
                                                         apiName: "apiName")
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded = provider.loadedState else {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListProviderTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListProviderTests.swift
@@ -94,15 +94,15 @@ class AppSyncListProviderTests: XCTestCase {
 
     func testInitWithModelMetadataShouldBeNotLoadedState() throws {
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
-                                                        appSyncAssociatedField: "post",
+                                                        appSyncAssociatedFields: ["post"],
                                                         apiName: "apiName")
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
-        guard case .notLoaded(let associatedIdentifiers, let associatedField) = provider.loadedState else {
+        guard case .notLoaded(let associatedIdentifiers, let associatedFields) = provider.loadedState else {
             XCTFail("Should be in not loaded state")
             return
         }
         XCTAssertEqual(associatedIdentifiers, ["postId"])
-        XCTAssertEqual(associatedField, "post")
+        XCTAssertEqual(associatedFields, ["post"])
     }
 
     func testLoadedStateLoadSuccess() async throws {
@@ -137,7 +137,7 @@ class AppSyncListProviderTests: XCTestCase {
             return event
         }
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
-                                                        appSyncAssociatedField: "post",
+                                                        appSyncAssociatedFields: ["post"],
                                                         apiName: "apiName")
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded = provider.loadedState else {
@@ -174,7 +174,7 @@ class AppSyncListProviderTests: XCTestCase {
             return event
         }
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
-                                                        appSyncAssociatedField: "post",
+                                                        appSyncAssociatedFields: ["post"],
                                                         apiName: "apiName")
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded = provider.loadedState else {
@@ -221,7 +221,7 @@ class AppSyncListProviderTests: XCTestCase {
             return event
         }
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
-                                                        appSyncAssociatedField: "post",
+                                                        appSyncAssociatedFields: ["post"],
                                                         apiName: "apiName")
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded = provider.loadedState else {
@@ -258,7 +258,7 @@ class AppSyncListProviderTests: XCTestCase {
             return event
         }
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
-                                                        appSyncAssociatedField: "post",
+                                                        appSyncAssociatedFields: ["post"],
                                                         apiName: "apiName")
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded = provider.loadedState else {
@@ -294,7 +294,7 @@ class AppSyncListProviderTests: XCTestCase {
             return event
         }
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
-                                                 appSyncAssociatedField: "post",
+                                                 appSyncAssociatedFields: ["post"],
                                                  apiName: "apiName")
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded = provider.loadedState else {
@@ -343,7 +343,7 @@ class AppSyncListProviderTests: XCTestCase {
             return event
         }
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
-                                                        appSyncAssociatedField: "post",
+                                                        appSyncAssociatedFields: ["post"],
                                                         apiName: "apiName")
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded = provider.loadedState else {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncModelMetadataTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncModelMetadataTests.swift
@@ -58,14 +58,14 @@ class ModelMetadataTests: XCTestCase {
         XCTAssertEqual(posts.count, 2)
         for post in posts {
             guard case .object(let associationData) = post["comments"],
-                  case .string(let associatedField) = associationData["appSyncAssociatedField"],
+                  case .array(let associatedFields) = associationData["appSyncAssociatedFields"],
                   case .array(let associatedIdentifiers) = associationData["appSyncAssociatedIdentifiers"],
                   case .string(let apiName) = associationData["apiName"] else {
                 XCTFail("Missing association metadata for comments")
                 return
             }
             XCTAssertEqual(associatedIdentifiers[0], "postId")
-            XCTAssertEqual(associatedField, "post")
+            XCTAssertEqual(associatedFields, ["post"])
             XCTAssertEqual(apiName, "apiName")
         }
     }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncModelMetadataTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncModelMetadataTests.swift
@@ -79,14 +79,14 @@ class ModelMetadataTests: XCTestCase {
 
         let post = AppSyncModelMetadataUtils.addMetadata(toModel: json, apiName: "apiName")
         guard case .object(let associationData) = post["comments"],
-              case .string(let associatedField) = associationData["appSyncAssociatedField"],
+              case .array(let associatedFields) = associationData["appSyncAssociatedFields"],
               case .array(let associatedIdentifiers) = associationData["appSyncAssociatedIdentifiers"],
               case .string(let apiName) = associationData["apiName"] else {
             XCTFail("Missing association metadata for comments")
             return
         }
         XCTAssertEqual(associatedIdentifiers[0], "postId")
-        XCTAssertEqual(associatedField, "post")
+        XCTAssertEqual(associatedFields, ["post"])
         XCTAssertEqual(apiName, "apiName")
     }
 

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLResponseDecoderLazyPostComment4V2Tests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLResponseDecoderLazyPostComment4V2Tests.swift
@@ -184,9 +184,9 @@ class GraphQLResponseDecoderLazyPostComment4V2Tests: XCTestCase, SharedTestCases
             return
         }
         switch comments.listProvider.getState() {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
+        case .notLoaded(let associatedIdentifiers, let associatedFields):
             XCTAssertEqual(associatedIdentifiers, ["postId"])
-            XCTAssertEqual(associatedField, LazyChildComment4V2.CodingKeys.post.stringValue)
+            XCTAssertEqual(associatedFields, [LazyChildComment4V2.CodingKeys.post.stringValue])
         case .loaded:
             XCTFail("Should be not loaded with post data")
         }
@@ -414,9 +414,9 @@ class GraphQLResponseDecoderLazyPostComment4V2Tests: XCTestCase, SharedTestCases
             return
         }
         switch comments.listProvider.getState() {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
+        case .notLoaded(let associatedIdentifiers, let associatedFields):
             XCTAssertEqual(associatedIdentifiers, ["postId"])
-            XCTAssertEqual(associatedField, LazyChildComment4V2.CodingKeys.post.stringValue)
+            XCTAssertEqual(associatedFields, [LazyChildComment4V2.CodingKeys.post.stringValue])
         case .loaded:
             XCTFail("Should be not loaded with post data")
         }
@@ -531,9 +531,9 @@ class GraphQLResponseDecoderLazyPostComment4V2Tests: XCTestCase, SharedTestCases
             return
         }
         switch comments.listProvider.getState() {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
+        case .notLoaded(let associatedIdentifiers, let associatedFields):
             XCTAssertEqual(associatedIdentifiers, ["id1"])
-            XCTAssertEqual(associatedField, "post")
+            XCTAssertEqual(associatedFields, ["post"])
         case .loaded:
             XCTFail("Should be in not loaded state")
         }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLResponseDecoderPostComment4V2Tests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLResponseDecoderPostComment4V2Tests.swift
@@ -178,9 +178,9 @@ class GraphQLResponseDecoderPostComment4V2Tests: XCTestCase, SharedTestCasesPost
             return
         }
         switch comments.listProvider.getState() {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
+        case .notLoaded(let associatedIdentifiers, let associatedFields):
             XCTAssertEqual(associatedIdentifiers, ["postId"])
-            XCTAssertEqual(associatedField, ChildComment4V2.CodingKeys.post.stringValue)
+            XCTAssertEqual(associatedFields, [ChildComment4V2.CodingKeys.post.stringValue])
         case .loaded:
             XCTFail("Should be not loaded with post data")
         }
@@ -366,9 +366,9 @@ class GraphQLResponseDecoderPostComment4V2Tests: XCTestCase, SharedTestCasesPost
             return
         }
         switch comments.listProvider.getState() {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
+        case .notLoaded(let associatedIdentifiers, let associatedFields):
             XCTAssertEqual(associatedIdentifiers, ["postId"])
-            XCTAssertEqual(associatedField, ChildComment4V2.CodingKeys.post.stringValue)
+            XCTAssertEqual(associatedFields, [ChildComment4V2.CodingKeys.post.stringValue])
         case .loaded:
             XCTFail("Should be not loaded with post data")
         }
@@ -430,9 +430,9 @@ class GraphQLResponseDecoderPostComment4V2Tests: XCTestCase, SharedTestCasesPost
             return
         }
         switch comments.listProvider.getState() {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
+        case .notLoaded(let associatedIdentifiers, let associatedFields):
             XCTAssertEqual(associatedIdentifiers, ["id1"])
-            XCTAssertEqual(associatedField, "post")
+            XCTAssertEqual(associatedFields, ["post"])
         case .loaded:
             XCTFail("Should be in not loaded state")
         }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/Statement+Model.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/Statement+Model.swift
@@ -154,10 +154,10 @@ extension Statement: StatementModelConvertible {
 
     private func convertCollection(field: ModelField, schema: ModelSchema, from element: Element, path: [String]) -> Any? {
         if field.isArray && field.hasAssociation,
-           case let .some(.hasMany(associatedFieldName: associatedFieldName, targetNames: targetNames)) = field.association
+           case let .some(.hasMany(associatedFieldName: associatedFieldName, associatedFieldNames: associatedFieldNames)) = field.association
         {
             // Construct the lazy list based on the field reference name and `@@primarykey` or primary key field of the parent
-            if targetNames.count <= 1, let associatedFieldName = associatedFieldName {
+            if associatedFieldNames.count <= 1, let associatedFieldName = associatedFieldName {
                 let primaryKeyName = schema.primaryKey.isCompositeKey
                     ? ModelIdentifierFormat.Custom.sqlColumnName
                     : schema.primaryKey.fields.first.flatMap { $0.name }
@@ -176,7 +176,7 @@ extension Statement: StatementModelConvertible {
                     .compactMap { $0 }
                     .map { String(describing: $0) }
                 return DataStoreListDecoder.lazyInit(associatedIds: primaryKeyValues,
-                                                     associatedWith: targetNames)
+                                                     associatedWith: associatedFieldNames)
             }
             
         }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreListDecoderTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreListDecoderTests.swift
@@ -57,8 +57,8 @@ class DataStoreListDecoderTests: BaseDataStoreTests {
 
     func testDataStoreListDecoderShouldDecodeFromAssociationData() throws {
         let json: JSONValue = [
-            "associatedId": "postId",
-            "associatedField": "post"
+            "dataStoreAssociatedIdentifiers": ["postId"],
+            "dataStoreAssociatedFields": ["post"]
         ]
         let data = try encoder.encode(json)
         let harness = try decoder.decode(DataStoreListDecoderHarness<Post4>.self, from: data)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreListDecoderTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreListDecoderTests.swift
@@ -72,7 +72,7 @@ class DataStoreListDecoderTests: BaseDataStoreTests {
             return
         }
         XCTAssertEqual(associatedIdentifiers, ["postId"])
-        XCTAssertEqual(associatedField, "post")
+        XCTAssertEqual(associatedField, ["post"])
     }
 
     func testDataStoreListDecoderShouldNotDecodeForInvalidAssociationData() throws {

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreListProviderFunctionalTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreListProviderFunctionalTests.swift
@@ -16,7 +16,8 @@ class DataStoreListProviderFunctionalTests: BaseDataStoreTests {
 
     func testDataStoreListProviderWithAssociationDataShouldLoad() async throws {
         let postId = preparePost4DataForTest()
-        let provider = DataStoreListProvider<Comment4>(associatedIdentifiers: [postId], associatedField: "post")
+        let provider = DataStoreListProvider<Comment4>(metadata: .init(dataStoreAssociatedIdentifiers: [postId],
+                                                                       dataStoreAssociatedFields: ["post"]))
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
             return

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreListProviderTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreListProviderTests.swift
@@ -48,7 +48,8 @@ class DataStoreListProviderTests: XCTestCase {
     }
 
     func testInitWithAssociationDataShouldBeInNotLoadedState() {
-        let provider = DataStoreListProvider<Post4>(associatedIdentifiers: ["id"], associatedField: "field")
+        let provider = DataStoreListProvider<Post4>(metadata: .init(dataStoreAssociatedIdentifiers: ["id"],
+                                                                    dataStoreAssociatedFields: ["field"]))
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
             return
@@ -62,7 +63,8 @@ class DataStoreListProviderTests: XCTestCase {
                                  Comment4(content: "content")])
             }
 
-        let provider = DataStoreListProvider<Comment4>(associatedIdentifiers: ["postId"], associatedField: "post")
+        let provider = DataStoreListProvider<Comment4>(metadata: .init(dataStoreAssociatedIdentifiers: ["postId"],
+                                                                    dataStoreAssociatedFields: ["post"]))
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
             return
@@ -93,8 +95,9 @@ class DataStoreListProviderTests: XCTestCase {
             QueryModelsResponder<Comment4> { _, _, _, _ in
                 return .failure(DataStoreError.internalOperation("", "", nil))
             }
-
-        let provider = DataStoreListProvider<Comment4>(associatedIdentifiers: ["postId"], associatedField: "post")
+        
+        let provider = DataStoreListProvider<Comment4>(metadata: .init(dataStoreAssociatedIdentifiers: ["postId"],
+                                                                    dataStoreAssociatedFields: ["post"]))
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
             return

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsLazyPostComment4V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsLazyPostComment4V2Tests.swift
@@ -90,9 +90,9 @@ final class StorageEngineTestsLazyPostComment4V2Tests: StorageEngineTestsBase, S
         }
         XCTAssertEqual(queriedPost.id, queriedPost.id)
         switch queriedPost.comments?.listProvider.getState() {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
+        case .notLoaded(let associatedIdentifiers, let associatedFields):
             XCTAssertEqual(associatedIdentifiers, [post.id])
-            XCTAssertEqual(associatedField, LazyChildComment4V2.CodingKeys.post.stringValue)
+            XCTAssertEqual(associatedFields, [LazyChildComment4V2.CodingKeys.post.stringValue])
         case .loaded:
             XCTFail("Should be not loaded")
         default:
@@ -288,9 +288,9 @@ final class StorageEngineTestsLazyPostComment4V2Tests: StorageEngineTestsBase, S
         }
         
         switch comments.listProvider.getState() {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
+        case .notLoaded(let associatedIdentifiers, let associatedFields):
             XCTAssertEqual(associatedIdentifiers, [post.id])
-            XCTAssertEqual(associatedField, "post")
+            XCTAssertEqual(associatedFields, ["post"])
         case .loaded:
             XCTFail("Should not be loaded")
         }
@@ -396,9 +396,9 @@ final class StorageEngineTestsLazyPostComment4V2Tests: StorageEngineTestsBase, S
         }
         
         switch comments1.listProvider.getState() {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
+        case .notLoaded(let associatedIdentifiers, let associatedFields):
             XCTAssertEqual(associatedIdentifiers, [post1.id])
-            XCTAssertEqual(associatedField, "post")
+            XCTAssertEqual(associatedFields, ["post"])
         case .loaded:
             XCTFail("Should not be loaded")
         }
@@ -408,9 +408,9 @@ final class StorageEngineTestsLazyPostComment4V2Tests: StorageEngineTestsBase, S
             return
         }
         switch comments2.listProvider.getState() {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
+        case .notLoaded(let associatedIdentifiers, let associatedFields):
             XCTAssertEqual(associatedIdentifiers, [post2.id])
-            XCTAssertEqual(associatedField, "post")
+            XCTAssertEqual(associatedFields, ["post"])
         case .loaded:
             XCTFail("Should not be loaded")
         }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsPostComment4V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsPostComment4V2Tests.swift
@@ -182,9 +182,9 @@ final class StorageEngineTestsPostComment4V2Tests: StorageEngineTestsBase, Share
         }
 
         switch comments.listProvider.getState() {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
+        case .notLoaded(let associatedIdentifiers, let associatedFields):
             XCTAssertEqual(associatedIdentifiers, [post.id])
-            XCTAssertEqual(associatedField, "post")
+            XCTAssertEqual(associatedFields, ["post"])
         case .loaded(let comments):
             print("loaded comments \(comments)")
             XCTFail("Should not be loaded")
@@ -236,18 +236,18 @@ final class StorageEngineTestsPostComment4V2Tests: StorageEngineTestsBase, Share
             return
         }
         switch postId1.comments?.listProvider.getState() {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
+        case .notLoaded(let associatedIdentifiers, let associatedFields):
             XCTAssertEqual(associatedIdentifiers, [postId1.id])
-            XCTAssertEqual(associatedField, "post")
+            XCTAssertEqual(associatedFields, ["post"])
         case .loaded:
             XCTFail("Should not be loaded")
         default:
             XCTFail("missing comments")
         }
         switch postId2.comments?.listProvider.getState() {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
+        case .notLoaded(let associatedIdentifiers, let associatedFields):
             XCTAssertEqual(associatedIdentifiers, [postId2.id])
-            XCTAssertEqual(associatedField, "post")
+            XCTAssertEqual(associatedFields, ["post"])
         case .loaded:
             XCTFail("Should not be loaded")
         default:

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL1/AWSDataStoreLazyLoadPostComment4V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL1/AWSDataStoreLazyLoadPostComment4V2Tests.swift
@@ -134,8 +134,8 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Missing comments on post")
             return
         }
-        assertList(comments, state: .isNotLoaded(associatedId: post.identifier,
-                                                 associatedField: "post"))
+        assertList(comments, state: .isNotLoaded(associatedIds: [post.identifier],
+                                                 associatedFields: ["post"]))
         
         try await comments.fetch()
         assertList(comments, state: .isLoaded(count: 1))

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL10/AWSDataStoreLazyLoadPostComment7Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL10/AWSDataStoreLazyLoadPostComment7Tests.swift
@@ -85,8 +85,8 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Missing comments on post")
             return
         }
-        assertList(comments, state: .isNotLoaded(associatedId: post.identifier,
-                                                 associatedField: "post"))
+        assertList(comments, state: .isNotLoaded(associatedIds: [post.identifier],
+                                                 associatedFields: ["post"]))
         try await comments.fetch()
         assertList(comments, state: .isLoaded(count: 1))
         guard let comment = comments.first else {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL11/Post8+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL11/Post8+Schema.swift
@@ -28,7 +28,7 @@ extension Post8 {
     model.fields(
       .field(post8.postId, is: .required, ofType: .string),
       .field(post8.title, is: .required, ofType: .string),
-      .hasMany(post8.comments, is: .optional, ofType: Comment8.self, associatedWith: Comment8.keys.postId),
+      .hasMany(post8.comments, is: .optional, ofType: Comment8.self, associatedWith: Comment8.keys.postId, targetNames: ["postId", "postTitle"]),
       .field(post8.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(post8.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL11/Post8+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL11/Post8+Schema.swift
@@ -28,7 +28,7 @@ extension Post8 {
     model.fields(
       .field(post8.postId, is: .required, ofType: .string),
       .field(post8.title, is: .required, ofType: .string),
-      .hasMany(post8.comments, is: .optional, ofType: Comment8.self, associatedWithFields: [Comment8.keys.postId, Comment8.keys.postTitle]),
+      .hasMany(post8.comments, is: .optional, ofType: Comment8.self, associatedFields: [Comment8.keys.postId, Comment8.keys.postTitle]),
       .field(post8.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(post8.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL11/Post8+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL11/Post8+Schema.swift
@@ -28,7 +28,7 @@ extension Post8 {
     model.fields(
       .field(post8.postId, is: .required, ofType: .string),
       .field(post8.title, is: .required, ofType: .string),
-      .hasMany(post8.comments, is: .optional, ofType: Comment8.self, associatedWith: Comment8.keys.postId, targetNames: ["postId", "postTitle"]),
+      .hasMany(post8.comments, is: .optional, ofType: Comment8.self, associatedWithFields: [Comment8.keys.postId, Comment8.keys.postTitle]),
       .field(post8.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(post8.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/DefaultPK/AWSDataStoreLazyLoadDefaultPKTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/DefaultPK/AWSDataStoreLazyLoadDefaultPKTests.swift
@@ -132,8 +132,8 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Missing children on parent")
             return
         }
-        assertList(children, state: .isNotLoaded(associatedId: parent.identifier,
-                                                 associatedField: "parent"))
+        assertList(children, state: .isNotLoaded(associatedIds: [parent.identifier],
+                                                 associatedFields: ["parent"]))
         
         try await children.fetch()
         assertList(children, state: .isLoaded(count: 1))

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL2/AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL2/AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift
@@ -89,8 +89,8 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
             XCTFail("Missing comments on post")
             return
         }
-        assertList(comments, state: .isNotLoaded(associatedId: post.identifier,
-                                                 associatedField: "post"))
+        assertList(comments, state: .isNotLoaded(associatedIds: [post.identifier],
+                                                 associatedFields: ["post"]))
         
         try await comments.fetch()
         assertList(comments, state: .isLoaded(count: 1))

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL3/AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL3/AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests.swift
@@ -70,8 +70,8 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
             XCTFail("Missing comments on post")
             return
         }
-        assertList(comments, state: .isNotLoaded(associatedId: post.identifier,
-                                                 associatedField: "post"))
+        assertList(comments, state: .isNotLoaded(associatedIds: [post.identifier],
+                                                 associatedFields: ["post"]))
         try await comments.fetch()
         assertList(comments, state: .isLoaded(count: 1))
         guard let comment = comments.first else {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL4/AWSDataStoreLazyLoadPostTagTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL4/AWSDataStoreLazyLoadPostTagTests.swift
@@ -46,8 +46,8 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Missing postTags on post")
             return
         }
-        assertList(postTags, state: .isNotLoaded(associatedId: post.identifier,
-                                                 associatedField: "postWithTagsCompositeKey"))
+        assertList(postTags, state: .isNotLoaded(associatedIds: [post.identifier],
+                                                 associatedFields: ["postWithTagsCompositeKey"]))
         try await postTags.fetch()
         assertList(postTags, state: .isLoaded(count: 1))
     }
@@ -58,8 +58,8 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Missing postTags on post")
             return
         }
-        assertList(postTags, state: .isNotLoaded(associatedId: tag.identifier,
-                                                 associatedField: "tagWithCompositeKey"))
+        assertList(postTags, state: .isNotLoaded(associatedIds: [tag.identifier],
+                                                 associatedFields: ["tagWithCompositeKey"]))
         try await postTags.fetch()
         assertList(postTags, state: .isLoaded(count: 1))
     }
@@ -110,8 +110,8 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Missing postTags on post")
             return
         }
-        assertList(postTags, state: .isNotLoaded(associatedId: post.identifier,
-                                                 associatedField: "postWithTagsCompositeKey"))
+        assertList(postTags, state: .isNotLoaded(associatedIds: [post.identifier],
+                                                 associatedFields: ["postWithTagsCompositeKey"]))
         try await postTags.fetch()
         assertList(postTags, state: .isLoaded(count: 0))
     }
@@ -121,8 +121,8 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Missing postTags on post")
             return
         }
-        assertList(postTags, state: .isNotLoaded(associatedId: tag.identifier,
-                                                 associatedField: "tagWithCompositeKey"))
+        assertList(postTags, state: .isNotLoaded(associatedIds: [tag.identifier],
+                                                 associatedFields: ["tagWithCompositeKey"]))
         try await postTags.fetch()
         assertList(postTags, state: .isLoaded(count: 0))
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL7/Post4+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL7/Post4+Schema.swift
@@ -28,7 +28,7 @@ extension Post4 {
     model.fields(
       .field(post4.postId, is: .required, ofType: .string),
       .field(post4.title, is: .required, ofType: .string),
-      .hasMany(post4.comments, is: .optional, ofType: Comment4.self, associatedWith: Comment4.keys.post4CommentsPostId, targetNames: ["post4CommentsPostId", "post4CommentsTitle"]),
+      .hasMany(post4.comments, is: .optional, ofType: Comment4.self, associatedWithFields: [Comment4.keys.post4CommentsPostId, Comment4.keys.post4CommentsTitle]),
       .field(post4.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(post4.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL7/Post4+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL7/Post4+Schema.swift
@@ -28,7 +28,7 @@ extension Post4 {
     model.fields(
       .field(post4.postId, is: .required, ofType: .string),
       .field(post4.title, is: .required, ofType: .string),
-      .hasMany(post4.comments, is: .optional, ofType: Comment4.self, associatedWith: Comment4.keys.post4CommentsPostId),
+      .hasMany(post4.comments, is: .optional, ofType: Comment4.self, associatedWith: Comment4.keys.post4CommentsPostId, targetNames: ["post4CommentsPostId", "post4CommentsTitle"]),
       .field(post4.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(post4.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL7/Post4+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL7/Post4+Schema.swift
@@ -28,7 +28,7 @@ extension Post4 {
     model.fields(
       .field(post4.postId, is: .required, ofType: .string),
       .field(post4.title, is: .required, ofType: .string),
-      .hasMany(post4.comments, is: .optional, ofType: Comment4.self, associatedWithFields: [Comment4.keys.post4CommentsPostId, Comment4.keys.post4CommentsTitle]),
+      .hasMany(post4.comments, is: .optional, ofType: Comment4.self, associatedFields: [Comment4.keys.post4CommentsPostId, Comment4.keys.post4CommentsTitle]),
       .field(post4.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(post4.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/AWSDataStoreLazyLoadBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/AWSDataStoreLazyLoadBaseTest.swift
@@ -189,18 +189,18 @@ class AWSDataStoreLazyLoadBaseTest: XCTestCase {
     }
     
     enum AssertListState {
-        case isNotLoaded(associatedId: String, associatedField: String)
+        case isNotLoaded(associatedIds: [String], associatedFields: [String])
         case isLoaded(count: Int)
     }
     
     func assertList<M: Model>(_ list: List<M>, state: AssertListState) {
         switch state {
-        case .isNotLoaded(let expectedAssociatedId, let expectedAssociatedField):
-            if case .notLoaded(let associatedIdentifiers, let associatedField) = list.listProvider.getState() {
-                XCTAssertEqual(associatedIdentifiers.first, expectedAssociatedId)
-                XCTAssertEqual(associatedField, expectedAssociatedField)
+        case .isNotLoaded(let expectedAssociatedIds, let expectedAssociatedFields):
+            if case .notLoaded(let associatedIdentifiers, let associatedFields) = list.listProvider.getState() {
+                XCTAssertEqual(associatedIdentifiers, expectedAssociatedIds)
+                XCTAssertEqual(associatedFields, expectedAssociatedFields)
             } else {
-                XCTFail("It should be not loaded with expected associatedId \(expectedAssociatedId) associatedField \(expectedAssociatedField)")
+                XCTFail("It should be not loaded with expected associatedIds \(expectedAssociatedIds) associatedFields \(expectedAssociatedFields)")
             }
         case .isLoaded(let count):
             if case .loaded(let loadedList) = list.listProvider.getState() {

--- a/AmplifyTests/CategoryTests/DataStore/Model/ListTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/Model/ListTests.swift
@@ -59,7 +59,7 @@ class ListTests: XCTestCase {
         }
 
         public func getState() -> ModelListProviderState<Element> {
-            state ?? .notLoaded(associatedIdentifiers: [""], associatedField: "")
+            state ?? .notLoaded(associatedIdentifiers: [""], associatedFields: [""])
         }
         
         public func load(completion: (Result<[Element], CoreError>) -> Void) {

--- a/AmplifyTests/CategoryTests/DataStore/ModelFieldAssociationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/ModelFieldAssociationTests.swift
@@ -28,7 +28,7 @@ class ModelFieldAssociationTests: XCTestCase {
 
     func testHasManyWithCodingKeys() {
         let hasMany = ModelAssociation.hasMany(associatedWith: Comment.keys.post)
-        guard case .hasMany(let fieldName) = hasMany else {
+        guard case .hasMany(let fieldName, let targetNames) = hasMany else {
             XCTFail("Should create hasMany association")
             return
         }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->


## Table of contents

- Library Changes `data-dev-preview` https://github.com/aws-amplify/amplify-swift/pull/2730  (You are here)
- Library Changes `v1` - https://github.com/aws-amplify/amplify-swift/pull/2734
- Library Changes `main` - https://github.com/aws-amplify/amplify-swift/pull/2735
- Codegen Changes - https://github.com/aws-amplify/amplify-codegen/pull/538 


## Description
<!-- Why is this change required? What problem does it solve? -->

This PR fixes the use case for lazy loading a list for uni-directional has-many use cases where the parent model contains a custom primary key. A uni-directional has-many use case is the following:
```
# LL.7. Implicit Uni-directional Has Many
# CLI.4. Implicit Uni-directional Has Many

type Post4 @model {
  postId: ID! @primaryKey(sortKeyFields:["title"])
  title: String!
  comments: [Comment4] @hasMany
}
type Comment4 @model {
  commentId: ID! @primaryKey(sortKeyFields:["content"])
  content: String!
}

# LL.11. Explicit Uni-directional Has Many
# CLI.8. Explicit Uni-directional Has Many

type Post8 @model {
  postId: ID! @primaryKey(sortKeyFields:["title"])
  title: String!
  comments: [Comment8] @hasMany(indexName:"byPost", fields:["postId", "title"])
}
type Comment8 @model {
  commentId: ID! @primaryKey(sortKeyFields:["content"])
  content: String!
  postId: ID @index(name: "byPost", sortKeyFields:["postTitle"]) # customized foreign key for parent primary key
  postTitle: String # customized foreign key for parent sort key
}
```

The Post has a custom primary key (postId and title), and the child does not have a model reference to the post. 

Querying for a post, and then traversing to the comment, and lazy loading the comment previously was incorrectly constructing the filter (Query for Comments by filter on post identifiers). It was missing the post's second identifier of the composite key.
```
LazyList's query for comments by postId == post.id
```

The correct logic is to do
```
LazyList's query for comments by postId == post.id && postTitle == post.title
```

This is working for bi-directional since the post reference on the comment can resolve the targetNames (fields on the Comment, which reference the post). It is not working on for uni-directional because the Comment does not have a reference to the post, only the fields of the post's composite key on the comment. 

This PR manually modifies the codegenerated types to include the associatedFieldNames on the comments field on the Post. When querying for a post, the associatedFieldNames will be used if available to pass which fields to construct the filter on. This is only necessary when the parent model has a composite primary key. The changes in this PR is backwards compatible with previous codegenerated hasMany relationships which do not contain associatedFieldNames, however the use case can only be solved for the customer when they upgrade to the latest codegen and regenerate the models with the associatedFieldNames.


## Examples use cases

**Use case: bi-directional has-many belongs-to**

Comment belongs-to Post will have a reference like "post"
```
struct Comment: Model {
  var post: Post
}
```

`associatedFields` will be ["post"].
`associatedIdentifiers` will be ["postId123"]

```
query(Comment.self, filter: field("post") == associatedIdentifiers[0])
```


**Use case: bi-directional has-many belongs-to with CPK on parent**

```
struct Comment: Model {
  var post: Post
}
extension Comment {
   .belongsTo(comment.post, is: .optional, ofType: Post.self, targetNames: ["postId", "postTitle"]),
}
struct Post: Model {
  var id: //
  var title // title being a primary key of post
}
```


`associatedFields` will be ["post"].
`associatedIdentifiers` will be ["postId123", "title123"]

```
let columnNames = getColumnNames(["post"]) // ["postId", "postTitle"]
query(Comment.self, filter: field("postId") == "postId123" && field("postTitle") == "title123")
```

**Use case: uni-directional has-many**
```
struct Comment: Model {
  var postId: String
}

struct Post: Model {
  var id: String
}
```

`associatedFields` will be ["postId"].
`associatedIdentifiers` will be ["postId123"]

```
query(Comment.self, filter: field("postId") == "postId123")
```


**Use case: uni-directional has-many with CPK on parent**

This is the use case that has a problem being fixed by this PR (and codegen changes to add associatedFields to the hasMany modelField)
```
struct Comment: Model {
  var postId: String
  var postTitle: String
}


struct Post: Model {
  var id: String
  var title: String
  var comments: List<Comment>
}
extension Post {
  .hasMany(post.comments, is: .optional, ofType: Comment4.self, associatedFields: [Comment.keys.postId, Comment.keys.postTitle]),
}
```

`associatedFields` will be ["postId", "postTitle"].
`associatedIdentifiers` will be ["postId123", "title123"]

```
query(Comment.self, filter: field("postId") == "postId123" && field("postTitle") == "title123")
```
## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
