### PR TITLE
fix(datastore): swap `like` for `instr` in sql queries

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/QueryPredicate+SQLite.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/QueryPredicate+SQLite.swift
@@ -11,26 +11,28 @@ import SQLite
 
 extension QueryOperator {
 
-    var sqlOperation: String {
+    func sqlOperation(column: String) -> String {
         switch self {
         case .notEqual(let value):
-            return value == nil ? "is not null" : "<> ?"
+            return value == nil ? "\(column) is not null" : "\(column) <> ?"
         case .equals(let value):
-            return value == nil ? "is null" : "= ?"
+            return value == nil ? "\(column) is null" : "\(column) = ?"
         case .lessOrEqual:
-            return "<= ?"
+            return "\(column) <= ?"
         case .lessThan:
-            return "< ?"
+            return "\(column) < ?"
         case .greaterOrEqual:
-            return ">= ?"
+            return "\(column) >= ?"
         case .greaterThan:
-            return "> ?"
+            return "\(column) > ?"
         case .between:
-            return "between ? and ?"
-        case .beginsWith, .contains:
-            return "like ?"
+            return "\(column) between ? and ?"
+        case .beginsWith:
+            return "instr(\(column), ?) = 1"
+        case .contains:
+            return "instr(\(column), ?) > 0"
         case .notContains:
-            return "not like ?"
+            return "instr(\(column), ?) = 0"
         }
     }
 
@@ -45,12 +47,10 @@ extension QueryOperator {
              .greaterOrEqual(let value),
              .greaterThan(let value):
             return [value.asBinding()]
-        case .contains(let value):
-            return ["%\(value)%"]
-        case .beginsWith(let value):
-            return ["\(value)%"]
-        case .notContains(let value):
-            return ["%\(value)%"]
+        case .contains(let value),
+            .beginsWith(let value),
+            .notContains(let value):
+            return [value.asBinding()]
         }
     }
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/SQLStatement+Condition.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/SQLStatement+Condition.swift
@@ -31,9 +31,9 @@ private func translateQueryPredicate(from modelSchema: ModelSchema,
         if let operation = pred as? QueryPredicateOperation {
             let column = resolveColumn(operation)
             if predicateIndex == 0 {
-                sql.append("\(indent)\(column) \(operation.operator.sqlOperation)")
+                sql.append("\(indent)\(operation.operator.sqlOperation(column: column))")
             } else {
-                sql.append("\(indent)\(groupType.rawValue) \(column) \(operation.operator.sqlOperation)")
+                sql.append("\(indent)\(groupType.rawValue) \(operation.operator.sqlOperation(column: column))")
             }
 
             bindings.append(contentsOf: operation.operator.bindings)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLStatementTests.swift
@@ -1052,11 +1052,11 @@ class SQLStatementTests: XCTestCase {
                         matches: "\"root\".\"rating\" between ? and ?",
                         bindings: [3, 5])
         assertPredicate(post.title.beginsWith("gelato"),
-                        matches: "\"root\".\"title\" like ?",
-                        bindings: ["gelato%"])
+                        matches: "instr(\"root\".\"title\", ?) = 1",
+                        bindings: ["gelato"])
         assertPredicate(post.title ~= "gelato",
-                        matches: "\"root\".\"title\" like ?",
-                        bindings: ["%gelato%"])
+                        matches: "instr(\"root\".\"title\", ?) > 0",
+                        bindings: ["gelato"])
     }
 
     /// - Given: a grouped predicate
@@ -1086,20 +1086,22 @@ class SQLStatementTests: XCTestCase {
             and "status" <> ?
             and "updatedAt" is null
             and (
-              "content" like ?
-              or "title" like ?
+              instr("content", ?) > 0
+              or instr("title", ?) = 1
             )
           )
         """, statement.stringValue)
 
+        // "content" like ?
+        // or "title" like ?
         let variables = statement.variables
         XCTAssertEqual(variables[0] as? Int, 1)
         XCTAssertEqual(variables[1] as? Int, 0)
         XCTAssertEqual(variables[2] as? Int, 2)
         XCTAssertEqual(variables[3] as? Int, 4)
         XCTAssertEqual(variables[4] as? String, PostStatus.draft.rawValue)
-        XCTAssertEqual(variables[5] as? String, "%gelato%")
-        XCTAssertEqual(variables[6] as? String, "ice cream%")
+        XCTAssertEqual(variables[5] as? String, "gelato")
+        XCTAssertEqual(variables[6] as? String, "ice cream")
     }
 
     /// - Given: a `Model` type
@@ -1319,11 +1321,14 @@ class SQLStatementTests: XCTestCase {
                 and "root"."rating" between ? and ?
                 and "root"."updatedAt" is null
                 and (
-                  "root"."content" like ?
-                  or "root"."title" like ?
+                  instr("root"."content", ?) > 0
+                  or instr("root"."title", ?) = 1
                 )
               )
             """
