### PR TITLE
[DRAFT] fix(datastore): sync update mutations with changed fields

### DIFF
--- a/Amplify/Categories/DataStore/Subscribe/MutationEvent.swift
+++ b/Amplify/Categories/DataStore/Subscribe/MutationEvent.swift
@@ -20,6 +20,11 @@ public struct MutationEvent: Model {
     public var version: Int?
     public var inProcess: Bool
     public var graphQLFilterJSON: String?
+    
+    // MutationEvent, which is also the payload to DataStore.observe API is public and so we should make sure that
+    // this is the right direction to go, since there's already a disparity across platforms on the observe API's
+    // event type.
+    public var changedFields: [String]?
 
     public init(id: EventIdentifier = UUID().uuidString,
                 modelId: ModelId,
@@ -29,7 +34,8 @@ public struct MutationEvent: Model {
                 createdAt: Temporal.DateTime = .now(),
                 version: Int? = nil,
                 inProcess: Bool = false,
-                graphQLFilterJSON: String? = nil) {
+                graphQLFilterJSON: String? = nil,
+                changedFields: [String]? = nil) {
         self.id = id
         self.modelId = modelId
         self.modelName = modelName
@@ -39,20 +45,23 @@ public struct MutationEvent: Model {
         self.version = version
         self.inProcess = inProcess
         self.graphQLFilterJSON = graphQLFilterJSON
+        self.changedFields = changedFields
     }
 
     public init<M: Model>(model: M,
                           modelSchema: ModelSchema,
                           mutationType: MutationType,
                           version: Int? = nil,
-                          graphQLFilterJSON: String? = nil) throws {
+                          graphQLFilterJSON: String? = nil,
+                          changedFields: [String]? = nil) throws {
         let json = try model.toJSON()
         self.init(modelId: model.identifier(schema: modelSchema).stringValue,
                   modelName: modelSchema.name,
                   json: json,
                   mutationType: mutationType,
                   version: version,
-                  graphQLFilterJSON: graphQLFilterJSON)
+                  graphQLFilterJSON: graphQLFilterJSON,
+                  changedFields: changedFields)
 
     }
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -28,7 +28,8 @@ protocol ModelSyncGraphQLRequestFactory {
                                modelSchema: ModelSchema,
                                where filter: GraphQLFilter?,
                                version: Int?,
-                               authType: AWSAuthorizationType?) -> GraphQLRequest<MutationSyncResult>
+                               authType: AWSAuthorizationType?,
+                               changedFields: [String]?) -> GraphQLRequest<MutationSyncResult>
 
     static func deleteMutation(of model: Model,
                                modelSchema: ModelSchema,
@@ -89,8 +90,14 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
     public static func updateMutation(of model: Model,
                                       where filter: GraphQLFilter? = nil,
                                       version: Int? = nil,
-                                      authType: AWSAuthorizationType? = nil) -> GraphQLRequest<MutationSyncResult> {
-        updateMutation(of: model, modelSchema: model.schema, where: filter, version: version, authType: authType)
+                                      authType: AWSAuthorizationType? = nil,
+                                      changedFields: [String]? = nil) -> GraphQLRequest<MutationSyncResult> {
+        updateMutation(of: model,
+                       modelSchema: model.schema,
+                       where: filter,
+                       version: version,
+                       authType: authType,
+                       changedFields: changedFields)
     }
 
     public static func subscription(to modelType: Model.Type,
@@ -131,13 +138,15 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                       modelSchema: ModelSchema,
                                       where filter: GraphQLFilter? = nil,
                                       version: Int? = nil,
-                                      authType: AWSAuthorizationType? = nil) -> GraphQLRequest<MutationSyncResult> {
+                                      authType: AWSAuthorizationType? = nil,
+                                      changedFields: [String]? = nil) -> GraphQLRequest<MutationSyncResult> {
         createOrUpdateMutation(of: model,
                                modelSchema: modelSchema,
                                where: filter,
                                type: .update,
                                version: version,
-                               authType: authType)
+                               authType: authType,
+                               changedFields: changedFields)
     }
 
     public static func deleteMutation(of model: Model,
@@ -246,12 +255,13 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                                where filter: GraphQLFilter? = nil,
                                                type: GraphQLMutationType,
                                                version: Int? = nil,
-                                               authType: AWSAuthorizationType? = nil) -> GraphQLRequest<MutationSyncResult> {
+                                               authType: AWSAuthorizationType? = nil,
+                                               changedFields: [String]? = nil) -> GraphQLRequest<MutationSyncResult> {
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: modelSchema.name,
                                                                operationType: .mutation,
                                                                primaryKeysOnly: false)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: type))
-        documentBuilder.add(decorator: ModelDecorator(model: model, mutationType: type))
+        documentBuilder.add(decorator: ModelDecorator(model: model, mutationType: type, changedFields: changedFields))
         if let filter = filter {
             documentBuilder.add(decorator: FilterDecorator(filter: filter))
         }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
@@ -140,7 +140,8 @@ class SyncMutationToCloudOperation: AsynchronousOperation {
                 request = GraphQLRequest<MutationSyncResult>.updateMutation(of: model,
                                                                             modelSchema: modelSchema,
                                                                             where: graphQLFilter,
-                                                                            version: mutationEvent.version)
+                                                                            version: mutationEvent.version,
+                                                                            changedFields: mutationEvent.changedFields ?? [])
             case .create:
                 let model = try mutationEvent.decodeModel()
                 guard let modelSchema = ModelRegistry.modelSchema(from: mutationEvent.modelName) else {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
DataStore's sync models to AppSync on updates will perform an update mutation. The model gets translated to the GraphQL input as is. The graphql input should only contain changed fields. This is important for auto-merge strategy to work properly.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
