### PR TITLE
test(datastore): fix contains and notContains with random number test cases

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
@@ -345,13 +345,13 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
 
         let postsContaining1InTitle = try await Amplify.DataStore.query(
             Post.self,
-            where: Post.keys.title.contains("1")
+            where: Post.keys.title.contains("_1_")
         )
         XCTAssertEqual(postsContaining1InTitle.count, 1)
 
         let postsNotContaining1InTitle = try await Amplify.DataStore.query(
             Post.self,
-            where: Post.keys.title.notContains("1")
+            where: Post.keys.title.notContains("_1_")
         )
         XCTAssertEqual(
             posts.count - postsContaining1InTitle.count,
@@ -360,7 +360,7 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
 
         XCTAssertTrue(
             postsNotContaining1InTitle.filter(
-                { $0.title.contains("1") }
+                { $0.title.contains("_1_") }
             ).isEmpty
         )
     }
@@ -423,7 +423,7 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
         let randomTitleNumber = String(Int.random(in: 0..<numberOfPosts))
 
         let postWithDuplicateTitleAndDifferentStatus = Post(
-            title: "title_\(randomTitleNumber)",
+            title: "title_\(randomTitleNumber)_",
             content: "content",
             createdAt: .now(),
             status: .published
@@ -433,7 +433,7 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
 
         let postsContainingRandomTitleNumber = try await Amplify.DataStore.query(
             Post.self,
-            where: Post.keys.title.contains(randomTitleNumber)
+            where: Post.keys.title.contains("_\(randomTitleNumber)_")
         )
 
         XCTAssertEqual(postsContainingRandomTitleNumber.count, 2)
@@ -455,7 +455,7 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
 
         let postsContainingRandomTitleNumberAndNotContainingDraftStatus = try await Amplify.DataStore.query(
             Post.self,
-            where: Post.keys.title.contains(randomTitleNumber)
+            where: Post.keys.title.contains("_\(randomTitleNumber)_")
             && Post.keys.status.notContains(PostStatus.published.rawValue)
         )
 
@@ -466,7 +466,7 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
 
         XCTAssertEqual(
             postsContainingRandomTitleNumberAndNotContainingDraftStatus[0].title,
-            "title_\(randomTitleNumber)"
+            "title_\(randomTitleNumber)_"
         )
 
         XCTAssertNotEqual(
@@ -486,12 +486,12 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
 
         try await Amplify.DataStore.delete(
             Post.self,
-            where: Post.keys.title.notContains("1")
+            where: Post.keys.title.notContains("_1_")
         )
 
         let postsIncluding1InTitle = try await Amplify.DataStore.query(Post.self)
         XCTAssertEqual(postsIncluding1InTitle.count, 1)
-        XCTAssertEqual(postsIncluding1InTitle[0].title, "title_1")
+        XCTAssertEqual(postsIncluding1InTitle[0].title, "title_1_")
     }
 
 
@@ -505,9 +505,9 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
             .init(title: title, content: content, createdAt: .now())
         }
 
-        let post1 = post(title: "title_1", content: "a")
-        let post2 = post(title: "title_1", content: "b")
-        let post3 = post(title: "title_3", content: "c")
+        let post1 = post(title: "title_1_", content: "a")
+        let post2 = post(title: "title_1_", content: "b")
+        let post3 = post(title: "title_3_", content: "c")
 
         _ = try await Amplify.DataStore.save(post1)
         _ = try await Amplify.DataStore.save(post2)
@@ -518,7 +518,7 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
 
         try await Amplify.DataStore.delete(
             Post.self,
-            where: Post.keys.title.notContains("1")
+            where: Post.keys.title.notContains("_1_")
             || Post.keys.content.notContains("a")
         )
 
@@ -645,7 +645,7 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
     func setUpLocalStore(numberOfPosts: Int) async throws -> [Post] {
         let posts = (0..<numberOfPosts).map {
             Post(
-                title: "title_\($0)",
+                title: "title_\($0)_",
                 content: "content",
                 createdAt: .now(),
                 rating: Double(Int.random(in: 0 ... 5)),

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "amplify-swift-utils-notifications",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/aws-amplify/amplify-swift-utils-notifications.git",
+      "state" : {
+        "revision" : "d4fd3c17e8d40efc821f448d3d6cff75b8f3b0dd",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "aws-appsync-realtime-client-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
The random number test cases here will cause error when the random value is single digits.

## Description
<!-- Why is this change required? What problem does it solve? -->

Considering data set `[title_<1...n>, n = 50]`. 
when the random number is `1...5`, for example: 1, the `contains` operation will match `_1,_11,_12,_13,_21...`, which are more than 2 records. 
By simply appending a `_` in the end to indicate the ending resolved the issue.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] ~PR title conforms to conventional commit style~
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
