### PR TITLE
fix(datastore): lazy load on save with sync on identifiers

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -68,7 +68,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
         storageEngine.save(model,
                            modelSchema: modelSchema,
                            condition: condition,
-                           eagerLoad: true,
+                           eagerLoad: isEagerLoad,
                            completion: publishingCompletion)
     }
     

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Core/DataStoreModelDecoder.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Core/DataStoreModelDecoder.swift
@@ -15,18 +15,33 @@ public struct DataStoreModelDecoder: ModelProviderDecoder {
     
     /// Metadata that contains the foreign key value of a parent model, which is the primary key of the model to be loaded.
     struct Metadata: Codable {
-        let identifier: String?
+        let identifiers: [LazyReferenceIdentifier]
         let source: String
         
-        init(identifier: String?, source: String = DataStoreSource) {
-            self.identifier = identifier
+        init(identifiers: [LazyReferenceIdentifier], source: String = DataStoreSource) {
+            self.identifiers = identifiers
             self.source = source
+        }
+        
+        func toJsonObject() -> Any? {
+            return [
+                "identifiers": identifiers.map({
+                    [
+                        "name": $0.name,
+                        "value": $0.value
+                    ]
+                }),
+                "source": source
+            ]
         }
     }
     
     /// Create a SQLite payload that is capable of initializting a LazyReference, by decoding to `DataStoreModelDecoder.Metadata`.
-    static func lazyInit(identifier: Binding?) -> [String: Binding?] {
-        return ["identifier": identifier, "source": DataStoreSource]
+    static func lazyInit(identifiers: [LazyReferenceIdentifier]) -> Metadata? {
+        if identifiers.isEmpty {
+            return nil
+        }
+        return Metadata(identifiers: identifiers)
     }
     
     public static func decode<ModelType: Model>(modelType: ModelType.Type, decoder: Decoder) -> AnyModelProvider<ModelType>? {

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Core/DataStoreModelProvider.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Core/DataStoreModelProvider.swift
@@ -14,11 +14,7 @@ public class DataStoreModelProvider<ModelType: Model>: ModelProvider {
     
     // Create a "not loaded" model provider with the identifier metadata, useful for hydrating the model
     init(metadata: DataStoreModelDecoder.Metadata) {
-        if let identifier = metadata.identifier {
-            self.loadedState = .notLoaded(identifiers: [.init(name: ModelType.schema.primaryKey.sqlName, value: identifier)])
-        } else {
-            self.loadedState = .notLoaded(identifiers: nil)
-        }
+        self.loadedState = .notLoaded(identifiers: metadata.identifiers)
     }
     
     // Create a "loaded" model provider with the model instance
@@ -31,10 +27,14 @@ public class DataStoreModelProvider<ModelType: Model>: ModelProvider {
     public func load() async throws -> ModelType? {
         switch loadedState {
         case .notLoaded(let identifiers):
-            guard let identifiers = identifiers, let identifier = identifiers.first else {
+            guard let identifiers = identifiers, !identifiers.isEmpty else {
                 return nil
             }
-            let queryPredicate: QueryPredicate = field(identifier.name).eq(identifier.value)
+            let identifierValue = identifiers.count == 1
+            ? identifiers.first?.value
+            : identifiers.map({ "\"\($0.value)\""}).joined(separator: ModelIdentifierFormat.Custom.separator)
+            
+            let queryPredicate: QueryPredicate = field(ModelType.schema.primaryKey.sqlName).eq(identifierValue)
             let models = try await Amplify.DataStore.query(ModelType.self, where: queryPredicate)
             guard let model = models.first else {
                 return nil
@@ -53,12 +53,9 @@ public class DataStoreModelProvider<ModelType: Model>: ModelProvider {
     public func encode(to encoder: Encoder) throws {
         switch loadedState {
         case .notLoaded(let identifiers):
-            if let identifier = identifiers?.first {
-                let metadata = DataStoreModelDecoder.Metadata(identifier: identifier.value)
-                var container = encoder.singleValueContainer()
-                try container.encode(metadata)
-            }
-            
+            let metadata = DataStoreModelDecoder.Metadata(identifiers: identifiers ?? [])
+                        var container = encoder.singleValueContainer()
+                        try container.encode(metadata)
         case .loaded(let element):
             try element.encode(to: encoder)
         }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/Statement+Model.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/Statement+Model.swift
@@ -121,14 +121,23 @@ extension Statement: StatementModelConvertible {
             return convertCollection(field: field, schema: schema, from: element, path: path)
 
         case (.model, false):
-            let foreignKey = field.association.map(getTargetNames).map {
-                field.foreignKeySqlName(withAssociationTargets: $0)
-            }
-            let targetBinding = foreignKey.flatMap {
+            let targetNames = getTargetNames(field: field)
+            var associatedFieldValues = targetNames.map {
                 getValue(from: element, by: path + [$0])
+            }.compactMap { $0 }
+                .map { String(describing: $0) }
+            
+            if associatedFieldValues.isEmpty {
+                associatedFieldValues = associatedValues(
+                    from: path + [field.foreignKeySqlName(withAssociationTargets: targetNames)],
+                    element: element
+                )
             }
-            return DataStoreModelDecoder.lazyInit(identifier: targetBinding)
-
+            let emptyFieldNames = [String](repeating: "", count: associatedFieldValues.count)
+            return DataStoreModelDecoder.lazyInit(identifiers: zip(emptyFieldNames,
+                                                                   associatedFieldValues).map {
+                LazyReferenceIdentifier(name: $0.0, value: $0.1)
+            })?.toJsonObject()
         case let (.model(modelName), true):
             guard let modelSchema = getModelSchema(for: modelName, with: statement)
             else {
@@ -151,7 +160,15 @@ extension Statement: StatementModelConvertible {
     private func getModelSchema(for modelName: ModelName, with statement: SelectStatement) -> ModelSchema? {
         return statement.metadata.columnMapping.values.first { $0.0.name == modelName }.map { $0.0 }
     }
-
+    
+    private func associatedValues(from foreignKeyPath: [String], element: Element) -> [String] {
+        return [getValue(from: element, by: foreignKeyPath)]
+            .compactMap({ $0 })
+            .map({ String(describing: $0) })
+            .flatMap({ $0.split(separator: ModelIdentifierFormat.Custom.separator.first!) })
+            .map({ String($0).trimmingCharacters(in: .init(charactersIn: "\"")) })
+    }
+    
     private func convertCollection(field: ModelField, schema: ModelSchema, from element: Element, path: [String]) -> Any? {
         if field.isArray && field.hasAssociation,
            case let .some(.hasMany(associatedFieldName: associatedFieldName, associatedFieldNames: associatedFieldNames)) = field.association
@@ -183,14 +200,14 @@ extension Statement: StatementModelConvertible {
 
         return nil
     }
-
-    private func getTargetNames(assoication: ModelAssociation) -> [String] {
-        switch assoication {
-        case let .hasOne(associatedFieldName: _, targetNames: targets):
+    
+    private func getTargetNames(field: ModelField) -> [String] {
+        switch field.association {
+        case let .some(.hasOne(_, targetNames: targets)):
             return targets
-        case let.belongsTo(associatedFieldName: _, targetNames: targets):
+        case let .some(.belongsTo(_, targetNames: targets)):
             return targets
-        case .hasMany:
+        default:
             return []
         }
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsLazyPostComment4V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsLazyPostComment4V2Tests.swift
@@ -208,7 +208,7 @@ final class StorageEngineTestsLazyPostComment4V2Tests: StorageEngineTestsBase, S
                 XCTFail("Missing identifiers")
                 return
             }
-            XCTAssertEqual(identifiers[0], .init(name: "id", value: "postId"))
+            XCTAssertEqual(identifiers[0], .init(name: "", value: "postId"))
         case .loaded:
             XCTFail("Should be not loaded")
         }
@@ -263,7 +263,7 @@ final class StorageEngineTestsLazyPostComment4V2Tests: StorageEngineTestsBase, S
                 XCTFail("Missing identifiers")
                 return
             }
-            XCTAssertEqual(identifiers[0], .init(name: "id", value: post.id))
+            XCTAssertEqual(identifiers[0], .init(name: "", value: post.id))
         case .loaded:
             XCTFail("lazy loaded post should be not loaded")
         }
@@ -354,7 +354,7 @@ final class StorageEngineTestsLazyPostComment4V2Tests: StorageEngineTestsBase, S
                 XCTFail("Missing identifiers")
                 return
             }
-            XCTAssertEqual(identifiers[0], .init(name: "id", value: "postId1"))
+            XCTAssertEqual(identifiers[0], .init(name: "", value: "postId1"))
         case .loaded:
             XCTFail("Should be not loaded")
         }
@@ -364,7 +364,7 @@ final class StorageEngineTestsLazyPostComment4V2Tests: StorageEngineTestsBase, S
                 XCTFail("Missing identifiers")
                 return
             }
-            XCTAssertEqual(identifiers[0], .init(name: "id", value: "postId2"))
+            XCTAssertEqual(identifiers[0], .init(name: "", value: "postId2"))
         case .loaded:
             XCTFail("Should be not loaded")
         }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL1/AWSDataStoreLazyLoadPostComment4V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL1/AWSDataStoreLazyLoadPostComment4V2Tests.swift
@@ -42,7 +42,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
         let comment = Comment(content: "content", post: post)
         let savedPost = try await saveAndWaitForSync(post)
         let savedComment = try await saveAndWaitForSync(comment)
-        try await assertComment(savedComment, hasEagerLoaded: savedPost)
+        try await assertComment(savedComment, canLazyLoad: savedPost)
         try await assertPost(savedPost, canLazyLoad: savedComment)
         let queriedComment = try await query(for: savedComment)
         try await assertComment(queriedComment, canLazyLoad: savedPost)
@@ -62,7 +62,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Could not encode comment")
             return
         }
-        try await assertComment(savedComment, hasEagerLoaded: savedPost)
+        try await assertComment(savedComment, canLazyLoad: savedPost)
         
         guard let decodedComment = try? ModelRegistry.decode(modelName: Comment.modelName,
                                                              from: encodedComment) as? Comment else {
@@ -71,7 +71,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
             return
         }
         
-        try await assertComment(decodedComment, hasEagerLoaded: savedPost)
+        try await assertComment(decodedComment, canLazyLoad: savedPost)
     }
     
     func testLazyLoadOnQueryAfterEncodeDecoder() async throws {
@@ -117,7 +117,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
     func assertComment(_ comment: Comment,
                        canLazyLoad post: Post) async throws {
         assertLazyReference(comment._post,
-                        state: .notLoaded(identifiers: [.init(name: "id", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.identifier)]))
         guard let loadedPost = try await comment.post else {
             XCTFail("Failed to load the post from the comment")
             return
@@ -146,7 +146,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
         
         // further nested models should not be loaded
         assertLazyReference(comment._post,
-                        state: .notLoaded(identifiers: [.init(name: "id", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.identifier)]))
     }
     
     func testSaveWithoutPost() async throws {
@@ -172,7 +172,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
         let savedComment = try await saveAndWaitForSync(comment)
         let queriedComment = try await query(for: savedComment)
         assertLazyReference(queriedComment._post,
-                        state: .notLoaded(identifiers: [.init(name: "id", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.identifier)]))
         let savedQueriedComment = try await saveAndWaitForSync(queriedComment, assertVersion: 2)
         let queriedComment2 = try await query(for: savedQueriedComment)
         try await assertComment(queriedComment2, canLazyLoad: savedPost)
@@ -187,7 +187,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
         let savedComment = try await saveAndWaitForSync(comment)
         var queriedComment = try await query(for: savedComment)
         assertLazyReference(queriedComment._post,
-                        state: .notLoaded(identifiers: [.init(name: "id", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.identifier)]))
         
         let newPost = Post(title: "title")
         _ = try await saveAndWaitForSync(newPost)
@@ -206,7 +206,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
         let savedComment = try await saveAndWaitForSync(comment)
         var queriedComment = try await query(for: savedComment)
         assertLazyReference(queriedComment._post,
-                        state: .notLoaded(identifiers: [.init(name: "id", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.identifier)]))
         
         queriedComment.setPost(nil)
         let saveCommentRemovePost = try await saveAndWaitForSync(queriedComment, assertVersion: 2)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL10/AWSDataStoreLazyLoadPostComment7Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL10/AWSDataStoreLazyLoadPostComment7Tests.swift
@@ -36,7 +36,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
         let comment = Comment(commentId: UUID().uuidString, content: "content", post: post)
         let savedPost = try await saveAndWaitForSync(post)
         let savedComment = try await saveAndWaitForSync(comment)
-        try await assertComment(savedComment, hasEagerLoaded: savedPost)
+        try await assertComment(savedComment, canLazyLoad: savedPost)
         try await assertPost(savedPost, canLazyLoad: savedComment)
         let queriedComment = try await query(for: savedComment)
         try await assertComment(queriedComment, canLazyLoad: savedPost)
@@ -68,7 +68,8 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
     func assertComment(_ comment: Comment,
                        canLazyLoad post: Post) async throws {
         assertLazyReference(comment._post,
-                        state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.postId),
+                                                        .init(name: "", value: post.title)]))
         guard let loadedPost = try await comment.post else {
             XCTFail("Failed to load the post from the comment")
             return
@@ -94,7 +95,8 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
             return
         }
         assertLazyReference(comment._post,
-                        state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.postId),
+                                                        .init(name: "", value: post.title)]))
     }
     
     func testSaveWithoutPost() async throws {
@@ -120,7 +122,8 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
         let savedComment = try await saveAndWaitForSync(comment)
         let queriedComment = try await query(for: savedComment)
         assertLazyReference(queriedComment._post,
-                        state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.postId),
+                                                        .init(name: "", value: post.title)]))
         let savedQueriedComment = try await saveAndWaitForSync(queriedComment, assertVersion: 2)
         let queriedComment2 = try await query(for: savedQueriedComment)
         try await assertComment(queriedComment2, canLazyLoad: savedPost)
@@ -135,7 +138,8 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
         let savedComment = try await saveAndWaitForSync(comment)
         var queriedComment = try await query(for: savedComment)
         assertLazyReference(queriedComment._post,
-                        state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.postId),
+                                                        .init(name: "", value: post.title)]))
         
         let newPost = Post(postId: UUID().uuidString, title: "title")
         _ = try await saveAndWaitForSync(newPost)
@@ -154,7 +158,8 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
         let savedComment = try await saveAndWaitForSync(comment)
         var queriedComment = try await query(for: savedComment)
         assertLazyReference(queriedComment._post,
-                        state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.postId),
+                                                        .init(name: "", value: post.title)]))
         
         queriedComment.setPost(nil)
         let saveCommentRemovePost = try await saveAndWaitForSync(queriedComment, assertVersion: 2)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKChildTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKChildTests.swift
