### PR TITLE
feat(storage): Add pagination support.

### DIFF
--- a/Amplify/Categories/Storage/Operation/Request/StorageListRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageListRequest.swift
@@ -5,39 +5,84 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+/// - Tag: StorageListRequest
 public struct StorageListRequest: AmplifyOperationRequest {
+
     /// Options to adjust the behavior of this request, including plugin-options
+    /// - Tag: StorageListRequest
     public let options: Options
 
+    /// - Tag: StorageListRequest.init
     public init(options: Options) {
         self.options = options
     }
 }
 
 public extension StorageListRequest {
-    /// Options to adjust the behavior of this request, including plugin-options
+
+    /// Options available to callers of
+    /// [StorageCategoryBehavior.list](x-source-tag://StorageCategoryBehavior.list).
+    ///
+    /// Tag: StorageListRequestOptions
     struct Options {
+
         /// Access level of the storage system. Defaults to `public`
+        ///
+        /// - Tag: StorageListRequestOptions.accessLevel
         public let accessLevel: StorageAccessLevel
 
         /// Target user to apply the action on
+        ///
+        /// - Tag: StorageListRequestOptions.targetIdentityId
         public let targetIdentityId: String?
 
         /// Path to the keys
+        ///
+        /// - Tag: StorageListRequestOptions.path
         public let path: String?
+
+        /// Number between 1 and 1,000 that indicates the limit of how many entries to fetch when
+        /// retreiving file lists from the server.
+        ///
+        /// NOTE: Plugins may decide to throw or perform normalization when encoutering vaues outside
+        ///       the specified range.
+        ///
+        /// - SeeAlso:
+        /// [StorageListRequestOptions.nextToken](x-source-tag://StorageListRequestOptions.nextToken)
+        /// [StorageListResult.nextToken](x-source-tag://StorageListResult.nextToken)
+        ///
+        /// - Tag: StorageListRequestOptions.pageSize
+        public let pageSize: UInt
+
+        /// Opaque string indicating the page offset at which to resume a listing. This is usually a copy of
+        /// the value from [StorageListResult.nextToken](x-source-tag://StorageListResult.nextToken).
+        ///
+        /// - SeeAlso:
+        /// [StorageListRequestOptions.pageSize](x-source-tag://StorageListRequestOptions.pageSize)
+        /// [StorageListResult.nextToken](x-source-tag://StorageListResult.nextToken)
+        ///
+        /// - Tag: StorageListRequestOptions.nextToken
+        public let nextToken: String?
 
         /// Extra plugin specific options, only used in special circumstances when the existing options do not provide
         /// a way to utilize the underlying storage system's functionality. See plugin documentation for expected
         /// key/values
+        ///
+        /// - Tag: StorageListRequestOptions.pluginOptions
         public let pluginOptions: Any?
 
+        /// - Tag: StorageListRequestOptions.init
         public init(accessLevel: StorageAccessLevel = .guest,
                     targetIdentityId: String? = nil,
                     path: String? = nil,
+                    pageSize: UInt = 1000,
+                    nextToken: String? = nil,
                     pluginOptions: Any? = nil) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.path = path
+            self.pageSize = pageSize
+            self.nextToken = nextToken
             self.pluginOptions = pluginOptions
         }
     }

--- a/Amplify/Categories/Storage/Result/StorageListResult.swift
+++ b/Amplify/Categories/Storage/Result/StorageListResult.swift
@@ -7,35 +7,71 @@
 
 import Foundation
 
