### PR TITLE
test(api): fix flaky integration test cases

### DIFF
--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "c54c028cfc3ee70fde8c077547a1a1f6ef1137d9",
-        "version" : "0.6.0"
+        "revision" : "30649be4b9d0788f987ae851c48d48ac6d00f2c2",
+        "version" : "0.6.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/smithy-swift.git",
       "state" : {
-        "revision" : "f59ed07c29d4e03f91ea8324edf7a2486bd86a9c",
-        "version" : "0.6.0"
+        "revision" : "3e9e420f69c28dee260c03b19c3e93b392128d42",
+        "version" : "0.6.1"
       }
     },
     {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario2Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario2Tests.swift
@@ -49,6 +49,7 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
 
     override func tearDown() async throws {
         await Amplify.reset()
+        try await Task.sleep(seconds: 1)
     }
 
     // Create Project2 in different ways, then retrieve it

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+List.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+List.swift
@@ -159,14 +159,18 @@ extension GraphQLConnectionScenario3Tests {
             XCTFail("Could not create comment")
             return
         }
+
         let predicate = Comment3.keys.postID.eq(post.id)
-        let result = try await Amplify.API.query(request: .list(Comment3.self, where: predicate))
-        switch result {
-        case .success(let comments):
-            XCTAssertEqual(comments.count, 1)
-        case .failure(let response):
-            XCTFail("Failed with: \(response)")
+        guard case .success(var comments) = try await Amplify.API.query(request: .list(Comment3.self, where: predicate))
+        else {
+            XCTFail("Failed to retrieve comments")
+            return
         }
+
+        while comments.count == 0 && comments.hasNextPage() {
+            comments = try await comments.getNextPage()
+        }
+        XCTAssertEqual(comments.count, 1)
     }
 
     /// Test paginated list query returns a List containing pagination functionality. This test also aggregates page

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests.swift
@@ -49,6 +49,7 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
 
     override func tearDown() async throws {
         await Amplify.reset()
+        try await Task.sleep(seconds: 1)
     }
 
     func testQuerySinglePost() async throws {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/GraphQLLazyLoadBaseTest.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/GraphQLLazyLoadBaseTest.swift
@@ -21,6 +21,7 @@ class GraphQLLazyLoadBaseTest: XCTestCase {
     
     override func tearDown() async throws {
         await Amplify.reset()
+        try await Task.sleep(seconds: 1)
     }
     
     func setupConfig() {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
API category flaky test case `testListCommentsByPostID`.

## Description
<!-- Why is this change required? What problem does it solve? -->
If the backend storage is DynamoDB and no GSI on the query predication fields, the `query` GraphQL list operation may return items with empty list of items and an non-null next token.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [X] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