@@ -94,7 +94,8 @@ extension AWSDataStoreLazyLoadCompositePKTests {
         // query child and load the parent - CompositePKChild
         let queriedCompositePKChild = try await query(for: savedCompositePKChild)
         assertLazyReference(queriedCompositePKChild._parent,
-                            state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: savedParent.identifier)]))
+                            state: .notLoaded(identifiers: [.init(name: "", value: savedParent.customId),
+                                                            .init(name: "", value: savedParent.content)]))
         let loadedParent = try await queriedCompositePKChild.parent
         assertLazyReference(queriedCompositePKChild._parent,
                             state: .loaded(model: loadedParent))

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKImplicitTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKImplicitTests.swift
@@ -80,7 +80,8 @@ extension AWSDataStoreLazyLoadCompositePKTests {
         // query child and load the parent - ImplicitChild
         let queriedImplicitChild = try await query(for: savedChild)
         assertLazyReference(queriedImplicitChild._parent,
-                            state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: savedParent.identifier)]))
+                            state: .notLoaded(identifiers: [.init(name: "", value: savedParent.customId),
+                                                            .init(name: "", value: savedParent.content)]))
         let loadedParent = try await queriedImplicitChild.parent
         assertLazyReference(queriedImplicitChild._parent,
                             state: .loaded(model: loadedParent))

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKStrangeExplicitTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKStrangeExplicitTests.swift
@@ -79,7 +79,8 @@ extension AWSDataStoreLazyLoadCompositePKTests {
         // query children and load the parent - StrangeExplicitChild
         let queriedStrangeImplicitChild = try await query(for: savedChild)
         assertLazyReference(queriedStrangeImplicitChild._parent,
-                            state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: savedParent.identifier)]))
+                            state: .notLoaded(identifiers: [.init(name: "", value: savedParent.customId),
+                                                            .init(name: "", value: savedParent.content)]))
         let loadedParent3 = try await queriedStrangeImplicitChild.parent
         assertLazyReference(queriedStrangeImplicitChild._parent,
                             state: .loaded(model: loadedParent3))

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/DefaultPK/AWSDataStoreLazyLoadDefaultPKTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/DefaultPK/AWSDataStoreLazyLoadDefaultPKTests.swift
@@ -40,7 +40,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
         let child = Child(parent: parent)
         let savedParent = try await saveAndWaitForSync(parent)
         let savedChild = try await saveAndWaitForSync(child)
