### PR TITLE
test(datastore): fix datastore integration test

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -500,7 +500,6 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     private func publishMutationEvent<M: Model>(from model: M,
                                                 modelSchema: ModelSchema,
                                                 mutationType: MutationEvent.MutationType) {
-
         let metadata = MutationSyncMetadata.keys
         let metadataId = MutationSyncMetadata.identifier(modelName: modelSchema.name,
                                                          modelId: model.identifier(schema: modelSchema).stringValue)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/AWSDataStorePluginConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/AWSDataStorePluginConfigurationTests.swift
@@ -6,10 +6,15 @@
 //
 
 import XCTest
-import Amplify
+@testable import Amplify
 import AWSDataStorePlugin
 
 class AWSDataStorePluginConfigurationTests: XCTestCase {
+
+    override func tearDown() async throws {
+        await Amplify.reset()
+        try await Task.sleep(seconds: 1)
+    }
 
     // Note this test requires the ability to write a new database in the Documents directcory, so it must be embedded
     // in a host app

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario6Tests.swift
@@ -205,7 +205,7 @@ class DataStoreConnectionScenario6Tests: SyncEngineIntegrationTestBase {
         let post2 = try await savePost(title: "title", blog: blog2)
         _ = try await saveComment(id: commentId2, post: post2, content: "content")
 
-        await waitForExpectations(timeout: 5)
+        await waitForExpectations(timeout: 10)
 
         let outboxMutationProcessed = expectation(description: "received outboxMutationProcessed")
         var processedSoFar = 0

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreConfigurationTests.swift
@@ -14,13 +14,10 @@ import AWSPluginsCore
 
 class DataStoreConfigurationTests: XCTestCase {
 
-    override func setUp() async throws {
-        await Amplify.reset()
-    }
-
     override func tearDown() async throws {
         try await Amplify.DataStore.clear()
         await Amplify.reset()
+        try await Task.sleep(seconds: 1)
     }
 
     func testConfigureWithSameSchemaDoesNotDeleteDatabase() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
@@ -33,9 +33,16 @@ class HubEventsIntegrationTestBase: XCTestCase {
     // swiftlint:enable force_try
     // swiftlint:enable force_cast
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         continueAfterFailure = false
+    }
+
+    override func tearDown() async throws {
+        storageAdapter.delete(untypedModelType: ModelSyncMetadata.self, withIdentifier: ModelIdentifier<ModelSyncMetadata, ModelIdentifierFormat.Default>.makeDefault(id:"Post")) { _ in }
+        storageAdapter.delete(untypedModelType: ModelSyncMetadata.self, withIdentifier: ModelIdentifier<ModelSyncMetadata, ModelIdentifierFormat.Default>.makeDefault(id:"Comment")) { _ in }
+        await Amplify.reset()
+        try await Task.sleep(seconds: 1)
     }
 
     func startAmplify(withModels models: AmplifyModelRegistration) async {
@@ -50,12 +57,5 @@ class HubEventsIntegrationTestBase: XCTestCase {
             XCTFail(String(describing: error))
             return
         }
-    }
-
-    override func tearDown() async throws {
-        print("Amplify reset")
-        storageAdapter.delete(untypedModelType: ModelSyncMetadata.self, withIdentifier: ModelIdentifier<ModelSyncMetadata, ModelIdentifierFormat.Default>.makeDefault(id:"Post")) { _ in }
-        storageAdapter.delete(untypedModelType: ModelSyncMetadata.self, withIdentifier: ModelIdentifier<ModelSyncMetadata, ModelIdentifierFormat.Default>.makeDefault(id:"Comment")) { _ in }
-        await Amplify.reset()
     }
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
- add 1 second sleep after `Amplify.reset()`
- fix the amplify setUp order of `SyncEngineIntegrationTestBase`

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [X] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
