### PR TITLE
fix: revert CPK has-one associatedFields

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelField+Association.swift
@@ -88,7 +88,7 @@ import Foundation
 ///   directly by host applications. The behavior of this may change without warning.
 public enum ModelAssociation {
     case hasMany(associatedFieldName: String?, associatedFieldNames: [String] = [])
-    case hasOne(associatedFieldName: String?, associatedFieldNames: [String] = [], targetNames: [String])
+    case hasOne(associatedFieldName: String?, targetNames: [String])
     case belongsTo(associatedFieldName: String?, targetNames: [String])
 
     public static let belongsTo: ModelAssociation = .belongsTo(associatedFieldName: nil, targetNames: [])
@@ -104,19 +104,14 @@ public enum ModelAssociation {
                         associatedFieldNames: associatedFields.map { $0.stringValue })
     }
 
-    @available(*, deprecated, message: "Use hasOne(associatedWith:associatedFields:targetNames:)")
-    public static func hasOne(associatedWith: CodingKey?,
-                              targetName: String? = nil) -> ModelAssociation {
+    @available(*, deprecated, message: "Use hasOne(associatedWith:targetNames:)")
+    public static func hasOne(associatedWith: CodingKey?, targetName: String? = nil) -> ModelAssociation {
         let targetNames = targetName.map { [$0] } ?? []
         return .hasOne(associatedWith: associatedWith, targetNames: targetNames)
     }
 
-    public static func hasOne(associatedWith: CodingKey? = nil,
-                              associatedFields: [CodingKey] = [],
-                              targetNames: [String] = []) -> ModelAssociation {
-        return .hasOne(associatedFieldName: associatedWith?.stringValue,
-                       associatedFieldNames: associatedFields.map { $0.stringValue },
-                       targetNames: targetNames)
+    public static func hasOne(associatedWith: CodingKey?, targetNames: [String] = []) -> ModelAssociation {
+        return .hasOne(associatedFieldName: associatedWith?.stringValue, targetNames: targetNames)
     }
 
     @available(*, deprecated, message: "Use belongsTo(associatedWith:targetNames:)")
@@ -242,7 +237,7 @@ extension ModelField {
             let associatedModel = requiredAssociatedModelName
             switch association {
             case .belongsTo(let associatedKey, _),
-                    .hasOne(let associatedKey, _, _),
+                    .hasOne(let associatedKey, _),
                     .hasMany(let associatedKey, _):
                 // TODO handle modelName casing (convert to camelCase)
                 let key = associatedKey ?? associatedModel

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -280,21 +280,6 @@ public enum ModelFieldDefinition {
                       association: .hasOne(associatedWith: associatedKey, targetNames: targetNames))
     }
 
-    public static func hasOne(_ key: CodingKey,
-                              is nullability: ModelFieldNullability = .required,
-                              isReadOnly: Bool = false,
-                              ofType type: Model.Type,
-                              associatedFields associatedKeys: [CodingKey],
-                              targetNames: [String]) -> ModelFieldDefinition {
-        return .field(key,
-                      is: nullability,
-                      isReadOnly: isReadOnly,
-                      ofType: .model(type: type),
-                      association: .hasOne(associatedWith: associatedKeys.first,
-                                           associatedFields: associatedKeys,
-                                           targetNames: targetNames))
-    }
-
     public static func belongsTo(_ key: CodingKey,
                                  is nullability: ModelFieldNullability = .required,
                                  isReadOnly: Bool = false,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -207,7 +207,7 @@ extension Model {
         let defaultFieldName = modelName.camelCased() + modelField.name.pascalCased() + "Id"
         if case let .belongsTo(_, targetNames) = modelField.association, !targetNames.isEmpty {
             return targetNames
-        } else if case let .hasOne(_, _, targetNames) = modelField.association,
+        } else if case let .hasOne(_, targetNames) = modelField.association,
                   !targetNames.isEmpty {
             return targetNames
         }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
@@ -131,7 +131,7 @@ extension QueryPredicateOperation: GraphQLFilterConvertible {
             }
             let targetName = targetNames.first ?? defaultFieldName
             return targetName
-        case .hasOne(_, _, let targetNames):
+        case .hasOne(_, let targetNames):
             guard targetNames.count == 1 else {
                 preconditionFailure("QueryPredicate not supported on associated field with composite key: \(field)")
             }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/ModelSchema+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/ModelSchema+SQLite.swift
@@ -82,7 +82,7 @@ extension ModelField: SQLColumn {
     var sqlName: String {
         if case let .belongsTo(_, targetNames) = association {
             return foreignKeySqlName(withAssociationTargets: targetNames)
-        } else if case let .hasOne(_, _, targetNames) = association {
+        } else if case let .hasOne(_, targetNames) = association {
             return foreignKeySqlName(withAssociationTargets: targetNames)
         }
         return name

--- a/AmplifyTests/CategoryTests/DataStore/ModelFieldAssociationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/ModelFieldAssociationTests.swift
@@ -37,7 +37,7 @@ class ModelFieldAssociationTests: XCTestCase {
 
     func testHasOneWithCodingKeys() {
         let hasOne = ModelAssociation.hasOne(associatedWith: Comment.keys.post, targetName: nil)
-        guard case .hasOne(let fieldName, _, let target) = hasOne else {
+        guard case .hasOne(let fieldName, let target) = hasOne else {
             XCTFail("Should create hasOne association")
             return
         }
@@ -47,7 +47,7 @@ class ModelFieldAssociationTests: XCTestCase {
 
     func testHasOneWithCodingKeysWithTargetName() {
         let hasOne = ModelAssociation.hasOne(associatedWith: Comment.keys.post, targetName: "postID")
-        guard case .hasOne(let fieldName, _, let target) = hasOne else {
+        guard case .hasOne(let fieldName, let target) = hasOne else {
             XCTFail("Should create hasOne association")
             return
         }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
We recently added this change https://github.com/aws-amplify/amplify-swift/pull/2734 expecting codegen to generate  has-one with `associatedFields` in https://github.com/aws-amplify/amplify-codegen/pull/541. We were working through some implementation details in https://github.com/aws-amplify/amplify-swift/pull/2737 that no longer depends on has-one to have `associatedFields`. This change is to revert it until we identify an actual need to move forward with the codegen changes. 
 
## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