-        try await assertChild(savedChild, hasEagerLoaded: savedParent)
+        try await assertChild(savedChild, canLazyLoad: savedParent)
         try await assertParent(savedParent, canLazyLoad: savedChild)
         let queriedChild = try await query(for: savedChild)
         try await assertChild(queriedChild, canLazyLoad: savedParent)
@@ -60,7 +60,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Could not encode child")
             return
         }
-        try await assertChild(savedChild, hasEagerLoaded: savedParent)
+        try await assertChild(savedChild, canLazyLoad: savedParent)
         
         guard let decodedChild = try? ModelRegistry.decode(modelName: Child.modelName,
                                                              from: encodedChild) as? Child else {
@@ -69,7 +69,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
             return
         }
         
-        try await assertChild(decodedChild, hasEagerLoaded: savedParent)
+        try await assertChild(decodedChild, canLazyLoad: savedParent)
     }
     
     func testLazyLoadOnQueryAfterEncodeDecoder() async throws {
@@ -115,7 +115,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
     func assertChild(_ child: Child,
                        canLazyLoad parent: Parent) async throws {
         assertLazyReference(child._parent,
-                        state: .notLoaded(identifiers: [.init(name: "id", value: parent.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: parent.identifier)]))
         guard let loadedParent = try await child.parent else {
             XCTFail("Failed to load the parent from the child")
             return
@@ -144,7 +144,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
         
         // further nested models should not be loaded
         assertLazyReference(child._parent,
-                        state: .notLoaded(identifiers: [.init(name: "id", value: parent.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: parent.identifier)]))
     }
     
     func testSaveWithoutPost() async throws {
@@ -170,7 +170,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
         let savedChild = try await saveAndWaitForSync(child)
         let queriedChild = try await query(for: savedChild)
         assertLazyReference(queriedChild._parent,
-                        state: .notLoaded(identifiers: [.init(name: "id", value: parent.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: parent.identifier)]))
         let savedqueriedChild = try await saveAndWaitForSync(queriedChild, assertVersion: 2)
         let queriedChild2 = try await query(for: savedqueriedChild)
         try await assertChild(queriedChild2, canLazyLoad: savedParent)
@@ -185,7 +185,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
         let savedChild = try await saveAndWaitForSync(child)
         var queriedChild = try await query(for: savedChild)
         assertLazyReference(queriedChild._parent,
-                        state: .notLoaded(identifiers: [.init(name: "id", value: parent.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: parent.identifier)]))
         
         let newParent = DefaultPKParent()
         _ = try await saveAndWaitForSync(newParent)
@@ -204,7 +204,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
         let savedChild = try await saveAndWaitForSync(child)
         var queriedChild = try await query(for: savedChild)
         assertLazyReference(queriedChild._parent,
-                        state: .notLoaded(identifiers: [.init(name: "id", value: parent.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: parent.identifier)]))
         
         queriedChild.setParent(nil)
         let saveCommentRemovePost = try await saveAndWaitForSync(queriedChild, assertVersion: 2)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL13/AWSDataStoreLazyLoadPhoneCallTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL13/AWSDataStoreLazyLoadPhoneCallTests.swift
@@ -53,9 +53,9 @@ class AWSDataStoreLazyLoadPhoneCallTests: AWSDataStoreLazyLoadBaseTest {
         let savedPhoneCall = try await saveAndWaitForSync(phoneCall)
         let queriedPhoneCall = try await query(for: savedPhoneCall)
         assertLazyReference(queriedPhoneCall._caller,
-                            state: .notLoaded(identifiers: [.init(name: "id", value: caller.id)]))
+                            state: .notLoaded(identifiers: [.init(name: "", value: caller.id)]))
         assertLazyReference(queriedPhoneCall._callee,
-                            state: .notLoaded(identifiers: [.init(name: "id", value: callee.id)]))
+                            state: .notLoaded(identifiers: [.init(name: "", value: callee.id)]))
         let loadedCaller = try await queriedPhoneCall.caller
         let loadedCallee = try await queriedPhoneCall.callee
         assertLazyReference(queriedPhoneCall._caller, state: .loaded(model: savedCaller))
@@ -99,11 +99,11 @@ class AWSDataStoreLazyLoadPhoneCallTests: AWSDataStoreLazyLoadBaseTest {
         XCTAssertEqual(savedPhoneCall.phoneCallTranscriptId, transcript.id)
         let savedTranscript = try await saveAndWaitForSync(transcript)
         assertLazyReference(savedTranscript._phoneCall,
-                            state: .loaded(model: savedPhoneCall))
+                            state: .notLoaded(identifiers: [.init(name: "", value: savedPhoneCall.id)]))
         
         let queriedTranscript = try await query(for: savedTranscript)
         assertLazyReference(queriedTranscript._phoneCall,
-                            state: .notLoaded(identifiers: [.init(name: "id", value: savedPhoneCall.id)]))
+                            state: .notLoaded(identifiers: [.init(name: "", value: savedPhoneCall.id)]))
         let loadedPhoneCall = try await queriedTranscript.phoneCall!
         assertLazyReference(queriedTranscript._phoneCall,
                             state: .loaded(model: savedPhoneCall))

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL2/AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL2/AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift
@@ -72,7 +72,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
     func assertComment(_ comment: Comment,
                        canLazyLoad post: Post) async throws {
         assertLazyReference(comment._post,
-                        state: .notLoaded(identifiers: [.init(name: "id", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.identifier)]))
         guard let loadedPost = try await comment.post else {
             XCTFail("Failed to load the post from the comment")
             return
@@ -101,7 +101,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         
         // further nested models should not be loaded
         assertLazyReference(comment._post,
-                        state: .notLoaded(identifiers: [.init(name: "id", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.identifier)]))
     }
     
     func testSaveWithoutPost() async throws {
@@ -127,7 +127,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         let savedComment = try await saveAndWaitForSync(comment)
         let queriedComment = try await query(for: savedComment)
         assertLazyReference(queriedComment._post,
-                        state: .notLoaded(identifiers: [.init(name: "id", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.identifier)]))
         let savedQueriedComment = try await saveAndWaitForSync(queriedComment, assertVersion: 2)
         let queriedComment2 = try await query(for: savedQueriedComment)
         try await assertComment(queriedComment2, canLazyLoad: savedPost)
@@ -142,7 +142,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         let savedComment = try await saveAndWaitForSync(comment)
         var queriedComment = try await query(for: savedComment)
         assertLazyReference(queriedComment._post,
-                        state: .notLoaded(identifiers: [.init(name: "id", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.identifier)]))
         
         let newPost = Post(name: "name")
         _ = try await saveAndWaitForSync(newPost)
@@ -161,7 +161,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         let savedComment = try await saveAndWaitForSync(comment)
         var queriedComment = try await query(for: savedComment)
         assertLazyReference(queriedComment._post,
-                        state: .notLoaded(identifiers: [.init(name: "id", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.identifier)]))
         
         queriedComment.setPost(nil)
         let saveCommentRemovePost = try await saveAndWaitForSync(queriedComment, assertVersion: 2)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL3/AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL3/AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests.swift
@@ -21,7 +21,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
         let comment = Comment(content: "content", post: post)
         let savedPost = try await saveAndWaitForSync(post)
         let savedComment = try await saveAndWaitForSync(comment)
-        try await assertComment(savedComment, hasEagerLoaded: savedPost)
+        try await assertComment(savedComment, canLazyLoad: savedPost)
         try await assertPost(savedPost, canLazyLoad: savedComment)
         let queriedComment = try await query(for: savedComment)
         try await assertComment(queriedComment, canLazyLoad: savedPost)
@@ -53,7 +53,8 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
     func assertComment(_ comment: Comment,
                        canLazyLoad post: Post) async throws {
         assertLazyReference(comment._post,
-                        state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: post.identifier)]))
+                            state: .notLoaded(identifiers: [.init(name: "", value: post.id),
+                                                            .init(name: "", value: post.title)]))
         guard let loadedPost = try await comment.post else {
             XCTFail("Failed to load the post from the comment")
             return
@@ -79,7 +80,8 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
             return
         }
         assertLazyReference(comment._post,
-                        state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.id),
+                                                        .init(name: "", value: post.title)]))
     }
     
     func testSaveWithoutPost() async throws {
@@ -105,7 +107,8 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
         let savedComment = try await saveAndWaitForSync(comment)
         let queriedComment = try await query(for: savedComment)
         assertLazyReference(queriedComment._post,
-                        state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.id),
+                                                        .init(name: "", value: post.title)]))
         let savedQueriedComment = try await saveAndWaitForSync(queriedComment, assertVersion: 2)
         let queriedComment2 = try await query(for: savedQueriedComment)
         try await assertComment(queriedComment2, canLazyLoad: savedPost)