+
+        // "root"."content" like ?
+        // or "root"."title" like ?
         XCTAssertEqual(statement.stringValue, expectedStatement)
 
         let variables = statement.variables
@@ -1331,8 +1336,8 @@ class SQLStatementTests: XCTestCase {
         XCTAssertEqual(variables[1] as? Int, 0)
         XCTAssertEqual(variables[2] as? Int, 2)
         XCTAssertEqual(variables[3] as? Int, 4)
-        XCTAssertEqual(variables[4] as? String, "%gelato%")
-        XCTAssertEqual(variables[5] as? String, "ice cream%")
+        XCTAssertEqual(variables[4] as? String, "gelato")
+        XCTAssertEqual(variables[5] as? String, "ice cream")
     }
 
     func testTranslateQueryPredicateWithNameSpaceWhenFieldNameSpecified() {

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLStatementTests.swift
@@ -1092,8 +1092,6 @@ class SQLStatementTests: XCTestCase {
           )
         """, statement.stringValue)
 
-        // "content" like ?
-        // or "title" like ?
         let variables = statement.variables
         XCTAssertEqual(variables[0] as? Int, 1)
         XCTAssertEqual(variables[1] as? Int, 0)
@@ -1327,8 +1325,6 @@ class SQLStatementTests: XCTestCase {
               )
             """
 
-        // "root"."content" like ?
-        // or "root"."title" like ?
         XCTAssertEqual(statement.stringValue, expectedStatement)
 
         let variables = statement.variables


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
Moving from `like` to `instr` for DataStore predicates.

*Simplified overview for brevity, the actual SQL queries use bindings
| API                                     | Previous                   | New                               |
|--------------------------|---------------------|-----------------------|
| `foo.contains("bar")`       | `like "%bar%"`        | `instr(foo, "bar") > 0` |
| `foo.notContains("bar")` | `not like "%bar%"` | `instr(foo, "bar") = 0` |
| `foo.beginsWith("bar")`    | `like "bar%"`           | `instr(foo, "bar") = 1` |

## Performance Testing Results

### Basic sqlite3 Tests
1 million simple entries
| # | `like` | `instr` |
|---|----|----|
| 1 | 0.08s user 0.02s system 72% cpu 0.147 total | 0.08s user 0.03s system 82% cpu 0.129 total |
| 2 | 0.08s user 0.02s system 77% cpu 0.139 total | 0.08s user 0.02s system 82% cpu 0.126 total |
| 3 | 0.09s user 0.02s system 80% cpu 0.137 total | 0.08s user 0.02s system 93% cpu 0.102 total |
| 4 | 0.08s user 0.02s system 72% cpu 0.147 total | 0.08s user 0.02s system 87% cpu 0.111 total |
| 5 | 0.09s user 0.02s system 81% cpu 0.133 total | 0.08s user 0.02s system 87% cpu 0.113 total |
| 6 | 0.09s user 0.02s system 91% cpu 0.113 total | 0.07s user 0.02s system 92% cpu 0.092 total |
| 7 | 0.09s user 0.02s system 90% cpu 0.119 total | 0.08s user 0.02s system 81% cpu 0.117 total |
| 8 | 0.08s user 0.02s system 88% cpu 0.114 total | 0.08s user 0.02s system 83% cpu 0.122 total |
| 9 | 0.09s user 0.02s system 81% cpu 0.132 total | 0.08s user 0.02s system 71% cpu 0.136 total |
| 10 | 0.09s user 0.02s system 86% cpu 0.126 total | 0.08s user 0.02s system 87% cpu 0.117 total |


<details>
<summary>Methodology</summary>

```bash
>> cat /tmp/tbl_input.txt | head -n1
3SSfXmcBSzV7RstFMxpBX4jdA, 0

>> cat /tmp/tbl_input.txt | tail -n1
H8hz8n9IqeHds5WdCuqLVkjMp, 999999

>> wc -l tbl_input.txt
1000000 tbl_input.txt
 
// create table
>> echo "create table ptest(a text, b int);" | sqlite3 perf.sqlite
// import 1 million entries
>> echo ".import tbl_input.txt ptest --csv" | sqlite3 perf.sqlite
// query `contains` using `instr`
>> time echo "select a from ptest where instr(a, '42') > 0;" | sqlite3 perf.sqlite
// results from 10 runs
 sqlite3 perf.sqlite  0.08s user 0.03s system 82% cpu 0.129 total
 sqlite3 perf.sqlite  0.08s user 0.02s system 82% cpu 0.126 total
 sqlite3 perf.sqlite  0.08s user 0.02s system 93% cpu 0.102 total
 sqlite3 perf.sqlite  0.08s user 0.02s system 87% cpu 0.111 total
 sqlite3 perf.sqlite  0.08s user 0.02s system 87% cpu 0.113 total
 sqlite3 perf.sqlite  0.07s user 0.02s system 92% cpu 0.092 total
 sqlite3 perf.sqlite  0.08s user 0.02s system 81% cpu 0.117 total
 sqlite3 perf.sqlite  0.08s user 0.02s system 83% cpu 0.122 total
 sqlite3 perf.sqlite  0.08s user 0.02s system 71% cpu 0.136 total
 sqlite3 perf.sqlite  0.08s user 0.02s system 87% cpu 0.117 total
 
// query `contains` using `like`
>> time echo "select a from ptest where a like '%42%';" | sqlite3 perf.sqlite
// results from 10 runs
 sqlite3 perf.sqlite  0.08s user 0.02s system 72% cpu 0.147 total
 sqlite3 perf.sqlite  0.08s user 0.02s system 77% cpu 0.139 total
 sqlite3 perf.sqlite  0.09s user 0.02s system 80% cpu 0.137 total
 sqlite3 perf.sqlite  0.09s user 0.02s system 81% cpu 0.133 total
 sqlite3 perf.sqlite  0.09s user 0.02s system 91% cpu 0.113 total
 sqlite3 perf.sqlite  0.09s user 0.02s system 90% cpu 0.119 total
 sqlite3 perf.sqlite  0.08s user 0.02s system 88% cpu 0.114 total
 sqlite3 perf.sqlite  0.09s user 0.02s system 81% cpu 0.132 total
 sqlite3 perf.sqlite  0.09s user 0.02s system 86% cpu 0.126 total
```
</details>



### Amplify DataStore Swift v2 Results
Compiled with optimizations (release mode)
10k records

| Predicate | `like` | `instr` |
|---|----|----|
| `query - contains` |  0.02407 | 0.02385 |
| `query - notContains` | 0.69535  |  0.75542 |
| `query - beginsWith` | 0.70660 | 0.75350 |
| `delete - contains` | 1.38273 | 1.53042 |
| `delete - notContains` | 63.00009 | 59.14374 |
| `delete - beginsWith` | 1.40701 | 1.38627 |

<details>
<summary>Methodology</summary>

```swift
func perfRun(label: String, _ f: () async throws -> Void) async throws {
    let start = CFAbsoluteTimeGetCurrent()
    try await f()
    let elapsed = CFAbsoluteTimeGetCurrent() - start
    print(label, elapsed, "seconds")
    return
}

try await Amplify.DataStore.clear()

let numberOfPosts = 10_000
let posts = (0..<numberOfPosts).map {
    Post(
        title: "title_\($0)",
        content: "content",
        createdAt: Temporal.DateTime.now(),
        rating: Double(Int.random(in: 0 ... 5)),
        status: .draft
    )
}

for post in posts {
    try await Amplify.DataStore.save(post)
}

let posts = try await Amplify.DataStore.query(Post.self)
assert(posts.count == numberOfPosts)


try await perfRun(label: ">> Query | contains") {
    _ = try await Amplify.DataStore.query(
        Post.self,
        where: Post.keys.title.contains("42")
    )
}

try await perfRun(label: ">> Query | notContains") {
    _ = try await Amplify.DataStore.query(
        Post.self,
        where: Post.keys.title.notContains("00")
    )
}

try await perfRun(label: ">> Query | beginsWith") {
    _ = try await Amplify.DataStore.query(
        Post.self,
        where: Post.keys.title.beginsWith("title")
    )
}

try await perfRun(label: ">> Delete | contains") {
    try await Amplify.DataStore.delete(
        Post.self,
        where: Post.keys.title.contains("42")
    )
}

try await perfRun(label: ">> Delete | notContains") {
    try await Amplify.DataStore.delete(
        Post.self,
        where: Post.keys.title.notContains("00")
    )
}

try await perfRun(label: ">> Delete | beginsWith") {
    try await Amplify.DataStore.delete(
        Post.self,
        where: Post.keys.title.beginsWith("title")
    )
}

 // Results
 instr - RELEASE
 >> Query | contains 0.023855924606323242 seconds
 >> Query | notContains 0.7554209232330322 seconds
 >> Query | beginsWith 0.7535010576248169 seconds
 >> Delete | contains 1.5304239988327026 seconds
 >> Delete | notContains 59.143746972084045 seconds
 >> Delete | beginsWith 1.3862730264663696 seconds

 like - RELEASE
 >> Query | contains 0.02407097816467285 seconds
 >> Query | notContains 0.6953569650650024 seconds
 >> Query | beginsWith 0.7066099643707275 seconds
 >> Delete | contains 1.3827320337295532 seconds
 >> Delete | notContains 63.00009608268738 seconds
 >> Delete | beginsWith 1.4070169925689697 seconds
```
</details>


## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
