### PR TITLE
fix(datastore): v1 swap `like` for `instr` in sql queries

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QueryPredicate+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QueryPredicate+SQLite.swift
@@ -26,19 +26,11 @@ extension QueryOperator {
         case .greaterThan:
             return "\(column) > ?"
         case .between:
-<<<<<<< HEAD:AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QueryPredicate+SQLite.swift
-            return "between ? and ?"
-        case .beginsWith, .contains:
-            return "like ?"
-=======
             return "\(column) between ? and ?"
         case .beginsWith:
             return "instr(\(column), ?) = 1"
         case .contains:
             return "instr(\(column), ?) > 0"
-        case .notContains:
-            return "instr(\(column), ?) = 0"
->>>>>>> d90cae79 (swap like and not like for instr in sql queries):AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/QueryPredicate+SQLite.swift
         }
     }
 
@@ -53,17 +45,9 @@ extension QueryOperator {
              .greaterOrEqual(let value),
              .greaterThan(let value):
             return [value.asBinding()]
-<<<<<<< HEAD:AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QueryPredicate+SQLite.swift
-        case .contains(let value):
-            return ["%\(value)%"]
-        case .beginsWith(let value):
-            return ["\(value)%"]
-=======
         case .contains(let value),
-            .beginsWith(let value),
-            .notContains(let value):
+             .beginsWith(let value):
             return [value.asBinding()]
->>>>>>> d90cae79 (swap like and not like for instr in sql queries):AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/QueryPredicate+SQLite.swift
         }
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QueryPredicate+SQLite.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QueryPredicate+SQLite.swift
@@ -11,24 +11,34 @@ import SQLite
 
 extension QueryOperator {
 
-    var sqlOperation: String {
+    func sqlOperation(column: String) -> String {
         switch self {
         case .notEqual(let value):
-            return value == nil ? "is not null" : "<> ?"
+            return value == nil ? "\(column) is not null" : "\(column) <> ?"
         case .equals(let value):
-            return value == nil ? "is null" : "= ?"
+            return value == nil ? "\(column) is null" : "\(column) = ?"
         case .lessOrEqual:
-            return "<= ?"
+            return "\(column) <= ?"
         case .lessThan:
-            return "< ?"
+            return "\(column) < ?"
         case .greaterOrEqual:
-            return ">= ?"
+            return "\(column) >= ?"
         case .greaterThan:
-            return "> ?"
+            return "\(column) > ?"
         case .between:
+<<<<<<< HEAD:AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QueryPredicate+SQLite.swift
             return "between ? and ?"
         case .beginsWith, .contains:
             return "like ?"
+=======
+            return "\(column) between ? and ?"
+        case .beginsWith:
+            return "instr(\(column), ?) = 1"
+        case .contains:
+            return "instr(\(column), ?) > 0"
+        case .notContains:
+            return "instr(\(column), ?) = 0"
+>>>>>>> d90cae79 (swap like and not like for instr in sql queries):AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/QueryPredicate+SQLite.swift
         }
     }
 
@@ -43,10 +53,17 @@ extension QueryOperator {
              .greaterOrEqual(let value),
              .greaterThan(let value):
             return [value.asBinding()]
+<<<<<<< HEAD:AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/QueryPredicate+SQLite.swift
         case .contains(let value):
             return ["%\(value)%"]
         case .beginsWith(let value):
             return ["\(value)%"]
+=======
+        case .contains(let value),
+            .beginsWith(let value),
+            .notContains(let value):
+            return [value.asBinding()]
+>>>>>>> d90cae79 (swap like and not like for instr in sql queries):AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/QueryPredicate+SQLite.swift
         }
     }
 }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Storage/SQLite/SQLStatement+Condition.swift