@@ -120,7 +123,8 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
         let savedComment = try await saveAndWaitForSync(comment)
         var queriedComment = try await query(for: savedComment)
         assertLazyReference(queriedComment._post,
-                        state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.id),
+                                                        .init(name: "", value: post.title)]))
         
         let newPost = Post(title: "title")
         _ = try await saveAndWaitForSync(newPost)
@@ -139,7 +143,8 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
         let savedComment = try await saveAndWaitForSync(comment)
         var queriedComment = try await query(for: savedComment)
         assertLazyReference(queriedComment._post,
-                        state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: post.identifier)]))
+                        state: .notLoaded(identifiers: [.init(name: "", value: post.id),
+                                                        .init(name: "", value: post.title)]))
         
         queriedComment.setPost(nil)
         let saveCommentRemovePost = try await saveAndWaitForSync(queriedComment, assertVersion: 2)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL4/AWSDataStoreLazyLoadPostTagTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL4/AWSDataStoreLazyLoadPostTagTests.swift
@@ -30,8 +30,10 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         
         try await assertPost(savedPost, canLazyLoad: savedPostTag)
         try await assertTag(savedTag, canLazyLoad: savedPostTag)
-        assertLazyReference(savedPostTag._postWithTagsCompositeKey, state: .loaded(model: savedPost))
-        assertLazyReference(savedPostTag._tagWithCompositeKey, state: .loaded(model: savedTag))
+        assertLazyReference(savedPostTag._postWithTagsCompositeKey, state: .notLoaded(identifiers: [.init(name: "", value: savedPost.postId),
+                                                                                                    .init(name: "", value: savedPost.title)]))
+        assertLazyReference(savedPostTag._tagWithCompositeKey, state: .notLoaded(identifiers: [.init(name: "", value: savedTag.id),
+                                                                                               .init(name: "", value: savedTag.name)]))
         let queriedPost = try await query(for: savedPost)
         try await assertPost(queriedPost, canLazyLoad: savedPostTag)
         let queriedTag = try await query(for: savedTag)
