### PR TITLE
feat(datastore): add notContains query operator

### DIFF
--- a/Amplify/Categories/DataStore/Query/ModelKey.swift
+++ b/Amplify/Categories/DataStore/Query/ModelKey.swift
@@ -56,6 +56,11 @@ extension CodingKey where Self: ModelKey {
         return key.contains(value)
     }
 
+    // MARK: - not contains
+    public func notContains(_ value: String) -> QueryPredicateOperation {
+        return field(stringValue).notContains(value)
+    }
+
     // MARK: - eq
 
     public func eq(_ value: Persistable?) -> QueryPredicateOperation {

--- a/Amplify/Categories/DataStore/Query/QueryField.swift
+++ b/Amplify/Categories/DataStore/Query/QueryField.swift
@@ -34,6 +34,7 @@ public protocol QueryFieldOperation {
     func beginsWith(_ value: String) -> QueryPredicateOperation
     func between(start: Persistable, end: Persistable) -> QueryPredicateOperation
     func contains(_ value: String) -> QueryPredicateOperation
+    func notContains(_ value: String) -> QueryPredicateOperation
     func eq(_ value: Persistable?) -> QueryPredicateOperation
     func eq(_ value: EnumPersistable) -> QueryPredicateOperation
     func ge(_ value: Persistable) -> QueryPredicateOperation
@@ -82,6 +83,11 @@ public struct QueryField: QueryFieldOperation {
 
     public static func ~= (key: Self, value: String) -> QueryPredicateOperation {
         return key.contains(value)
+    }
+
+    // MARK: - not contains
+    public func notContains(_ value: String) -> QueryPredicateOperation {
+        return QueryPredicateOperation(field: name, operator: .notContains(value))
     }
 
     // MARK: - eq

--- a/Amplify/Categories/DataStore/Query/QueryOperator.swift
+++ b/Amplify/Categories/DataStore/Query/QueryOperator.swift
@@ -15,6 +15,7 @@ public enum QueryOperator {
     case greaterOrEqual(_ value: Persistable)
     case greaterThan(_ value: Persistable)
     case contains(_ value: String)
+    case notContains(_ value: String)
     case between(start: Persistable, end: Persistable)
     case beginsWith(_ value: String)
 
@@ -37,6 +38,10 @@ public enum QueryOperator {
                 return targetString.contains(predicateString)
             }
             return false
+        case .notContains(let predicateString):
+            if let targetString = target as? String {
+                return !targetString.contains(predicateString)
+            }
         case .between(let start, let end):
             return PersistableHelper.isBetween(start, end, target)
         case .beginsWith(let predicateValue):

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
@@ -185,6 +185,8 @@ extension QueryOperator {
             return "between"
         case .beginsWith:
             return "beginsWith"
+        case .notContains:
+            return "notContains"
         }
     }
 
@@ -207,6 +209,8 @@ extension QueryOperator {
         case .between(let start, let end):
             return [start.graphQLValue(), end.graphQLValue()]
         case .beginsWith(let value):
+            return value
+        case .notContains(let value):
             return value
         }
     }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/QueryPredicate+SQLite.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/QueryPredicate+SQLite.swift
@@ -29,6 +29,8 @@ extension QueryOperator {
             return "between ? and ?"
         case .beginsWith, .contains:
             return "like ?"
+        case .notContains:
+            return "not like ?"
         }
     }
 
@@ -47,6 +49,8 @@ extension QueryOperator {
             return ["%\(value)%"]
         case .beginsWith(let value):
             return ["\(value)%"]
+        case .notContains(let value):
+            return ["%\(value)%"]
         }
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
@@ -333,6 +333,10 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
         XCTAssertEqual(posts.count, 0)
     }
 
+
+    /// Given: 5 `Posts` with titles containing 0...4
+    /// When: Querying `Posts` where title`notContains("1")`
+    /// Then: 4 posts should be returned, none of which contain `"1"` in the title
     func testQueryNotContains() async throws {
         setUp(withModels: TestModelRegistration())
         _ = try await setUpLocalStore(numberOfPosts: 5)
@@ -349,10 +353,131 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
             Post.self,
             where: Post.keys.title.notContains("1")
         )
-        XCTAssertEqual(postsNotContaining1InTitle.count, 4)
+        XCTAssertEqual(
+            posts.count - postsContaining1InTitle.count,
+            postsNotContaining1InTitle.count
+        )
+
+        XCTAssertTrue(
+            postsNotContaining1InTitle.filter(
+                { $0.title.contains("1") }
+            ).isEmpty
+        )
     }
 
 
