### PR TITLE
fix: DefaultModelProvider return nil from not loaded state

### DIFF
--- a/Amplify/Categories/DataStore/Model/Lazy/DefaultModelProvider.swift
+++ b/Amplify/Categories/DataStore/Model/Lazy/DefaultModelProvider.swift
@@ -24,7 +24,7 @@ public struct DefaultModelProvider<Element: Model>: ModelProvider {
     public func load() async throws -> Element? {
         switch loadedState {
         case .notLoaded:
-            throw CoreError.clientValidation("DefaultModelProvider does not provide loading capabilities", "")
+            return nil
         case .loaded(let model):
             return model
         }

--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
@@ -83,6 +83,10 @@
 		21698CC72889D75F004BD994 /* GraphQLAuthDirectiveIntegrationTests+Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CC22889D75F004BD994 /* GraphQLAuthDirectiveIntegrationTests+Auth.swift */; };
 		21698CC92889D75F004BD994 /* SocialNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CC42889D75F004BD994 /* SocialNote.swift */; };
 		21698CCB2889D75F004BD994 /* GraphQLAuthDirectiveIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21698CC62889D75F004BD994 /* GraphQLAuthDirectiveIntegrationTests.swift */; };
+		2170971329915C1500FD7EB2 /* GraphQLLazyLoadCompositePKChildTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2170971229915C1500FD7EB2 /* GraphQLLazyLoadCompositePKChildTests.swift */; };
+		2170971529915C9F00FD7EB2 /* GraphQLLazyLoadCompositePKImplicitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2170971429915C9F00FD7EB2 /* GraphQLLazyLoadCompositePKImplicitTests.swift */; };
+		2170971729915CCC00FD7EB2 /* GraphQLLazyLoadCompositePKStrangeExplicitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2170971629915CCC00FD7EB2 /* GraphQLLazyLoadCompositePKStrangeExplicitTests.swift */; };
+		2170971929915CEC00FD7EB2 /* GraphQLLazyLoadCompositePKChildSansTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2170971829915CEC00FD7EB2 /* GraphQLLazyLoadCompositePKChildSansTests.swift */; };
 		218D0193291AE3750068D133 /* Post4V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218D018F291AE3750068D133 /* Post4V2.swift */; };
 		218D0194291AE3750068D133 /* Comment4V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218D0190291AE3750068D133 /* Comment4V2.swift */; };
 		218D0195291AE3750068D133 /* Comment4V2+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218D0191291AE3750068D133 /* Comment4V2+Schema.swift */; };
@@ -405,6 +409,10 @@
 		21698CC42889D75F004BD994 /* SocialNote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocialNote.swift; sourceTree = "<group>"; };
 		21698CC52889D75F004BD994 /* GraphQLAuthDirectiveIntegrationTests+Support.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphQLAuthDirectiveIntegrationTests+Support.swift"; sourceTree = "<group>"; };
 		21698CC62889D75F004BD994 /* GraphQLAuthDirectiveIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQLAuthDirectiveIntegrationTests.swift; sourceTree = "<group>"; };
+		2170971229915C1500FD7EB2 /* GraphQLLazyLoadCompositePKChildTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLLazyLoadCompositePKChildTests.swift; sourceTree = "<group>"; };
+		2170971429915C9F00FD7EB2 /* GraphQLLazyLoadCompositePKImplicitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLLazyLoadCompositePKImplicitTests.swift; sourceTree = "<group>"; };
+		2170971629915CCC00FD7EB2 /* GraphQLLazyLoadCompositePKStrangeExplicitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLLazyLoadCompositePKStrangeExplicitTests.swift; sourceTree = "<group>"; };
+		2170971829915CEC00FD7EB2 /* GraphQLLazyLoadCompositePKChildSansTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLLazyLoadCompositePKChildSansTests.swift; sourceTree = "<group>"; };
 		218D018F291AE3750068D133 /* Post4V2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post4V2.swift; sourceTree = "<group>"; };
 		218D0190291AE3750068D133 /* Comment4V2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment4V2.swift; sourceTree = "<group>"; };
 		218D0191291AE3750068D133 /* Comment4V2+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Comment4V2+Schema.swift"; sourceTree = "<group>"; };
@@ -1078,6 +1086,10 @@
 			isa = PBXGroup;
 			children = (
 				21FA8EFA295C9647009F6A07 /* GraphQLLazyLoadCompositePKTests.swift */,
+				2170971229915C1500FD7EB2 /* GraphQLLazyLoadCompositePKChildTests.swift */,
+				2170971429915C9F00FD7EB2 /* GraphQLLazyLoadCompositePKImplicitTests.swift */,
+				2170971629915CCC00FD7EB2 /* GraphQLLazyLoadCompositePKStrangeExplicitTests.swift */,
+				2170971829915CEC00FD7EB2 /* GraphQLLazyLoadCompositePKChildSansTests.swift */,
 				21908A58291D762B005021F7 /* ChildSansBelongsTo.swift */,
 				21908A53291D762B005021F7 /* ChildSansBelongsTo+Schema.swift */,
 				21908A5B291D762B005021F7 /* CompositePKChild.swift */,
@@ -1864,6 +1876,7 @@
 				21908A20291D75E4005021F7 /* Project2.swift in Sources */,
 				219089F4291D75C3005021F7 /* Comment8V2.swift in Sources */,
 				21908A60291D762B005021F7 /* DefaultPKChild.swift in Sources */,
+				2170971929915CEC00FD7EB2 /* GraphQLLazyLoadCompositePKChildSansTests.swift in Sources */,
 				219089F8291D75C3005021F7 /* MyCustomModel8.swift in Sources */,
 				21908A2A291D75EB005021F7 /* Comment4.swift in Sources */,
 				21908A19291D75DD005021F7 /* Team1.swift in Sources */,
@@ -1916,6 +1929,7 @@
 				21EA888228F9BCD90000BA75 /* TestConfigHelper.swift in Sources */,
 				21AB5C4029819A4000CCA482 /* ListIntContainer.swift in Sources */,
 				21908A0E291D75D6005021F7 /* TagWithCompositeKey+Schema.swift in Sources */,
+				2170971329915C1500FD7EB2 /* GraphQLLazyLoadCompositePKChildTests.swift in Sources */,
 				21908A6B291D762B005021F7 /* CompositePKParent+Schema.swift in Sources */,
 				21BC111F2971ADA4000E189E /* User14.swift in Sources */,
 				21BC111E2971ADA4000E189E /* User14+Schema.swift in Sources */,
@@ -1944,10 +1958,12 @@
 				21BC11202971ADA4000E189E /* Comment14+Schema.swift in Sources */,
 				21BC11212971ADA4000E189E /* Post14+Schema.swift in Sources */,
 				21908A21291D75E4005021F7 /* GraphQLLazyLoadProjectTeam2Tests.swift in Sources */,
+				2170971529915C9F00FD7EB2 /* GraphQLLazyLoadCompositePKImplicitTests.swift in Sources */,
 				219089FE291D75CE005021F7 /* GraphQLLazyLoadPostCommentWithCompositeKeyTests.swift in Sources */,
 				21908A76291D7631005021F7 /* GraphQLLazyLoadPostComment8Tests.swift in Sources */,
 				21908A23291D75E4005021F7 /* Project2+Schema.swift in Sources */,
 				21908A49291D7608005021F7 /* GraphQLLazyLoadPostComment7Tests.swift in Sources */,