@@ -65,8 +67,10 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
     }
     
     func assertPostTag(_ postTag: PostTag, canLazyLoadTag tag: Tag, canLazyLoadPost post: Post) async throws {
-        assertLazyReference(postTag._tagWithCompositeKey, state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: tag.identifier)]))
-        assertLazyReference(postTag._postWithTagsCompositeKey, state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: post.identifier)]))
+        assertLazyReference(postTag._tagWithCompositeKey, state: .notLoaded(identifiers: [.init(name: "", value: tag.id),
+                                                                                          .init(name: "", value: tag.name)]))
+        assertLazyReference(postTag._postWithTagsCompositeKey, state: .notLoaded(identifiers: [.init(name: "", value: post.postId),
+                                                                                               .init(name: "", value: post.title)]))
         let loadedTag = try await postTag.tagWithCompositeKey
         assertLazyReference(postTag._tagWithCompositeKey, state: .loaded(model: loadedTag))
         try await assertTag(loadedTag, canLazyLoad: postTag)
@@ -90,7 +94,9 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         _ = try await saveAndWaitForSync(newPost)
         queriedPostTag.setPostWithTagsCompositeKey(newPost)
         let savedPostTagWithNewPost = try await saveAndWaitForSync(queriedPostTag, assertVersion: 2)
