### PR TITLE
[DRAFT] fix(datastore): sync partial results

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -172,8 +172,13 @@ final class InitialSyncOperation: AsynchronousOperation {
         let syncQueryResult: SyncQueryResult
         switch graphQLResult {
         case .failure(let graphQLResponseError):
-            finish(result: .failure(DataStoreError.api(graphQLResponseError)))
-            return
+            if case .partial(let queryResult, let errors) = graphQLResponseError {
+                log.verbose("Received partially-successful response. Continue processing data. Dropping errors: \(errors)")
+                syncQueryResult = queryResult
+            } else {
+                finish(result: .failure(DataStoreError.api(graphQLResponseError)))
+                return
+            }
         case .success(let queryResult):
             syncQueryResult = queryResult
         }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

SyncQuery should reconcile items that it gets from the graphQL response, not just on success but on partial (data, errors) cases as well.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
