### PR TITLE
fix(notifications): rename hub payload event requestNotificationsPermissions in integration tests

### DIFF
--- a/AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp/PushNotificationHostApp/ContentView.swift
+++ b/AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp/PushNotificationHostApp/ContentView.swift
@@ -59,7 +59,7 @@ struct ContentView: View {
 
     func listenHubEvent() {
         pushNotificationHubSubscription = Amplify.Hub.listen(to: .pushNotifications) { payload in
-            if payload.eventName == HubPayload.EventName.Notifications.Push.registerForRemoteNotifications {
+            if payload.eventName == HubPayload.EventName.Notifications.Push.requestNotificationsPermissions {
                 self.hubEvents.append(payload.eventDescription)
             }
         }


### PR DESCRIPTION
## Description
rename hub payload event requestNotificationsPermissions in integration tests

## General Checklist

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