-        assertLazyReference(savedPostTagWithNewPost._postWithTagsCompositeKey, state: .loaded(model: newPost))
+        assertLazyReference(savedPostTagWithNewPost._postWithTagsCompositeKey,
+                            state: .notLoaded(identifiers: [.init(name: "", value: newPost.postId),
+                                                            .init(name: "", value: newPost.title)]))
         let queriedPreviousPost = try await query(for: savedPost)
         try await assertPostWithNoPostTag(queriedPreviousPost)
         
@@ -100,7 +106,9 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         _ = try await saveAndWaitForSync(newTag)
         queriedPostTagWithNewPost.setTagWithCompositeKey(newTag)
         let savedPostTagWithNewTag = try await saveAndWaitForSync(queriedPostTagWithNewPost, assertVersion: 3)
-        assertLazyReference(savedPostTagWithNewTag._tagWithCompositeKey, state: .loaded(model: newTag))
+        assertLazyReference(savedPostTagWithNewTag._tagWithCompositeKey,
+                            state: .notLoaded(identifiers: [.init(name: "", value: newTag.id),
+                                                            .init(name: "", value: newTag.name)]))
         let queriedPreviousTag = try await query(for: savedTag)
         try await assertTagWithNoPostTag(queriedPreviousTag)
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL5/AWSDataStoreLazyLoadProjectTeam1Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL5/AWSDataStoreLazyLoadProjectTeam1Tests.swift
@@ -88,10 +88,13 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
         queriedTeam.setProject(queriedProjectWithTeam)
         let savedTeamWithProject = try await saveAndWaitForSync(queriedTeam, assertVersion: 2)
         
