### PR TITLE
test(datastore): fix ObserveQuery with predicate test case

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
@@ -32,16 +32,23 @@ class SyncEngineIntegrationTestBase: DataStoreTestBase {
     // swiftlint:enable force_try
     // swiftlint:enable force_cast
 
-    func setUp(withModels models: AmplifyModelRegistration, logLevel: LogLevel = .error) async {
-
+    func setUp(
+        withModels models: AmplifyModelRegistration,
+        logLevel: LogLevel = .error,
+        dataStoreConfiguration: DataStoreConfiguration? = nil
+    ) async {
         continueAfterFailure = false
 
         Amplify.Logging.logLevel = logLevel
 
         do {
             try Amplify.add(plugin: AWSAPIPlugin(modelRegistration: models))
-            try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models,
-                                                       configuration: .custom(syncMaxRecords: 100)))
+            try Amplify.add(
+                plugin: AWSDataStorePlugin(
+                    modelRegistration: models,
+                    configuration: dataStoreConfiguration ?? .custom(syncMaxRecords: 100)
+                )
+            )
         } catch {
             XCTFail(String(describing: error))
             return
@@ -61,9 +68,13 @@ class SyncEngineIntegrationTestBase: DataStoreTestBase {
         try await Amplify.DataStore.clear()
     }
 
-    func startAmplify() throws {
-        let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(
+    func getTestConfiguration() throws -> AmplifyConfiguration {
+        try TestConfigHelper.retrieveAmplifyConfiguration(
             forResource: Self.amplifyConfigurationFile)
+    }
+
+    func startAmplify() throws {
+        let amplifyConfig = try getTestConfiguration()
         do {
             try Amplify.configure(amplifyConfig)
         } catch {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "c54c028cfc3ee70fde8c077547a1a1f6ef1137d9",
-        "version" : "0.6.0"
+        "revision" : "30649be4b9d0788f987ae851c48d48ac6d00f2c2",
+        "version" : "0.6.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/smithy-swift.git",
       "state" : {
-        "revision" : "f59ed07c29d4e03f91ea8324edf7a2486bd86a9c",
-        "version" : "0.6.0"
+        "revision" : "3e9e420f69c28dee260c03b19c3e93b392128d42",
+        "version" : "0.6.1"
       }
     },
     {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
As described in [doc](https://docs.amplify.aws/lib/datastore/sync/q/platform/ios/#selectively-syncing-a-subset-of-your-data), the datastore plugin is syncing the entire contents from cloud to local up to the max number of records set in configuration(*default is 1000*). 
For the case of `testInitialSyncWithPredicate`, it clears the whole database and trying to sync back to the latest created records. It will be failed if the cloud data set has more records than the max number of records that could be synced to local.
This fix setups the DataStore plugin with sync predication to only sync recent records.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [X] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
