### PR TITLE
[DRAFT] feat(datastore): Add ConnectivityMonitor to RemoteSyncEngine

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Network/ConnectivityMonitor.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Network/ConnectivityMonitor.swift
@@ -1,0 +1,93 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Network
+
+typealias ConnectivityUpdates = (ConnectivityPath) -> Void
+
+protocol AnyConnectivityMonitor {
+    func start(connectivityUpdatesQueue: DispatchQueue, onConnectivityUpdates: @escaping ConnectivityUpdates)
+    func cancel()
+}
+
+class ConnectivityMonitor {
+
+    private let connectivityUpdatesQueue = DispatchQueue(
+        label: "com.amazonaws.ConnectivityMonitor.connectivityUpdatesQueue",
+        qos: .background
+    )
+    private var monitor: AnyConnectivityMonitor?
+
+    init(monitor: AnyConnectivityMonitor? = nil) {
+        self.monitor = monitor
+    }
+
+    func start(onUpdates: @escaping ConnectivityUpdates) {
+        if let monitor = monitor {
+            monitor.start(
+                connectivityUpdatesQueue: connectivityUpdatesQueue,
+                onConnectivityUpdates: onUpdates
+            )
+        } else if #available(iOS 12.0, *) {
+            let monitor = NetworkMonitor()
+            self.monitor = monitor
+            monitor.start(
+                connectivityUpdatesQueue: connectivityUpdatesQueue,
+                onConnectivityUpdates: onUpdates
+            )
+        }
+    }
+
+    func cancel() {
+        guard let monitor = monitor else {
+            return
+        }
+        monitor.cancel()
+    }
+
+    deinit {
+        cancel()
+    }
+}
+
+@available(iOS 12.0, macOS 10.14, tvOS 12.0, watchOS 6.0, *)
+class NetworkMonitor: AnyConnectivityMonitor {
+    private var monitor: NWPathMonitor?
+    private var onConnectivityUpdates: ConnectivityUpdates?
+    private var connectivityUpdatesQueue: DispatchQueue?
+    private let queue = DispatchQueue(label: "com.amazonaws.NetworkMonitor.queue", qos: .background)
+
+    func start(connectivityUpdatesQueue: DispatchQueue, onConnectivityUpdates: @escaping ConnectivityUpdates) {
+        self.connectivityUpdatesQueue = connectivityUpdatesQueue
+        self.onConnectivityUpdates = onConnectivityUpdates
+        // A new instance is required each time a monitor is started
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = didUpdate(path:)
+        monitor.start(queue: queue)
+        self.monitor = monitor
+    }
+
+    func cancel() {
+        guard let monitor = monitor else { return }
+        defer {
+            self.monitor = nil
+        }
+        monitor.cancel()
+    }
+
+    func didUpdate(path: NWPath) {
+        guard let onConnectivityUpdates = onConnectivityUpdates,
+              let connectivityUpdatesQueue = connectivityUpdatesQueue else {
+            return
+        }
+        let connectivityPath = ConnectivityPath(path: path)
+        connectivityUpdatesQueue.async {
+            onConnectivityUpdates(connectivityPath)
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Network/ConnectivityPath.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Network/ConnectivityPath.swift
@@ -1,0 +1,125 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Network
+
+struct ConnectivityPath {
+    let status: ConnectivityStatus
+    let availableInterfaces: [ConnectivityInterface]
+    let isExpensive: Bool
+    let supportsDNS: Bool
+    let supportsIPv4: Bool
+    let supportsIPv6: Bool
+
+    init(
+        status: ConnectivityStatus = .unsatisfied,
+        availableInterfaces: [ConnectivityInterface] = [],
+        isExpensive: Bool = false,
+        supportsDNS: Bool = false,
+        supportsIPv4: Bool = false,
+        supportsIPv6: Bool = false
+    ) {
+        self.status = status
+        self.availableInterfaces = availableInterfaces
+        self.isExpensive = isExpensive
+        self.supportsDNS = supportsDNS
+        self.supportsIPv4 = supportsIPv4
+        self.supportsIPv6 = supportsIPv6
+    }
+}
+
+extension ConnectivityPath: CustomStringConvertible {
+    var description: String {
+        [
+            "\(status): \(availableInterfaces.description)",
+            "Expensive = \(isExpensive ? "YES" : "NO")",
+            "DNS = \(supportsDNS ? "YES" : "NO")",
+            "IPv4 = \(supportsIPv4 ? "YES" : "NO")",
+            "IPv6 = \(supportsIPv6 ? "YES" : "NO")"
+        ].joined(separator: "; ")
+    }
+}
+
+extension ConnectivityPath {
+    @available(iOS 12.0, *)
+    init(path: NWPath) {
+        self.status = ConnectivityStatus(status: path.status)
+        self.availableInterfaces = path.availableInterfaces.map { ConnectivityInterface(interface: $0) }
+        self.isExpensive = path.isExpensive
+        self.supportsDNS = path.supportsDNS
+        self.supportsIPv4 = path.supportsIPv4
+        self.supportsIPv6 = path.supportsIPv6
+    }
+}
+
+enum ConnectivityInterfaceType: String {
+    case other
+    case wifi
+    case cellular
+    case wiredEthernet
+    case loopback
+}
+
+extension ConnectivityInterfaceType {
+    @available(iOS 12.0, *)
+    init(interfaceType: NWInterface.InterfaceType) {
+        switch interfaceType {
+        case .other:
+            self = .other
+        case .wifi:
+            self = .wifi
+        case .cellular:
+            self = .cellular
+        case .wiredEthernet:
+            self = .wiredEthernet
+        case .loopback:
+            self = .loopback
+        @unknown default:
+            self = .other
+        }
+    }
+}
+
+struct ConnectivityInterface {
+    public let name: String
+    public let type: ConnectivityInterfaceType
+
+    public init(name: String, type: ConnectivityInterfaceType) {
+        self.name = name
+        self.type = type
+    }
+}
+extension ConnectivityInterface {
+    @available(iOS 12.0, *)
+    init(interface: NWInterface) {
+        self.name = interface.name
+        self.type = ConnectivityInterfaceType(interfaceType: interface.type)
+    }
+}
+
+enum ConnectivityStatus: String {
+    case satisfied
+    case unsatisfied
+    case requiresConnection
+}
+
+extension ConnectivityStatus {
+    @available(iOS 12.0, *)
+    init(status: NWPath.Status) {
+        switch status {
+        case .satisfied:
+            self = .satisfied
+        case .unsatisfied:
+            self = .unsatisfied
+        case .requiresConnection:
+            self = .requiresConnection
+        @unknown default:
+            self = .unsatisfied
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
@@ -61,6 +61,10 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
     var currentAttemptNumber: Int
 
     var finishedCompletionBlock: DataStoreCallback<Void>?
+    
+    /// Monitor for connectivity updates
+    let connectivityMonitor: ConnectivityMonitor
+    var connectivityStatus: AtomicValue<ConnectivityStatus>
 
     /// Initializes the CloudSyncEngine with the specified storageAdapter as the provider for persistence of
     /// MutationEvents, sync metadata, and conflict resolution metadata. Immediately initializes the incoming mutation
@@ -72,7 +76,9 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
                      reconciliationQueueFactory: IncomingEventReconciliationQueueFactory? = nil,
                      stateMachine: StateMachine<State, Action>? = nil,
                      networkReachabilityPublisher: AnyPublisher<ReachabilityUpdate, Never>? = nil,
-                     requestRetryablePolicy: RequestRetryablePolicy? = nil) throws {
+                     requestRetryablePolicy: RequestRetryablePolicy? = nil,
+                     connectivityMonitor: ConnectivityMonitor = ConnectivityMonitor(),
+                     connectivityStatus: AtomicValue<ConnectivityStatus> = .init(initialValue: .satisfied)) throws {
 
         let mutationDatabaseAdapter = try AWSMutationDatabaseAdapter(storageAdapter: storageAdapter)
         let awsMutationEventPublisher = AWSMutationEventPublisher(eventSource: mutationDatabaseAdapter)
@@ -107,7 +113,9 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
                   reconciliationQueueFactory: reconciliationQueueFactory,
                   stateMachine: stateMachine,
                   networkReachabilityPublisher: networkReachabilityPublisher,
-                  requestRetryablePolicy: requestRetryablePolicy)
+                  requestRetryablePolicy: requestRetryablePolicy,
+                  connectivityMonitor: connectivityMonitor,
+                  connectivityStatus: connectivityStatus)
     }
 
     init(storageAdapter: StorageEngineAdapter,
@@ -120,7 +128,9 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
          reconciliationQueueFactory: @escaping IncomingEventReconciliationQueueFactory,
          stateMachine: StateMachine<State, Action>,
          networkReachabilityPublisher: AnyPublisher<ReachabilityUpdate, Never>?,
-         requestRetryablePolicy: RequestRetryablePolicy) {
+         requestRetryablePolicy: RequestRetryablePolicy,
+         connectivityMonitor: ConnectivityMonitor,
+         connectivityStatus: AtomicValue<ConnectivityStatus>) {
         self.storageAdapter = storageAdapter
         self.dataStoreConfiguration = dataStoreConfiguration
         self.authModeStrategy = authModeStrategy
@@ -132,7 +142,8 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         self.remoteSyncTopicPublisher = PassthroughSubject<RemoteSyncEngineEvent, DataStoreError>()
         self.networkReachabilityPublisher = networkReachabilityPublisher
         self.requestRetryablePolicy = requestRetryablePolicy
-
+        self.connectivityMonitor = connectivityMonitor
+        self.connectivityStatus = connectivityStatus
         self.currentAttemptNumber = 1
 
         self.stateMachine = stateMachine
@@ -149,6 +160,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         }
 
         self.authModeStrategy.authDelegate = self
+        connectivityMonitor.start(onUpdates: handleConnectivityUpdates(connectivity:))
     }
 
     // swiftlint:disable cyclomatic_complexity
@@ -400,7 +412,13 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
                                                    data: networkStatusEvent)
         Amplify.Hub.dispatch(to: .dataStore, payload: networkStatusEventPayload)
     }
-
+    
+    /// Handle updates from the ConnectivityMonitor
+    func handleConnectivityUpdates(connectivity: ConnectivityPath) {
+        log.verbose("Connectivity status: \(connectivity.status)")
+        self.connectivityStatus.set(connectivity.status)
+    }
+    
     /// Must be invoked from workQueue (as during a `respond` call)
     func cleanup() {
         reconciliationQueue?.cancel()


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
This PR starts will pulling in the ConnectivityMonitor, see https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/58 for a reference implementation. The code copied over is owned by the DataStore plugin and used internally by the RemoteSyncEngine. There is also another NetworkMonitor usage in analytics here https://github.com/aws-amplify/amplify-swift/blob/main/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Utils/NetworkMonitor.swift for reference.

The initial commit only adds the classes and instantiates a connectivity monitor, and does not build much logic around it. 

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
