### PR TITLE
fix(PushNotifications): Checking if there is a Provisioning Profile with the APS Entitlement in order to determine the ChannelType

### DIFF
--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Context/AWSPinpointFactory.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Context/AWSPinpointFactory.swift
@@ -29,10 +29,18 @@ public class AWSPinpointFactory {
             return existingContext
         }
 
-        var isDebug = false
+        var isDebug: Bool
+        /// Check for the APS Environment entitlement in a provisioning profile first
+        if let apsEnvironment = ProvisioningProfileReader().apsEnvironment() {
+            isDebug = apsEnvironment == .development
+        } else {
+        /// Fallback to the DEBUG flag
         #if DEBUG
             isDebug = true
+        #else
+            isDebug = false
         #endif
+        }
         let configuration = PinpointContextConfiguration(
             appId: appId,
             region: region,
@@ -43,5 +51,84 @@ public class AWSPinpointFactory {
         let pinpointContext = try PinpointContext(with: configuration)
         instances[key] = pinpointContext
         return pinpointContext
+    }
+}
+
+private struct ProvisioningProfileReader {
+    enum APSEnvironment: String {
+        case development
+        case production
+    }
+
+    private struct Keys {
+        static let entitlements = "Entitlements"
+        static var apsEnvironment: String {
+        #if os(macOS)
+            return "com.apple.developer.aps-environment"
+        #else
+            return "aps-environment"
+        #endif
+        }
+    }
+
+    private let fileName = "embedded"
+    private var fileExtension: String = {
+    #if os(macOS)
+        return "provisionprofile"
+    #else
+        return "mobileprovision"
+    #endif
+    }()
+
+    private var url: URL? {
+#if os(macOS)
+        if let url = Bundle.main.url(forResource: fileName, withExtension: fileExtension) {
+            return url
+        }
+
+        guard let enumerator =  FileManager.default.enumerator(
+            at: Bundle.main.bundleURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else {
+            return nil
+        }
+
+        let provisioningFile = "\(fileName).\(fileExtension)"
+        for case let url as URL in enumerator where provisioningFile == url.lastPathComponent {
+            return url
+        }
+
+        return nil
+#else
+        return Bundle.main.url(forResource: fileName, withExtension: fileExtension)
+#endif
+    }
+
+    private var contents: Data? {
+        guard let url = url,
+              let contents =  try? String(contentsOf: url, encoding: .isoLatin1) else {
+            return nil
+        }
+
+        let scanner = Scanner(string: contents)
+        guard scanner.scanUpToString("<plist") != nil,
+              let plist = scanner.scanUpToString("</plist>") else {
+            return nil
+        }
+
+        return "\(plist)</plist>".data(using: .isoLatin1)
+    }
+
+    func apsEnvironment() -> APSEnvironment? {
+        if let contents = contents,
+           let provisioning = try? PropertyListSerialization.propertyList(from: contents,
+                                                                          format: nil) as? [String: Any],
+           let entitlements = provisioning[Keys.entitlements] as? [String: Any],
+           let apnsEnvironment = entitlements[Keys.apsEnvironment] as? String {
+            return APSEnvironment(rawValue: apnsEnvironment)
+        }
+
+        return nil
     }
 }

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Context/AWSPinpointFactory.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Context/AWSPinpointFactory.swift
@@ -21,6 +21,8 @@ public class AWSPinpointFactory {
     private init() {}
     
     static var credentialsProvider = AWSAuthService().getCredentialsProvider()
+
+    static var provisioningProfileReader: ProvisioningProfileReader = .default
     
     public static func sharedPinpoint(appId: String,
                                       region: String) throws -> AWSPinpointBehavior {
@@ -31,7 +33,7 @@ public class AWSPinpointFactory {
 
         var isDebug: Bool
         /// Check for the APS Environment entitlement in a provisioning profile first
-        if let apsEnvironment = ProvisioningProfileReader().apsEnvironment() {
+        if let apsEnvironment = provisioningProfileReader.profile()?.apsEnvironment {
             isDebug = apsEnvironment == .development
         } else {
         /// Fallback to the DEBUG flag
@@ -54,81 +56,3 @@ public class AWSPinpointFactory {
     }
 }
 
-private struct ProvisioningProfileReader {
-    enum APSEnvironment: String {
-        case development
-        case production
-    }
-
-    private struct Keys {
-        static let entitlements = "Entitlements"
-        static var apsEnvironment: String {
-        #if os(macOS)
-            return "com.apple.developer.aps-environment"
-        #else
-            return "aps-environment"
-        #endif
-        }
-    }
-
-    private let fileName = "embedded"
-    private var fileExtension: String = {
-    #if os(macOS)
-        return "provisionprofile"
-    #else
-        return "mobileprovision"
-    #endif
-    }()
-
-    private var url: URL? {
-#if os(macOS)
-        if let url = Bundle.main.url(forResource: fileName, withExtension: fileExtension) {
-            return url
-        }
-
-        guard let enumerator =  FileManager.default.enumerator(
-            at: Bundle.main.bundleURL,
-            includingPropertiesForKeys: [.isRegularFileKey],
-            options: [.skipsHiddenFiles, .skipsPackageDescendants]
-        ) else {
-            return nil
-        }
-
-        let provisioningFile = "\(fileName).\(fileExtension)"
-        for case let url as URL in enumerator where provisioningFile == url.lastPathComponent {
-            return url
-        }
-
-        return nil
-#else
-        return Bundle.main.url(forResource: fileName, withExtension: fileExtension)
-#endif
-    }
-
-    private var contents: Data? {
-        guard let url = url,
-              let contents =  try? String(contentsOf: url, encoding: .isoLatin1) else {
-            return nil
-        }
-
-        let scanner = Scanner(string: contents)
-        guard scanner.scanUpToString("<plist") != nil,
-              let plist = scanner.scanUpToString("</plist>") else {
-            return nil
-        }
-
-        return "\(plist)</plist>".data(using: .isoLatin1)
-    }
-
-    func apsEnvironment() -> APSEnvironment? {
-        if let contents = contents,
-           let provisioning = try? PropertyListSerialization.propertyList(from: contents,
-                                                                          format: nil) as? [String: Any],
-           let entitlements = provisioning[Keys.entitlements] as? [String: Any],
-           let apnsEnvironment = entitlements[Keys.apsEnvironment] as? String {
-            return APSEnvironment(rawValue: apnsEnvironment)
-        }
-
-        return nil
-    }
-}

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Support/Utils/ProvisioningProfileReader.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Support/Utils/ProvisioningProfileReader.swift
@@ -7,8 +7,7 @@
 
 import Foundation
 
-@_spi(InternalAWSPinpoint)
-public struct ProvisioningProfile {
+struct ProvisioningProfile {
     enum APSEnvironment: String {
         case development
         case production
@@ -17,20 +16,17 @@ public struct ProvisioningProfile {
     var apsEnvironment: APSEnvironment?
 }
 
-@_spi(InternalAWSPinpoint)
-public protocol ProvisioningProfileReader {
+protocol ProvisioningProfileReader {
     func profile() -> ProvisioningProfile?
 }
 
-@_spi(InternalAWSPinpoint)
-public extension ProvisioningProfileReader where Self == DefaultProvisioningProfileReader {
+extension ProvisioningProfileReader where Self == DefaultProvisioningProfileReader {
     static var `default`: ProvisioningProfileReader {
         DefaultProvisioningProfileReader()
     }
 }
 
-@_spi(InternalAWSPinpoint)
-public struct DefaultProvisioningProfileReader: ProvisioningProfileReader {
+struct DefaultProvisioningProfileReader: ProvisioningProfileReader {
     private struct Keys {
         static let entitlements = "Entitlements"
         static var apsEnvironment: String {
@@ -91,7 +87,7 @@ public struct DefaultProvisioningProfileReader: ProvisioningProfileReader {
         return "\(plist)</plist>".data(using: .isoLatin1)
     }
 
-    public func profile() -> ProvisioningProfile? {
+    func profile() -> ProvisioningProfile? {
         guard let contents = contents,
               let provisioning = try? PropertyListSerialization.propertyList(
                   from: contents,

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Support/Utils/ProvisioningProfileReader.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Support/Utils/ProvisioningProfileReader.swift
@@ -1,0 +1,111 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+@_spi(InternalAWSPinpoint)
+public struct ProvisioningProfile {
+    enum APSEnvironment: String {
+        case development
+        case production
+    }
+
+    var apsEnvironment: APSEnvironment?
+}
+
+@_spi(InternalAWSPinpoint)
+public protocol ProvisioningProfileReader {
+    func profile() -> ProvisioningProfile?
+}
+
+@_spi(InternalAWSPinpoint)
+public extension ProvisioningProfileReader where Self == DefaultProvisioningProfileReader {
+    static var `default`: ProvisioningProfileReader {
+        DefaultProvisioningProfileReader()
+    }
+}
+
+@_spi(InternalAWSPinpoint)
+public struct DefaultProvisioningProfileReader: ProvisioningProfileReader {
+    private struct Keys {
+        static let entitlements = "Entitlements"
+        static var apsEnvironment: String {
+        #if os(macOS)
+            return "com.apple.developer.aps-environment"
+        #else
+            return "aps-environment"
+        #endif
+        }
+    }
+
+    private let fileName = "embedded"
+    private var fileExtension: String = {
+    #if os(macOS)
+        return "provisionprofile"
+    #else
+        return "mobileprovision"
+    #endif
+    }()
+
+    private var url: URL? {
+#if os(macOS)
+        if let url = Bundle.main.url(forResource: fileName, withExtension: fileExtension) {
+            return url
+        }
+
+        guard let enumerator =  FileManager.default.enumerator(
+            at: Bundle.main.bundleURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else {
+            return nil
+        }
+
+        let provisioningFile = "\(fileName).\(fileExtension)"
+        for case let url as URL in enumerator where provisioningFile == url.lastPathComponent {
+            return url
+        }
+
+        return nil
+#else
+        return Bundle.main.url(forResource: fileName, withExtension: fileExtension)
+#endif
+    }
+
+    private var contents: Data? {
+        guard let url = url,
+              let contents =  try? String(contentsOf: url, encoding: .isoLatin1) else {
+            return nil
+        }
+
+        let scanner = Scanner(string: contents)
+        guard scanner.scanUpToString("<plist") != nil,
+              let plist = scanner.scanUpToString("</plist>") else {
+            return nil
+        }
+
+        return "\(plist)</plist>".data(using: .isoLatin1)
+    }
+
+    public func profile() -> ProvisioningProfile? {
+        guard let contents = contents,
+              let provisioning = try? PropertyListSerialization.propertyList(
+                  from: contents,
+                  format: nil
+              ) as? [String: Any] else {
+            return nil
+        }
+
+        var profile = ProvisioningProfile()
+        if let entitlements = provisioning[Keys.entitlements] as? [String: Any],
+           let apnsEnvironment = entitlements[Keys.apsEnvironment] as? String {
+            profile.apsEnvironment = ProvisioningProfile.APSEnvironment(rawValue: apnsEnvironment)
+        }
+
+        return profile
+    }
+}

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AWSPinpointFactoryTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AWSPinpointFactoryTests.swift
@@ -1,0 +1,70 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AmplifyTestCommon
+@_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
+import XCTest
+
+final class AWSPinpointFactoryTests: XCTestCase {
+    private var appId: String {
+        UUID().uuidString
+    }
+    private let region = "region"
+    private var mockedProfileReader: MockProvisioningProfileReader!
+
+    override func setUp() {
+        mockedProfileReader = MockProvisioningProfileReader()
+        AWSPinpointFactory.provisioningProfileReader = mockedProfileReader
+        AWSPinpointFactory.credentialsProvider = MockCredentialsProvider()
+    }
+
+    /// - Given: There is a provisioning profile that set the APS entitlement to production
+    /// - When: A Pinpoint Context is created
+    /// - Then: The endpoint's isDebug flag should be set to false
+    func testSharedPinpoint_withProvisioningProfile_andAPSProduction_shouldSetDebugToFalse() async throws {
+        mockedProfileReader.mockedProfile = .init(
+            apsEnvironment: .production
+        )
+
+        let pinpoint = try AWSPinpointFactory.sharedPinpoint(appId: appId, region: region)
+        let context = try XCTUnwrap(pinpoint as? PinpointContext)
+        let endpoint = await context.endpointClient.currentEndpointProfile()
+        XCTAssertFalse(endpoint.isDebug)
+    }
+
+    /// - Given: There is a provisioning profile that set the APS entitlement to development
+    /// - When: A Pinpoint Context is created
+    /// - Then: The endpoint's isDebug flag should be set to true
+    func testSharedPinpoint_withProvisioningProfile_andAPSDevelopment_shouldSetDebugToFalse() async throws {
+        mockedProfileReader.mockedProfile = .init(
+            apsEnvironment: .development
+        )
+
+        let pinpoint = try AWSPinpointFactory.sharedPinpoint(appId: appId, region: region)
+        let context = try XCTUnwrap(pinpoint as? PinpointContext)
+        let endpoint = await context.endpointClient.currentEndpointProfile()
+        XCTAssertTrue(endpoint.isDebug)
+    }
+
+    /// - Given: There is no provisioning profile
+    /// - When: A Pinpoint Context is created
+    /// - Then: The endpoint's isDebug flag should be determined based on the presence of the DEBUG flag
+    func testSharedPinpoint_withoutProvisioningProfile_shouldSetDebugAccodingToDEBUGFlag() async throws {
+        mockedProfileReader.mockedProfile = nil
+        var isDebug: Bool
+    #if DEBUG
+        isDebug = true
+    #else
+        isDebug = false
+    #endif
+
+        let pinpoint = try AWSPinpointFactory.sharedPinpoint(appId: appId, region: region)
+        let context = try XCTUnwrap(pinpoint as? PinpointContext)
+        let endpoint = await context.endpointClient.currentEndpointProfile()
+        XCTAssertEqual(endpoint.isDebug, isDebug)
+    }
+}

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockProvisioningProfileReader.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockProvisioningProfileReader.swift
@@ -1,0 +1,21 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+@_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
+
+class MockProvisioningProfileReader: ProvisioningProfileReader {
+    var mockedProfile: ProvisioningProfile? {
+        didSet {
+            print("ROBOCITO: Set mockedProfile to \(mockedProfile)")
+        }
+    }
+
+    func profile() -> ProvisioningProfile? {
+        return mockedProfile
+    }
+}

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockProvisioningProfileReader.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockProvisioningProfileReader.swift
@@ -9,11 +9,7 @@ import Foundation
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
 class MockProvisioningProfileReader: ProvisioningProfileReader {
-    var mockedProfile: ProvisioningProfile? {
-        didSet {
-            print("ROBOCITO: Set mockedProfile to \(mockedProfile)")
-        }
-    }
+    var mockedProfile: ProvisioningProfile?
 
     func profile() -> ProvisioningProfile? {
         return mockedProfile


### PR DESCRIPTION
## Issue \#
https://github.com/aws-amplify/amplify-swift/issues/2809

## Description
For some reason, apps distributed through TestFlight using a release config seem to incorrectly set `isDebug` to `true` in the `PinpointConfiguration`, which then results in the `APNS_SANDBOX` channel being used instead of `APNS`.

@iheffernan suggested to read for the [APS entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/aps-environment) in the provisioning profile (if there is one present) and use that to determine the debug status, and that seemed to resolve their issue.

I'm keeping the `DEBUG` flag check as a fallback for when there is no provisioning profile, or the APS entitlement can't be found.

## General Checklist
- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