+    /// Given: 50 `Posts` with titles containing 0...49
+    /// When: Querying posts with multiple `notContains(...)` chained with `&&`
+    /// e.g. `notContains(a) && notContains(b)`
+    /// Then: Posts returned should not contain either `a` or `b`
+    func testQueryMultipleNotContains() async throws {
+        setUp(withModels: TestModelRegistration())
+        _ = try await setUpLocalStore(numberOfPosts: 50)
+        let posts = try await Amplify.DataStore.query(Post.self)
+        XCTAssertEqual(posts.count, 50)
+
+        let titleValueOne = "25", titleValueTwo = "42"
+
+        let postsContaining25or42InTitle = try await Amplify.DataStore.query(
+            Post.self,
+            where: Post.keys.title.contains(titleValueOne)
+            || Post.keys.title.contains(titleValueTwo)
+        )
+        XCTAssertEqual(postsContaining25or42InTitle.count, 2)
+
+        let postsNotContaining25or42InTitle = try await Amplify.DataStore.query(
+            Post.self,
+            where: Post.keys.title.notContains(titleValueOne)
+            && Post.keys.title.notContains(titleValueTwo)
+        )
+
+        XCTAssertEqual(
+            posts.count - postsContaining25or42InTitle.count,
+            postsNotContaining25or42InTitle.count
+        )
+
+        XCTAssertTrue(
+            postsNotContaining25or42InTitle.filter(
+                { $0.title.contains(titleValueOne) }
+            ).isEmpty
+        )
+
+        XCTAssertTrue(
+            postsNotContaining25or42InTitle.filter(
+                { $0.title.contains(titleValueTwo) }
+            ).isEmpty
+        )
+    }
+
+    /// Given: 50 saved `Post`s
+    /// When: Querying for posts with `contains(a)` and `notContains()`
+    /// where `a` == `<char in 2 posts>` and `b` == `<status of 1 / 2 posts>`
+    /// Then: The result should contain a single `Post` that contains `a` but doesn't contain `b`
+    func testQueryNotContainsAndContains() async throws {
+        let numberOfPosts = 50
+        setUp(withModels: TestModelRegistration())
+        _ = try await setUpLocalStore(numberOfPosts: numberOfPosts)
+        let posts = try await Amplify.DataStore.query(Post.self)
+        XCTAssertEqual(posts.count, numberOfPosts)
+
+        let randomTitleNumber = String(Int.random(in: 0..<numberOfPosts))
+
+        let postWithDuplicateTitleAndDifferentStatus = Post(
+            title: "title_\(randomTitleNumber)",
+            content: "content",
+            createdAt: .now(),
+            status: .published
+        )
+
+        _ = try await Amplify.DataStore.save(postWithDuplicateTitleAndDifferentStatus)
+
+        let postsContainingRandomTitleNumber = try await Amplify.DataStore.query(
+            Post.self,
+            where: Post.keys.title.contains(randomTitleNumber)
+        )
+
+        XCTAssertEqual(postsContainingRandomTitleNumber.count, 2)
+        XCTAssertEqual(
+            postsContainingRandomTitleNumber
+                .lazy
+                .filter({ $0.status == .draft })
+                .count,
+            1
+        )
+
+        XCTAssertEqual(
+            postsContainingRandomTitleNumber
+                .lazy
+                .filter({ $0.status == .published })
+                .count,
+            1
+        )
+
+        let postsContainingRandomTitleNumberAndNotContainingDraftStatus = try await Amplify.DataStore.query(
+            Post.self,
+            where: Post.keys.title.contains(randomTitleNumber)
+            && Post.keys.status.notContains(PostStatus.published.rawValue)
+        )
+
+        XCTAssertEqual(
+            postsContainingRandomTitleNumberAndNotContainingDraftStatus.count,
+            1
+        )
+
+        XCTAssertEqual(
+            postsContainingRandomTitleNumberAndNotContainingDraftStatus[0].title,
+            "title_\(randomTitleNumber)"
+        )
+
+        XCTAssertNotEqual(
+            postsContainingRandomTitleNumberAndNotContainingDraftStatus[0].status,
+            .published
+        )
+    }
+
+    /// Given: 5 saved `Post`s
+    /// When: Deleting with `notContains(a)` where `a` is contained in only one post
+    /// Then: All but one `Post` should be deleted. The `Post` containing `a` should remain.
     func testDeleteNotContains() async throws {
         setUp(withModels: TestModelRegistration())
         _ = try await setUpLocalStore(numberOfPosts: 5)
@@ -366,6 +491,40 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
 
         let postsIncluding1InTitle = try await Amplify.DataStore.query(Post.self)
         XCTAssertEqual(postsIncluding1InTitle.count, 1)
+        XCTAssertEqual(postsIncluding1InTitle[0].title, "title_1")
+    }
+
+
+    /// Given: 3 saved `Post`s where  2 `Post` titles contain `x` and 1 of those `Post`s content field contain `y`
+    /// When: Deleting with `notContains(x) || notContains(y)`. Then querying for remaining `Post`s
+    /// Then: The query should return a single `Post` that does **not** contain `x` in the title but **does** contain `y` in the content.
+    func testDeleteJoinedOrNotContains() async throws {
+        setUp(withModels: TestModelRegistration())
+
+        func post(title: String, content: String) -> Post {
+            .init(title: title, content: content, createdAt: .now())
+        }
+
+        let post1 = post(title: "title_1", content: "a")
+        let post2 = post(title: "title_1", content: "b")
+        let post3 = post(title: "title_3", content: "c")
+
+        _ = try await Amplify.DataStore.save(post1)
+        _ = try await Amplify.DataStore.save(post2)
+        _ = try await Amplify.DataStore.save(post3)
+
+        let posts = try await Amplify.DataStore.query(Post.self)
+        XCTAssertEqual(posts.count, 3)
+
+        try await Amplify.DataStore.delete(
+            Post.self,
+            where: Post.keys.title.notContains("1")
+            || Post.keys.content.notContains("a")
+        )
+
+        let postsAfterDeletingNotContains1andNotContainsA = try await Amplify.DataStore.query(Post.self)
+        XCTAssertEqual(postsAfterDeletingNotContains1andNotContainsA.count, 1)
+        XCTAssertEqual(postsAfterDeletingNotContains1andNotContainsA[0].content, "a")
     }
 
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
@@ -333,6 +333,42 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
         XCTAssertEqual(posts.count, 0)
     }
 
