### PR TITLE
fix(storage): update storage to support downloading if a file already exist locally

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/FileSystem.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/FileSystem.swift
@@ -175,9 +175,7 @@ class FileSystem {
     }
 
     func moveFile(from sourceFileURL: URL, to destinationURL: URL) throws {
-        guard !FileManager.default.fileExists(atPath: destinationURL.path) else {
-            throw Failure.fatalError(errorDescription: "File already exists at destination: \(destinationURL.path)")
-        }
+        removeFileIfExists(fileURL: destinationURL)
         try FileManager.default.moveItem(atPath: sourceFileURL.path, toPath: destinationURL.path)
     }
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileSystemTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileSystemTests.swift
@@ -46,6 +46,39 @@ extension Bytes {
 
 class FileSystemTests: XCTestCase {
 
+    func testMoveFile() throws {
+        let fs = FileSystem()
+        let directoryURL = fs.createTemporaryDirectoryURL()
+        try fs.createDirectory(at: directoryURL)
+        let bytes = Bytes.megabytes(3)
+        let data = bytes.generateRandomData()
+        let sourceFileUrl = try fs.createTemporaryFile(data: data, baseURL: directoryURL)
+        XCTAssertTrue(fs.fileExists(atURL: sourceFileUrl))
+        let destinationUrl = fs.documentsURL.appendingPathComponent("destination.tmp")
+        try fs.moveFile(from: sourceFileUrl, to: destinationUrl)
+        XCTAssertTrue(fs.fileExists(atURL: destinationUrl))
+        fs.removeDirectoryIfExists(directoryURL: sourceFileUrl)
+        fs.removeDirectoryIfExists(directoryURL: destinationUrl)
+    }
+    
+    func testMoveDuplicateFile() throws {
+        let fs = FileSystem()
+        let directoryURL = fs.createTemporaryDirectoryURL()
+        try fs.createDirectory(at: directoryURL)
+        let bytes = Bytes.megabytes(3)
+        let data = bytes.generateRandomData()
+        var sourceFileUrl = try fs.createTemporaryFile(data: data, baseURL: directoryURL)
+        XCTAssertTrue(fs.fileExists(atURL: sourceFileUrl))
+        let destinationUrl = fs.documentsURL.appendingPathComponent("destination.tmp")
+        try fs.moveFile(from: sourceFileUrl, to: destinationUrl)
+        XCTAssertTrue(fs.fileExists(atURL: destinationUrl))
+        sourceFileUrl = try fs.createTemporaryFile(data: data, baseURL: directoryURL)
+        try fs.moveFile(from: sourceFileUrl, to: destinationUrl)
+        XCTAssertTrue(fs.fileExists(atURL: destinationUrl))
+        fs.removeDirectoryIfExists(directoryURL: sourceFileUrl)
+        fs.removeDirectoryIfExists(directoryURL: destinationUrl)
+    }
+    
     func testFileExists() throws {
         let fs = FileSystem()
         let directoryURL = fs.createTemporaryDirectoryURL()

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileSystemTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileSystemTests.swift
@@ -46,7 +46,7 @@ extension Bytes {
 
 class FileSystemTests: XCTestCase {
 
-    func testMoveFile() throws {
+    func testMoveFile_Succeeds_WhenMoveFileExecuted() throws {
         let fs = FileSystem()
         let directoryURL = fs.createTemporaryDirectoryURL()
         try fs.createDirectory(at: directoryURL)
@@ -61,7 +61,7 @@ class FileSystemTests: XCTestCase {
         fs.removeDirectoryIfExists(directoryURL: destinationUrl)
     }
     
-    func testMoveDuplicateFile() throws {
+    func testMoveFile_Succeeds_WhenFileAlreadyExists() throws {
         let fs = FileSystem()
         let directoryURL = fs.createTemporaryDirectoryURL()
         try fs.createDirectory(at: directoryURL)


### PR DESCRIPTION
## Issue 
https://github.com/aws-amplify/amplify-swift/issues/2607

## Description
Update Storage V2 to support downloading of file that already exists locally.  This matches current behavior in Amplify Swift V1 and Amplify Android library.

## General Checklist

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