+				2170971729915CCC00FD7EB2 /* GraphQLLazyLoadCompositePKStrangeExplicitTests.swift in Sources */,
 				21908A2D291D75EB005021F7 /* Post4+Schema.swift in Sources */,
 				218D0196291AE3750068D133 /* Post4V2+Schema.swift in Sources */,
 				21AB5C3E29819A4000CCA482 /* NestedTypeTestModel.swift in Sources */,

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/CompositePK/CompositePKParent+Schema.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/CompositePK/CompositePKParent+Schema.swift
@@ -34,7 +34,7 @@ extension CompositePKParent {
       .hasMany(compositePKParent.children, is: .optional, ofType: CompositePKChild.self, associatedWith: CompositePKChild.keys.parent),
       .hasMany(compositePKParent.implicitChildren, is: .optional, ofType: ImplicitChild.self, associatedWith: ImplicitChild.keys.parent),
       .hasMany(compositePKParent.strangeChildren, is: .optional, ofType: StrangeExplicitChild.self, associatedWith: StrangeExplicitChild.keys.parent),
-      .hasMany(compositePKParent.childrenSansBelongsTo, is: .optional, ofType: ChildSansBelongsTo.self, associatedWith: ChildSansBelongsTo.keys.compositePKParentChildrenSansBelongsToCustomId),
+      .hasMany(compositePKParent.childrenSansBelongsTo, is: .optional, ofType: ChildSansBelongsTo.self, associatedFields: [ChildSansBelongsTo.keys.compositePKParentChildrenSansBelongsToCustomId, ChildSansBelongsTo.keys.compositePKParentChildrenSansBelongsToContent]),
       .field(compositePKParent.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(compositePKParent.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/CompositePK/GraphQLLazyLoadCompositePKChildSansTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/CompositePK/GraphQLLazyLoadCompositePKChildSansTests.swift
@@ -1,0 +1,109 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Combine
+import XCTest
+
+@testable import Amplify
+import AWSPluginsCore
+
+extension GraphQLLazyLoadCompositePKTests {
+    
+    // MARK: - CompositePKParent / ChildSansBelongsTo
+   
+    func initChildSansBelongsTo(with parent: CompositePKParent) -> ChildSansBelongsTo {
+        ChildSansBelongsTo(
+            childId: UUID().uuidString,
+            content: "content",
+            compositePKParentChildrenSansBelongsToCustomId: parent.customId,
+            compositePKParentChildrenSansBelongsToContent: parent.content)
+    }
+    
+    func testSaveChildSansBelongsTo() async throws {
+        await setup(withModels: CompositePKModels())
+        
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initChildSansBelongsTo(with: savedParent)
+        try await mutate(.create(child))
+    }
+    
+    func testUpdateChildSansBelongsTo() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initChildSansBelongsTo(with: parent)
+        var savedChild = try await mutate(.create(child))
+        XCTAssertEqual(savedChild.compositePKParentChildrenSansBelongsToCustomId, savedParent.customId)
+        XCTAssertEqual(savedChild.compositePKParentChildrenSansBelongsToContent, savedParent.content)
+        
+        // update the child to a new parent
+        let newParent = initParent()
+        let savedNewParent = try await mutate(.create(newParent))
+        savedChild.compositePKParentChildrenSansBelongsToCustomId = savedNewParent.customId
+        savedChild.compositePKParentChildrenSansBelongsToContent = savedNewParent.content
+        let updatedChild = try await mutate(.update(savedChild))
+        XCTAssertEqual(updatedChild.compositePKParentChildrenSansBelongsToCustomId, savedNewParent.customId)
+        XCTAssertEqual(updatedChild.compositePKParentChildrenSansBelongsToContent, savedNewParent.content)
+    }
+    
+    func testDeleteChildSansBelongsTo() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initChildSansBelongsTo(with: parent)
+        let savedChild = try await mutate(.create(child))
+ 
+        try await mutate(.delete(savedChild))
+        try await assertModelDoesNotExist(savedChild)
+        
+        try await mutate(.delete(savedParent))
+        try await assertModelDoesNotExist(savedParent)
+    }
+    
+    func testGetChildSansBelongsTo() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initChildSansBelongsTo(with: parent)
+        let savedChild = try await mutate(.create(child))
+        
+        // query parent and load the children
+        let queriedParent = try await query(.get(CompositePKParent.self,
+                                                 byIdentifier: .identifier(customId: savedParent.customId,
+                                                                           content: savedParent.content)))!
+        
+        assertList(queriedParent.childrenSansBelongsTo!, state: .isNotLoaded(associatedIdentifiers: [queriedParent.customId,
+                                                                                                     queriedParent.content],
+                                                                             associatedFields: ["compositePKParentChildrenSansBelongsToCustomId", "compositePKParentChildrenSansBelongsToContent"]))
+        try await queriedParent.childrenSansBelongsTo?.fetch()
+        assertList(queriedParent.childrenSansBelongsTo!, state: .isLoaded(count: 1))
+        
+        // query children and verify the parent - ChildSansBelongsTo
+        let queriedChildSansBelongsTo = try await query(.get(ChildSansBelongsTo.self,
+                                                             byIdentifier: .identifier(childId: savedChild.childId,
+                                                                                       content: savedChild.content)))!
+        XCTAssertEqual(queriedChildSansBelongsTo.compositePKParentChildrenSansBelongsToCustomId, savedParent.customId)
+        XCTAssertEqual(queriedChildSansBelongsTo.compositePKParentChildrenSansBelongsToContent, savedParent.content)
+    }
+    
+    func testListChildSansBelongsTo() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initChildSansBelongsTo(with: savedParent)
+        try await mutate(.create(child))
+        
+        var queriedChild = try await listQuery(.list(ChildSansBelongsTo.self,
+                                                     where: ChildSansBelongsTo.keys.childId == child.childId && ChildSansBelongsTo.keys.content == child.content))
+        while queriedChild.hasNextPage() {
+            queriedChild = try await queriedChild.getNextPage()
+        }
+        assertList(queriedChild, state: .isLoaded(count: 1))
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/CompositePK/GraphQLLazyLoadCompositePKChildTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/CompositePK/GraphQLLazyLoadCompositePKChildTests.swift
@@ -1,0 +1,124 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Combine
+import XCTest
+
+@testable import Amplify
+import AWSPluginsCore
+
+extension GraphQLLazyLoadCompositePKTests {
+
+    // MARK: - CompositePKParent / CompositePKChild
+    
+    func initChild(with parent: CompositePKParent? = nil) -> CompositePKChild {
+        CompositePKChild(childId: UUID().uuidString, content: "content", parent: parent)
+    }
+    
+    func testSaveCompositePKChild() async throws {
+        await setup(withModels: CompositePKModels())
+        
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initChild(with: savedParent)
+        try await mutate(.create(child))
+    }
+    
+    func testUpdateCompositePKChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initChild(with: parent)
+        var savedChild = try await mutate(.create(child))
+        let loadedParent = try await savedChild.parent
+        XCTAssertEqual(loadedParent?.identifier, savedParent.identifier)
+        
+        // update the child to a new parent
+        let newParent = initParent()
+        let savedNewParent = try await mutate(.create(newParent))
+        savedChild.setParent(savedNewParent)
+        let updatedChild = try await mutate(.update(savedChild))
+        let loadedNewParent = try await updatedChild.parent
+        XCTAssertEqual(loadedNewParent?.identifier, savedNewParent.identifier)
+    }
+    
+    func testUpdateFromNoParentCompositePKChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        
+        let childWithoutParent = initChild()
+        var savedChild = try await mutate(.create(childWithoutParent))
+        let nilParent = try await savedChild.parent
+        XCTAssertNil(nilParent)
+        
+        // update the child to a parent
+        savedChild.setParent(savedParent)
+        let savedChildWithParent = try await mutate(.update(savedChild))
+        let loadedParent = try await savedChildWithParent.parent
+        XCTAssertEqual(loadedParent?.identifier, savedParent.identifier)
+    }
+    
+    func testDeleteCompositePKChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initChild(with: parent)
+        let savedChild = try await mutate(.create(child))
+        
+        try await mutate(.delete(savedParent))
+        try await assertModelDoesNotExist(savedParent)
+        try await mutate(.delete(savedChild))
+        try await assertModelDoesNotExist(savedChild)
+    }
+    
+    func testGetCompositePKChild() async throws {
+        await setup(withModels: CompositePKModels())
+
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initChild(with: parent)
+        let savedCompositePKChild = try await mutate(.create(child))
+
+        // query parent and load the children
+        let queriedParent = try await query(.get(CompositePKParent.self,
+                                                 byIdentifier: .identifier(customId: savedParent.customId,
+                                                                           content: savedParent.content)))!
+        assertList(queriedParent.children!, state: .isNotLoaded(associatedIdentifiers: [queriedParent.customId,
+                                                                                        queriedParent.content],
+                                                                associatedFields: ["parent"]))
+        try await queriedParent.children?.fetch()
+        assertList(queriedParent.children!, state: .isLoaded(count: 1))
+
+        // query child and load the parent - CompositePKChild
+        let queriedCompositePKChild = try await query(.get(CompositePKChild.self,
+                                                           byIdentifier: .identifier(childId: savedCompositePKChild.childId,
+                                                                                     content: savedCompositePKChild.content)))!
+        assertLazyReference(queriedCompositePKChild._parent,
+                            state: .notLoaded(identifiers: [.init(name: "customId", value: savedParent.customId),
+                                                            .init(name: "content", value: savedParent.content)]))
+        let loadedParent = try await queriedCompositePKChild.parent
+        assertLazyReference(queriedCompositePKChild._parent,
+                            state: .loaded(model: loadedParent))
+    }
+
+    func testListCompositePKChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initChild(with: savedParent)
+        try await mutate(.create(child))
+
+        var queriedChild = try await listQuery(.list(CompositePKChild.self,
+                                                     where: CompositePKChild.keys.childId == child.childId))
+        while queriedChild.hasNextPage() {
+            queriedChild = try await queriedChild.getNextPage()
+        }
+        assertList(queriedChild, state: .isLoaded(count: 1))
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/CompositePK/GraphQLLazyLoadCompositePKImplicitTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/CompositePK/GraphQLLazyLoadCompositePKImplicitTests.swift
@@ -1,0 +1,110 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Combine
+import XCTest
+
+@testable import Amplify
+import AWSPluginsCore
+
+extension GraphQLLazyLoadCompositePKTests {
+    
+    // MARK: - CompositePKParent / ImplicitChild
+    
+    func initImplicitChild(with parent: CompositePKParent) -> ImplicitChild {
+        ImplicitChild(childId: UUID().uuidString, content: "content", parent: parent)
+    }
+    
+    func testSaveImplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initImplicitChild(with: savedParent)
+        try await mutate(.create(child))
+    }
+    
+    func testUpdateImplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initImplicitChild(with: parent)
+        var savedChild = try await mutate(.create(child))
+        let loadedParent = try await savedChild.parent
+        XCTAssertEqual(loadedParent.identifier, savedParent.identifier)
+        
+        // update the child to a new parent
+        let newParent = initParent()
+        let savedNewParent = try await mutate(.create(newParent))
+        savedChild.setParent(savedNewParent)
+        let updatedChild = try await mutate(.update(savedChild))
+        let loadedNewParent = try await updatedChild.parent
+        XCTAssertEqual(loadedNewParent.identifier, savedNewParent.identifier)
+        
+    }
+    
+    func testDeleteImplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initImplicitChild(with: parent)
+        let savedChild = try await mutate(.create(child))
+        
+        try await mutate(.delete(savedChild))
+        try await assertModelDoesNotExist(savedChild)
+        try await mutate(.delete(savedParent))
+        try await assertModelDoesNotExist(savedParent)
+    }
+    
+    func testGetImplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initImplicitChild(with: parent)
+        let savedChild = try await mutate(.create(child))
+        
+        // query parent and load the children
+        let queriedParent = try await query(.get(CompositePKParent.self,
+                                                 byIdentifier: .identifier(customId: savedParent.customId,
+                                                                           content: savedParent.content)))!
+        
+        assertList(queriedParent.implicitChildren!, state: .isNotLoaded(associatedIdentifiers: [queriedParent.customId,
+                                                                                                queriedParent.content],
+                                                                        associatedFields: ["parent"]))
+        try await queriedParent.implicitChildren?.fetch()
+        assertList(queriedParent.implicitChildren!, state: .isLoaded(count: 1))
+
+       
+        // query child and load the parent - ImplicitChild
+        let queriedImplicitChild = try await query(.get(ImplicitChild.self,
+                                                        byIdentifier: .identifier(childId: savedChild.childId,
+                                                                                  content: savedChild.content)))!
+        assertLazyReference(queriedImplicitChild._parent,
+                            state: .notLoaded(identifiers: [.init(name: "customId", value: savedParent.customId),
+                                                            .init(name: "content", value: savedParent.content)]))
+        let loadedParent = try await queriedImplicitChild.parent
+        assertLazyReference(queriedImplicitChild._parent,
+                            state: .loaded(model: loadedParent))
+    }
+    
+    func testListImplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initImplicitChild(with: savedParent)
+        try await mutate(.create(child))
+        
+        var queriedChild = try await listQuery(
+            .list(ImplicitChild.self,
+                  where: ImplicitChild.keys.childId == child.childId && ImplicitChild.keys.content == child.content))
+        while queriedChild.hasNextPage() {
+            queriedChild = try await queriedChild.getNextPage()
+        }
+        assertList(queriedChild, state: .isLoaded(count: 1))
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/CompositePK/GraphQLLazyLoadCompositePKStrangeExplicitTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/CompositePK/GraphQLLazyLoadCompositePKStrangeExplicitTests.swift
@@ -1,0 +1,109 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Combine
+import XCTest
+
+@testable import Amplify
+import AWSPluginsCore
+
+extension GraphQLLazyLoadCompositePKTests {
+    
+    // MARK: - CompositePKParent / StrangeExplicitChild
+    
+    func initStrangeExplicitChild(with parent: CompositePKParent) -> StrangeExplicitChild {
+        StrangeExplicitChild(strangeId: UUID().uuidString, content: "content", parent: parent)
+    }
+    
+    func testSaveStrangeExplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initStrangeExplicitChild(with: savedParent)
+        try await mutate(.create(child))
+    }
+    
+    func testUpdateStrangeExplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initStrangeExplicitChild(with: parent)
+        var savedChild = try await mutate(.create(child))
+        let loadedParent = try await savedChild.parent
+        XCTAssertEqual(loadedParent.identifier, savedParent.identifier)
+        
+        // update the child to a new parent
+        let newParent = initParent()
+        let savedNewParent = try await mutate(.create(newParent))
+        savedChild.setParent(savedNewParent)
+        let updatedChild = try await mutate(.update(savedChild))
+        let loadedNewParent = try await updatedChild.parent
+        XCTAssertEqual(loadedNewParent.identifier, savedNewParent.identifier)
+        
+    }
+    
+    func testDeleteStrangeExplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initStrangeExplicitChild(with: parent)
+        let savedChild = try await mutate(.create(child))
+        
+        try await mutate(.delete(savedChild))
+        try await assertModelDoesNotExist(savedChild)
+        try await mutate(.delete(savedParent))
+        try await assertModelDoesNotExist(savedParent)
+    }
+    
+    func testGetStrangeExplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initStrangeExplicitChild(with: parent)
+        let savedChild = try await mutate(.create(child))
+        
+        // query parent and load the children
+        let queriedParent = try await query(.get(CompositePKParent.self,
+                                                 byIdentifier: .identifier(customId: savedParent.customId,
+                                                                           content: savedParent.content)))!
+        
+        assertList(queriedParent.strangeChildren!, state: .isNotLoaded(associatedIdentifiers: [queriedParent.customId,
+                                                                                               queriedParent.content],
+                                                                       associatedFields: ["parent"]))
+        try await queriedParent.strangeChildren?.fetch()
+        assertList(queriedParent.strangeChildren!, state: .isLoaded(count: 1))
+        
+        // query children and load the parent - StrangeExplicitChild
+        let queriedStrangeImplicitChild = try await query(.get(StrangeExplicitChild.self,
+                                                           byIdentifier: .identifier(strangeId: savedChild.strangeId,
+                                                                                     content: savedChild.content)))!
+        assertLazyReference(queriedStrangeImplicitChild._parent,
+                            state: .notLoaded(identifiers: [.init(name: "customId", value: savedParent.customId),
+                                                            .init(name: "content", value: savedParent.content)]))
+        let loadedParent3 = try await queriedStrangeImplicitChild.parent
+        assertLazyReference(queriedStrangeImplicitChild._parent,
+                            state: .loaded(model: loadedParent3))
+    }
+    
+    func testListStrangeExplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
+        let child = initStrangeExplicitChild(with: savedParent)
+        try await mutate(.create(child))
+        
+        var queriedChild = try await listQuery(
+            .list(StrangeExplicitChild.self,
+                  where: StrangeExplicitChild.keys.strangeId == child.strangeId && StrangeExplicitChild.keys.content == child.content))
+        while queriedChild.hasNextPage() {
+            queriedChild = try await queriedChild.getNextPage()
+        }
+        assertList(queriedChild, state: .isLoaded(count: 1))
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/CompositePK/GraphQLLazyLoadCompositePKTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/CompositePK/GraphQLLazyLoadCompositePKTests.swift
@@ -18,220 +18,94 @@ final class GraphQLLazyLoadCompositePKTests: GraphQLLazyLoadBaseTest {
         await setup(withModels: CompositePKModels())
     }
     
