### PR TITLE
ci: fix doc generation step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
   generate_api_docs:
     <<: *defaults
     steps:
-      - shallow_checkout
+      - checkout
       - ruby/install-deps
       - run:
           name: Jazzy API doc generation

--- a/CircleciScripts/jazzy_doc_gen.sh
+++ b/CircleciScripts/jazzy_doc_gen.sh
@@ -7,6 +7,9 @@ set -e
 
 echo "Working Directory: $CIRCLE_WORKING_DIRECTORY"
 
+git config user.email $GITHUB_EMAIL
+git config user.name $GITHUB_USER
+
 cd $CIRCLE_WORKING_DIRECTORY
 bundle exec jazzy --swift-build-tool spm --build-tool-arguments -Xswiftc,-swift-version,-Xswiftc,5
 ln -s ../readme-images docs


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

Shallow checkout doesn't apply to generate api doc step as several skip ci commits will be pushed to `release` branch. The shallow checkout depends on the current branch HEAD hash is same to the CircleCI job commit hash.

## Description
<!-- Why is this change required? What problem does it solve? -->
- roll back to normal checkout
- set git user to CircleCI predefined one for doc commit

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
