### PR TITLE
fix(v1): CPK has-many has-one associatedFields

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
@@ -87,8 +87,8 @@ import Foundation
 /// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
 ///   directly by host applications. The behavior of this may change without warning.
 public enum ModelAssociation {
-    case hasMany(associatedFieldName: String?)
-    case hasOne(associatedFieldName: String?, targetNames: [String])
+    case hasMany(associatedFieldName: String?, associatedFieldNames: [String] = [])
+    case hasOne(associatedFieldName: String?, associatedFieldNames: [String] = [], targetNames: [String])
     case belongsTo(associatedFieldName: String?, targetNames: [String])
 
     public static let belongsTo: ModelAssociation = .belongsTo(associatedFieldName: nil, targetNames: [])
@@ -98,18 +98,25 @@ public enum ModelAssociation {
         return .belongsTo(associatedFieldName: nil, targetNames: targetNames)
     }
 
-    public static func hasMany(associatedWith: CodingKey?) -> ModelAssociation {
-        return .hasMany(associatedFieldName: associatedWith?.stringValue)
+    public static func hasMany(associatedWith: CodingKey? = nil,
+                               associatedFields: [CodingKey] = []) -> ModelAssociation {
+        return .hasMany(associatedFieldName: associatedWith?.stringValue,
+                        associatedFieldNames: associatedFields.map { $0.stringValue })
     }
 
-    @available(*, deprecated, message: "Use hasOne(associatedWith:targetNames:)")
-    public static func hasOne(associatedWith: CodingKey?, targetName: String? = nil) -> ModelAssociation {
+    @available(*, deprecated, message: "Use hasOne(associatedWith:associatedFields:targetNames:)")
+    public static func hasOne(associatedWith: CodingKey?,
+                              targetName: String? = nil) -> ModelAssociation {
         let targetNames = targetName.map { [$0] } ?? []
         return .hasOne(associatedWith: associatedWith, targetNames: targetNames)
     }
 
-    public static func hasOne(associatedWith: CodingKey?, targetNames: [String] = []) -> ModelAssociation {
-        return .hasOne(associatedFieldName: associatedWith?.stringValue, targetNames: targetNames)
+    public static func hasOne(associatedWith: CodingKey? = nil,
+                              associatedFields: [CodingKey] = [],
+                              targetNames: [String] = []) -> ModelAssociation {
+        return .hasOne(associatedFieldName: associatedWith?.stringValue,
+                       associatedFieldNames: associatedFields.map { $0.stringValue },
+                       targetNames: targetNames)
     }
 
     @available(*, deprecated, message: "Use belongsTo(associatedWith:targetNames:)")
@@ -234,13 +241,9 @@ extension ModelField {
         if hasAssociation {
             let associatedModel = requiredAssociatedModelName
             switch association {
-            case .belongsTo(let associatedKey, _):
-                // TODO handle modelName casing (convert to camelCase)
-                let key = associatedKey ?? associatedModel
-                let schema = ModelRegistry.modelSchema(from: associatedModel)
-                return schema?.field(withName: key)
-            case .hasOne(let associatedKey, _),
-                 .hasMany(let associatedKey):
+            case .belongsTo(let associatedKey, _),
+                    .hasOne(let associatedKey, _, _),
+                    .hasMany(let associatedKey, _):
                 // TODO handle modelName casing (convert to camelCase)
                 let key = associatedKey ?? associatedModel
                 let schema = ModelRegistry.modelSchema(from: associatedModel)

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -241,6 +241,19 @@ public enum ModelFieldDefinition {
                       association: .hasMany(associatedWith: associatedKey))
     }
 
+    public static func hasMany(_ key: CodingKey,
+                               is nullability: ModelFieldNullability = .required,
+                               isReadOnly: Bool = false,
+                               ofType type: Model.Type,
+                               associatedFields associatedKeys: [CodingKey]) -> ModelFieldDefinition {
+        return .field(key,
+                      is: nullability,
+                      isReadOnly: isReadOnly,
+                      ofType: .collection(of: type),
+                      association: .hasMany(associatedWith: associatedKeys.first,
+                                            associatedFields: associatedKeys))
+    }
+
     public static func hasOne(_ key: CodingKey,
                               is nullability: ModelFieldNullability = .required,
                               isReadOnly: Bool = false,
@@ -265,6 +278,21 @@ public enum ModelFieldDefinition {
                       isReadOnly: isReadOnly,
                       ofType: .model(type: type),
                       association: .hasOne(associatedWith: associatedKey, targetNames: targetNames))
+    }
+
+    public static func hasOne(_ key: CodingKey,
+                              is nullability: ModelFieldNullability = .required,
+                              isReadOnly: Bool = false,
+                              ofType type: Model.Type,
+                              associatedFields associatedKeys: [CodingKey],
+                              targetNames: [String]) -> ModelFieldDefinition {
+        return .field(key,
+                      is: nullability,
+                      isReadOnly: isReadOnly,
+                      ofType: .model(type: type),
+                      association: .hasOne(associatedWith: associatedKeys.first,
+                                           associatedFields: associatedKeys,
+                                           targetNames: targetNames))
     }
 
     public static func belongsTo(_ key: CodingKey,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -207,7 +207,7 @@ extension Model {
         let defaultFieldName = modelName.camelCased() + modelField.name.pascalCased() + "Id"
         if case let .belongsTo(_, targetNames) = modelField.association, !targetNames.isEmpty {
             return targetNames
-        } else if case let .hasOne(_, targetNames) = modelField.association,
+        } else if case let .hasOne(_, _, targetNames) = modelField.association,
                   !targetNames.isEmpty {
             return targetNames
         }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
@@ -131,7 +131,7 @@ extension QueryPredicateOperation: GraphQLFilterConvertible {
             }
             let targetName = targetNames.first ?? defaultFieldName
             return targetName
-        case .hasOne(_, let targetNames):
+        case .hasOne(_, _, let targetNames):
             guard targetNames.count == 1 else {
                 preconditionFailure("QueryPredicate not supported on associated field with composite key: \(field)")
             }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/ModelSchema+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/ModelSchema+SQLite.swift
@@ -82,7 +82,7 @@ extension ModelField: SQLColumn {
     var sqlName: String {
         if case let .belongsTo(_, targetNames) = association {
             return foreignKeySqlName(withAssociationTargets: targetNames)
-        } else if case let .hasOne(_, targetNames) = association {
+        } else if case let .hasOne(_, _, targetNames) = association {
             return foreignKeySqlName(withAssociationTargets: targetNames)
         }
         return name

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Subscribe/DataStoreObserveQueryOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Subscribe/DataStoreObserveQueryOperationTests.swift
@@ -92,7 +92,7 @@ class DataStoreObserveQueryOperationTests: XCTestCase {
         let secondSnapshot = expectation(description: "second query snapshots")
         let thirdSnapshot = expectation(description: "third query snapshot")
         thirdSnapshot.isInverted = true
-        
+
         var querySnapshots = [DataStoreQuerySnapshot<Post>]()
         let dispatchedModelSyncedEvent = AtomicValue(initialValue: false)
         let operation = AWSDataStoreObserveQueryOperation(

--- a/AmplifyTests/CategoryTests/DataStore/ModelFieldAssociationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/ModelFieldAssociationTests.swift
@@ -28,7 +28,7 @@ class ModelFieldAssociationTests: XCTestCase {
 
     func testHasManyWithCodingKeys() {
         let hasMany = ModelAssociation.hasMany(associatedWith: Comment.keys.post)
-        guard case .hasMany(let fieldName) = hasMany else {
+        guard case .hasMany(let fieldName, _) = hasMany else {
             XCTFail("Should create hasMany association")
             return
         }
@@ -37,7 +37,7 @@ class ModelFieldAssociationTests: XCTestCase {
 
     func testHasOneWithCodingKeys() {
         let hasOne = ModelAssociation.hasOne(associatedWith: Comment.keys.post, targetName: nil)
-        guard case .hasOne(let fieldName, let target) = hasOne else {
+        guard case .hasOne(let fieldName, _, let target) = hasOne else {
             XCTFail("Should create hasOne association")
             return
         }
@@ -47,7 +47,7 @@ class ModelFieldAssociationTests: XCTestCase {
 
     func testHasOneWithCodingKeysWithTargetName() {
         let hasOne = ModelAssociation.hasOne(associatedWith: Comment.keys.post, targetName: "postID")
-        guard case .hasOne(let fieldName, let target) = hasOne else {
+        guard case .hasOne(let fieldName, _, let target) = hasOne else {
             XCTFail("Should create hasOne association")
             return
         }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
## Table of contents

- Library Changes `data-dev-preview` https://github.com/aws-amplify/amplify-swift/pull/2730 
- Library Changes `v1` - https://github.com/aws-amplify/amplify-swift/pull/2734 (You are here)
- Library Changes `main` - https://github.com/aws-amplify/amplify-swift/pull/2735
- Codegen Changes - https://github.com/aws-amplify/amplify-codegen/pull/538 
- Codegen Changes has-one - https://github.com/aws-amplify/amplify-codegen/pull/541

## Description
<!-- Why is this change required? What problem does it solve? -->
This PR does not attempt to fix the uni-directional has-many lazy loading list issue, see https://github.com/aws-amplify/amplify-swift/pull/2730  for more details and the fix. Since the CPK codegen changes (https://github.com/aws-amplify/amplify-codegen/pull/538 ) are available in `v1`, this PR introduces that parameter to make sure newly generated types continue to compile with the added `associatedWithFields` argument to hasMany model fields. When we are ready to move forward with the backport of https://github.com/aws-amplify/amplify-swift/pull/2711 then it will be solved on `v1`. 

We are also fixing uni-directional has-one CPK use case by extending has-one with `associatedFields. Corresponding codegen changes are in https://github.com/aws-amplify/amplify-codegen/pull/541


## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
