### PR TITLE
fix(datastore): detect duplicate mutation event by both modelName and modelId

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
@@ -49,7 +49,7 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
         }
 
         MutationEvent.pendingMutationEvents(
-            for: mutationEvent.modelId,
+            forMutationEvent: mutationEvent,
             storageAdapter: storageAdapter) { result in
                 switch result {
                 case .failure(let dataStoreError):

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -131,11 +131,9 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
             return
         }
 
-        let remoteModelIds = remoteModels.map { $0.model.identifier }
-
         do {
             try storageAdapter.transaction {
-                queryPendingMutations(forModelIds: remoteModelIds)
+                queryPendingMutations(withModels: remoteModels.map(\.model))
                     .subscribe(on: workQueue)
                     .flatMap { mutationEvents -> Future<([RemoteModel], [LocalMetadata]), DataStoreError> in
                         let remoteModelsToApply = self.reconcile(remoteModels, pendingMutations: mutationEvents)
@@ -166,7 +164,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
         }
     }
 
-    func queryPendingMutations(forModelIds modelIds: [String]) -> Future<[MutationEvent], DataStoreError> {
+    func queryPendingMutations(withModels models: [Model]) -> Future<[MutationEvent], DataStoreError> {
         Future<[MutationEvent], DataStoreError> { promise in
             var result: Result<[MutationEvent], DataStoreError> = .failure(Self.unfulfilledDataStoreError())
             guard !self.isCancelled else {
@@ -177,23 +175,25 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
             }
             guard let storageAdapter = self.storageAdapter else {
                 let error = DataStoreError.nilStorageAdapter()
-                self.notifyDropped(count: modelIds.count, error: error)
+                self.notifyDropped(count: models.count, error: error)
                 result = .failure(error)
                 promise(result)
                 return
             }
 
-            guard !modelIds.isEmpty else {
+            guard !models.isEmpty else {
                 result = .success([])
                 promise(result)
                 return
             }
 
-            MutationEvent.pendingMutationEvents(for: modelIds,
-                                                storageAdapter: storageAdapter) { queryResult in
+            MutationEvent.pendingMutationEvents(
+                forModels: models,
+                storageAdapter: storageAdapter
+            ) { queryResult in
                 switch queryResult {
                 case .failure(let dataStoreError):
-                    self.notifyDropped(count: modelIds.count, error: dataStoreError)
+                    self.notifyDropped(count: models.count, error: dataStoreError)
                     result = .failure(dataStoreError)
                 case .success(let mutationEvents):
                     result = .success(mutationEvents)

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Support/MutationEvent+Extensions.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Support/MutationEvent+Extensions.swift
@@ -40,8 +40,9 @@ extension MutationEvent {
                                                       storageAdapter: StorageEngineAdapter,
                                                       completion: @escaping DataStoreCallback<Void>) {
         MutationEvent.pendingMutationEvents(
-            for: mutationEvent.modelId,
-            storageAdapter: storageAdapter) { queryResult in
+            forMutationEvent: mutationEvent,
+            storageAdapter: storageAdapter
+        ) { queryResult in
             switch queryResult {
             case .failure(let dataStoreError):
                 completion(.failure(dataStoreError))

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -222,7 +222,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         let expect = expectation(description: "storage adapter error")
 
         storageAdapter = nil
-        operation.queryPendingMutations(forModelIds: [anyPostMutationSync.model.id])
+        operation.queryPendingMutations(withModels: [anyPostMutationSync.model])
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .failure(let error):
@@ -242,7 +242,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         let expect = expectation(description: "should complete successfully for empty input")
         expect.expectedFulfillmentCount = 2
 
-        operation.queryPendingMutations(forModelIds: [])
+        operation.queryPendingMutations(withModels: [])
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .failure(let error):
@@ -266,7 +266,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
             return .success([self.anyPostMutationEvent])
         }
         storageAdapter.responders[.queryModelTypePredicate] = queryResponder
-        operation.queryPendingMutations(forModelIds: [anyPostMutationSync.model.id])
+        operation.queryPendingMutations(withModels: [anyPostMutationSync.model])
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .failure(let error):
@@ -297,7 +297,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
             }
         }.store(in: &cancellables)
         storageAdapter.responders[.queryModelTypePredicate] = queryResponder
-        operation.queryPendingMutations(forModelIds: [anyPostMutationSync.model.id])
+        operation.queryPendingMutations(withModels: [anyPostMutationSync.model])
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .failure:

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/MutationEventExtensionsTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/MutationEventExtensionsTests.swift
@@ -37,7 +37,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
                                                            version: nil)
         let responseMutationSync = createMutationSync(model: post, version: 1)
 
-        setUpPendingMutationQueue(modelId, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
+        setUpPendingMutationQueue(post, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
 
         let reconciledEvent = MutationEvent.reconcile(pendingMutationEvent: pendingMutationEvent,
                                                       with: requestMutationEvent,
@@ -62,7 +62,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         wait(for: [updatingVersionExpectation], timeout: 1)
 
         // query for head of mutation event table for given model id and check if it has the updated version
-        MutationEvent.pendingMutationEvents(for: post.id,
+        MutationEvent.pendingMutationEvents(forModel: post,
                                             storageAdapter: storageAdapter) { result in
             switch result {
             case .failure(let error):
@@ -106,7 +106,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
                                                                  version: nil)
         let responseMutationSync = createMutationSync(model: post, version: 1)
 
-        setUpPendingMutationQueue(modelId,
+        setUpPendingMutationQueue(post,
                                   [requestMutationEvent, pendingUpdateMutationEvent, pendingDeleteMutationEvent],
                                   pendingUpdateMutationEvent)
 
@@ -133,7 +133,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         wait(for: [updatingVersionExpectation], timeout: 1)
 
         // query for head of mutation event table for given model id and check if it has the updated version
-        MutationEvent.pendingMutationEvents(for: post.id,
+        MutationEvent.pendingMutationEvents(forModel: post,
                                             storageAdapter: storageAdapter) { result in
             switch result {
             case .failure(let error):
@@ -173,7 +173,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
                                                            version: 2)
         let responseMutationSync = createMutationSync(model: post1, version: 1)
 
-        setUpPendingMutationQueue(modelId, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
+        setUpPendingMutationQueue(post1, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
 
         let reconciledEvent = MutationEvent.reconcile(pendingMutationEvent: pendingMutationEvent,
                                                       with: requestMutationEvent,
@@ -197,7 +197,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         wait(for: [updatingVersionExpectation], timeout: 1)
 
         // query for head of mutation event table for given model id and check if it has the correct version
-        MutationEvent.pendingMutationEvents(for: post1.id,
+        MutationEvent.pendingMutationEvents(forModel: post1,
                                             storageAdapter: storageAdapter) { result in
             switch result {
             case .failure(let error):
@@ -237,7 +237,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
                                                            version: 1)
         let responseMutationSync = createMutationSync(model: post3, version: 2)
 
-        setUpPendingMutationQueue(modelId, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
+        setUpPendingMutationQueue(post1, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
 
         let reconciledEvent = MutationEvent.reconcile(pendingMutationEvent: pendingMutationEvent,
                                                       with: requestMutationEvent,
@@ -261,7 +261,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         wait(for: [updatingVersionExpectation], timeout: 1)
 
         // query for head of mutation event table for given model id and check if it has the correct version
-        MutationEvent.pendingMutationEvents(for: post1.id,
+        MutationEvent.pendingMutationEvents(forModel: post1,
                                             storageAdapter: storageAdapter) { result in
             switch result {
             case .failure(let error):
@@ -300,7 +300,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
                                                            version: 1)
         let responseMutationSync = createMutationSync(model: post1, version: 2)
 
-        setUpPendingMutationQueue(modelId, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
+        setUpPendingMutationQueue(post1, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
 
         let reconciledEvent = MutationEvent.reconcile(pendingMutationEvent: pendingMutationEvent,
                                                       with: requestMutationEvent,
@@ -324,7 +324,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         wait(for: [updatingVersionExpectation], timeout: 1)
 
         // query for head of mutation event table for given model id and check if it has the correct version
-        MutationEvent.pendingMutationEvents(for: post1.id,
+        MutationEvent.pendingMutationEvents(forModel: post1,
                                             storageAdapter: storageAdapter) { result in
             switch result {
             case .failure(let error):
@@ -366,7 +366,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         return MutationSync(model: AnyModel(model), syncMetadata: metadata)
     }
 
-    private func setUpPendingMutationQueue(_ modelId: String,
+    private func setUpPendingMutationQueue(_ model: Model,
                                            _ mutationEvents: [MutationEvent],
                                            _ expectedHeadOfQueue: MutationEvent) {
         for mutationEvent in mutationEvents {
@@ -383,8 +383,10 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
 
         // verify the head of queue is expected
         let headOfQueueExpectation = expectation(description: "head of mutation event queue is as expected")
-        MutationEvent.pendingMutationEvents(for: modelId,
-                                            storageAdapter: storageAdapter) { result in
+        MutationEvent.pendingMutationEvents(
+            forModel: model,
+            storageAdapter: storageAdapter
+        ) { result in
             switch result {
             case .failure(let error):
                 XCTFail("Error : \(error)")

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/MutationEventQueryTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/MutationEventQueryTests.swift
@@ -18,9 +18,9 @@ class MutationEventQueryTests: BaseDataStoreTests {
 
     func testQueryPendingMutation_EmptyResult() {
         let querySuccess = expectation(description: "query mutation events success")
-        let modelIds = [UUID().uuidString, UUID().uuidString]
+        let mutationEvents = [generateRandomMutationEvent(), generateRandomMutationEvent()]
 
-        MutationEvent.pendingMutationEvents(for: modelIds, storageAdapter: storageAdapter) { result in
+        MutationEvent.pendingMutationEvents(forMutationEvents: mutationEvents, storageAdapter: storageAdapter) { result in
             switch result {
             case .success(let mutationEvents):
                 XCTAssertTrue(mutationEvents.isEmpty)
@@ -33,19 +33,17 @@ class MutationEventQueryTests: BaseDataStoreTests {
     }
 
     func testQueryPendingMutationEvent() {
-        let mutationEvent = MutationEvent(id: UUID().uuidString,
-                                          modelId: UUID().uuidString,
-                                          modelName: Post.modelName,
-                                          json: "",
-                                          mutationType: .create)
+        let mutationEvent = generateRandomMutationEvent()
 
         let querySuccess = expectation(description: "query for pending mutation events")
 
         storageAdapter.save(mutationEvent) { result in
             switch result {
             case .success:
-                MutationEvent.pendingMutationEvents(for: mutationEvent.modelId,
-                                                    storageAdapter: self.storageAdapter) { result in
+                MutationEvent.pendingMutationEvents(
+                    forMutationEvent: mutationEvent,
+                    storageAdapter: self.storageAdapter
+                ) { result in
                     switch result {
                     case .success(let mutationEvents):
                         XCTAssertEqual(mutationEvents.count, 1)
@@ -61,16 +59,8 @@ class MutationEventQueryTests: BaseDataStoreTests {
     }
 
     func testQueryPendingMutationEventsForModelIds() {
-        let mutationEvent1 = MutationEvent(id: UUID().uuidString,
-                                           modelId: UUID().uuidString,
-                                           modelName: Post.modelName,
-                                           json: "",
-                                           mutationType: .create)
-        let mutationEvent2 = MutationEvent(id: UUID().uuidString,
-                                           modelId: UUID().uuidString,
-                                           modelName: Post.modelName,
-                                           json: "",
-                                           mutationType: .create)
+        let mutationEvent1 = generateRandomMutationEvent()
+        let mutationEvent2 = generateRandomMutationEvent()
 
         let saveMutationEvent1 = expectation(description: "save mutationEvent1 success")
         storageAdapter.save(mutationEvent1) { result in
@@ -93,11 +83,13 @@ class MutationEventQueryTests: BaseDataStoreTests {
         wait(for: [saveMutationEvent2], timeout: 1)
 
         let querySuccess = expectation(description: "query for metadata success")
-        var modelIds = [mutationEvent1.modelId]
-        modelIds.append(contentsOf: (1 ... 999).map { _ in UUID().uuidString })
-        modelIds.append(mutationEvent2.modelId)
-        MutationEvent.pendingMutationEvents(for: modelIds,
-                                            storageAdapter: storageAdapter) { result in
+        var mutationEvents = [mutationEvent1]
+        mutationEvents.append(contentsOf: (1 ... 999).map { _ in generateRandomMutationEvent() })
+        mutationEvents.append(mutationEvent2)
+        MutationEvent.pendingMutationEvents(
+            forMutationEvents: mutationEvents,
+            storageAdapter: storageAdapter
+        ) { result in
             switch result {
             case .success(let mutationEvents):
                 XCTAssertEqual(mutationEvents.count, 2)
@@ -107,5 +99,15 @@ class MutationEventQueryTests: BaseDataStoreTests {
         }
 
         wait(for: [querySuccess], timeout: 1)
+    }
+
+    private func generateRandomMutationEvent() -> MutationEvent {
+        MutationEvent(
+            id: UUID().uuidString,
+            modelId: UUID().uuidString,
+            modelName: Post.modelName,
+            json: "",
+            mutationType: .create
+        )
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -479,6 +479,37 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
         try await Amplify.DataStore.start()
     }
 
+    /// Create model instances for different models but same primary key value
+    ///
+    /// Given - DataStore with clean state
+    /// When
+    ///     - create post and comment with the same random id
+    /// Then
+    ///     - all instances should be created successfully with the same id
+    func testCreateModelInstances_withSamePrimaryKeyForDifferentModels_allSucceed() async throws {
+        await setUp(withModels: TestModelRegistration())
+        try await startAmplifyAndWaitForSync()
+
+        let uuid = UUID().uuidString
+        let newPost = Post(
+            id: uuid,
+            title: UUID().uuidString,
+            content: UUID().uuidString,
+            createdAt: .now()
+        )
+
+        let createdPost = try await Amplify.DataStore.save(newPost)
+        let newComment = Comment(
+            id: uuid,
+            content: UUID().uuidString,
+            createdAt: .now(),
+            post: newPost
+        )
+        let createdComment = try await Amplify.DataStore.save(newComment)
+
+        XCTAssertEqual(createdPost.id, createdComment.id)
+    }
+
     ///
     /// - Given: DataStore with clean state
     /// - When:


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/2832

## Description
<!-- Why is this change required? What problem does it solve? -->
Currently, detecting mutation event duplication is only by model's primary key value. Logically, this should be the combination of model type name and model's primary key.

## General Checklist
<!-- Check or cross out if not relevant -->

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [X] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
