### PR TITLE
fix(predictions): make predictions plugin init internal

### DIFF
--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin.swift
@@ -41,8 +41,7 @@ final public class AWSPredictionsPlugin: PredictionsCategoryPlugin {
     }
      */
 
-    public init() {
-    }
+    init() {}
 }
 
 extension AWSPredictionsPlugin: AmplifyVersionable { }

--- a/Package.swift
+++ b/Package.swift
@@ -328,7 +328,6 @@ let predictionsTargets: [Target] = [
         dependencies: [
             .target(name: "Amplify"),
             .target(name: "AWSPluginsCore"),
-//            .target(name: "CoreMLPredictionsPlugin"), TODO: Re-add
             .product(name: "AWSComprehend", package: "aws-sdk-swift"),
             .product(name: "AWSPolly", package: "aws-sdk-swift"),
             .product(name: "AWSRekognition", package: "aws-sdk-swift"),
@@ -337,9 +336,7 @@ let predictionsTargets: [Target] = [
             .product(name: "AWSTranslate", package: "aws-sdk-swift")
         ],
         path: "AmplifyPlugins/Predictions/AWSPredictionsPlugin",
-        exclude: [
-            "Resources/Info.plist"
-        ]
+        exclude: []
     ),
     .testTarget(
         name: "AWSPredictionsPluginUnitTests",


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
Makes `AWSPredictionsPlugin.init` internal until the v2 implementation lands to avoid accidentally calling unimplemented (`fatalError`) APIs.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