-    func testCompositePKParent() async throws {
+    func testIncludesAllChildren() async throws {
         await setup(withModels: CompositePKModels())
         
-        let compositePKParent = CompositePKParent(customId: UUID().uuidString,
-                                                  content: "content")
-        let savedParent = try await mutate(.create(compositePKParent))
-        let compositePKChild = CompositePKChild(childId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedCompositePKChild = try await mutate(.create(compositePKChild))
-        let implicitChild = ImplicitChild(childId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedImplicitChild = try await mutate(.create(implicitChild))
-        let strangeExplicitChild = StrangeExplicitChild(strangeId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedStrangeImplicitChild = try await mutate(.create(strangeExplicitChild))
-        let childSansBelongsTo = ChildSansBelongsTo(
-            childId: UUID().uuidString,
-            content: "content",
-            compositePKParentChildrenSansBelongsToCustomId: savedParent.customId,
-            compositePKParentChildrenSansBelongsToContent: savedParent.content)
-        let savedChildSansBelongsTo = try await mutate(.create(childSansBelongsTo))
-    }
-    
-    func testCompositePKParentUpdate() async throws {
-        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await mutate(.create(parent))
         
-        let compositePKParent = CompositePKParent(customId: UUID().uuidString,
-                                                  content: "content")
-        let savedParent = try await mutate(.create(compositePKParent))
-        let compositePKChild = CompositePKChild(childId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedCompositePKChild = try await mutate(.create(compositePKChild))
-        let implicitChild = ImplicitChild(childId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedImplicitChild = try await mutate(.create(implicitChild))
-        let strangeExplicitChild = StrangeExplicitChild(strangeId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedStrangeImplicitChild = try await mutate(.create(strangeExplicitChild))
-        let childSansBelongsTo = ChildSansBelongsTo(
-            childId: UUID().uuidString,
-            content: "content",
-            compositePKParentChildrenSansBelongsToCustomId: savedParent.customId,
-            compositePKParentChildrenSansBelongsToContent: savedParent.content)
-        let savedChildSansBelongsTo = try await mutate(.create(childSansBelongsTo))
+        let child = initChild(with: savedParent)
+        try await mutate(.create(child))
+        let implicitChild = initImplicitChild(with: savedParent)
+        try await mutate(.create(implicitChild))
+        let explicitChild = initStrangeExplicitChild(with: savedParent)
+        try await mutate(.create(explicitChild))
+        let sansChild = initChildSansBelongsTo(with: savedParent)
+        try await mutate(.create(sansChild))
         
-    }
-    
-    func testCompositePKParentDelete() async throws {
-        await setup(withModels: CompositePKModels())
-        
-        let compositePKParent = CompositePKParent(customId: UUID().uuidString,
-                                                  content: "content")
-        let savedParent = try await mutate(.create(compositePKParent))
-        let compositePKChild = CompositePKChild(childId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedCompositePKChild = try await mutate(.create(compositePKChild))
-        let implicitChild = ImplicitChild(childId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedImplicitChild = try await mutate(.create(implicitChild))
-        let strangeExplicitChild = StrangeExplicitChild(strangeId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedStrangeImplicitChild = try await mutate(.create(strangeExplicitChild))
-        let childSansBelongsTo = ChildSansBelongsTo(
-            childId: UUID().uuidString,
-            content: "content",
-            compositePKParentChildrenSansBelongsToCustomId: savedParent.customId,
-            compositePKParentChildrenSansBelongsToContent: savedParent.content)
-        let savedChildSansBelongsTo = try await mutate(.create(childSansBelongsTo))
-        try await mutate(.delete(savedParent))
-        try await assertModelDoesNotExist(savedParent)
-        try await mutate(.delete(savedCompositePKChild))
-        try await assertModelDoesNotExist(savedCompositePKChild)
-        /*
-         GraphQLResponseError<ImplicitChild>: GraphQL service returned a successful response containing errors: [Amplify.GraphQLError(message: "Cannot return null for non-nullable type: \'CompositePKParent\' within parent \'ImplicitChild\' (/deleteImplicitChild/parent)", locations: nil, path: Optional([Amplify.JSONValue.string("deleteImplicitChild"), Amplify.JSONValue.string("parent")]), extensions: nil)]
-         */
-        //try await mutate(.delete(savedImplicitChild))
-        //try await assertModelDoesNotExist(savedImplicitChild)
-        /*
-         GraphQLResponseError<StrangeExplicitChild>: GraphQL service returned a successful response containing errors: [Amplify.GraphQLError(message: "Cannot return null for non-nullable type: \'CompositePKParent\' within parent \'StrangeExplicitChild\' (/deleteStrangeExplicitChild/parent)", locations: nil, path: Optional([Amplify.JSONValue.string("deleteStrangeExplicitChild"), Amplify.JSONValue.string("parent")]), extensions: nil)]
-         */
-        //try await mutate(.delete(strangeExplicitChild))
-        //try await assertModelDoesNotExist(strangeExplicitChild)
-    }
-    
-    func testCompositePKParentGet() async throws {
-        await setup(withModels: CompositePKModels())
-        
-        let compositePKParent = CompositePKParent(customId: UUID().uuidString,
-                                                  content: "content")
-        let savedParent = try await mutate(.create(compositePKParent))
-        let compositePKChild = CompositePKChild(childId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedCompositePKChild = try await mutate(.create(compositePKChild))
-        let implicitChild = ImplicitChild(childId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedImplicitChild = try await mutate(.create(implicitChild))
-        let strangeExplicitChild = StrangeExplicitChild(strangeId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedStrangeImplicitChild = try await mutate(.create(strangeExplicitChild))
-        let childSansBelongsTo = ChildSansBelongsTo(
-            childId: UUID().uuidString,
-            content: "content",
-            compositePKParentChildrenSansBelongsToCustomId: savedParent.customId,
-            compositePKParentChildrenSansBelongsToContent: savedParent.content)
-        let savedChildSansBelongsTo = try await mutate(.create(childSansBelongsTo))
-        
-        // query parent and load the children
-        let queriedParent = try await query(.get(CompositePKParent.self,
-                                                 byIdentifier: .identifier(customId: savedParent.customId,
-                                                                           content: savedParent.content)))!
-        assertList(queriedParent.children!, state: .isNotLoaded(associatedIdentifiers: [queriedParent.customId,
-                                                                                        queriedParent.content],
-                                                                associatedFields: ["parent"]))
-        try await queriedParent.children?.fetch()
-        assertList(queriedParent.children!, state: .isLoaded(count: 1))
-        
-        assertList(queriedParent.implicitChildren!, state: .isNotLoaded(associatedIdentifiers: [queriedParent.customId,
-                                                                                                queriedParent.content],
-                                                                        associatedFields: ["parent"]))
-        try await queriedParent.implicitChildren?.fetch()
-        assertList(queriedParent.implicitChildren!, state: .isLoaded(count: 1))
-        
-        assertList(queriedParent.strangeChildren!, state: .isNotLoaded(associatedIdentifiers: [queriedParent.customId,
-                                                                                               queriedParent.content],
-                                                                       associatedFields: ["parent"]))
-        try await queriedParent.strangeChildren?.fetch()
-        assertList(queriedParent.strangeChildren!, state: .isLoaded(count: 1))
-        
-        // Problem: the filter that is created is only on part of the identifier, missing `compositePKParentChildrenSansBelongsToContent`
-        /*
-         "query" : "query ListChildSansBelongsTos($filter: ModelChildSansBelongsToFilterInput, $limit: Int) {\n  listChildSansBelongsTos(filter: $filter, limit: $limit) {\n    items {\n      childId\n      content\n      compositePKParentChildrenSansBelongsToContent\n      compositePKParentChildrenSansBelongsToCustomId\n      createdAt\n      updatedAt\n      __typename\n    }\n    nextToken\n  }\n}",
-         "variables" : {
-           "limit" : 1000,
-           "filter" : {
-             "and" : [
-               {
-                 "compositePKParentChildrenSansBelongsToCustomId" : {
-                   "eq" : "0E05FF6B-3A27-4B4C-B35B-1354FA573961"
-                 }
-               }
-             ]
-           }
-         }
-       }
-         */
-        assertList(queriedParent.childrenSansBelongsTo!, state: .isNotLoaded(associatedIdentifiers: [queriedParent.customId,
-                                                                                                     queriedParent.content],
-                                                                             associatedFields: ["compositePKParentChildrenSansBelongsToCustomId"]))
-        try await queriedParent.childrenSansBelongsTo?.fetch()
-        assertList(queriedParent.childrenSansBelongsTo!, state: .isLoaded(count: 1))
-        
-        // query children and load the parent - CompositePKChild
-        let queriedCompositePKChild = try await query(.get(CompositePKChild.self,
-                                                           byIdentifier: .identifier(childId: savedCompositePKChild.childId,
-                                                                                     content: savedCompositePKChild.content)))!
-        assertLazyReference(queriedCompositePKChild._parent,
-                            state: .notLoaded(identifiers: [.init(name: "customId", value: savedParent.customId),
-                                                            .init(name: "content", value: savedParent.content)]))
-        let loadedParent = try await queriedCompositePKChild.parent
-        assertLazyReference(queriedCompositePKChild._parent,
-                            state: .loaded(model: loadedParent))
-        
-        // query children and load the parent - ImplicitChild
-        let queriedImplicitChild = try await query(.get(ImplicitChild.self,
-                                                           byIdentifier: .identifier(childId: savedImplicitChild.childId,
-                                                                                     content: savedImplicitChild.content)))!
-        assertLazyReference(queriedImplicitChild._parent,
-                            state: .notLoaded(identifiers: [.init(name: "customId", value: savedParent.customId),
-                                                            .init(name: "content", value: savedParent.content)]))
-        let loadedParent2 = try await queriedImplicitChild.parent
-        assertLazyReference(queriedImplicitChild._parent,
-                            state: .loaded(model: loadedParent2))
-        
-        // query children and load the parent - StrangeExplicitChild
-        let queriedStrangeImplicitChild = try await query(.get(StrangeExplicitChild.self,
-                                                           byIdentifier: .identifier(strangeId: savedStrangeImplicitChild.strangeId,
-                                                                                     content: savedStrangeImplicitChild.content)))!
-        assertLazyReference(queriedStrangeImplicitChild._parent,
-                            state: .notLoaded(identifiers: [.init(name: "customId", value: savedParent.customId),
-                                                            .init(name: "content", value: savedParent.content)]))
-        let loadedParent3 = try await queriedStrangeImplicitChild.parent
-        assertLazyReference(queriedStrangeImplicitChild._parent,
-                            state: .loaded(model: loadedParent3))
-        
-        // query children and verify the parent - ChildSansBelongsTo
-        let queriedChildSansBelongsTo = try await query(.get(ChildSansBelongsTo.self,
-                                                           byIdentifier: .identifier(childId: savedChildSansBelongsTo.childId,
-                                                                                     content: savedChildSansBelongsTo.content)))!
-        XCTAssertEqual(queriedChildSansBelongsTo.compositePKParentChildrenSansBelongsToCustomId, savedParent.customId)
-        XCTAssertEqual(queriedChildSansBelongsTo.compositePKParentChildrenSansBelongsToContent, savedParent.content)
-    }
-    
-    func testCompositePKParentList() async throws {
-        await setup(withModels: CompositePKModels())
-        
-        let compositePKParent = CompositePKParent(customId: UUID().uuidString,
-                                                  content: "content")
-        let savedParent = try await mutate(.create(compositePKParent))
-        let compositePKChild = CompositePKChild(childId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedCompositePKChild = try await mutate(.create(compositePKChild))
-        let implicitChild = ImplicitChild(childId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedImplicitChild = try await mutate(.create(implicitChild))
-        let strangeExplicitChild = StrangeExplicitChild(strangeId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedStrangeImplicitChild = try await mutate(.create(strangeExplicitChild))
-        let childSansBelongsTo = ChildSansBelongsTo(
-            childId: UUID().uuidString,
-            content: "content",
-            compositePKParentChildrenSansBelongsToCustomId: savedParent.customId,
-            compositePKParentChildrenSansBelongsToContent: savedParent.content)
-        let savedChildSansBelongsTo = try await mutate(.create(childSansBelongsTo))
-        
-        let queriedParents = try await listQuery(.list(CompositePKParent.self,
-                                                       where: CompositePKParent.keys.customId == savedParent.customId && CompositePKParent.keys.content == savedParent.content))
-        assertList(queriedParents, state: .isLoaded(count: 1))
-        
-        let queriedImplicitChildren = try await listQuery(.list(ImplicitChild.self,
-                                                                where: ImplicitChild.keys.childId == implicitChild.childId && ImplicitChild.keys.content == implicitChild.content))
-        assertList(queriedImplicitChildren, state: .isLoaded(count: 1))
-
-        let queriedStrangeChildren = try await listQuery(.list(StrangeExplicitChild.self,
-                                                                where: StrangeExplicitChild.keys.strangeId == strangeExplicitChild.strangeId && StrangeExplicitChild.keys.content == strangeExplicitChild.content))
-        assertList(queriedStrangeChildren, state: .isLoaded(count: 1))
-        
-        let queriedChildSansBelongsToChildren = try await listQuery(.list(ChildSansBelongsTo.self,
-                                                                where: ChildSansBelongsTo.keys.childId == childSansBelongsTo.childId && ChildSansBelongsTo.keys.content == childSansBelongsTo.content))
-        assertList(queriedChildSansBelongsToChildren, state: .isLoaded(count: 1))
+        let request = GraphQLRequest<CompositePKParent>.get(CompositePKParent.self,
+                                                            byIdentifier: .identifier(customId: savedParent.customId,
+                                                                                      content: savedParent.content),
+                                                            includes: { parent in
+            [parent.children, parent.implicitChildren, parent.strangeChildren, parent.childrenSansBelongsTo]
+        })
+        let expectedDocument = """
+        query GetCompositePKParent($content: String!, $customId: ID!) {
+          getCompositePKParent(content: $content, customId: $customId) {
+            customId
+            content
+            createdAt
+            updatedAt
+            __typename
+            children {
+              items {
+                childId
+                content
+                createdAt
+                updatedAt
+                parent {
+                  customId
+                  content
+                  __typename
+                }
+                __typename
+              }
+            }
+            implicitChildren {
+              items {
+                childId
+                content
+                createdAt
+                updatedAt
+                parent {
+                  customId
+                  content
+                  __typename
+                }
+                __typename
+              }
+            }
+            strangeChildren {
+              items {
+                strangeId
+                content
+                createdAt
+                updatedAt
+                parent {
+                  customId
+                  content
+                  __typename
+                }
+                __typename
+              }
+            }
+            childrenSansBelongsTo {
+              items {
+                childId
+                content
+                compositePKParentChildrenSansBelongsToContent
+                compositePKParentChildrenSansBelongsToCustomId
+                createdAt
+                updatedAt
+                __typename
+              }
+            }
+          }
+        }
+        """
+        XCTAssertEqual(request.document, expectedDocument)
+        let queriedParent = try await query(request)!
+        XCTAssertNotNil(queriedParent)
     }
 }
 
@@ -248,5 +122,10 @@ extension GraphQLLazyLoadCompositePKTests {
             ModelRegistry.register(modelType: StrangeExplicitChild.self)
             ModelRegistry.register(modelType: ChildSansBelongsTo.self)
         }
+    }
+    
+    func initParent() -> CompositePKParent {
+        CompositePKParent(customId: UUID().uuidString,
+                          content: "content")
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKChildSansTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKChildSansTests.swift
@@ -1,0 +1,91 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Combine
+import XCTest
+
+@testable import Amplify
+import AWSPluginsCore
+
+extension AWSDataStoreLazyLoadCompositePKTests {
+    
+    // MARK: - CompositePKParent / ChildSansBelongsTo
+    
+    func initChildSansBelongsTo(with parent: CompositePKParent) -> ChildSansBelongsTo {
+        ChildSansBelongsTo(
+            childId: UUID().uuidString,
+            content: "content",
+            compositePKParentChildrenSansBelongsToCustomId: parent.customId,
+            compositePKParentChildrenSansBelongsToContent: parent.content)
+    }
+    
+    func testSaveChildSansBelongsTo() async throws {
+        await setup(withModels: CompositePKModels())
+        
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        let child = initChildSansBelongsTo(with: savedParent)
+        try await saveAndWaitForSync(child)
+    }
+    
+    func testUpdateChildSansBelongsTo() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        let child = initChildSansBelongsTo(with: parent)
+        var savedChild = try await saveAndWaitForSync(child)
+        XCTAssertEqual(savedChild.compositePKParentChildrenSansBelongsToCustomId, savedParent.customId)
+        XCTAssertEqual(savedChild.compositePKParentChildrenSansBelongsToContent, savedParent.content)
+        
+        // update the child to a new parent
+        let newParent = initParent()
+        let savedNewParent = try await saveAndWaitForSync(newParent)
+        savedChild.compositePKParentChildrenSansBelongsToCustomId = savedNewParent.customId
+        savedChild.compositePKParentChildrenSansBelongsToContent = savedNewParent.content
+        let updatedChild = try await updateAndWaitForSync(savedChild)
+        XCTAssertEqual(updatedChild.compositePKParentChildrenSansBelongsToCustomId, savedNewParent.customId)
+        XCTAssertEqual(updatedChild.compositePKParentChildrenSansBelongsToContent, savedNewParent.content)
+    }
+    
+    func testDeleteChildSansBelongsTo() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        let child = initChildSansBelongsTo(with: parent)
+        let savedChild = try await saveAndWaitForSync(child)
+        
+        try await deleteAndWaitForSync(savedChild)
+        try await assertModelDoesNotExist(savedChild)
+        
+        try await deleteAndWaitForSync(savedParent)
+        try await assertModelDoesNotExist(savedParent)
+    }
+    
+    func testGetChildSansBelongsTo() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        let child = initChildSansBelongsTo(with: parent)
+        let savedChild = try await saveAndWaitForSync(child)
+        
+        // query parent and load the children
+        let queriedParent = try await query(for: savedParent)
+        assertList(queriedParent.childrenSansBelongsTo!, state: .isNotLoaded(associatedIds: [queriedParent.customId,
+                                                                                             queriedParent.content],
+                                                                             associatedFields: [
+                                                                                "compositePKParentChildrenSansBelongsToCustomId",
+                                                                                "compositePKParentChildrenSansBelongsToContent"]))
+        try await queriedParent.childrenSansBelongsTo?.fetch()
+        assertList(queriedParent.childrenSansBelongsTo!, state: .isLoaded(count: 1))
+        
+        // query children and verify the parent - ChildSansBelongsTo
+        let queriedChildSansBelongsTo = try await query(for: savedChild)
+        XCTAssertEqual(queriedChildSansBelongsTo.compositePKParentChildrenSansBelongsToCustomId, savedParent.customId)
+        XCTAssertEqual(queriedChildSansBelongsTo.compositePKParentChildrenSansBelongsToContent, savedParent.content)
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKChildTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKChildTests.swift
@@ -1,0 +1,102 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Combine
+import XCTest
+
+@testable import Amplify
+import AWSPluginsCore
+
+extension AWSDataStoreLazyLoadCompositePKTests {
+    
+    // MARK: - CompositePKParent / CompositePKChild
+    
+    func initChild(with parent: CompositePKParent? = nil) -> CompositePKChild {
+        CompositePKChild(childId: UUID().uuidString, content: "content", parent: parent)
+    }
+    
+    func testSaveCompositePKChild() async throws {
+        await setup(withModels: CompositePKModels())
+        
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        let child = initChild(with: savedParent)
+        try await saveAndWaitForSync(child)
+    }
+    
+    func testUpdateCompositePKChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        let child = initChild(with: parent)
+        var savedChild = try await saveAndWaitForSync(child)
+        let loadedParent = try await savedChild.parent
+        XCTAssertEqual(loadedParent?.identifier, savedParent.identifier)
+        
+        // update the child to a new parent
+        let newParent = initParent()
+        let savedNewParent = try await saveAndWaitForSync(newParent)
+        savedChild.setParent(savedNewParent)
+        let updatedChild = try await updateAndWaitForSync(savedChild)
+        let loadedNewParent = try await updatedChild.parent
+        XCTAssertEqual(loadedNewParent?.identifier, savedNewParent.identifier)
+    }
+    
+    func testUpdateFromNoParentCompositePKChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        
+        let childWithoutParent = initChild()
+        var savedChild = try await saveAndWaitForSync(childWithoutParent)
+        let nilParent = try await savedChild.parent
+        XCTAssertNil(nilParent)
+        
+        // update the child to a parent
+        savedChild.setParent(savedParent)
+        let savedChildWithParent = try await updateAndWaitForSync(savedChild)
+        let loadedParent = try await savedChildWithParent.parent
+        XCTAssertEqual(loadedParent?.identifier, savedParent.identifier)
+    }
+    
+    func testDeleteCompositePKChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        let child = initChild(with: parent)
+        let savedChild = try await saveAndWaitForSync(child)
+        
+        try await deleteAndWaitForSync(savedParent)
+        try await assertModelDoesNotExist(savedParent)
+        try await assertModelDoesNotExist(savedChild)
+    }
+    
+    func testGetCompositePKChild() async throws {
+        await setup(withModels: CompositePKModels())
+        
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        let child = initChild(with: parent)
+        let savedCompositePKChild = try await saveAndWaitForSync(child)
+        
+        // query parent and load the children
+        let queriedParent = try await query(for: savedParent)
+        assertList(queriedParent.children!, state: .isNotLoaded(associatedIds: [queriedParent.identifier],
+                                                                associatedFields: ["parent"]))
+        try await queriedParent.children?.fetch()
+        assertList(queriedParent.children!, state: .isLoaded(count: 1))
+        
+        // query child and load the parent - CompositePKChild
+        let queriedCompositePKChild = try await query(for: savedCompositePKChild)
+        assertLazyReference(queriedCompositePKChild._parent,
+                            state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: savedParent.identifier)]))
+        let loadedParent = try await queriedCompositePKChild.parent
+        assertLazyReference(queriedCompositePKChild._parent,
+                            state: .loaded(model: loadedParent))
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKImplicitTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKImplicitTests.swift
@@ -1,0 +1,88 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Combine
+import XCTest
+
+@testable import Amplify
+import AWSPluginsCore
+
+extension AWSDataStoreLazyLoadCompositePKTests {
+    
+    // MARK: - CompositePKParent / ImplicitChild
+    
+    func initImplicitChild(with parent: CompositePKParent) -> ImplicitChild {
+        ImplicitChild(childId: UUID().uuidString, content: "content", parent: parent)
+    }
+    
+    func testSaveImplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        let child = initImplicitChild(with: savedParent)
+        try await saveAndWaitForSync(child)
+    }
+    
+    func testUpdateImplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        let child = initImplicitChild(with: parent)
+        var savedChild = try await saveAndWaitForSync(child)
+        let loadedParent = try await savedChild.parent
+        XCTAssertEqual(loadedParent.identifier, savedParent.identifier)
+        
+        // update the child to a new parent
+        let newParent = initParent()
+        let savedNewParent = try await saveAndWaitForSync(newParent)
+        savedChild.setParent(savedNewParent)
+        let updatedChild = try await updateAndWaitForSync(savedChild)
+        let loadedNewParent = try await updatedChild.parent
+        XCTAssertEqual(loadedNewParent.identifier, savedNewParent.identifier)
+        
+    }
+    
+    func testDeleteImplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        let child = initImplicitChild(with: parent)
+        let savedChild = try await saveAndWaitForSync(child)
+        
+        try await deleteAndWaitForSync(savedChild)
+        try await assertModelDoesNotExist(savedChild)
+        try await deleteAndWaitForSync(savedParent)
+        try await assertModelDoesNotExist(savedParent)
+    }
+    
+    func testGetImplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        let child = initImplicitChild(with: parent)
+        let savedChild = try await saveAndWaitForSync(child)
+        
+        // query parent and load the children
+        let queriedParent = try await query(for: savedParent)
+        
+        assertList(queriedParent.implicitChildren!, state: .isNotLoaded(associatedIds: [queriedParent.identifier],
+                                                                        associatedFields: ["parent"]))
+        try await queriedParent.implicitChildren?.fetch()
+        assertList(queriedParent.implicitChildren!, state: .isLoaded(count: 1))
+        
+        
+        // query child and load the parent - ImplicitChild
+        let queriedImplicitChild = try await query(for: savedChild)
+        assertLazyReference(queriedImplicitChild._parent,
+                            state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: savedParent.identifier)]))
+        let loadedParent = try await queriedImplicitChild.parent
+        assertLazyReference(queriedImplicitChild._parent,
+                            state: .loaded(model: loadedParent))
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKStrangeExplicitTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKStrangeExplicitTests.swift
@@ -1,0 +1,87 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Combine
+import XCTest
+
+@testable import Amplify
+import AWSPluginsCore
+
+extension AWSDataStoreLazyLoadCompositePKTests {
+    
+    // MARK: - CompositePKParent / StrangeExplicitChild
+    
+    func initStrangeExplicitChild(with parent: CompositePKParent) -> StrangeExplicitChild {
+        StrangeExplicitChild(strangeId: UUID().uuidString, content: "content", parent: parent)
+    }
+    
+    func testSaveStrangeExplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        let child = initStrangeExplicitChild(with: savedParent)
+        try await saveAndWaitForSync(child)
+    }
+    
+    func testUpdateStrangeExplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        let child = initStrangeExplicitChild(with: parent)
+        var savedChild = try await saveAndWaitForSync(child)
+        let loadedParent = try await savedChild.parent
+        XCTAssertEqual(loadedParent.identifier, savedParent.identifier)
+        
+        // update the child to a new parent
+        let newParent = initParent()
+        let savedNewParent = try await saveAndWaitForSync(newParent)
+        savedChild.setParent(savedNewParent)
+        let updatedChild = try await updateAndWaitForSync(savedChild)
+        let loadedNewParent = try await updatedChild.parent
+        XCTAssertEqual(loadedNewParent.identifier, savedNewParent.identifier)
+        
+    }
+    
+    func testDeleteStrangeExplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        let child = initStrangeExplicitChild(with: parent)
+        let savedChild = try await saveAndWaitForSync(child)
+        
+        try await deleteAndWaitForSync(savedChild)
+        try await assertModelDoesNotExist(savedChild)
+        try await deleteAndWaitForSync(savedParent)
+        try await assertModelDoesNotExist(savedParent)
+    }
+    
+    func testGetStrangeExplicitChild() async throws {
+        await setup(withModels: CompositePKModels())
+        let parent = initParent()
+        let savedParent = try await saveAndWaitForSync(parent)
+        let child = initStrangeExplicitChild(with: parent)
+        let savedChild = try await saveAndWaitForSync(child)
+        
+        // query parent and load the children
+        let queriedParent = try await query(for: savedParent)
+        
+        assertList(queriedParent.strangeChildren!, state: .isNotLoaded(associatedIds: [queriedParent.identifier],
+                                                                       associatedFields: ["parent"]))
+        try await queriedParent.strangeChildren?.fetch()
+        assertList(queriedParent.strangeChildren!, state: .isLoaded(count: 1))
+        
+        // query children and load the parent - StrangeExplicitChild
+        let queriedStrangeImplicitChild = try await query(for: savedChild)
+        assertLazyReference(queriedStrangeImplicitChild._parent,
+                            state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: savedParent.identifier)]))
+        let loadedParent3 = try await queriedStrangeImplicitChild.parent
+        assertLazyReference(queriedStrangeImplicitChild._parent,
+                            state: .loaded(model: loadedParent3))
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import AWSPluginsCore
 
 class AWSDataStoreLazyLoadCompositePKTests: AWSDataStoreLazyLoadBaseTest {
+    
     func testStart() async throws {
         await setup(withModels: CompositePKModels())
         try await startAndWaitForReady()
@@ -20,67 +21,8 @@ class AWSDataStoreLazyLoadCompositePKTests: AWSDataStoreLazyLoadBaseTest {
     
     func testSaveCompositePKParent() async throws {
         await setup(withModels: CompositePKModels())
-        let compositePKParent = CompositePKParent(customId: UUID().uuidString,
-                                                  content: "content")
-        let savedParent = try await saveAndWaitForSync(compositePKParent)
-    }
-    
-    func testSaveCompositePKChild() async throws {
-        await setup(withModels: CompositePKModels())
-        let compositePKParent = CompositePKParent(customId: UUID().uuidString,
-                                                  content: "content")
-        let savedParent = try await saveAndWaitForSync(compositePKParent)
-        
-        let compositePKChild = CompositePKChild(childId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedCompositePKChild = try await saveAndWaitForSync(compositePKChild)
-    }
-    
-    func testSaveImplicitChild() async throws {
-        await setup(withModels: CompositePKModels())
-        let compositePKParent = CompositePKParent(customId: UUID().uuidString,
-                                                  content: "content")
-        let savedParent = try await saveAndWaitForSync(compositePKParent)
-        
-        let implicitChild = ImplicitChild(childId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedImplicitChild = try await saveAndWaitForSync(implicitChild)
-    }
-    
-    func testSaveExplicitChild() async throws {
-        await setup(withModels: CompositePKModels())
-        let compositePKParent = CompositePKParent(customId: UUID().uuidString,
-                                                  content: "content")
-        let savedParent = try await saveAndWaitForSync(compositePKParent)
-        
-        let childSansBelongsTo = ChildSansBelongsTo(
-            childId: UUID().uuidString,
-            content: "content",
-            compositePKParentChildrenSansBelongsToCustomId: savedParent.customId,
-            compositePKParentChildrenSansBelongsToContent: savedParent.content)
-        let savedChildSansBelongsTo = try await saveAndWaitForSync(childSansBelongsTo)
-    }
-    
-    func testSaveStrangeImplicitChild() async throws {
-        await setup(withModels: CompositePKModels())
-        let compositePKParent = CompositePKParent(customId: UUID().uuidString,
-                                                  content: "content")
-        let savedParent = try await saveAndWaitForSync(compositePKParent)
-        
-        let strangeExplicitChild = StrangeExplicitChild(strangeId: UUID().uuidString, content: "content", parent: savedParent)
-        let savedStrangeExplicitChild = try await saveAndWaitForSync(strangeExplicitChild)
-    }
-    
-    func testSaveSansBelongsTo() async throws {
-        await setup(withModels: CompositePKModels())
-        let compositePKParent = CompositePKParent(customId: UUID().uuidString,
-                                                  content: "content")
-        let savedParent = try await saveAndWaitForSync(compositePKParent)
-        
-        let childSansBelongsTo = ChildSansBelongsTo(
-            childId: UUID().uuidString,
-            content: "content",
-            compositePKParentChildrenSansBelongsToCustomId: savedParent.customId,
-            compositePKParentChildrenSansBelongsToContent: savedParent.content)
-        let savedChildSansBelongsTo = try await saveAndWaitForSync(childSansBelongsTo)
+        let parent = initParent()
+        try await saveAndWaitForSync(parent)
     }
 }
 
@@ -95,5 +37,10 @@ extension AWSDataStoreLazyLoadCompositePKTests {
             ModelRegistry.register(modelType: StrangeExplicitChild.self)
             ModelRegistry.register(modelType: ChildSansBelongsTo.self)
         }
+    }
+    
+    func initParent() -> CompositePKParent {
+        CompositePKParent(customId: UUID().uuidString,
+                          content: "content")
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/CompositePKChild.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/CompositePKChild.swift
@@ -34,7 +34,7 @@ public struct CompositePKChild: Model {
       self.createdAt = createdAt
       self.updatedAt = updatedAt
   }
-  public mutating func setParent(parent: CompositePKParent? = nil) {
+  public mutating func setParent(_ parent: CompositePKParent? = nil) {
     self._parent = LazyReference(parent)
   }
   public init(from decoder: Decoder) throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/CompositePKParent+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/CompositePKParent+Schema.swift
@@ -34,7 +34,7 @@ extension CompositePKParent {
       .hasMany(compositePKParent.children, is: .optional, ofType: CompositePKChild.self, associatedWith: CompositePKChild.keys.parent),
       .hasMany(compositePKParent.implicitChildren, is: .optional, ofType: ImplicitChild.self, associatedWith: ImplicitChild.keys.parent),
       .hasMany(compositePKParent.strangeChildren, is: .optional, ofType: StrangeExplicitChild.self, associatedWith: StrangeExplicitChild.keys.parent),
-      .hasMany(compositePKParent.childrenSansBelongsTo, is: .optional, ofType: ChildSansBelongsTo.self, associatedWith: ChildSansBelongsTo.keys.compositePKParentChildrenSansBelongsToCustomId),
+      .hasMany(compositePKParent.childrenSansBelongsTo, is: .optional, ofType: ChildSansBelongsTo.self, associatedFields: [ChildSansBelongsTo.keys.compositePKParentChildrenSansBelongsToCustomId, ChildSansBelongsTo.keys.compositePKParentChildrenSansBelongsToContent]),
       .field(compositePKParent.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(compositePKParent.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/StrangeExplicitChild.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/StrangeExplicitChild.swift
@@ -34,7 +34,7 @@ public struct StrangeExplicitChild: Model {
       self.createdAt = createdAt
       self.updatedAt = updatedAt
   }
-  public mutating func setParent(parent: CompositePKParent) {
+  public mutating func setParent(_ parent: CompositePKParent) {
     self._parent = LazyReference(parent)
   }
   public init(from decoder: Decoder) throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
@@ -169,6 +169,10 @@
 		213DBC6228A5808400B30280 /* TodoIAMPublic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BBFA8D289BFE4E00B32A39 /* TodoIAMPublic.swift */; };
 		213DBC6328A5841400B30280 /* HubListenerTestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BBFE13289C073100B32A39 /* HubListenerTestUtilities.swift */; };
 		21619C1129480AA100E0900F /* AWSDataStoreLazyLoadProjectTeam1SnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21619C1029480AA100E0900F /* AWSDataStoreLazyLoadProjectTeam1SnapshotTests.swift */; };
+		2170971B2991AC2000FD7EB2 /* AWSDataStoreLazyLoadCompositePKChildTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2170971A2991AC2000FD7EB2 /* AWSDataStoreLazyLoadCompositePKChildTests.swift */; };
+		2170971D2991AC3400FD7EB2 /* AWSDataStoreLazyLoadCompositePKChildSansTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2170971C2991AC3400FD7EB2 /* AWSDataStoreLazyLoadCompositePKChildSansTests.swift */; };
+		2170971F2991AC4600FD7EB2 /* AWSDataStoreLazyLoadCompositePKImplicitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2170971E2991AC4600FD7EB2 /* AWSDataStoreLazyLoadCompositePKImplicitTests.swift */; };
+		217097212991AC5500FD7EB2 /* AWSDataStoreLazyLoadCompositePKStrangeExplicitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217097202991AC5500FD7EB2 /* AWSDataStoreLazyLoadCompositePKStrangeExplicitTests.swift */; };
 		217AA7BD2909C1D00042CD5D /* AWSDataStoreLazyLoadProjectTeam5Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217AA7BC2909C1D00042CD5D /* AWSDataStoreLazyLoadProjectTeam5Tests.swift */; };
 		217AA7BF2909C6330042CD5D /* AWSDataStoreLazyLoadProjectTeam6Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217AA7BE2909C6330042CD5D /* AWSDataStoreLazyLoadProjectTeam6Tests.swift */; };
 		217AA7C12909ED420042CD5D /* AWSDataStoreLazyLoadPostComment7Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217AA7C02909ED420042CD5D /* AWSDataStoreLazyLoadPostComment7Tests.swift */; };
