### PR TITLE
fix(datastore): full sync when sync predicate changes

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/Persistable.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Persistable.swift
@@ -20,7 +20,7 @@ import Foundation
 /// - `Temporal.Time`
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
-public protocol Persistable {}
+public protocol Persistable: Encodable {}
 
 extension Bool: Persistable {}
 extension Double: Persistable {}

--- a/Amplify/Categories/DataStore/Query/QueryOperator.swift
+++ b/Amplify/Categories/DataStore/Query/QueryOperator.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum QueryOperator {
+public enum QueryOperator: Encodable {
     case notEqual(_ value: Persistable?)
     case equals(_ value: Persistable?)
     case lessOrEqual(_ value: Persistable)
@@ -18,7 +18,7 @@ public enum QueryOperator {
     case notContains(_ value: String)
     case between(start: Persistable, end: Persistable)
     case beginsWith(_ value: String)
-
+    
     public func evaluate(target: Any) -> Bool {
         switch self {
         case .notEqual(let predicateValue):
@@ -50,5 +50,61 @@ public enum QueryOperator {
             }
         }
         return false
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case value
+        case start
+        case end
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        switch self {
+        case .notEqual(let value):
+            try container.encode("notEqual", forKey: .type)
+            if let value = value {
+                try container.encode(value, forKey: .value)
+            }
+        case .equals(let value):
+            try container.encode("equals", forKey: .type)
+            if let value = value {
+                try container.encode(value, forKey: .value)
+            }
+        case .lessOrEqual(let value):
+            try container.encode("lessOrEqual", forKey: .type)
+            try container.encode(value, forKey: .value)
+            
+        case .lessThan(let value):
+            try container.encode("lessThan", forKey: .type)
+            try container.encode(value, forKey: .value)
+            
+        case .greaterOrEqual(let value):
+            try container.encode("greaterOrEqual", forKey: .type)
+            try container.encode(value, forKey: .value)
+            
+        case .greaterThan(let value):
+            try container.encode("greaterThan", forKey: .type)
+            try container.encode(value, forKey: .value)
+            
+        case .contains(let value):
+            try container.encode("contains", forKey: .type)
+            try container.encode(value, forKey: .value)
+            
+        case .notContains(let value):
+            try container.encode("notContains", forKey: .type)
+            try container.encode(value, forKey: .value)
+            
+        case .between(let start, let end):
+            try container.encode("between", forKey: .type)
+            try container.encode(start, forKey: .start)
+            try container.encode(end, forKey: .end)
+            
+        case .beginsWith(let value):
+            try container.encode("beginsWith", forKey: .type)
+            try container.encode(value, forKey: .value)
+        }
     }
 }

--- a/Amplify/Categories/DataStore/Query/QueryPredicate.swift
+++ b/Amplify/Categories/DataStore/Query/QueryPredicate.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 /// Protocol that indicates concrete types conforming to it can be used a predicate member.
-public protocol QueryPredicate: Evaluable {}
+public protocol QueryPredicate: Evaluable, Encodable {}
 
-public enum QueryPredicateGroupType: String {
+public enum QueryPredicateGroupType: String, Encodable {
     case and
     case or
     case not
@@ -26,14 +26,14 @@ public func not<Predicate: QueryPredicate>(_ predicate: Predicate) -> QueryPredi
 /// The case `.all` is a predicate used as an argument to select all of a single modeltype. We
 /// chose `.all` instead of `nil` because we didn't want to use the implicit nature of `nil` to
 /// specify an action applies to an entire data set.
-public enum QueryPredicateConstant: QueryPredicate {
+public enum QueryPredicateConstant: QueryPredicate, Encodable {
     case all
     public func evaluate(target: Model) -> Bool {
         return true
     }
 }
 
-public class QueryPredicateGroup: QueryPredicate {
+public class QueryPredicateGroup: QueryPredicate, Encodable {
     public internal(set) var type: QueryPredicateGroupType
     public internal(set) var predicates: [QueryPredicate]
 
@@ -92,9 +92,37 @@ public class QueryPredicateGroup: QueryPredicate {
             return !predicate.evaluate(target: target)
         }
     }
+    
+    // MARK: - Encodable conformance
+    
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case predicates
+    }
+
+    struct AnyQueryPredicate: Encodable {
+        private let _encode: (Encoder) throws -> Void
+
+        init(_ base: QueryPredicate) {
+            _encode = base.encode
+        }
+
+        func encode(to encoder: Encoder) throws {
+            try _encode(encoder)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type.rawValue, forKey: .type)
+        
+        let anyPredicates = predicates.map(AnyQueryPredicate.init)
+        try container.encode(anyPredicates, forKey: .predicates)
+    }
+    
 }
 
-public class QueryPredicateOperation: QueryPredicate {
+public class QueryPredicateOperation: QueryPredicate, Encodable {
 
     public let field: String
     public let `operator`: QueryOperator

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata+Schema.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata+Schema.swift
@@ -15,6 +15,7 @@ extension ModelSyncMetadata {
     public enum CodingKeys: String, ModelKey {
         case id
         case lastSync
+        case syncPredicate
     }
 
     public static let keys = CodingKeys.self
@@ -27,7 +28,8 @@ extension ModelSyncMetadata {
 
         definition.fields(
             .id(),
-            .field(keys.lastSync, is: .optional, ofType: .int)
+            .field(keys.lastSync, is: .optional, ofType: .int),
+            .field(keys.syncPredicate, is: .optional, ofType: .string)
         )
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata.swift
@@ -13,10 +13,15 @@ public struct ModelSyncMetadata: Model {
 
     /// The timestamp (in Unix seconds) at which the last sync was started, as reported by the service
     public var lastSync: Int64?
+    
+    /// The sync predicate for this model, extracted out from the sync expression.
+    public var syncPredicate: String?
 
     public init(id: String,
-                lastSync: Int64?) {
+                lastSync: Int64? = nil,
+                syncPredicate: String? = nil) {
         self.id = id
         self.lastSync = lastSync
+        self.syncPredicate = syncPredicate
     }
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Migration/ModelSyncMetadataMigration.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Migration/ModelSyncMetadataMigration.swift
@@ -1,0 +1,108 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Foundation
+import SQLite
+import AWSPluginsCore
+
+class ModelSyncMetadataMigration: ModelMigration {
+    
+    weak var storageAdapter: SQLiteStorageEngineAdapter?
+    
+    func apply() throws {
+        try performModelMetadataSyncPredicateUpgrade()
+    }
+    
+    init(storageAdapter: SQLiteStorageEngineAdapter? = nil) {
+        self.storageAdapter = storageAdapter
+    }
+    
+    /// Add the new syncPredicate column for the ModelSyncMetadata system table.
+    ///
+    /// ModelSyncMetadata's syncPredicate column was added in Amplify version 2.22.0 to
+    /// support a bug fix related to persisting the sync predicate of the sync expression.
+    /// Apps before upgrading to this version of the plugin will have created the table already.
+    /// Upgraded apps will not re-create the table with the CreateTableStatement, neither will throw an error
+    /// (CreateTableStatement is run with 'create table if not exists' doing a no-op). This function
+    /// checks if the column exists on the table, and if it doesn't, alter the table to add the new column.
+    ///
+    /// For more details, see https://github.com/aws-amplify/amplify-swift/pull/2757.
+    /// - Returns: `true` if upgrade occured, `false` otherwise.
+    @discardableResult
+    func performModelMetadataSyncPredicateUpgrade() throws -> Bool {
+        do {
+            guard let field = ModelSyncMetadata.schema.field(
+                withName: ModelSyncMetadata.keys.syncPredicate.stringValue) else {
+                log.error("Could not find corresponding ModelField from ModelSyncMetadata for syncPredicate")
+                return false
+            }
+            let exists = try columnExists(modelSchema: ModelSyncMetadata.schema,
+                                          field: field)
+            guard !exists else {
+                log.debug("Detected ModelSyncMetadata table has syncPredicate column. No migration needed")
+                return false
+            }
+            
+            log.debug("Detected ModelSyncMetadata table exists without syncPredicate column.")
+            guard let storageAdapter = storageAdapter else {
+                log.debug("Missing SQLiteStorageEngineAdapter for model migration")
+                throw DataStoreError.nilStorageAdapter()
+            }
+            guard let connection = storageAdapter.connection else {
+                throw DataStoreError.nilSQLiteConnection()
+            }
+            let addColumnStatement = AlterTableAddColumnStatement(
+                modelSchema: ModelSyncMetadata.schema,
+                field: field).stringValue
+            try connection.execute(addColumnStatement)
+            log.debug("ModelSyncMetadata table altered to add syncPredicate column.")
+            return true
+        } catch {
+            throw DataStoreError.invalidOperation(causedBy: error)
+        }
+    }
+
+    func columnExists(modelSchema: ModelSchema, field: ModelField) throws -> Bool {
+        guard let storageAdapter = storageAdapter else {
+            log.debug("Missing SQLiteStorageEngineAdapter for model migration")
+            throw DataStoreError.nilStorageAdapter()
+        }
+        guard let connection = storageAdapter.connection else {
+            throw DataStoreError.nilSQLiteConnection()
+        }
+        
+        let tableInfoStatement = TableInfoStatement(modelSchema: modelSchema)
+        do {
+            let existingColumns = try connection.prepare(tableInfoStatement.stringValue).run()
+            let columnToFind = field.name
+            var columnExists = false
+            for column in existingColumns {
+                // The second element is the column name
+                if column.count >= 2,
+                    let columnName = column[1],
+                    let columNameString = columnName as? String,
+                    columnToFind == columNameString {
+                    columnExists = true
+                    break
+                }
+            }
+            return columnExists
+        } catch {
+            throw DataStoreError.invalidOperation(causedBy: error)
+        }
+    }
+}
+
+extension ModelSyncMetadataMigration: DefaultLogger {
+    public static var log: Logger {
+        Amplify.Logging.logger(forCategory: CategoryType.dataStore.displayName, forNamespace: String(describing: self))
+    }
+    public var log: Logger {
+        Self.log
+    }
+}

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/SQLStatement+AlterTable.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/SQLStatement+AlterTable.swift
@@ -22,3 +22,13 @@ struct AlterTableStatement: SQLStatement {
         self.modelSchema = toModelSchema
     }
 }
+
+struct AlterTableAddColumnStatement: SQLStatement {
+    var modelSchema: ModelSchema
+    var field: ModelField
+    
+    var stringValue: String {
+        "ALTER TABLE \"\(modelSchema.name)\" ADD COLUMN \"\(field.sqlName)\" \"\(field.sqlType)\";"
+    }
+}
+

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/SQLStatement+TableInfoStatement.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/SQLStatement+TableInfoStatement.swift
@@ -1,0 +1,18 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Foundation
+import SQLite
+
+struct TableInfoStatement: SQLStatement {
+    let modelSchema: ModelSchema
+
+    var stringValue: String {
+        return "PRAGMA table_info(\"\(modelSchema.name)\");"
+    }
+}

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -117,8 +117,12 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
         let delegate = SQLiteMutationSyncMetadataMigrationDelegate(
             storageAdapter: self,
             modelSchemas: modelSchemas)
-        let modelMigration = MutationSyncMetadataMigration(delegate: delegate)
-        let modelMigrations = ModelMigrations(modelMigrations: [modelMigration])
+        let mutationSyncMetadataMigration = MutationSyncMetadataMigration(delegate: delegate)
+        
+        let modelSyncMetadataMigration = ModelSyncMetadataMigration(storageAdapter: self)
+        
+        let modelMigrations = ModelMigrations(modelMigrations: [mutationSyncMetadataMigration,
+                                                                modelSyncMetadataMigration])
         do {
             try modelMigrations.apply()
         } catch {

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/QueryPredicateTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/QueryPredicateTests.swift
@@ -13,6 +13,17 @@ import XCTest
 
 class QueryPredicateTests: XCTestCase {
 
+    private lazy var _encoder: JSONEncoder = {
+        var encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+    
+    var encoder: JSONEncoder {
+        _encoder
+    }
+    
     /// it should create a simple `QueryPredicateOperation`
     func testSingleQueryPredicateOperation() {
         let post = Post.keys
@@ -36,6 +47,10 @@ class QueryPredicateTests: XCTestCase {
         )
 
         XCTAssertEqual(predicate, expected)
+        
+        let predicateString = String(data: try! encoder.encode(predicate), encoding: .utf8)!
+        let expectedString = String(data: try! encoder.encode(expected), encoding: .utf8)!
+        XCTAssert(predicateString == expectedString)
     }
 
     /// it should create a valid `QueryPredicateOperation` with nested predicates
@@ -68,6 +83,10 @@ class QueryPredicateTests: XCTestCase {
             ]
         )
         XCTAssert(predicate == expected)
+        
+        let predicateString = String(data: try! encoder.encode(predicate), encoding: .utf8)!
+        let expectedString = String(data: try! encoder.encode(expected), encoding: .utf8)!
+        XCTAssert(predicateString == expectedString)
     }
 
     /// it should verify that predicates created using functions match their operators
@@ -144,6 +163,9 @@ class QueryPredicateTests: XCTestCase {
             && !(post.updatedAt == nil)
 
         XCTAssertEqual(funcationPredicate, operatorPredicate)
+        
+        let funcationPredicateString = String(data: try! encoder.encode(funcationPredicate), encoding: .utf8)!
+        let operatorPredicateString = String(data: try! encoder.encode(operatorPredicate), encoding: .utf8)!
+        XCTAssert(funcationPredicateString == operatorPredicateString)
     }
-
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Migration/ModelSyncMutationMigrationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Migration/ModelSyncMutationMigrationTests.swift
@@ -1,0 +1,101 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import SQLite
+
+@testable import Amplify
+@testable import AWSPluginsCore
+@testable import AmplifyTestCommon
+@testable import AWSDataStorePlugin
+
+final class ModelSyncMetadataMigrationTests: XCTestCase {
+
+    var connection: Connection!
+    var storageEngine: StorageEngine!
+    var storageAdapter: SQLiteStorageEngineAdapter!
+    var dataStorePlugin: AWSDataStorePlugin!
+    
+    override func setUp() async throws {
+        await Amplify.reset()
+        
+        do {
+            connection = try Connection(.inMemory)
+            storageAdapter = try SQLiteStorageEngineAdapter(connection: connection)
+        } catch {
+            XCTFail(String(describing: error))
+            return
+        }
+    }
+    
+    /// Use the latest schema and create the table with it.
+    /// The column should be found and no upgrade should occur.
+    func testPerformModelMetadataSyncPredicateUpgrade_ColumnExists() throws {
+        try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
+        guard let field = ModelSyncMetadata.schema.field(
+            withName: ModelSyncMetadata.keys.syncPredicate.stringValue) else {
+            XCTFail("Could not find corresponding ModelField from ModelSyncMetadata for syncPredicate")
+            return
+        }
+        let modelSyncMetadataMigration = ModelSyncMetadataMigration(storageAdapter: storageAdapter)
+        
+        let exists = try modelSyncMetadataMigration.columnExists(modelSchema: ModelSyncMetadata.schema, field: field)
+        XCTAssertTrue(exists)
+        
+        do {
+            let result = try modelSyncMetadataMigration.performModelMetadataSyncPredicateUpgrade()
+            XCTAssertFalse(result)
+        } catch {
+            XCTFail("Failed to perform upgrade \(error)")
+        }
+    }
+    
+    /// Create a local copy of the previous ModelSyncMetadata, without sync predicate
+    /// Create the table with the previous schema, and perform the upgrade.
+    /// The upgrade should have occurred successfully.
+    func testPerformModelMetadataSyncPredicateUpgrade_ColumnDoesNotExist() throws {
+        struct ModelSyncMetadata: Model {
+            public let id: String
+            public var lastSync: Int?
+            
+            public init(id: String,
+                        lastSync: Int?) {
+                self.id = id
+                self.lastSync = lastSync
+            }
+            public enum CodingKeys: String, ModelKey {
+                case id
+                case lastSync
+            }
+            public static let keys = CodingKeys.self
+            public static let schema = defineSchema { definition in
+                definition.attributes(.isSystem)
+                definition.fields(
+                    .id(),
+                    .field(keys.lastSync, is: .optional, ofType: .int)
+                )
+            }
+        }
+
+        try storageAdapter.setUp(modelSchemas: [ModelSyncMetadata.schema])
+        guard let field = AWSPluginsCore.ModelSyncMetadata.schema.field(
+            withName: AWSPluginsCore.ModelSyncMetadata.keys.syncPredicate.stringValue) else {
+            XCTFail("Could not find corresponding ModelField from ModelSyncMetadata for syncPredicate")
+            return
+        }
+        let modelSyncMetadataMigration = ModelSyncMetadataMigration(storageAdapter: storageAdapter)
+        let exists = try modelSyncMetadataMigration.columnExists(modelSchema: AWSPluginsCore.ModelSyncMetadata.schema, field: field)
+        XCTAssertFalse(exists)
+        
+        do {
+            let result = try modelSyncMetadataMigration.performModelMetadataSyncPredicateUpgrade()
+            XCTAssertTrue(result)
+        } catch {
+            XCTFail("Failed to perform upgrade \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/3383

## Description
<!-- Why is this change required? What problem does it solve? -->
Perform a full sync when the sync expression for the model changes. To do this, we have to persist and retrieve it from the sync metadata table for comparison with the incoming sync predicate.

The sync expression can be made up of mulitple predicates, each correponding to a specific model. InitialSyncOperation extracts out the first sync predicate from the sync expression for the corresponding model. This `QueryPredicate` is then used to compare with the existing persisted sync predicate from the last sync run, stored in the ModelSyncMetadata table.

We extend the ModelSyncMetadata table to add a new column, make QueryPredicate Encodable so we can encode the sync predicate and store it as a String. The encoder has the output formatting set to `.sortedKeys` to make sure the same string is generated every time. We do a string comparision of the incoming sync predicate with the persisted one to see if it was changed.

We do a full sync on these scenarios:
- no previous sync predicate and now there is a sync predicate
- there is a previous sync predicate and no current sync predicate
- both exist but they do not match

When there are matching sync predicates or no previous and current sync predicates, then the sync type falls back to the previous logic to determine full or delta (based on the sync interval).

### Existing app upgrade scenario

Extending the ModelSyncMetadata table means that existing apps that have already created the table will not recreate it for the new column. The most optimal way, without deleting the local data, is to add a new column if we can detect the column doesn't exist. This is in the ModelSyncMetadataMigration logic.


### Verification

```
Detected ModelSyncMetadata table exists without syncPredicate column.
ALTER TABLE "ModelSyncMetadata" ADD COLUMN "syncPredicate" "text";
ModelSyncMetadata table altered to add syncPredicate column.
```

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass https://github.com/aws-amplify/amplify-swift/actions/runs/7062531087
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~~If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
