### PR TITLE
fix(datastore-v1): detect duplicate mutation event by both modelName and modelId

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
@@ -51,7 +51,7 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
         }
 
         MutationEvent.pendingMutationEvents(
-            for: mutationEvent.modelId,
+            forMutationEvent: mutationEvent,
             storageAdapter: storageAdapter) { result in
                 switch result {
                 case .failure(let dataStoreError):

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Extensions.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/Support/MutationEvent+Extensions.swift
@@ -40,7 +40,7 @@ extension MutationEvent {
                                                       storageAdapter: StorageEngineAdapter,
                                                       completion: @escaping DataStoreCallback<Void>) {
         MutationEvent.pendingMutationEvents(
-            for: mutationEvent.modelId,
+            forMutationEvent: mutationEvent,
             storageAdapter: storageAdapter) { queryResult in
             switch queryResult {
             case .failure(let dataStoreError):

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -219,7 +219,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         let expect = expectation(description: "storage adapter error")
 
         storageAdapter = nil
-        operation.queryPendingMutations(forModelIds: [anyPostMutationSync.model.id])
+        operation.queryPendingMutations(forModels: [anyPostMutationSync.model])
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .failure(let error):
@@ -239,7 +239,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         let expect = expectation(description: "should complete successfully for empty input")
         expect.expectedFulfillmentCount = 2
 
-        operation.queryPendingMutations(forModelIds: [])
+        operation.queryPendingMutations(forModels: [])
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .failure(let error):
@@ -263,7 +263,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
             return .success([self.anyPostMutationEvent])
         }
         storageAdapter.responders[.queryModelTypePredicate] = queryResponder
-        operation.queryPendingMutations(forModelIds: [anyPostMutationSync.model.id])
+        operation.queryPendingMutations(forModels: [anyPostMutationSync.model])
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .failure(let error):
@@ -294,7 +294,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
             }
         }.store(in: &cancellables)
         storageAdapter.responders[.queryModelTypePredicate] = queryResponder
-        operation.queryPendingMutations(forModelIds: [anyPostMutationSync.model.id])
+        operation.queryPendingMutations(forModels: [anyPostMutationSync.model])
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .failure:
@@ -694,6 +694,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
                 expect.fulfill()
             }).store(in: &cancellables)
         waitForExpectations(timeout: 1)
+        Amplify.Hub.removeListener(hubListener)
     }
 
     func testApplyRemoteModels_deleteDisposition() {
@@ -750,6 +751,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
                 expect.fulfill()
             }).store(in: &cancellables)
         waitForExpectations(timeout: 1)
+        Amplify.Hub.removeListener(hubListener)
     }
 
     func testApplyRemoteModels_multipleDispositions() {
@@ -826,6 +828,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
                 expect.fulfill()
             }).store(in: &cancellables)
         waitForExpectations(timeout: 1)
+        Amplify.Hub.removeListener(hubListener)
     }
 
     func testApplyRemoteModels_saveFail() throws {

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/Support/MutationEventExtensionsTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/Support/MutationEventExtensionsTests.swift
@@ -38,7 +38,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
                                                            version: nil)
         let responseMutationSync = createMutationSync(model: post, version: 1)
 