@@ -826,6 +830,10 @@
 		213DBC5A28A5800F00B30280 /* TestConfigHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConfigHelper.swift; sourceTree = "<group>"; };
 		213DBC5C28A5801900B30280 /* TestConfigHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConfigHelper.swift; sourceTree = "<group>"; };
 		21619C1029480AA100E0900F /* AWSDataStoreLazyLoadProjectTeam1SnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadProjectTeam1SnapshotTests.swift; sourceTree = "<group>"; };
+		2170971A2991AC2000FD7EB2 /* AWSDataStoreLazyLoadCompositePKChildTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadCompositePKChildTests.swift; sourceTree = "<group>"; };
+		2170971C2991AC3400FD7EB2 /* AWSDataStoreLazyLoadCompositePKChildSansTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadCompositePKChildSansTests.swift; sourceTree = "<group>"; };
+		2170971E2991AC4600FD7EB2 /* AWSDataStoreLazyLoadCompositePKImplicitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadCompositePKImplicitTests.swift; sourceTree = "<group>"; };
+		217097202991AC5500FD7EB2 /* AWSDataStoreLazyLoadCompositePKStrangeExplicitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadCompositePKStrangeExplicitTests.swift; sourceTree = "<group>"; };
 		217AA7BC2909C1D00042CD5D /* AWSDataStoreLazyLoadProjectTeam5Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadProjectTeam5Tests.swift; sourceTree = "<group>"; };
 		217AA7BE2909C6330042CD5D /* AWSDataStoreLazyLoadProjectTeam6Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadProjectTeam6Tests.swift; sourceTree = "<group>"; };
 		217AA7C02909ED420042CD5D /* AWSDataStoreLazyLoadPostComment7Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadPostComment7Tests.swift; sourceTree = "<group>"; };
@@ -2650,6 +2658,10 @@
 			isa = PBXGroup;
 			children = (
 				21C3C4C4293FDA12009194A0 /* AWSDataStoreLazyLoadCompositePKTests.swift */,
