### PR TITLE
chore: enable ds/api lazy load tests

### DIFF
--- a/.github/workflows/integ_test_api.yml
+++ b/.github/workflows/integ_test_api.yml
@@ -136,7 +136,6 @@ jobs:
           scheme: AWSAPIPluginGraphQLLambdaAuthTests
 
   api-lazy-load-test:
-    if: ${{ false }}
     needs: prepare-for-test
     runs-on: macos-12
     environment: IntegrationTest

--- a/.github/workflows/integ_test_datastore_lazy_load.yml
+++ b/.github/workflows/integ_test_datastore_lazy_load.yml
@@ -2,7 +2,7 @@ name: DataStore Lazy Load Tests
 on:
   workflow_dispatch:
   push:
-    branches: [data-dev-preview]
+    branches: [main]
 
 permissions:
     id-token: write


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
Enable DataStore and API's lazy loading test targets

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
