### PR TITLE
fix(datastore): wait for reconciliation queue finished while reseting

### DIFF
--- a/.github/workflows/integ_test_datastore.yml
+++ b/.github/workflows/integ_test_datastore.yml
@@ -2,11 +2,11 @@ name: DataStore Integration Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, 5d/fix-datastore-integration-test]
 
 permissions:
     id-token: write
-    contents: read 
+    contents: read
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -56,4 +56,4 @@ jobs:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginIntegrationTests
 
- 
+

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -2,11 +2,11 @@ name: DataStore TransformerV2 Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, 5d/fix-datastore-integration-test]
 
 permissions:
     id-token: write
-    contents: read 
+    contents: read
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -56,4 +56,4 @@ jobs:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginV2Tests
 
- 
+

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin+Resettable.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin+Resettable.swift
@@ -12,7 +12,7 @@ extension AWSAPIPlugin: Resettable {
 
     public func reset() async {
         mapper.reset()
-
+        queue.cancelAllOperations()
         await session.cancelAndReset()
 
         session = nil

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
@@ -379,6 +379,8 @@ final class StorageEngine: StorageEngineBehavior {
 extension StorageEngine: Resettable {
     func reset() async {
         // TOOD: Perform cleanup on StorageAdapter, including releasing its `Connection` if needed
+        operationQueue.cancelAllOperations()
+
         if let resettable = syncEngine as? Resettable {
             log.verbose("Resetting syncEngine")
             await resettable.reset()

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -209,6 +209,11 @@ extension AWSIncomingEventReconciliationQueue: Resettable {
 
         log.verbose("Resetting reconcileAndSaveQueue")
         reconcileAndSaveQueue.cancelAllOperations()
+        await withCheckedContinuation({ (continuation: CheckedContinuation<Void, Never>) in
+            reconcileAndSaveQueue.waitUntilOperationsAreFinished()
+            continuation.resume()
+        })
+
         // Reset is used in internal testing only. Some operations get kicked off at this point and do not finish
         // We're sometimes hitting a deadlock when waiting for them to finish. Commenting this out and letting
         // the tests continue onto the next works pretty well, but ideally ReconcileAndLocalSaveOperation's should 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -415,6 +415,11 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
             storageAdapter.save(inProcessModel.syncMetadata,
                                 condition: nil,
                                 eagerLoad: self.isEagerLoad) { result in
+                if self.isFinished || self.isCancelled {
+                    promise(.successfulVoid)
+                    return
+                }
+
                 switch result {
                 case .failure(let dataStoreError):
                     self.notifyDropped(error: dataStoreError)
@@ -436,6 +441,10 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
 
     private func notify(savedModel: AppliedModel,
                         mutationType: MutationEvent.MutationType) {
+        if self.isFinished || self.isCancelled {
+            return
+        }
+
         let version = savedModel.syncMetadata.version
 
         // TODO: Dispatch/notify error if we can't erase to any model? Would imply an error in JSON decoding,

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
@@ -40,7 +40,7 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
         let post = Post.keys
         let predicate = (post.id <= 1 && post.title == "title1")
             || (post.rating > 2 && post.status == PostStatus.private)
-        
+
         let queriedPosts = try await Amplify.DataStore.query(Post.self, where: predicate)
         XCTAssertEqual(queriedPosts.count, 2)
     }
@@ -59,11 +59,11 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
         let queriedPosts = try await Amplify.DataStore.query(Post.self, paginate: .page(0, limit: 10))
         XCTAssertEqual(queriedPosts.count, 10)
         posts.append(contentsOf: queriedPosts)
-        
+
         let queriedPosts2 = try await Amplify.DataStore.query(Post.self, paginate: .page(1, limit: 10))
         XCTAssertEqual(queriedPosts2.count, 5)
         posts.append(contentsOf: queriedPosts2)
-        
+
         let idSet = Set(posts.map { $0.id })
         XCTAssertEqual(idSet.count, 15)
     }
@@ -239,7 +239,7 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
 
         let queriedPosts = try await Amplify.DataStore.query(Post.self,
                                                       where: Post.keys.rating >= 2)
-            
+
         var posts = [Post]()
         var currentPage: UInt = 0
         var shouldRepeat = true

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreScalarTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreScalarTests.swift
@@ -149,6 +149,9 @@ class DataStoreScalarTests: SyncEngineIntegrationTestBase {
                                       enumNullableList: [.valueTwo],
                                       nullableEnumList: [.valueOne, .valueTwo],
                                       nullableEnumNullableList: [.valueTwo, .valueOne])
+        let savedModel = try await createModelUntilSynced(data: container)
+        XCTAssertEqual(savedModel, container)
+
         let updatedContainer = EnumTestModel(id: container.id,
                                              enumVal: .valueTwo,
                                              nullableEnumVal: nil,
@@ -156,13 +159,13 @@ class DataStoreScalarTests: SyncEngineIntegrationTestBase {
                                              enumNullableList: [.valueTwo, .valueOne],
                                              nullableEnumList: [.valueTwo, .valueOne],
                                              nullableEnumNullableList: [.valueOne, .valueTwo])
-        let savedModel = try await Amplify.DataStore.save(container)
-        XCTAssertEqual(savedModel, container)
-        let updatedModel = try await Amplify.DataStore.save(updatedContainer)
+        let updatedModel = try await updateModelWaitForSync(data: updatedContainer)
         XCTAssertEqual(updatedModel, updatedContainer)
+
         let queriedModel = try await Amplify.DataStore.query(EnumTestModel.self, byId: container.id)
         XCTAssertEqual(queriedModel, updatedContainer)
-        try await Amplify.DataStore.delete(updatedContainer)
+
+        try await deleteModelWaitForSync(data: updatedContainer)
         let emptyModel = try await Amplify.DataStore.query(EnumTestModel.self, byId: container.id)
         XCTAssertNil(emptyModel)
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TestSupport/SyncEngineIntegrationV2TestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TestSupport/SyncEngineIntegrationV2TestBase.swift
@@ -35,7 +35,6 @@ class SyncEngineIntegrationV2TestBase: DataStoreTestBase {
 
         continueAfterFailure = false
 
-        await Amplify.reset()
         Amplify.Logging.logLevel = logLevel
 
         do {
@@ -46,6 +45,12 @@ class SyncEngineIntegrationV2TestBase: DataStoreTestBase {
             XCTFail(String(describing: error))
             return
         }
+    }
+
+    override func tearDown() async throws {
+        try await super.tearDown()
+        await Amplify.reset()
+        try await Task.sleep(seconds: 1)
     }
 
     func stopDataStore() async throws {
@@ -96,5 +101,75 @@ class SyncEngineIntegrationV2TestBase: DataStoreTestBase {
         try Amplify.configure(amplifyConfig)
         try await Amplify.DataStore.start()
         await waitForExpectations(timeout: 100.0)
+    }
+
+    private func extractMutationEvent(event: DataStoreHubEvent) -> MutationEvent? {
+        if case .syncReceived(let mutationEvent) = event {
+            return mutationEvent
+        }
+        return nil
+    }
+
+    @discardableResult
+    func createModelUntilSynced<T: Model>(data: T) async throws -> T {
+        let expection = AsyncExpectation(description: "Wait for creating [\(data.modelName): \(data.identifier)]")
+        let cancellable = Amplify.Hub.publisher(for: .dataStore)
+            .map { DataStoreHubEvent(payload: $0) }
+            .compactMap(extractMutationEvent(event:))
+            .filter { $0.modelName == T.modelName }
+            .filter { $0.mutationType == MutationEvent.MutationType.create.rawValue }
+            .compactMap { try? $0.decodeModel() as? T }
+            .filter { $0.identifier == data.identifier }
+            .sink { _ in
+                Task { await expection.fulfill() }
+            }
+        defer { cancellable.cancel() }
+
+        let model = try await Amplify.DataStore.save(data)
+        await waitForExpectations([expection], timeout: 10)
+        return model
+    }
+
+    @discardableResult
+    func updateModelWaitFroSync<T: Model & Equatable>(data: T) async throws -> T {
+        try await updateModelWaitForSync(data: data, isEqual: { $0 == $1 })
+    }
+
+    @discardableResult
+    func updateModelWaitForSync<T: Model>(data: T, isEqual: @escaping (T, T) -> Bool) async throws -> T {
+        let expection = AsyncExpectation(description: "Wait for updating [\(data.modelName): \(data.identifier)]")
+        let cancellable = Amplify.Hub.publisher(for: .dataStore)
+            .map { DataStoreHubEvent(payload: $0) }
+            .compactMap(extractMutationEvent(event:))
+            .filter { $0.modelName == T.modelName }
+            .filter { $0.mutationType == MutationEvent.MutationType.update.rawValue }
+            .compactMap { try? $0.decodeModel() as? T }
+            .filter { isEqual($0, data) }
+            .sink { _ in
+                Task { await expection.fulfill() }
+            }
+        defer { cancellable.cancel() }
+
+        let model = try await Amplify.DataStore.save(data)
+        await waitForExpectations([expection], timeout: 10)
+        return model
+    }
+
+    func deleteModelWaitForSync<T: Model>(data: T, predicate: QueryPredicate? = nil) async throws {
+        let expection = AsyncExpectation(description: "Wait for deleting [\(data.modelName): \(data.identifier)]")
+        let cancellable = Amplify.Hub.publisher(for: .dataStore)
+            .map { DataStoreHubEvent(payload: $0) }
+            .compactMap(extractMutationEvent(event:))
+            .filter { $0.modelName == T.modelName }
+            .filter { $0.mutationType == MutationEvent.MutationType.delete.rawValue }
+            .compactMap { try? $0.decodeModel() as? T }
+            .filter { $0.identifier == data.identifier }
+            .sink { _ in
+                Task { await expection.fulfill() }
+            }
+        defer { cancellable.cancel() }
+
+        try await Amplify.DataStore.delete(data, where: predicate)
+        await waitForExpectations([expection], timeout: 10)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario1V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario1V2Tests.swift
@@ -42,54 +42,12 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
     func testSaveTeamAndProjectSyncToCloud() async throws {
         await setUp(withModels: TestModelRegistration())
         try await startAmplifyAndWaitForSync()
-        let team = Team1V2(name: "name1")
+        let team = randomTeam()
         // TODO: No need to add the `team` into the project, it is using explicit field `project1V2TeamId`
-        let project = Project1V2(team: team, project1V2TeamId: team.id)
+        let project = randomProject(with: team)
         
-        let syncedTeamReceived = expectation(description: "received team from sync path")
-        var hubListener = Amplify.Hub.listen(to: .dataStore,
-                                             eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
-            guard let mutationEvent = payload.data as? MutationEvent else {
-                XCTFail("Could not cast payload to mutation event")
-                return
-            }
-
-            if let syncedTeam = try? mutationEvent.decodeModel() as? Team1V2, syncedTeam.id == team.id {
-                XCTAssertTrue(syncedTeam == team)
-                syncedTeamReceived.fulfill()
-            }
-        }
-        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
-            XCTFail("Listener not registered for hub")
-            return
-        }
-
-        _ = try await Amplify.DataStore.save(team)
-        await waitForExpectations(timeout: networkTimeout)
-        
-        let syncProjectReceived = expectation(description: "received project from sync path")
-        hubListener = Amplify.Hub.listen(to: .dataStore,
-                                             eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
-            guard let mutationEvent = payload.data as? MutationEvent else {
-                XCTFail("Could not cast payload to mutation event")
-                return
-            }
-
-            if let syncedProject = try? mutationEvent.decodeModel() as? Project1V2,
-               syncedProject.id == project.id {
-                XCTAssertTrue(syncedProject == project)
-                XCTAssertEqual(mutationEvent.version, 1)
-                syncProjectReceived.fulfill()
-            }
-        }
-        
-        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
-            XCTFail("Listener not registered for hub")
-            return
-        }
-        
-        _ = try await Amplify.DataStore.save(project)
-        await waitForExpectations(timeout: networkTimeout)
+        _ = try await createModelUntilSynced(data: team)
+        _ = try await createModelUntilSynced(data: project)
 
         let queriedProjectOptional = try await Amplify.DataStore.query(Project1V2.self, byId: project.id)
         guard let queriedProject = queriedProjectOptional else {
@@ -103,10 +61,10 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
     func testUpdateProjectWithAnotherTeam() async throws {
         await setUp(withModels: TestModelRegistration())
         try await startAmplifyAndWaitForSync()
-        let team = Team1V2(name: "name1")
-        let anotherTeam = Team1V2(name: "name1")
+        let team = randomTeam()
+        let anotherTeam = randomTeam()
         // TODO: No need to add the `team` into the project, it is using explicit field `project1V2TeamId`
-        var project = Project1V2(team: team, project1V2TeamId: team.id)
+        var project = randomProject(with: team)
         let expectedUpdatedProject = Project1V2(id: project.id,
                                                 name: project.name,
                                                 team: anotherTeam, // Not needed
@@ -155,96 +113,21 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         await setUp(withModels: TestModelRegistration())
         try await startAmplifyAndWaitForSync()
         
-        let team = Team1V2(name: "name")
-        var project = Project1V2(team: team, project1V2TeamId: team.id)
+        let team = randomTeam()
+        var project = randomProject(with: team)
 
-        let createReceived = expectation(description: "received created items from cloud")
-        createReceived.expectedFulfillmentCount = 2 // 1 project and 1 team
-        var hubListener = Amplify.Hub.listen(to: .dataStore,
-                                             eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
-            guard let mutationEvent = payload.data as? MutationEvent else {
-                XCTFail("Could not cast payload to mutation event")
-                return
-            }
+        _ = try await createModelUntilSynced(data: team)
+        _ = try await createModelUntilSynced(data: project)
 
-            if let projectEvent = try? mutationEvent.decodeModel() as? Project1V2,
-               projectEvent.id == project.id {
-                if mutationEvent.mutationType == GraphQLMutationType.create.rawValue {
-                    XCTAssertEqual(mutationEvent.version, 1)
-                    createReceived.fulfill()
-                }
-            } else if let teamEvent = try? mutationEvent.decodeModel() as? Team1V2, teamEvent.id == team.id {
-                if mutationEvent.mutationType == GraphQLMutationType.create.rawValue {
-                    XCTAssertEqual(mutationEvent.version, 1)
-                    createReceived.fulfill()
-                }
-            }
-        }
-        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
-            XCTFail("Listener not registered for hub")
-            return
-        }
-
-        _ = try await Amplify.DataStore.save(team)
-        _ = try await Amplify.DataStore.save(project)
-
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
-        let updateReceived = expectation(description: "received update project from sync path")
-        hubListener = Amplify.Hub.listen(to: .dataStore,
-                                             eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
-            guard let mutationEvent = payload.data as? MutationEvent else {
-                XCTFail("Could not cast payload to mutation event")
-                return
-            }
-
-            if let projectEvent = try? mutationEvent.decodeModel() as? Project1V2,
-               projectEvent.id == project.id {
-                if mutationEvent.mutationType == GraphQLMutationType.update.rawValue {
-                    XCTAssertEqual(mutationEvent.version, 2)
-                    updateReceived.fulfill()
-                }
-            }
-        }
-        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
-            XCTFail("Listener not registered for hub")
-            return
-        }
-        
         project.name = "updatedName"
-        _ = try await Amplify.DataStore.save(project)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
-        
-        let deleteReceived = expectation(description: "Delete notification received")
-        deleteReceived.expectedFulfillmentCount = 2 // 1 project and 1 team
-        hubListener = Amplify.Hub.listen(to: .dataStore,
-                                             eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
-            guard let mutationEvent = payload.data as? MutationEvent else {
-                XCTFail("Could not cast payload to mutation event")
-                return
-            }
+        _ = try await updateModelWaitFroSync(data: project)
 
-            if let projectEvent = try? mutationEvent.decodeModel() as? Project1V2,
-               projectEvent.id == project.id {
-                if mutationEvent.mutationType == GraphQLMutationType.delete.rawValue {
-                    deleteReceived.fulfill()
-                }
-
-            } else if let teamEvent = try? mutationEvent.decodeModel() as? Team1V2, teamEvent.id == team.id {
-                if mutationEvent.mutationType == GraphQLMutationType.delete.rawValue {
-                    deleteReceived.fulfill()
-                }
-            }
-        }
-        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
-            XCTFail("Listener not registered for hub")
-            return
-        }
-        _ = try await Amplify.DataStore.delete(project)
+        _ = try await deleteModelWaitForSync(data: project)
         
         // TODO: Delete Team should not be necessary, cascade delete should delete the team when deleting the project.
         // Once cascade works for hasOne, the following code can be removed.
-        _ = try await Amplify.DataStore.delete(team)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        _ = try await deleteModelWaitForSync(data: team)
+
         let queriedProject = try await Amplify.DataStore.query(Project1V2.self, byId: project.id)
         XCTAssertNil(queriedProject)
 
@@ -256,73 +139,17 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         await setUp(withModels: TestModelRegistration())
         try await startAmplifyAndWaitForSync()
 
-        let team = Team1V2(name: "name")
-        let project = Project1V2(team: team, project1V2TeamId: team.id)
-        
-        let createReceived = expectation(description: "received created items from cloud")
-        createReceived.expectedFulfillmentCount = 2 // 1 project and 1 team
-        var hubListener = Amplify.Hub.listen(to: .dataStore,
-                                             eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
-            guard let mutationEvent = payload.data as? MutationEvent else {
-                XCTFail("Could not cast payload to mutation event")
-                return
-            }
+        let team = randomTeam()
+        let project = randomProject(with: team)
 
-            if let projectEvent = try? mutationEvent.decodeModel() as? Project1V2,
-               projectEvent.id == project.id {
-                if mutationEvent.mutationType == GraphQLMutationType.create.rawValue {
-                    XCTAssertEqual(mutationEvent.version, 1)
-                    createReceived.fulfill()
-                }
-            } else if let teamEvent = try? mutationEvent.decodeModel() as? Team1V2, teamEvent.id == team.id {
-                if mutationEvent.mutationType == GraphQLMutationType.create.rawValue {
-                    XCTAssertEqual(mutationEvent.version, 1)
-                    createReceived.fulfill()
-                }
-            }
+        _ = try await createModelUntilSynced(data: team)
+        _ = try await createModelUntilSynced(data: project)
 
-        }
-        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
-            XCTFail("Listener not registered for hub")
-            return
-        }
-        
-        _ = try await Amplify.DataStore.save(team)
-        _ = try await Amplify.DataStore.save(project)
-
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
-        
-        let deleteReceived = expectation(description: "Delete notification received")
-        deleteReceived.expectedFulfillmentCount = 2 // 1 project and 1 team
-        hubListener = Amplify.Hub.listen(to: .dataStore,
-                                             eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
-            guard let mutationEvent = payload.data as? MutationEvent else {
-                XCTFail("Could not cast payload to mutation event")
-                return
-            }
-
-            if let projectEvent = try? mutationEvent.decodeModel() as? Project1V2,
-               projectEvent.id == project.id {
-                if mutationEvent.mutationType == GraphQLMutationType.delete.rawValue {
-                    deleteReceived.fulfill()
-                }
-
-            } else if let teamEvent = try? mutationEvent.decodeModel() as? Team1V2, teamEvent.id == team.id {
-                if mutationEvent.mutationType == GraphQLMutationType.delete.rawValue {
-                    deleteReceived.fulfill()
-                }
-            }
-        }
-        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
-            XCTFail("Listener not registered for hub")
-            return
-        }
-        _ = try await Amplify.DataStore.delete(project)
+        _ = try await deleteModelWaitForSync(data: project)
 
         // TODO: Delete Team should not be necessary, cascade delete should delete the team when deleting the project.
         // Once cascade works for hasOne, the following code can be removed.
-        _ = try await Amplify.DataStore.delete(team)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        _ = try await deleteModelWaitForSync(data: team)
         let queriedProject = try await Amplify.DataStore.query(Project1V2.self, byId: project.id)
         XCTAssertNil(queriedProject)
 
@@ -334,12 +161,12 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         await setUp(withModels: TestModelRegistration())
         try await startAmplifyAndWaitForSync()
         
-        let team = Team1V2(name: "name")
-        let project = Project1V2(team: team, project1V2TeamId: team.id)
-        _ = try await Amplify.DataStore.save(team)
-        _ = try await Amplify.DataStore.save(project)
+        let team = randomTeam()
+        let project = randomProject(with: team)
+        _ = try await createModelUntilSynced(data: team)
+        _ = try await createModelUntilSynced(data: project)
         
-        _ = try await Amplify.DataStore.delete(project, where: Project1V2.keys.team.eq(team.id))
+        _ = try await deleteModelWaitForSync(data: project, predicate: Project1V2.keys.team.eq(team.id))
                                                
         let queriedProject = try await Amplify.DataStore.query(Project1V2.self, byId: project.id)
         XCTAssertNil(queriedProject)
@@ -349,10 +176,10 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         await setUp(withModels: TestModelRegistration())
         try await startAmplifyAndWaitForSync()
         
-        let team = Team1V2(name: "name")
-        let project = Project1V2(team: team, project1V2TeamId: team.id)
-        _ = try await Amplify.DataStore.save(team)
-        _ = try await Amplify.DataStore.save(project)
+        let team = randomTeam()
+        let project = randomProject(with: team)
+        _ = try await createModelUntilSynced(data: team)
+        _ = try await createModelUntilSynced(data: project)
 
         do {
             _ = try await Amplify.DataStore.delete(project, where: Project1V2.keys.team.eq("invalidTeamId"))
@@ -373,16 +200,27 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
     func testListProjectsByTeamID() async throws {
         await setUp(withModels: TestModelRegistration())
         try await startAmplifyAndWaitForSync()
-        let team = Team1V2(name: "name")
-        let project = Project1V2(team: team, project1V2TeamId: team.id)
-        _ = try await Amplify.DataStore.save(team)
-        _ = try await Amplify.DataStore.save(project)
+        let team = randomTeam()
+        let project = randomProject(with: team)
+        _ = try await createModelUntilSynced(data: team)
+        _ = try await createModelUntilSynced(data: project)
         
         let predicate = Project1V2.keys.team.eq(team.id)
         let projects = try await Amplify.DataStore.query(Project1V2.self, where: predicate)
         XCTAssertEqual(projects.count, 1)
         XCTAssertEqual(projects[0].id, project.id)
         XCTAssertEqual(projects[0].project1V2TeamId, team.id)
+    }
+
+    private func randomTeam() -> Team1V2 {
+        Team1V2(name: UUID().uuidString)
+    }
+
+    private func randomProject(with team: Team1V2? = nil) -> Project1V2 {
+        if let team = team {
+            return Project1V2(team: team, project1V2TeamId: team.id)
+        }
+        return Project1V2()
     }
 }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
@@ -759,7 +759,7 @@
 		21182131289BFB4B001B5945 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		21182133289BFB4F001B5945 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		21182136289BFB4F001B5945 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
-		2118213E289BFB63001B5945 /* amplify-ios-staging */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-ios-staging"; path = ../../../..; sourceTree = "<group>"; };
+		2118213E289BFB63001B5945 /* amplify-swift */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-swift"; path = ../../../..; sourceTree = "<group>"; };
 		211F5093296DD4C30040EB62 /* AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift; sourceTree = "<group>"; };
 		213848292947ACCF00BBA647 /* AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift; sourceTree = "<group>"; };
 		2138482B2947F89C00BBA647 /* AWSDataStoreLazyLoadingBlogPostCmment8V2SnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadingBlogPostCmment8V2SnapshotTests.swift; sourceTree = "<group>"; };


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
- Add wait for gracefully cancel `AWSIncomingEventReconciliationQueue` executing operations.
- Add operation status check for early exit.
- Fix test case `testQueryNotContainsAndContains` with more constrained query condition.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