-        setUpPendingMutationQueue(modelId, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
+        setUpPendingMutationQueue(post, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
 
         let reconciledEvent = MutationEvent.reconcile(pendingMutationEvent: pendingMutationEvent,
                                                       with: requestMutationEvent,
@@ -63,8 +63,10 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         wait(for: [updatingVersionExpectation], timeout: 1)
 
         // query for head of mutation event table for given model id and check if it has the updated version
-        MutationEvent.pendingMutationEvents(for: post.id,
-                                            storageAdapter: storageAdapter) { result in
+        MutationEvent.pendingMutationEvents(
+            forModel: post,
+            storageAdapter: storageAdapter
+        ) { result in
             switch result {
             case .failure(let error):
                 XCTFail("Error : \(error)")
@@ -107,7 +109,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
                                                                  version: nil)
         let responseMutationSync = createMutationSync(model: post, version: 1)
 
-        setUpPendingMutationQueue(modelId,
+        setUpPendingMutationQueue(post,
                                   [requestMutationEvent, pendingUpdateMutationEvent, pendingDeleteMutationEvent],
                                   pendingUpdateMutationEvent)
 
@@ -134,8 +136,10 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         wait(for: [updatingVersionExpectation], timeout: 1)
 
         // query for head of mutation event table for given model id and check if it has the updated version
-        MutationEvent.pendingMutationEvents(for: post.id,
-                                            storageAdapter: storageAdapter) { result in
+        MutationEvent.pendingMutationEvents(
+            forModel: post,
+            storageAdapter: storageAdapter
+        ) { result in
             switch result {
             case .failure(let error):
                 XCTFail("Error : \(error)")
@@ -174,7 +178,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
                                                            version: 2)
         let responseMutationSync = createMutationSync(model: post1, version: 1)
 
-        setUpPendingMutationQueue(modelId, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
+        setUpPendingMutationQueue(post1, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
 
         let reconciledEvent = MutationEvent.reconcile(pendingMutationEvent: pendingMutationEvent,
                                                       with: requestMutationEvent,
@@ -198,8 +202,10 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         wait(for: [updatingVersionExpectation], timeout: 1)
 
         // query for head of mutation event table for given model id and check if it has the correct version
-        MutationEvent.pendingMutationEvents(for: post1.id,
-                                            storageAdapter: storageAdapter) { result in
+        MutationEvent.pendingMutationEvents(
+            forModel: post1,
+            storageAdapter: storageAdapter
+        ) { result in
             switch result {
             case .failure(let error):
                 XCTFail("Error : \(error)")
@@ -238,7 +244,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
                                                            version: 1)
         let responseMutationSync = createMutationSync(model: post3, version: 2)
 
-        setUpPendingMutationQueue(modelId, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
+        setUpPendingMutationQueue(post1, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
 
         let reconciledEvent = MutationEvent.reconcile(pendingMutationEvent: pendingMutationEvent,
                                                       with: requestMutationEvent,
@@ -262,8 +268,10 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         wait(for: [updatingVersionExpectation], timeout: 1)
 
         // query for head of mutation event table for given model id and check if it has the correct version
-        MutationEvent.pendingMutationEvents(for: post1.id,
-                                            storageAdapter: storageAdapter) { result in
+        MutationEvent.pendingMutationEvents(
+            forModel: post1,
+            storageAdapter: storageAdapter
+        ) { result in
             switch result {
             case .failure(let error):
                 XCTFail("Error : \(error)")
@@ -301,7 +309,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
                                                            version: 1)
         let responseMutationSync = createMutationSync(model: post1, version: 2)
 
-        setUpPendingMutationQueue(modelId, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
+        setUpPendingMutationQueue(post1, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
 
         let reconciledEvent = MutationEvent.reconcile(pendingMutationEvent: pendingMutationEvent,
                                                       with: requestMutationEvent,
@@ -325,8 +333,10 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         wait(for: [updatingVersionExpectation], timeout: 1)
 
         // query for head of mutation event table for given model id and check if it has the correct version
-        MutationEvent.pendingMutationEvents(for: post1.id,
-                                            storageAdapter: storageAdapter) { result in
+        MutationEvent.pendingMutationEvents(
+            forModel: post1,
+            storageAdapter: storageAdapter
+        ) { result in
             switch result {
             case .failure(let error):
                 XCTFail("Error : \(error)")
@@ -367,7 +377,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         return MutationSync(model: AnyModel(model), syncMetadata: metadata)
     }
 
-    private func setUpPendingMutationQueue(_ modelId: String,
+    private func setUpPendingMutationQueue(_ model: Model,
                                            _ mutationEvents: [MutationEvent],
                                            _ expectedHeadOfQueue: MutationEvent) {
         for mutationEvent in mutationEvents {
@@ -384,8 +394,10 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
 
         // verify the head of queue is expected
         let headOfQueueExpectation = expectation(description: "head of mutation event queue is as expected")
-        MutationEvent.pendingMutationEvents(for: modelId,
-                                            storageAdapter: storageAdapter) { result in
+        MutationEvent.pendingMutationEvents(
+            forModel: model,
+            storageAdapter: storageAdapter
+        ) { result in
             switch result {
             case .failure(let error):
                 XCTFail("Error : \(error)")


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/2832

- [v2 PR](https://github.com/aws-amplify/amplify-swift/pull/2834)
## Description
<!-- Why is this change required? What problem does it solve? -->
Currently, detecting mutation event duplication is only by model's primary key value. Logically, this should be the combination of model type name and model's primary key.

## General Checklist
<!-- Check or cross out if not relevant -->

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [X] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
