### PR TITLE
ci: use default checkout action on deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - '3f:b4:9f:aa:0b:d7:c5:16:fb:44:44:35:cb:a7:70:e0'
-      - shallow_checkout
+      - checkout
       - ruby/install-deps
       - run:
           name: Release Amplify for Swift

--- a/CircleciScripts/jazzy_doc_gen.sh
+++ b/CircleciScripts/jazzy_doc_gen.sh
@@ -5,25 +5,13 @@
 
 set -e
 
-REPO="aws-amplify/amplify-swift.git"
+echo "Working Directory: $CIRCLE_WORKING_DIRECTORY"
 
-git clone git@github.com:$REPO $(mktemp -d -t amplify-release)
-TEMP_DIR=$_
-
-echo "Temporary Directory: $TEMP_DIR"
-
-generate_docs() {
-    cd $TEMP_DIR
-    git checkout gh-pages
-    git reset --hard origin/release
-    gem install -n /usr/local/bin jazzy
-    jazzy --swift-build-tool spm --build-tool-arguments -Xswiftc,-swift-version,-Xswiftc,5
-    ln -s ../readme-images docs
-    git add docs
-    git commit -m "chore: update API docs [skip ci]"
-    git push --force
-}
-
-generate_docs
+cd $CIRCLE_WORKING_DIRECTORY
+bundle exec jazzy --swift-build-tool spm --build-tool-arguments -Xswiftc,-swift-version,-Xswiftc,5
+ln -s ../readme-images docs
+git add docs
+git commit -m "chore: update API docs [skip ci]"
+git push origin HEAD:gh-pages -f
 
 set +e


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
`deploy` step relies on git history to [generate](https://github.com/aws-amplify/amplify-ci-support/blob/main/src/fastlane/release_actions/lib/fastlane/plugin/release_actions/helper/git.rb#L6-L13) the tag for releases. We may need to change the implementation of customize fastlane actions in [amplify-ci-support](https://github.com/aws-amplify/amplify-ci-support/tree/main).

For doc generation step, we don't need clone and install jazz as we've done in the previous steps of CI workflow.

## Description
<!-- Why is this change required? What problem does it solve? -->
- roll back to use offical full checkout for `deploy` step
- simplify doc generation step

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [ ] ~PR title conforms to conventional commit style~
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
