### PR TITLE
fix(test): DS transformer V2 tests should be update mutation on existing model

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionOptionalAssociations.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionOptionalAssociations.swift
@@ -207,7 +207,7 @@ class DataStoreConnectionOptionalAssociations: SyncEngineIntegrationV2TestBase {
         queriedComment.post = nil
         // A mock GraphQL request is created to assert that the request variables contains the "postId"
         // with the value `nil` which is sent to the API to persist the removal of the association.
-        let request = GraphQLRequest<Comment8>.createMutation(of: queriedComment, version: 1)
+        let request = GraphQLRequest<Comment8>.updateMutation(of: queriedComment, version: 1)
         guard let variables = request.variables,
               let input = variables["input"] as? [String: Any?],
               let postValue = input["postId"],


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
While going over previous integration tests, specifically DataStoreTransformerV2 tests. One of the tests was failing because we were trying to send `nil` values of the foreign key for create mutations. We shouldn't be sending a create mutation, but rather an update mutation on an existing model. updateMutations will set `nil` values for the FK to act as an removal of an assocation. The implementation change was introduced in https://github.com/aws-amplify/amplify-swift/pull/2701 to `data-dev-preview` and this test was not run to catch the failure

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
