### PR TITLE
fix(storage): Ensure progress from Amplify.Storage.uploadFile completes

### DIFF
--- a/Amplify/Core/Support/ChildTask.swift
+++ b/Amplify/Core/Support/ChildTask.swift
@@ -11,11 +11,11 @@ import Foundation
 /// Child Task is cancelled it will also cancel the parent.
 actor ChildTask<InProcess, Success, Failure: Error>: BufferingSequence {
     typealias Element = InProcess
-    let parent: Cancellable
-    var inProcessChannel: AmplifyAsyncSequence<InProcess>? = nil
-    var valueContinuations: [CheckedContinuation<Success, Error>] = []
-    var storedResult: Result<Success, Failure>? = nil
-    var isCancelled = false
+    private let parent: Cancellable
+    private var inProcessChannel: AmplifyAsyncSequence<InProcess>? = nil
+    private var valueContinuations: [CheckedContinuation<Success, Error>] = []
+    private var storedResult: Result<Success, Failure>? = nil
+    private var isCancelled = false
 
     var inProcess: AmplifyAsyncSequence<InProcess> {
         let channel: AmplifyAsyncSequence<InProcess>
@@ -75,9 +75,11 @@ actor ChildTask<InProcess, Success, Failure: Error>: BufferingSequence {
     func finish(_ result: Result<Success, Failure>) {
         if !valueContinuations.isEmpty {
             send(result)
-        } else {
-            // store result for when the value property is used
-            self.storedResult = result
+        }
+        // store result for when the value property is used
+        self.storedResult = result
+        if let channel = inProcessChannel {
+            channel.finish()
         }
     }
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/2840

## Description
<!-- Why is this change required? What problem does it solve? -->
This fix ensures that calling something like this **does not hang**:

```
let task = Amplify.Storage.uploadFile(key: key, local: url)
for await progress in await task.progress {
    ...
}
```

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
~~- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
