### PR TITLE
fix: CPK has-many has-one associatedFields

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -241,6 +241,19 @@ public enum ModelFieldDefinition {
                       association: .hasMany(associatedWith: associatedKey))
     }
 
+    public static func hasMany(_ key: CodingKey,
+                               is nullability: ModelFieldNullability = .required,
+                               isReadOnly: Bool = false,
+                               ofType type: Model.Type,
+                               associatedFields associatedKeys: [CodingKey]) -> ModelFieldDefinition {
+        return .field(key,
+                      is: nullability,
+                      isReadOnly: isReadOnly,
+                      ofType: .collection(of: type),
+                      association: .hasMany(associatedWith: associatedKeys.first,
+                                            associatedFields: associatedKeys))
+    }
+
     public static func hasOne(_ key: CodingKey,
                               is nullability: ModelFieldNullability = .required,
                               isReadOnly: Bool = false,
@@ -253,7 +266,22 @@ public enum ModelFieldDefinition {
                       ofType: .model(type: type),
                       association: .hasOne(associatedWith: associatedKey, targetNames: targetName.map { [$0] } ?? []))
     }
-
+    
+    public static func hasOne(_ key: CodingKey,
+                              is nullability: ModelFieldNullability = .required,
+                              isReadOnly: Bool = false,
+                              ofType type: Model.Type,
+                              associatedFields associatedKeys: [CodingKey],
+                              targetNames: [String]) -> ModelFieldDefinition {
+        return .field(key,
+                      is: nullability,
+                      isReadOnly: isReadOnly,
+                      ofType: .model(type: type),
+                      association: .hasOne(associatedWith: associatedKeys.first,
+                                           associatedFields: associatedKeys,
+                                           targetNames: targetNames))
+    }
+    
     public static func hasOne(_ key: CodingKey,
                               is nullability: ModelFieldNullability = .required,
                               isReadOnly: Bool = false,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -207,7 +207,7 @@ extension Model {
         let defaultFieldName = modelName.camelCased() + modelField.name.pascalCased() + "Id"
         if case let .belongsTo(_, targetNames) = modelField.association, !targetNames.isEmpty {
             return targetNames
-        } else if case let .hasOne(_, targetNames) = modelField.association,
+        } else if case let .hasOne(_, _, targetNames) = modelField.association,
                   !targetNames.isEmpty {
             return targetNames
         }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
@@ -131,7 +131,7 @@ extension QueryPredicateOperation: GraphQLFilterConvertible {
             }
             let targetName = targetNames.first ?? defaultFieldName
             return targetName
-        case .hasOne(_, let targetNames):
+        case .hasOne(_, _, let targetNames):
             guard targetNames.count == 1 else {
                 preconditionFailure("QueryPredicate not supported on associated field with composite key: \(field)")
             }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/ModelSchema+SQLite.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/ModelSchema+SQLite.swift
@@ -82,7 +82,7 @@ extension ModelField: SQLColumn {
     var sqlName: String {
         if case let .belongsTo(_, targetNames) = association {
             return foreignKeySqlName(withAssociationTargets: targetNames)
-        } else if case let .hasOne(_, targetNames) = association {
+        } else if case let .hasOne(_, _, targetNames) = association {
             return foreignKeySqlName(withAssociationTargets: targetNames)
         }
         return name

--- a/AmplifyTests/CategoryTests/DataStore/ModelFieldAssociationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/ModelFieldAssociationTests.swift
@@ -28,7 +28,7 @@ class ModelFieldAssociationTests: XCTestCase {
 
     func testHasManyWithCodingKeys() {
         let hasMany = ModelAssociation.hasMany(associatedWith: Comment.keys.post)
-        guard case .hasMany(let fieldName) = hasMany else {
+        guard case .hasMany(let fieldName, _) = hasMany else {
             XCTFail("Should create hasMany association")
             return
         }
@@ -37,7 +37,7 @@ class ModelFieldAssociationTests: XCTestCase {
 
     func testHasOneWithCodingKeys() {
         let hasOne = ModelAssociation.hasOne(associatedWith: Comment.keys.post, targetNames: [])
-        guard case .hasOne(let fieldName, let target) = hasOne else {
+        guard case .hasOne(let fieldName, _, let target) = hasOne else {
             XCTFail("Should create hasOne association")
             return
         }
@@ -47,7 +47,7 @@ class ModelFieldAssociationTests: XCTestCase {
 
     func testHasOneWithCodingKeysWithTargetName() {
         let hasOne = ModelAssociation.hasOne(associatedWith: Comment.keys.post, targetNames: ["postID"])
-        guard case .hasOne(let fieldName, let target) = hasOne else {
+        guard case .hasOne(let fieldName, _, let target) = hasOne else {
             XCTFail("Should create hasOne association")
             return
         }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
## Table of contents

- Library Changes `data-dev-preview` https://github.com/aws-amplify/amplify-swift/pull/2730 
- Library Changes `v1` - https://github.com/aws-amplify/amplify-swift/pull/2734 
- Library Changes `main` - https://github.com/aws-amplify/amplify-swift/pull/2735 (You are here)
- Codegen Changes has-many - https://github.com/aws-amplify/amplify-codegen/pull/538 
- Codegen Changes has-one - https://github.com/aws-amplify/amplify-codegen/pull/541

## Description
<!-- Why is this change required? What problem does it solve? -->
This PR does not attempt to fix the uni-directional has-many lazy loading list issue, see https://github.com/aws-amplify/amplify-swift/pull/2730  for more details and the fix. Since the CPK codegen changes (https://github.com/aws-amplify/amplify-codegen/pull/538 ) are available in `main`, this PR introduces that parameter to make sure newly generated types continue to compile with the added `associatedWithFields` argument to hasMany model fields. When we are ready to move forward the lazy loading feature branch https://github.com/aws-amplify/amplify-swift/pull/2658 , the fix will be included as well

We are also fixing uni-directional has-one CPK use case by extending has-one with `associatedFields`. Corresponding codegen changes are in https://github.com/aws-amplify/amplify-codegen/pull/541

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