+/// Represents the output of a call to
+/// [StorageCategoryBehavior.list](x-source-tag://StorageCategoryBehavior.list)
+///
+/// - Tag: StorageListResult
 public struct StorageListResult {
-    public init(items: [Item]) {
+
+    /// This is meant to be called by plugins implementing
+    /// [StorageCategoryBehavior.list](x-source-tag://StorageCategoryBehavior.list).
+    ///
+    /// - Tag: StorageListResult.init
+    public init(items: [Item], nextToken: String? = nil) {
         self.items = items
+        self.nextToken = nextToken
     }
 
-    // Array of Items in the Result
+    /// Array of Items in the Result
+    ///
+    /// - Tag: StorageListResult.items
     public var items: [Item]
+
+    /// Opaque string indicating the page offset at which to resume a listing. This value is usually copied to
+    /// [StorageListRequestOptions.nextToken](x-source-tag://StorageListRequestOptions.nextToken).
+    ///
+    /// - SeeAlso:
+    /// [StorageListRequestOptions.nextToken](x-source-tag://StorageListRequestOptions.nextToken)
+    ///
+    /// - Tag: StorageListResult.nextToken
+    public let nextToken: String?
 }
 
 extension StorageListResult {
 
+    /// - Tag: StorageListResultItem
     public struct Item {
 
         /// The unique identifier of the object in storage.
+        ///
+        /// - Tag: StorageListResultItem.key
         public let key: String
 
         /// Size in bytes of the object
+        ///
+        /// - Tag: StorageListResultItem.size
         public let size: Int?
 
         /// The date the Object was Last Modified
+        ///
+        /// - Tag: StorageListResultItem.lastModified
         public let lastModified: Date?
 
         /// The entity tag is an MD5 hash of the object.
         /// ETag reflects only changes to the contents of an object, not its metadata.
+        ///
+        /// - Tag: StorageListResultItem.eTag
         public let eTag: String?
 
         /// Additional results specific to the plugin.
+        ///
+        /// - Tag: StorageListResultItem.pluginResults
         public let pluginResults: Any?
 
+        /// This is meant to be called by plugins implementing
+        /// [StorageCategoryBehavior.list](x-source-tag://StorageCategoryBehavior.list).
+        ///
+        /// - Tag: StorageListResultItem.init
         public init(key: String,
                     size: Int? = nil,
                     eTag: String? = nil,

--- a/Amplify/Categories/Storage/StorageCategoryBehavior.swift
+++ b/Amplify/Categories/Storage/StorageCategoryBehavior.swift
@@ -7,7 +7,11 @@
 
 import Foundation
 
-/// Behavior of the Storage category that clients will use
+/// Behavior of the Storage category used though `Amplify.Storage.*`. Plugin implementations
+/// conform to this protocol indirectly though the
+/// [StorageCategoryPlugin](x-source-tag://StorageCategoryPlugin) protocol.
+///
+/// - Tag: StorageCategoryBehavior
 public protocol StorageCategoryBehavior {
 
     /// Retrieve the remote URL for the object from storage.
@@ -16,6 +20,8 @@ public protocol StorageCategoryBehavior {
     ///   - key: The unique identifier for the object in storage.
     ///   - options: Parameters to specific plugin behavior
     /// - Returns: requested Get URL
+    ///
+    /// - Tag: StorageCategoryBehavior.getURL
     @discardableResult
     func getURL(key: String,
                 options: StorageGetURLOperation.Request.Options?) async throws -> URL
@@ -26,6 +32,8 @@ public protocol StorageCategoryBehavior {
     ///   - key: The unique identifier for the object in storage
     ///   - options: Options to adjust the behavior of this request, including plugin-options
     /// - Returns: A task that provides progress updates and the key which was used to download
+    ///
+    /// - Tag: StorageCategoryBehavior.downloadData
     @discardableResult
     func downloadData(key: String,
                       options: StorageDownloadDataOperation.Request.Options?) -> StorageDownloadDataTask
@@ -37,6 +45,8 @@ public protocol StorageCategoryBehavior {
     ///   - local: The local file to download destination
     ///   - options: Parameters to specific plugin behavior
     /// - Returns: A task that provides progress updates and the key which was used to download
+    ///
+    /// - Tag: StorageCategoryBehavior.downloadFile
     @discardableResult
     func downloadFile(key: String,
                       local: URL,
@@ -49,6 +59,8 @@ public protocol StorageCategoryBehavior {
     ///   - data: The data in memory to be uploaded
     ///   - options: Parameters to specific plugin behavior
     /// - Returns: A task that provides progress updates and the key which was used to upload
+    ///
+    /// - Tag: StorageCategoryBehavior.uploadData
     @discardableResult
     func uploadData(key: String,
                     data: Data,
@@ -61,6 +73,8 @@ public protocol StorageCategoryBehavior {
     ///   - local: The path to a local file.
     ///   - options: Parameters to specific plugin behavior
     /// - Returns: A task that provides progress updates and the key which was used to upload
+    ///
+    /// - Tag: StorageCategoryBehavior.uploadFile
     @discardableResult
     func uploadFile(key: String,
                     local: URL,
@@ -72,6 +86,8 @@ public protocol StorageCategoryBehavior {
     ///   - key: The unique identifier of the object in storage.
     ///   - options: Parameters to specific plugin behavior
     /// - Returns: An operation object that provides notifications and actions related to the execution of the work
+    ///
+    /// - Tag: StorageCategoryBehavior.remove
     @discardableResult
     func remove(key: String,
                 options: StorageRemoveOperation.Request.Options?) async throws -> String
@@ -82,12 +98,16 @@ public protocol StorageCategoryBehavior {
     ///   - options: Parameters to specific plugin behavior
     ///   - resultListener: Triggered when the list is complete
     /// - Returns: An operation object that provides notifications and actions related to the execution of the work
+    ///
+    /// - Tag: StorageCategoryBehavior.list
     @discardableResult
     func list(options: StorageListOperation.Request.Options?) async throws -> StorageListResult
 
     /// Handles background events which are related to URLSession
     /// - Parameter identifier: identifier
     /// - Returns: returns true if the identifier is handled by Amplify
+    ///
+    /// - Tag: StorageCategoryBehavior.handleBackgroundEvents
     func handleBackgroundEvents(identifier: String) async -> Bool
 
 }

--- a/Amplify/Categories/Storage/StorageCategoryPlugin.swift
+++ b/Amplify/Categories/Storage/StorageCategoryPlugin.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+/// - Tag: StorageCategoryPlugin
 public protocol StorageCategoryPlugin: Plugin, StorageCategoryBehavior { }
 
 public extension StorageCategoryPlugin {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+ListBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+ListBehavior.swift
@@ -30,9 +30,9 @@ extension AWSS3StorageService {
             finalPrefix = prefix
         }
         let input = ListObjectsV2Input(bucket: bucket,
-                                       continuationToken: nil,
+                                       continuationToken: options.nextToken,
                                        delimiter: nil,
-                                       maxKeys: 1_000,
+                                       maxKeys: Int(options.pageSize),
                                        prefix: finalPrefix,
                                        startAfter: nil)
         do {
@@ -41,7 +41,7 @@ extension AWSS3StorageService {
             let items = try contents.map {
                 try StorageListResult.Item(s3Object: $0, prefix: prefix)
             }
-            return StorageListResult(items: items)
+            return StorageListResult(items: items, nextToken: response.nextContinuationToken)
         } catch let error as SdkError<ListObjectsV2OutputError> {
             throw error.storageError
         } catch {

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSS3StorageListRequestTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSS3StorageListRequestTests.swift
@@ -27,6 +27,23 @@ class StorageListRequestTests: XCTestCase {
         XCTAssertNil(storageErrorOptional)
     }
 
+    /// - Given: A an options parameter containing pagination options
+    /// - When: The containing request is validated
+    /// - Then: No errors are raised
+    func testValidateWithPaginationOptions() {
+        let pageSizeOnly = StorageListRequest(options: StorageListRequest.Options(pageSize: UInt.random(in: 1..<1_000)))
+        XCTAssertNil(pageSizeOnly.validate())
+
+        let nextTokenOnly = StorageListRequest(options: StorageListRequest.Options(nextToken: UUID().uuidString))
+        XCTAssertNil(nextTokenOnly.validate())
+
+        let pageSizeAndNextToken = StorageListRequest(options: StorageListRequest.Options(
+            pageSize: UInt.random(in: 1..<1_000),
+            nextToken: UUID().uuidString
+        ))
+        XCTAssertNil(pageSizeAndNextToken.validate())
+    }
+
     func testValidateEmptyTargetIdentityIdError() {
         let options = StorageListRequest.Options(accessLevel: .protected,
                                                  targetIdentityId: "",


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

https://github.com/aws-amplify/amplify-swift/issues/1286

## Description
<!-- Why is this change required? What problem does it solve? -->

This change brings the Swift implementation of Storage to parity with other libraries as it relates to listing pagination support.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
