### PR TITLE
chore: Remove v from release tags

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -98,7 +98,7 @@ platform :ios do
   desc "Tag in git and push to GitHub"
   private_lane :add_tag do |options|
     next_version = options[:version]
-    next_tag = "v#{next_version}"
+    next_tag = "#{next_version}"
 
     add_git_tag(tag: next_tag)
     push_git_tags(tag: next_tag)
@@ -134,7 +134,7 @@ platform :ios do
   private_lane :post_release do |options|
     version = options[:version].to_s
     changelog = options[:changelog]
-    tag = "v#{version}"
+    tag = "#{version}"
     plugin_root = File.expand_path("#{ENV['CIRCLE_WORKING_DIRECTORY']}/AmplifyPlugins")
   
     sh('bundle', 'exec', 'swift', 'package', 'update')


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
None 

## Description
<!-- Why is this change required? What problem does it solve? -->
Remove the character v from release tags for SPM to import correct next minor/major version

## General Checklist
<!-- Check or cross out if not relevant -->

~~- [ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~~
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