@@ -31,9 +31,9 @@ private func translateQueryPredicate(from modelSchema: ModelSchema,
         if let operation = pred as? QueryPredicateOperation {
             let column = resolveColumn(operation)
             if predicateIndex == 0 {
-                sql.append("\(indent)\(column) \(operation.operator.sqlOperation)")
+                sql.append("\(indent)\(operation.operator.sqlOperation(column: column))")
             } else {
-                sql.append("\(indent)\(groupType.rawValue) \(column) \(operation.operator.sqlOperation)")
+                sql.append("\(indent)\(groupType.rawValue) \(operation.operator.sqlOperation(column: column))")
             }
 
             bindings.append(contentsOf: operation.operator.bindings)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreLocalStoreTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginIntegrationTests/DataStoreLocalStoreTests.swift
@@ -442,6 +442,177 @@ class DataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
         sink.cancel()
     }
 
+    /// Given: Saved `Post`s containing SQL pattern matching symbols `%` and `_`
+    /// When: Querying with predicates containing those symbols.
+    /// Then: The query results should only contain values matching the predicate without
+    /// treating `%` and `_` as pattern matching symbols.
+    func testQueryPatternMatchingSymbols() async throws {
+        setUp(withModels: TestModelRegistration())
+
+        let posts = [
+            Post(
+                title: "_bc",
+                content: "",
+                createdAt: .now()
+            ),
+            Post(
+                title: "abc",
+                content: "",
+                createdAt: .now()
+            ),
+            Post(
+                title: "de%",
+                content: "",
+                createdAt: .now()
+            ),
+            Post(
+                title: "def",
+                content: "",
+                createdAt: .now()
+            )
+        ]
+
+        for post in posts {
+            let saveExpectation = expectation(description: "Save post completed")
+            Amplify.DataStore.save(post) { result in
+                switch result {
+                case .success:
+                    saveExpectation.fulfill()
+                case .failure(let error):
+                    XCTFail("Error saving post: \(post) - \(error)")
+                }
+            }
+            wait(for: [saveExpectation], timeout: 2)
+        }
+
+        let beginsWithExpectation = expectation(description: "query with beginsWith predicate completed")
+        // This should only contain 1 Post with the title "_bc"
+        // It should not contain the Post with the title "abc"
+        Amplify.DataStore.query(
+            Post.self,
+            where: Post.keys.title.beginsWith("_b")
+        ) { result in
+            switch result {
+            case .success(let posts):
+                XCTAssertEqual(posts.count, 1)
+                XCTAssertEqual(posts[0].title, "_bc")
+                beginsWithExpectation.fulfill()
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [beginsWithExpectation], timeout: 1)
+
+        let containsExpectation = expectation(description: "query with contains predicate completed")
+        // This should only contain the Post with the title "de%"
+        // It should not contain the Post with the title "def"
+        Amplify.DataStore.query(
+            Post.self,
+            where: Post.keys.title.contains("%")
+        ) { result in
+            switch result {
+            case .success(let posts):
+                XCTAssertEqual(posts.count, 1)
+                XCTAssertEqual(posts[0].title, "de%")
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [containsExpectation], timeout: 1)
+    }
+
+    /// Given: Saved `Post`s containing SQL pattern matching symbols `%` and `_`
+    /// When: Deleting with predicates containing those symbols and subsequently querying
+    /// for all `Post`s.
+    /// Then: The query results should only contain values matching the predicate without
+    /// treating `%` and `_` as pattern matching symbols.
+    func testDeletePatternMatchingSymbols() async throws {
+        setUp(withModels: TestModelRegistration())
+
+        let posts = [
+            Post(
+                title: "_bc",
+                content: "",
+                createdAt: .now()
+            ),
+            Post(
+                title: "abc",
+                content: "",
+                createdAt: .now()
+            ),
+            Post(
+                title: "de%",
+                content: "",
+                createdAt: .now()
+            ),
+            Post(
+                title: "def",
+                content: "",
+                createdAt: .now()
+            )
+        ]
+
+        for post in posts {
+            let saveExpectation = expectation(description: "Save post completed")
+            Amplify.DataStore.save(post) { result in
+                switch result {
+                case .success:
+                    saveExpectation.fulfill()
+                case .failure(let error):
+                    XCTFail("Error saving post: \(post) - \(error)")
+                }
+            }
+            wait(for: [saveExpectation], timeout: 2)
+        }
+
+        let beginsWithExpectation = expectation(description: "delete + query with beginsWith predicate completed")
+        // This should only delete 1 Post with the title "_bc"
+        // It should not delete the Post with the title "abc"
+        Amplify.DataStore.delete(
+            Post.self,
+            where: Post.keys.title.beginsWith("_b")
+        ) { deleteResult in
+            guard case .success = deleteResult else {
+                return XCTFail("Delete request failed")
+            }
+            Amplify.DataStore.query(Post.self) { result in
+                switch result {
+                case .success(let posts):
+                    XCTAssertEqual(posts.count, 3)
+                    XCTAssertTrue(posts.filter { $0.title == "_bc" }.isEmpty)
+                    beginsWithExpectation.fulfill()
+                case .failure(let error):
+                    XCTFail("\(error)")
+
+                }
+            }
+        }
+        wait(for: [beginsWithExpectation], timeout: 1)
+
+        let containsExpectation = expectation(description: "delete + query with contains predicate completed")
+        // This should only delete the Post with the title "de%"
+        // It should not delete the Post with the title "def"
+        Amplify.DataStore.delete(
+            Post.self,
+            where: Post.keys.title.contains("%")
+        ) { deleteResult in
+            guard case .success = deleteResult else {
+                return XCTFail("Delete request failed")
+            }
+            Amplify.DataStore.query(Post.self) { result in
+                switch result {
+                case .success(let posts):
+                    XCTAssertEqual(posts.count, 2)
+                    XCTAssertTrue(posts.filter { $0.title == "de%" }.isEmpty)
+                    containsExpectation.fulfill()
+                case .failure(let error):
+                    XCTFail("\(error)")
+                }
+            }
+        }
+        wait(for: [containsExpectation], timeout: 1)
+    }
+
     func testDeleteModelTypeWithPredicate() {
         setUp(withModels: TestModelRegistration())
         _ = setUpLocalStore(numberOfPosts: 5)

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
@@ -1087,8 +1087,6 @@ class SQLStatementTests: XCTestCase {
           )
         """, statement.stringValue)
 
-        // "content" like ?
-        // or "title" like ?
         let variables = statement.variables
         XCTAssertEqual(variables[0] as? Int, 1)
         XCTAssertEqual(variables[1] as? Int, 0)
@@ -1322,8 +1320,6 @@ class SQLStatementTests: XCTestCase {
               )
             """
 
-        // "root"."content" like ?
-        // or "root"."title" like ?
         XCTAssertEqual(statement.stringValue, expectedStatement)
 
         let variables = statement.variables

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/SQLStatementTests.swift
@@ -1047,11 +1047,11 @@ class SQLStatementTests: XCTestCase {
                         matches: "\"root\".\"rating\" between ? and ?",
                         bindings: [3, 5])
         assertPredicate(post.title.beginsWith("gelato"),
-                        matches: "\"root\".\"title\" like ?",
-                        bindings: ["gelato%"])
+                        matches: "instr(\"root\".\"title\", ?) = 1",
+                        bindings: ["gelato"])
         assertPredicate(post.title ~= "gelato",
-                        matches: "\"root\".\"title\" like ?",
-                        bindings: ["%gelato%"])
+                        matches: "instr(\"root\".\"title\", ?) > 0",
+                        bindings: ["gelato"])
     }
 
     /// - Given: a grouped predicate
@@ -1081,20 +1081,22 @@ class SQLStatementTests: XCTestCase {
             and "status" <> ?
             and "updatedAt" is null
             and (
-              "content" like ?
-              or "title" like ?
+              instr("content", ?) > 0
+              or instr("title", ?) = 1
             )
           )
         """, statement.stringValue)
 
+        // "content" like ?
+        // or "title" like ?
         let variables = statement.variables
         XCTAssertEqual(variables[0] as? Int, 1)
         XCTAssertEqual(variables[1] as? Int, 0)
         XCTAssertEqual(variables[2] as? Int, 2)
         XCTAssertEqual(variables[3] as? Int, 4)
         XCTAssertEqual(variables[4] as? String, PostStatus.draft.rawValue)
-        XCTAssertEqual(variables[5] as? String, "%gelato%")
-        XCTAssertEqual(variables[6] as? String, "ice cream%")
+        XCTAssertEqual(variables[5] as? String, "gelato")
+        XCTAssertEqual(variables[6] as? String, "ice cream")
     }
 
     /// - Given: a `Model` type
@@ -1314,11 +1316,14 @@ class SQLStatementTests: XCTestCase {
                 and "root"."rating" between ? and ?
                 and "root"."updatedAt" is null
                 and (
-                  "root"."content" like ?
-                  or "root"."title" like ?
+                  instr("root"."content", ?) > 0
+                  or instr("root"."title", ?) = 1
                 )
               )
             """
+
+        // "root"."content" like ?
+        // or "root"."title" like ?
         XCTAssertEqual(statement.stringValue, expectedStatement)
 
         let variables = statement.variables
@@ -1326,8 +1331,8 @@ class SQLStatementTests: XCTestCase {
         XCTAssertEqual(variables[1] as? Int, 0)
         XCTAssertEqual(variables[2] as? Int, 2)
         XCTAssertEqual(variables[3] as? Int, 4)
-        XCTAssertEqual(variables[4] as? String, "%gelato%")
-        XCTAssertEqual(variables[5] as? String, "ice cream%")
+        XCTAssertEqual(variables[4] as? String, "gelato")
+        XCTAssertEqual(variables[5] as? String, "ice cream")
     }
 
     func testTranslateQueryPredicateWithNameSpaceWhenFieldNameSpecified() {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
Moving from like to instr for DataStore predicates.

*Simplified overview for brevity, the actual SQL queries use bindings
| API                                     | Previous                   | New                               |
|--------------------------|---------------------|-----------------------|
| `foo.contains("bar")`       | `like "%bar%"`        | `instr(foo, "bar") > 0` |
| `foo.notContains("bar")` | `not like "%bar%"` | `instr(foo, "bar") = 0` |
| `foo.beginsWith("bar")`    | `like "bar%"`           | `instr(foo, "bar") = 1` |

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
