### PR TITLE
Ensuring Auth category can be tested from `swift test`

### DIFF
--- a/Amplify/Categories/Auth/AuthCategoryPluginPlaceholder.swift
+++ b/Amplify/Categories/Auth/AuthCategoryPluginPlaceholder.swift
@@ -1,0 +1,125 @@
+////
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+
+/// Placeholder implementation of the [AuthCategoryPlugin](x-source-tag://AuthCategoryPlugin)
+/// protocol. This plugin will throw an error for all functional features of the category.
+///
+/// - Tag: AuthCategoryPluginPlaceholder
+final class AuthCategoryPluginPlaceholder {
+    struct PluginError: Error, CustomStringConvertible {
+        var description: String
+    }
+}
+
+extension AuthCategoryPluginPlaceholder: AuthCategoryPlugin {
+
+    var key: PluginKey {
+        return "AuthCategoryPluginPlaceholder"
+    }
+
+    func configure(using configuration: Any?) throws {
+    }
+
+    func signUp(username: String, password: String?, options: AuthSignUpRequest.Options?) async throws -> AuthSignUpResult {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func confirmSignUp(for username: String, confirmationCode: String, options: AuthConfirmSignUpRequest.Options?) async throws -> AuthSignUpResult {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func resendSignUpCode(for username: String, options: AuthResendSignUpCodeRequest.Options?) async throws -> AuthCodeDeliveryDetails {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func signIn(username: String?, password: String?, options: AuthSignInRequest.Options?) async throws -> AuthSignInResult {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func signInWithWebUI(presentationAnchor: AuthUIPresentationAnchor?, options: AuthWebUISignInRequest.Options?) async throws -> AuthSignInResult {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func signInWithWebUI(for authProvider: AuthProvider, presentationAnchor: AuthUIPresentationAnchor?, options: AuthWebUISignInRequest.Options?) async throws -> AuthSignInResult {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func confirmSignIn(challengeResponse: String, options: AuthConfirmSignInRequest.Options?) async throws -> AuthSignInResult {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func signOut(options: AuthSignOutRequest.Options?) async -> AuthSignOutResult {
+        enum AuthSignOutResultError: AuthSignOutResult {
+            case placeholder(PlaceholderPluginError)
+        }
+        return AuthSignOutResultError.placeholder(
+            PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+        )
+    }
+
+    func deleteUser() async throws {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func fetchAuthSession(options: AuthFetchSessionRequest.Options?) async throws -> AuthSession {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func resetPassword(for username: String, options: AuthResetPasswordRequest.Options?) async throws -> AuthResetPasswordResult {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func confirmResetPassword(for username: String, with newPassword: String, confirmationCode: String, options: AuthConfirmResetPasswordRequest.Options?) async throws {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func reset() async {
+    }
+
+    func getCurrentUser() async throws -> AuthUser {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func fetchUserAttributes(options: AuthFetchUserAttributesRequest.Options?) async throws -> [AuthUserAttribute] {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func update(userAttribute: AuthUserAttribute, options: AuthUpdateUserAttributeRequest.Options?) async throws -> AuthUpdateAttributeResult {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func update(userAttributes: [AuthUserAttribute], options: AuthUpdateUserAttributesRequest.Options?) async throws -> [AuthUserAttributeKey : AuthUpdateAttributeResult] {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func resendConfirmationCode(forUserAttributeKey userAttributeKey: AuthUserAttributeKey, options: AuthAttributeResendConfirmationCodeRequest.Options?) async throws -> AuthCodeDeliveryDetails {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func confirm(userAttribute: AuthUserAttributeKey, confirmationCode: String, options: AuthConfirmUserAttributeRequest.Options?) async throws {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func update(oldPassword: String, to newPassword: String, options: AuthChangePasswordRequest.Options?) async throws {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func fetchDevices(options: AuthFetchDevicesRequest.Options?) async throws -> [AuthDevice] {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func forgetDevice(_ device: AuthDevice?, options: AuthForgetDeviceRequest.Options?) async throws {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+
+    func rememberDevice(options: AuthRememberDeviceRequest.Options?) async throws {
+        throw PlaceholderPluginError(pluginName: "AuthCategoryPlugin", selector: #function)
+    }
+}

--- a/Amplify/Categories/Auth/Internal/AuthCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Auth/Internal/AuthCategory+CategoryConfigurable.swift
@@ -18,7 +18,7 @@ extension AuthCategory: CategoryConfigurable {
             throw error
         }
 
-        try Amplify.configure(plugins: Array(plugins.values), using: configuration)
+        try Amplify.configure(plugins: [plugin], using: configuration)
 
         isConfigured = true
     }

--- a/Amplify/Categories/Auth/Internal/AuthCategory+Resettable.swift
+++ b/Amplify/Categories/Auth/Internal/AuthCategory+Resettable.swift
@@ -10,16 +10,7 @@ import Foundation
 extension AuthCategory: Resettable {
 
     public func reset() async {
-        await withTaskGroup(of: Void.self) { taskGroup in
-            for plugin in plugins.values {
-                taskGroup.addTask { [weak self] in
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
-                    await plugin.reset()
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
-                }
-            }
-            await taskGroup.waitForAll()
-        }
+        await plugin.reset()
         isConfigured = false
     }
 }

--- a/Amplify/Core/Error/PlaceholderPluginError.swift
+++ b/Amplify/Core/Error/PlaceholderPluginError.swift
@@ -1,0 +1,35 @@
+////
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+
+/// Error used by plugin placeholders.
+///
+/// See: [PlaceholderPluginError.init(pluginName:selector:)](x-source-tag://PlaceholderPluginError.init_pluginName_selector)
+///
+/// - Tag: PlaceholderPluginError
+struct PlaceholderPluginError: AmplifyError {
+
+    var errorDescription: ErrorDescription
+    var recoverySuggestion: RecoverySuggestion
+    var underlyingError: Error?
+
+    /// - Tag: PlaceholderPluginError.init_errorDescription_recoverySuggestion_error
+    init(errorDescription: ErrorDescription, recoverySuggestion: RecoverySuggestion, error: Error) {
+        self.errorDescription = errorDescription
+        self.recoverySuggestion = recoverySuggestion
+        self.underlyingError = error
+    }
+
+    /// - Tag: PlaceholderPluginError.init_pluginName_selector
+    init(pluginName: String, selector: String) {
+        self.errorDescription = "A \(pluginName) value must first be provided using `Amplify.add(plugin:)` before calling `\(selector)`."
+        self.recoverySuggestion = "Pass a \(pluginName) instance to Amplify.add(plugin:)"
+        self.underlyingError = nil
+    }
+}

--- a/Amplify/DevMenu/Data/PluginInfoHelper.swift
+++ b/Amplify/DevMenu/Data/PluginInfoHelper.swift
@@ -22,9 +22,7 @@ struct PluginInfoHelper {
             makePluginInfoItem(for: $0.key, versionable: $0.value as? AmplifyVersionable)
         })
         
-        pluginList.append(contentsOf: Amplify.Auth.plugins.map {
-            makePluginInfoItem(for: $0.key, versionable: $0.value as? AmplifyVersionable)
-        })
+        pluginList.append(makePluginInfoItem(for: Amplify.Auth.plugin.key, versionable: Amplify.Auth.plugin as? AmplifyVersionable))
         
         pluginList.append(contentsOf: Amplify.DataStore.plugins.map {
             makePluginInfoItem(for: $0.key, versionable: $0.value as? AmplifyVersionable)


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

In attempting to run unit tests from the command line using `swift test`, I noticed they crash because of a `fatal` being raised when attempting to fetch the current Auth plugin.

## Description
<!-- Why is this change required? What problem does it solve? -->

This change is a proposal for the library to use placeholder plugins to avoid using such a big hammer like `fatal`.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
~~- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
