### PR TITLE
ci: enable push notification category integration test

### DIFF
--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -55,46 +55,44 @@ jobs:
           project_path: ./AmplifyPlugins/Analytics/Tests/AnalyticsHostApp
           scheme: AWSPinpointAnalyticsPluginIntegrationTests
 
-  #  Disabling these tests because they do not currently work in CI. We will create a ticket to track
-  #  getting resolving this. In the meantime, they can be run locally.
-  #  
-  # push-notification-integration-test:
-  #   needs: prepare-for-test
-  #   runs-on: macos-12
-  #   environment: IntegrationTest
-  #   steps:
-  #     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-  #       with:
-  #         persist-credentials: false
 
-  #     - name: Make directory
-  #       run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
+  push-notification-integration-test:
+    needs: prepare-for-test
+    runs-on: macos-12
+    environment: IntegrationTest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          persist-credentials: false
 
-  #     - name: Copy integration test resouces
-  #       uses: ./.github/composite_actions/download_test_configuration
-  #       with:
-  #         resource_subfolder: push-notification
-  #         aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-  #         aws_region: ${{ secrets.AWS_REGION }}
-  #         aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG_V2 }}
+      - name: Make directory
+        run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
 
-  #     - name: Set up node
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: 16.x
+      - name: Copy integration test resouces
+        uses: ./.github/composite_actions/download_test_configuration
+        with:
+          resource_subfolder: push-notification
+          aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG_V2 }}
 
-  #     - name: Run Local Server
-  #       run: |
-  #         cd ./AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp/LocalServer
-  #         npm install
-  #         npm start &
-  #       shell: bash
+      - name: Set up node
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+        with:
+          node-version: 16.x
 
-  #     - name: Run Integration test
-  #       uses: ./.github/composite_actions/run_xcodebuild_test
-  #       with:
-  #         project_path: ./AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp
-  #         scheme: PushNotificationHostApp
+      - name: Run Local Server
+        run: |
+          cd ./AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp/LocalServer
+          npm install
+          npm start &
+        shell: bash
+
+      - name: Run Integration test
+        uses: ./.github/composite_actions/run_xcodebuild_test
+        with:
+          project_path: ./AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp
+          scheme: PushNotificationHostApp
 
   auth-integration-test:
     needs: prepare-for-test


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
- enable push notification integration test
  - added new amplify app and upload the configuration file to s3 for integration test

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
