### PR TITLE
added databaseName provider as optional parameter on DataStore plugin initializer

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin.swift
@@ -43,6 +43,9 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
 
     /// The DataStore configuration
     let dataStoreConfiguration: DataStoreConfiguration
+    
+    /// The database name provider
+    let databaseNameProvider: DatabaseNameProvider?
 
     /// A queue that regulates the execution of operations. This will be instantiated during initalization phase,
     /// and is clearable by `reset()`. This is implicitly unwrapped to be destroyed when resetting.
@@ -76,15 +79,17 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
 
     /// No-argument init that uses defaults for all providers
     public init(modelRegistration: AmplifyModelRegistration,
-                configuration dataStoreConfiguration: DataStoreConfiguration = .default) {
+                configuration dataStoreConfiguration: DataStoreConfiguration = .default,
+                databaseNameProvider: DatabaseNameProvider? = nil) {
         self.modelRegistration = modelRegistration
         self.dataStoreConfiguration = dataStoreConfiguration
+        self.databaseNameProvider = databaseNameProvider
         self.isSyncEnabled = false
         self.operationQueue = OperationQueue()
         self.validAPIPluginKey =  "awsAPIPlugin"
         self.validAuthPluginKey = "awsCognitoAuthPlugin"
         self.storageEngineBehaviorFactory =
-            StorageEngine.init(isSyncEnabled:dataStoreConfiguration:validAPIPluginKey:validAuthPluginKey:modelRegistryVersion:userDefault:)
+        StorageEngine.init(isSyncEnabled:dataStoreConfiguration:databaseNameProvider:validAPIPluginKey:validAuthPluginKey:modelRegistryVersion:userDefault:)
         self.dataStorePublisher = DataStorePublisher()
         self.dispatchedModelSyncedEvents = [:]
     }
@@ -92,6 +97,7 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
     /// Internal initializer for testing
     init(modelRegistration: AmplifyModelRegistration,
          configuration dataStoreConfiguration: DataStoreConfiguration = .default,
+         databaseNameProvider: DatabaseNameProvider? = nil,
          storageEngineBehaviorFactory: StorageEngineBehaviorFactory? = nil,
          dataStorePublisher: ModelSubcriptionBehavior,
          operationQueue: OperationQueue = OperationQueue(),
@@ -99,10 +105,11 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
          validAuthPluginKey: String) {
         self.modelRegistration = modelRegistration
         self.dataStoreConfiguration = dataStoreConfiguration
+        self.databaseNameProvider = databaseNameProvider
         self.operationQueue = operationQueue
         self.isSyncEnabled = false
         self.storageEngineBehaviorFactory = storageEngineBehaviorFactory ??
-            StorageEngine.init(isSyncEnabled:dataStoreConfiguration:validAPIPluginKey:validAuthPluginKey:modelRegistryVersion:userDefault:)
+        StorageEngine.init(isSyncEnabled:dataStoreConfiguration:databaseNameProvider:validAPIPluginKey:validAuthPluginKey:modelRegistryVersion:userDefault:)
         self.dataStorePublisher = dataStorePublisher
         self.dispatchedModelSyncedEvents = [:]
         self.validAPIPluginKey = validAPIPluginKey
@@ -178,6 +185,7 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
 
         storageEngine = try storageEngineBehaviorFactory(isSyncEnabled,
                                                          dataStoreConfiguration,
+                                                         databaseNameProvider,
                                                          validAPIPluginKey,
                                                          validAuthPluginKey,
                                                          modelRegistration.version,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
@@ -13,10 +13,13 @@ import AWSPluginsCore
 typealias StorageEngineBehaviorFactory =
     (Bool,
     DataStoreConfiguration,
+    DatabaseNameProvider?,
     String,
     String,
     String,
     UserDefaults) throws -> StorageEngineBehavior
+
+public typealias DatabaseNameProvider = () -> String
 
 // swiftlint:disable type_body_length
 final class StorageEngine: StorageEngineBehavior {
@@ -89,13 +92,14 @@ final class StorageEngine: StorageEngineBehavior {
 
     convenience init(isSyncEnabled: Bool,
                      dataStoreConfiguration: DataStoreConfiguration,
+                     databaseNameProvider: DatabaseNameProvider?,
                      validAPIPluginKey: String = "awsAPIPlugin",
                      validAuthPluginKey: String = "awsCognitoAuthPlugin",
                      modelRegistryVersion: String,
                      userDefault: UserDefaults = UserDefaults.standard) throws {
 
         let key = kCFBundleNameKey as String
-        let databaseName = Bundle.main.object(forInfoDictionaryKey: key) as? String ?? "app"
+        let databaseName = databaseNameProvider?() ?? Bundle.main.object(forInfoDictionaryKey: key) as? String ?? "app"
 
         let storageAdapter = try SQLiteStorageEngineAdapter(version: modelRegistryVersion, databaseName: databaseName)
 


### PR DESCRIPTION


## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
this changes will allow developers to specify a name for the DataStore database file, this is needed in apps that allow multiple users one at at time.

app is configured with a sync expression that syncs all records of a user based in his "accountId"
each user has a unique "accountId"
the app can be used by multiple users one at a time

scenario
there are 2 users User a and User b

1. User a logs in
2. data store is synced
3. User a logs out
4. User b logs in
5. data store is synced

in the above scenario user b records will not be synced, only the changes that happened between the time user a logged out and user b logged in will be synced, user b may be able to see user a records.

solution 1 (this is not a good solution but it is what can be done before changes on this pr)
clear data store before sync when it is detected that a different user has logged in

solution 2 (only possible with the changes in this pr)
specify datastore database name in a way that each user has its own database file.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
