### PR TITLE
fix: Making OptOut nil when no address is present on the endpoint.

### DIFF
--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Endpoint/EndpointClient.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Endpoint/EndpointClient.swift
@@ -191,7 +191,10 @@ actor EndpointClient: EndpointClientBehaviour {
         endpointProfile.effectiveDate.asISO8601String
     }
 
-    nonisolated private func getOptOut(from endpointProfile: PinpointEndpointProfile) -> String {
+    nonisolated private func getOptOut(from endpointProfile: PinpointEndpointProfile) -> String? {
+        if endpointProfile.deviceToken == nil {
+            return nil
+        }
         return endpointProfile.isOptOut ? EndpointClient.Constants.OptOut.all : EndpointClient.Constants.OptOut.none
     }
 

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EndpointClientTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EndpointClientTests.swift
@@ -188,7 +188,7 @@ class EndpointClientTests: XCTestCase {
         XCTAssertEqual(publicEndpoint.attributes?.count, 0)
         XCTAssertEqual(publicEndpoint.metrics?.count, 0)
         XCTAssertNil(publicEndpoint.channelType)
-        XCTAssertEqual(publicEndpoint.optOut, "NONE")
+        XCTAssertNil(publicEndpoint.optOut)
         XCTAssertEqual(publicEndpoint.demographic?.appVersion, mockModel.appVersion)
         XCTAssertEqual(publicEndpoint.demographic?.make, "apple")
         XCTAssertEqual(publicEndpoint.demographic?.model, mockModel.model)


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