+				2170971A2991AC2000FD7EB2 /* AWSDataStoreLazyLoadCompositePKChildTests.swift */,
+				2170971E2991AC4600FD7EB2 /* AWSDataStoreLazyLoadCompositePKImplicitTests.swift */,
+				217097202991AC5500FD7EB2 /* AWSDataStoreLazyLoadCompositePKStrangeExplicitTests.swift */,
+				2170971C2991AC3400FD7EB2 /* AWSDataStoreLazyLoadCompositePKChildSansTests.swift */,
 				210D5D5B2983006C00D748FE /* AWSDataStoreLazyLoadCompositePKSnapshotTests.swift */,
 				21801D5D29097D5700FFA37E /* ChildSansBelongsTo.swift */,
 				21801D5829097D5700FFA37E /* ChildSansBelongsTo+Schema.swift */,
@@ -3619,6 +3631,7 @@
 				210D5D4E2982F1E700D748FE /* AWSDataStoreLazyLoadPostComment7SnapshotTests.swift in Sources */,
 				21801C8728F9A38000FFA37E /* TestConfigHelper.swift in Sources */,
 				21801CE928F9A86800FFA37E /* Post8+Schema.swift in Sources */,
+				217097212991AC5500FD7EB2 /* AWSDataStoreLazyLoadCompositePKStrangeExplicitTests.swift in Sources */,
 				21801D6C29097D5800FFA37E /* DefaultPKParent.swift in Sources */,
 				210D5D502982F2F100D748FE /* AWSDataStoreLazyLoadPostComment8SnapshotTests.swift in Sources */,
 				21801CF528F9A86800FFA37E /* Comment7.swift in Sources */,
