### PR TITLE
fix(datastore): mutation event got ignored while executing parallel saving

### DIFF
--- a/Amplify/Core/Support/Optional+Extension.swift
+++ b/Amplify/Core/Support/Optional+Extension.swift
@@ -1,0 +1,26 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+		
+
+import Foundation
+
+extension Optional {
+    ///
+    /// Performing side effect function when data is exist
+    /// - parameters:
+    ///     - f: a function may perform side effects on wrapped data
+    /// - returns:
+    /// The original Optional object without touched.
+    @discardableResult
+    @_spi(OptionalExtension)
+    public func peek(_ f: @escaping (Wrapped) -> Void) -> Optional<Wrapped> {
+        if case .some(let wrapped) = self {
+            f(wrapped)
+        }
+        return self
+    }
+}

--- a/Amplify/Core/Support/Optional+Extension.swift
+++ b/Amplify/Core/Support/Optional+Extension.swift
@@ -14,7 +14,7 @@ extension Optional {
     /// - parameters:
     ///     - f: a function may perform side effects on wrapped data
     /// - returns:
-    /// The original Optional object without touched.
+    /// The original Optional object without changed
     @discardableResult
     @_spi(OptionalExtension)
     public func peek(_ f: @escaping (Wrapped) -> Void) -> Optional<Wrapped> {

--- a/Amplify/Core/Support/Optional+Extension.swift
+++ b/Amplify/Core/Support/Optional+Extension.swift
@@ -12,15 +12,11 @@ extension Optional {
     ///
     /// Performing side effect function when data is exist
     /// - parameters:
-    ///     - f: a function may perform side effects on wrapped data
-    /// - returns:
-    /// The original Optional object without changed
-    @discardableResult
+    ///     - then: a closure that takes wrapped data as a parameter
     @_spi(OptionalExtension)
-    public func peek(_ f: @escaping (Wrapped) -> Void) -> Optional<Wrapped> {
+    public func ifSome(_ then: (Wrapped) throws -> Void) rethrows {
         if case .some(let wrapped) = self {
-            f(wrapped)
+            try then(wrapped)
         }
-        return self
     }
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
@@ -215,24 +215,28 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
 
     /// Saves the deconflicted mutationEvent, invokes `nextEventPromise` if it exists, and the save was successful,
     /// and finally invokes the completion promise from the future of the original invocation of `submit`
-    func save(mutationEvent: MutationEvent,
-              storageAdapter: StorageEngineAdapter,
-              completionPromise: @escaping Future<MutationEvent, DataStoreError>.Promise) {
-
+    func save(
+        mutationEvent: MutationEvent,
+        storageAdapter: StorageEngineAdapter,
+        completionPromise: @escaping Future<MutationEvent, DataStoreError>.Promise
+    ) {
         log.verbose("\(#function) mutationEvent: \(mutationEvent)")
+        let nextEventPromise = self.nextEventPromise.getAndSet(nil)
         var eventToPersist = mutationEvent
-        if nextEventPromise.get() != nil {
+        if nextEventPromise != nil {
             eventToPersist.inProcess = true
         }
+
         storageAdapter.save(eventToPersist, condition: nil, eagerLoad: true) { result in
             switch result {
             case .failure(let dataStoreError):
                 self.log.verbose("\(#function): Error saving mutation event: \(dataStoreError)")
+                nextEventPromise.map(self.nextEventPromise.set)
             case .success(let savedMutationEvent):
                 self.log.verbose("\(#function): saved \(savedMutationEvent)")
-                if let nextEventPromise = self.nextEventPromise.getAndSet(nil) {
+                nextEventPromise.map {
                     self.log.verbose("\(#function): invoking nextEventPromise with \(savedMutationEvent)")
-                    nextEventPromise(.success(savedMutationEvent))
+                    $0(.success(savedMutationEvent))
                 }
             }
             self.log.verbose("\(#function): invoking completionPromise with \(result)")

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
@@ -234,10 +234,10 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
                 // restore the `nextEventPromise` value when failed to save mutation event
                 // as nextEventPromise is expecting to hanlde error of querying unprocessed mutaiton events
                 // not the failure of saving mutaiton event operation
-                nextEventPromise.peek(self.nextEventPromise.set(_:))
+                nextEventPromise.ifSome(self.nextEventPromise.set(_:))
             case .success(let savedMutationEvent):
                 self.log.verbose("\(#function): saved \(savedMutationEvent)")
-                nextEventPromise.peek {
+                nextEventPromise.ifSome {
                     self.log.verbose("\(#function): invoking nextEventPromise with \(savedMutationEvent)")
                     $0(.success(savedMutationEvent))
                 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "c54c028cfc3ee70fde8c077547a1a1f6ef1137d9",
-        "version" : "0.6.0"
+        "revision" : "30649be4b9d0788f987ae851c48d48ac6d00f2c2",
+        "version" : "0.6.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/smithy-swift.git",
       "state" : {
-        "revision" : "f59ed07c29d4e03f91ea8324edf7a2486bd86a9c",
-        "version" : "0.6.0"
+        "revision" : "3e9e420f69c28dee260c03b19c3e93b392128d42",
+        "version" : "0.6.1"
       }
     },
     {

--- a/AmplifyTests/CoreTests/Optional+ExtentionTests.swift
+++ b/AmplifyTests/CoreTests/Optional+ExtentionTests.swift
@@ -1,0 +1,45 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+		
+@_spi(OptionalExtension) import Amplify
+import XCTest
+
+class OptionalExtensionTests: XCTestCase {
+
+    /// - Given:
+    ///     Optional of integer with none
+    /// - When:
+    ///     apply a function to increase a captured local integer variable with value 0
+    /// - Then:
+    ///     - the peek function on optional should not be applied
+    ///     - local integer variable value stays 0
+    ///     - the optional stay unchanged
+    func testPeek_withNone_doNothing() {
+        var sideEffect = 0
+        let optional: Int? = .none
+        let afterPeek = optional.peek { _ in sideEffect += 1 }
+        XCTAssertEqual(0, sideEffect)
+        XCTAssertEqual(afterPeek, optional)
+    }
+
+    /// - Given:
+    ///     Optional of integer with value 10
+    /// - When:
+    ///     apply a function to increase a captured local integer variable with value 0
+    /// - Then:
+    ///     - the peek function on optioanl should be applied
+    ///     - capture local integer value equals 1
+    ///     - the optional stay unchanged
+    func testPeek_withValue_applyFunction() {
+        var sideEffect = 0
+        let optional: Int? = .some(10)
+        let afterPeek = optional.peek { _ in sideEffect += 1 }
+        XCTAssertEqual(1, sideEffect)
+        XCTAssertEqual(afterPeek, optional)
+    }
+
+}

--- a/AmplifyTests/CoreTests/Optional+ExtentionTests.swift
+++ b/AmplifyTests/CoreTests/Optional+ExtentionTests.swift
@@ -15,15 +15,13 @@ class OptionalExtensionTests: XCTestCase {
     /// - When:
     ///     apply a function to increase a captured local integer variable with value 0
     /// - Then:
-    ///     - the peek function on optional should not be applied
+    ///     - the ifSome function on optional should not be applied
     ///     - local integer variable value stays 0
-    ///     - the optional stay unchanged
-    func testPeek_withNone_doNothing() {
+    func testIfSome_withNone_doNothing() {
         var sideEffect = 0
         let optional: Int? = .none
-        let afterPeek = optional.peek { _ in sideEffect += 1 }
+        optional.ifSome { _ in sideEffect += 1 }
         XCTAssertEqual(0, sideEffect)
-        XCTAssertEqual(afterPeek, optional)
     }
 
     /// - Given:
@@ -31,15 +29,34 @@ class OptionalExtensionTests: XCTestCase {
     /// - When:
     ///     apply a function to increase a captured local integer variable with value 0
     /// - Then:
-    ///     - the peek function on optioanl should be applied
+    ///     - the ifSome function on optioanl should be applied
     ///     - capture local integer value equals 1
-    ///     - the optional stay unchanged
-    func testPeek_withValue_applyFunction() {
+    func testIfSome_withValue_applyFunction() {
         var sideEffect = 0
         let optional: Int? = .some(10)
-        let afterPeek = optional.peek { _ in sideEffect += 1 }
+        optional.ifSome { _ in sideEffect += 1 }
         XCTAssertEqual(1, sideEffect)
-        XCTAssertEqual(afterPeek, optional)
     }
 
+    /// - Given:
+    ///     Optional of integer with value 10
+    /// - When:
+    ///     apply a function that throw error
+    /// - Then:
+    ///     - the ifSome function on optioanl should be applied
+    ///     - the error is rethrowed
+    func testIfSome_withValue_applyFunctionRethrowError() {
+        let optional: Int? = .some(10)
+        let expectedError = TestRuntimeError()
+        XCTAssertThrowsError(try optional.ifSome {_ in
+            throw expectedError
+        }) { error in
+            XCTAssertEqual(expectedError, error as? TestRuntimeError)
+        }
+    }
+
+}
+
+fileprivate struct TestRuntimeError: Error, Equatable {
+    let id = UUID()
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/2059

## Related PR

v1 fix - https://github.com/aws-amplify/amplify-swift/pull/2782

## Description
<!-- Why is this change required? What problem does it solve? -->

In the `MutationEvent` [saving](https://github.com/aws-amplify/amplify-swift/blob/ac2b6a0/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter%2BMutationEventIngester.swift#L218-L242) implementation, we check `nextEventPromise` at the beginning to detect wether put the `MutationEvent` to `inProgress` status. After it's written to database, we change the `nextEventPromise` to `nil`. The operation between `non-nil` check at the beginning and set value `nil` for `nextEventPromise` doesn't lock the access of `nextEventPromise`. It may took over hundred milliseconds for writing to the database. In this duration, if there is any `MutationEvent` get saved, it will have `inProcess = true`. But only one of them will be handled back to the `MutationEventPublisher`.

This change simply `getAndSet` the `nextEventPromise` to `nil` to ensure only one thread has the access to stored `nextEventPromise` in Atomic container. Thus other parallel calls will have the MutationEvent with `inProgress = false`.

## General Checklist
<!-- Check or cross out if not relevant -->

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