+    func testQueryNotContains() async throws {
+        setUp(withModels: TestModelRegistration())
+        _ = try await setUpLocalStore(numberOfPosts: 5)
+        let posts = try await Amplify.DataStore.query(Post.self)
+        XCTAssertEqual(posts.count, 5)
+
+        let postsContaining1InTitle = try await Amplify.DataStore.query(
+            Post.self,
+            where: Post.keys.title.contains("1")
+        )
+        XCTAssertEqual(postsContaining1InTitle.count, 1)
+
+        let postsNotContaining1InTitle = try await Amplify.DataStore.query(
+            Post.self,
+            where: Post.keys.title.notContains("1")
+        )
+        XCTAssertEqual(postsNotContaining1InTitle.count, 4)
+    }
+
+
+    func testDeleteNotContains() async throws {
+        setUp(withModels: TestModelRegistration())
+        _ = try await setUpLocalStore(numberOfPosts: 5)
+        let posts = try await Amplify.DataStore.query(Post.self)
+        XCTAssertEqual(posts.count, 5)
+
+        try await Amplify.DataStore.delete(
+            Post.self,
+            where: Post.keys.title.notContains("1")
+        )
+
+        let postsIncluding1InTitle = try await Amplify.DataStore.query(Post.self)
+        XCTAssertEqual(postsIncluding1InTitle.count, 1)
+    }
+
+
     func setUpLocalStore(numberOfPosts: Int) async throws -> [Post] {
         let posts = (0..<numberOfPosts).map {
             Post(


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/1049

## Description
<!-- Why is this change required? What problem does it solve? -->
Related Android PR: https://github.com/aws-amplify/amplify-android/pull/1145

This change adds support for the `notContains` predicate for DataStore `query` and `delete` operations. This is a documented feature [[docs/swift/datastore/data-access/predicates](https://docs.amplify.aws/lib/datastore/data-access/q/platform/ios/#predicates)], however it is currently not supported in Amplify Swift. This addition reaches feature parity with regards to `notContains` with Android.

Functionally, it exposes a new static method `notContains(_ value: String) -> QueryPredicateOperation`, which is mapped to a `NOT LIKE '%value%'` operator.

Add tests cover multiple scenarios included `query` and `delete`, along with test cases for chained predicates (`&&` and `||`) for each top level API.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
