### PR TITLE
fix(Auth): Sign out when user does not exist during delete user task

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthDeleteUserTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthDeleteUserTask.swift
@@ -73,8 +73,7 @@ class AWSAuthDeleteUserTask: AuthDeleteUserTask, DefaultLogger {
             return
         }
         log.verbose("User not found, signing out")
-        let signOutData = SignOutEventData(
-            globalSignOut: true)
+        let signOutData = SignOutEventData(globalSignOut: true)
         let event = AuthenticationEvent(eventType: .signOutRequested(signOutData))
         await authStateMachine.send(event)
         _ = await taskHelper.didSignOut()

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthDeleteUserTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthDeleteUserTask.swift
@@ -31,11 +31,12 @@ class AWSAuthDeleteUserTask: AuthDeleteUserTask, DefaultLogger {
         let accessToken = try await taskHelper.getAccessToken()
 
         do {
-            try  await deleteUser(with: accessToken)
+            try await deleteUser(with: accessToken)
             log.verbose("Received Success")
         } catch {
             log.verbose("Delete user failed, reconfiguring auth state. \(error)")
             await waitForReConfigure()
+            await signOutIfUserWasNotFound(with: error)
             throw error
         }
     }
@@ -64,6 +65,19 @@ class AWSAuthDeleteUserTask: AuthDeleteUserTask, DefaultLogger {
                 continue
             }
         }
+    }
+
+    private func signOutIfUserWasNotFound(with error: Error) async {
+        guard case AuthError.service(_, _, let underlyingError) = error,
+              case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+            return
+        }
+        log.verbose("User not found, signing out")
+        let signOutData = SignOutEventData(
+            globalSignOut: true)
+        let event = AuthenticationEvent(eventType: .signOutRequested(signOutData))
+        await authStateMachine.send(event)
+        _ = await taskHelper.didSignOut()
     }
 
     private func waitForReConfigure() async {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignOutTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignOutTask.swift
@@ -35,7 +35,7 @@ class AWSAuthSignOutTask: AuthSignOutTask, DefaultLogger {
         if isValidAuthNStateToStart(authNState) {
             log.verbose("Sending signOut event")
             await sendSignOutEvent()
-            return await doSignOut()
+            return await taskHelper.didSignOut()
         } else if case .federatedToIdentityPool = authNState {
             let invalidStateError = AuthError.invalidState(
                 "The user is currently federated to identity pool. You must call clearFederationToIdentityPool to clear credentials.",
@@ -45,40 +45,6 @@ class AWSAuthSignOutTask: AuthSignOutTask, DefaultLogger {
             return invalidStateResult()
         }
 
-    }
-
-    private func doSignOut() async -> AuthSignOutResult {
-
-        let stateSequences = await authStateMachine.listen()
-        log.verbose("Waiting for signOut completion")
-        for await state in stateSequences {
-            guard case .configured(let authNState, _) = state else {
-                return invalidStateResult()
-            }
-
-            switch authNState {
-            case .signedOut(let data):
-                if data.revokeTokenError != nil ||
-                    data.globalSignOutError != nil ||
-                    data.hostedUIError != nil {
-                    return AWSCognitoSignOutResult.partial(
-                        revokeTokenError: data.revokeTokenError,
-                        globalSignOutError: data.globalSignOutError,
-                        hostedUIError: data.hostedUIError)
-                }
-                return AWSCognitoSignOutResult.complete
-            case .signingIn:
-                log.verbose("Cancel if a signIn is in progress")
-                await authStateMachine.send(AuthenticationEvent.init(eventType: .cancelSignIn))
-            case .signingOut(let state):
-                if case .error(let error) = state {
-                    return AWSCognitoSignOutResult.failed(error.authError)
-                }
-            default:
-                continue
-            }
-        }
-        fatalError()
     }
 
     func isValidAuthNStateToStart(_ authNState: AuthenticationState) -> Bool {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthenticationProviderDeleteUserTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthenticationProviderDeleteUserTests.swift
@@ -36,6 +36,35 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
         }
     }
 
+    /// Test a deleteUser when sign out failed
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   sign out failure
+    ///
+    /// - When:
+    ///    - I invoke deleteUser
+    /// - Then:
+    ///    - I should still be able to get a success for delete user
+    ///
+    func testSignOutFailureWhenDeleteUserIsSuccess() async {
+        mockIdentityProvider = MockIdentityProvider(
+            mockRevokeTokenResponse: { _ in
+                throw RevokeTokenOutputError.unsupportedTokenTypeException(.init())
+            }, mockGlobalSignOutResponse: { _ in
+                throw GlobalSignOutOutputError.internalErrorException(.init())
+            },
+            mockDeleteUserOutputResponse: { _ in
+                try DeleteUserOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+            }
+        )
+        do {
+            try await plugin.deleteUser()
+            print("Delete user success")
+        } catch {
+            XCTFail("Received failure with error \(error)")
+        }
+    }
+
 
     /// Test a deleteUser with network error from service
     ///
@@ -374,6 +403,7 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
     ///    - I invoke deleteUser
     /// - Then:
     ///    - I should get a .service error with .userNotFound error
+    ///      AuthN should be in signedOut state
     ///
     func testDeleteUserWithUserNotFoundException() async {
         mockIdentityProvider = MockIdentityProvider(
@@ -396,6 +426,19 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
                 XCTFail("Should produce userNotFound error but instead produced \(error)")
                 return
             }
+        }
+
+        switch await plugin.authStateMachine.currentState {
+        case .configured(let authNState, let authZState):
+            switch (authNState, authZState) {
+            case (.signedOut, .configured):
+                print("AuthN and AuthZ are in a valid state")
+            default:
+                XCTFail("AuthN should be in signed out state")
+            }
+        default:
+            XCTFail("Auth should be in configured state")
+
         }
     }
 


### PR DESCRIPTION
## Description
Clear the existing user data by signing out when we get a user not found exception during a delete process. During this scenario, the delete user task is stuck in signed in state even though the user does not exist. 

## General Checklist


- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
~- [ ] Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
~- [ ] If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