@@ -3684,9 +3697,11 @@
 				21801D0628F9AE9400FFA37E /* AWSDataStoreLazyLoadPostComment4V2Tests.swift in Sources */,
 				21801CDB28F9A86800FFA37E /* MyNestedModel8+Schema.swift in Sources */,
 				21801CE528F9A86800FFA37E /* PostTagsWithCompositeKey+Schema.swift in Sources */,
+				2170971D2991AC3400FD7EB2 /* AWSDataStoreLazyLoadCompositePKChildSansTests.swift in Sources */,
 				210D5D4A2982EF6B00D748FE /* AWSDataStoreLazyLoadPostCommentWithCompositeKeySnapshotTests.swift in Sources */,
 				21801D6929097D5800FFA37E /* CompositePKParent.swift in Sources */,
 				21801D2528FDA5E700FFA37E /* AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests.swift in Sources */,
+				2170971F2991AC4600FD7EB2 /* AWSDataStoreLazyLoadCompositePKImplicitTests.swift in Sources */,
 				210EB5EC294796C40060C185 /* AWSDataStoreLazyLoadPostComment4V2SnapshotTests.swift in Sources */,
 				21AB5C5829819BF100CCA482 /* EnumTestModel.swift in Sources */,
 				21801CDE28F9A86800FFA37E /* Post4+Schema.swift in Sources */,
@@ -3694,6 +3709,7 @@
 				21801D4A2906CF3B00FFA37E /* AWSDataStoreLazyLoadPostTagTests.swift in Sources */,
 				21801D6829097D5800FFA37E /* DefaultPKChild.swift in Sources */,
 				21801CDA28F9A86800FFA37E /* PostWithTagsCompositeKey.swift in Sources */,
+				2170971B2991AC2000FD7EB2 /* AWSDataStoreLazyLoadCompositePKChildTests.swift in Sources */,
 				210D5D562982F85100D748FE /* AWSDataStoreLazyLoadProjectTeam6SnapshotTests.swift in Sources */,
 				21801D0928F9B11E00FFA37E /* XCTestCase+AsyncTesting.swift in Sources */,
 				21801D7129097E9400FFA37E /* AWSDataStoreLazyLoadProjectTeam2Tests.swift in Sources */,


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
When there is no metadata to create a ModelProvider, the lazy reference will be instantiated with `nil` identifiers with a DefaultModelProvider. When this happens, `try await` on the computed property should simply return `nil` on `get()` and throw on `require()`. 

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