-        assertLazyReference(savedTeamWithProject._project, state: .loaded(model: projectWithTeam))
+        assertLazyReference(savedTeamWithProject._project,
+                            state: .notLoaded(identifiers: [.init(name: "", value: projectWithTeam.projectId),
+                                                            .init(name: "", value: projectWithTeam.name)]))
         var queriedTeamWithProject = try await query(for: savedTeamWithProject)
-        assertLazyReference(queriedTeamWithProject._project, state: .notLoaded(identifiers: [.init(name: "@@primaryKey", value: projectWithTeam.identifier)]))
-        
+        assertLazyReference(queriedTeamWithProject._project,
+                            state: .notLoaded(identifiers: [.init(name: "", value: projectWithTeam.projectId),
+                                                            .init(name: "", value: projectWithTeam.name)]))
         let loadedProject = try await queriedTeamWithProject.project!
         XCTAssertEqual(loadedProject.projectId, projectWithTeam.projectId)
     }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
This PR is a cherry-pick of https://github.com/aws-amplify/amplify-swift/pull/2737 to minimize the necessary changes needed. We remove the updated codegen changes and instead of storing "associatedFields" / "associatedkey" for lazy references (has-one  and belongs-to use cases), we're just storing the empty string "". Storing LazyReferenceIdentifier is an implementation detail, which is exposed via the `_state` property for internal plugins logic to operate against, such as Model+GraphQL.

Datastore.save has been updated to perform query with lazy load to return a model with associated models that are not yet loaded. The same model returned to the caller is synced to AppSync. Previously this model was eager loaded. Model+GraphQL translates the model to the GraphQL Input by extracting the identifiers out of associated models. Since the associated model is not yet loaded, the identifers are extracted out of the lazy reference `.notLoaded(identifiers)`.

DataStoreModelProvider, responsible for lazy loading a single model, used to hold the a single identifier value, which may be the value or a value concatenated with "#" for CPK. On`load()`, it will use the schema to find the primary key or use the  `@@primaryKey` column name.

Model+GraphQL will use the targetNames as for the GraphQL input keys and the identifiers array from  `.notLoaded(identifers)` of the LazyReference. This was previously not possible since the identifiers was already the concatenated version of the primary key.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
