### PR TITLE
fix(Auth): Adding missing Authorization header when a Client Secret is defined.

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ConfigurationHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ConfigurationHelper.swift
@@ -94,7 +94,11 @@ struct ConfigurationHelper {
                                            scopes: scopesArray,
                                            signInRedirectURI: signInRedirectURI,
                                            signOutRedirectURI: signOutRedirectURI)
-        return HostedUIConfigurationData(clientId: appClientId, oauth: oauth, clientSecret: nil)
+        var clientSecret: String?
+        if case .string(let appClientSecret) = configuration?.value(at: "AppClientSecret") {
+            clientSecret = appClientSecret
+        }
+        return HostedUIConfigurationData(clientId: appClientId, oauth: oauth, clientSecret: clientSecret)
     }
 
     static func parseIdentityPoolData(_ config: JSONValue) -> IdentityPoolConfigurationData? {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUIRequestHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUIRequestHelper.swift
@@ -116,6 +116,7 @@ struct HostedUIRequestHelper {
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
         urlRequest.httpBody = body.data(using: .utf8)
+        urlRequest.addHeaders(using: configuration)
         return urlRequest
     }
 
@@ -145,6 +146,7 @@ struct HostedUIRequestHelper {
             var urlRequest = URLRequest(url: url)
             urlRequest.httpMethod = "POST"
             urlRequest.httpBody = body.data(using: .utf8)
+            urlRequest.addHeaders(using: configuration)
             return urlRequest
         }
 
@@ -152,5 +154,16 @@ struct HostedUIRequestHelper {
         return content.replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "+", with: "-")
             .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+private extension URLRequest {
+    mutating func addHeaders(using configuration: HostedUIConfigurationData) {
+        guard let clientSecret = configuration.clientSecret,
+              let value = "\(configuration.clientId):\(clientSecret)".data(using: .utf8) else {
+            return
+        }
+
+        setValue("Basic \(value.base64EncodedString())", forHTTPHeaderField: "Authorization")
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/HostedUIRequestHelperTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/HostedUIRequestHelperTests.swift
@@ -1,0 +1,113 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+@testable import AWSCognitoAuthPlugin
+import Amplify
+import XCTest
+
+class HostedUIRequestHelperTests: XCTestCase {
+    private var configuration: HostedUIConfigurationData!
+    private let result = HostedUIResult(
+        code: "code",
+        state: "state",
+        codeVerifier: "codeVerifier",
+        options: .init(
+            scopes: [],
+            providerInfo: .init(
+                authProvider: nil,
+                idpIdentifier: nil
+            ),
+            presentationAnchor: nil,
+            preferPrivateSession: false)
+    )
+
+    override func setUp() {
+        createConfiguration()
+    }
+
+    override func tearDown() {
+        configuration = nil
+    }
+
+    private var encodedSecret: String? {
+        guard let clientSecret = configuration.clientSecret,
+              let value = "\(configuration.clientId):\(clientSecret)".data(using: .utf8) else {
+            return nil
+        }
+
+        return value.base64EncodedString()
+    }
+
+    private func createConfiguration(clientSecret: String? = nil) {
+        configuration = .init(
+            clientId: "clientId",
+            oauth: .init(
+                domain: "domain",
+                scopes: [],
+                signInRedirectURI: "app://",
+                signOutRedirectURI: "app://"
+            ),
+            clientSecret: clientSecret
+        )
+    }
+
+    /// Given: A HostedUI configuration without a client secret
+    /// When: HostedUIRequestHelper.createTokenRequest is invoked with said configuration
+    /// Then: A request is generated that does not include an Authorization header
+    func testCreateTokenRequest_withoutClientSecret_shouldNotAddAuthorizationHeader() throws {
+        let request = try HostedUIRequestHelper.createTokenRequest(
+            configuration: configuration,
+            result: result
+        )
+
+        XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+    }
+
+    /// Given: A HostedUI configuration that defines a client secret
+    /// When: HostedUIRequestHelper.createTokenRequest is invoked with said configuration
+    /// Then: A request is generated that includes an Authorization header and its value has an encoded version of the secret
+    func testCreateTokenRequest_withClientSecret_shouldEncodeSecretAndAddAuthorizationHeader() throws {
+        createConfiguration(clientSecret: "clientSecret")
+        let request = try HostedUIRequestHelper.createTokenRequest(
+            configuration: configuration,
+            result: result
+        )
+
+        let header = try XCTUnwrap(request.value(forHTTPHeaderField: "Authorization"))
+        let encodedSecret = try XCTUnwrap(encodedSecret)
+        XCTAssertEqual("Basic \(encodedSecret)", header)
+    }
+
+    /// Given: A HostedUI configuration without a client secret
+    /// When: HostedUIRequestHelper.createRefreshTokenRequest is invoked with said configuration
+    /// Then: A request is generated that does not include an Authorization header
+    func testCreateRefreshTokenRequest_withoutClientSecret_shouldNotAddAuthorizationHeader() throws {
+        let request = try HostedUIRequestHelper.createRefreshTokenRequest(
+            refreshToken: "refreshToken",
+            configuration: configuration
+        )
+
+        XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+    }
+
+    /// Given: A HostedUI configuration that defines a client secret
+    /// When: HostedUIRequestHelper.createRefreshTokenRequest is invoked with said configuration
+    /// Then: A request is generated that includes an Authorization header and its value has an encoded version of the secret
+    func testCreateRefreshTokenRequest_withClientSecret_shouldEncodeSecretAndAddAuthorizationHeader() throws {
+        createConfiguration(clientSecret: "clientSecret")
+        let request = try HostedUIRequestHelper.createRefreshTokenRequest(
+            refreshToken: "refreshToken",
+            configuration: configuration
+        )
+
+        let header = try XCTUnwrap(request.value(forHTTPHeaderField: "Authorization"))
+        let encodedSecret = try XCTUnwrap(encodedSecret)
+        XCTAssertEqual("Basic \(encodedSecret)", header)
+    }
+}


### PR DESCRIPTION
## Issue
https://github.com/aws-amplify/amplify-swift/issues/2799

## Description
Adding the missing `Authorization` header to HostedUI requests when an `AppClientSecret` is defined.

## General Checklist
- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
