### PR TITLE
fix(Auth): Fixing handling of service SdkError in Auth tasks

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthChangePasswordTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthChangePasswordTask.swift
@@ -39,8 +39,10 @@ class AWSAuthChangePasswordTask: AuthChangePasswordTask, DefaultLogger {
             let accessToken = try await taskHelper.getAccessToken()
             try await changePassword(with: accessToken)
             log.verbose("Received success")
-        } catch let error as ChangePasswordOutputError {
+        } catch let error as AuthErrorConvertible {
             throw error.authError
+        } catch let error as AuthError {
+            throw error
         } catch let error {
             throw AuthError.configuration("Unable to execute auth task", AuthPluginErrorConstants.configurationError, error)
         }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmResetPasswordTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmResetPasswordTask.swift
@@ -34,9 +34,7 @@ class AWSAuthConfirmResetPasswordTask: AuthConfirmResetPasswordTask, DefaultLogg
         do {
             
             try await confirmResetPassword()
-        } catch let error as ConfirmForgotPasswordOutputError {
-            throw error.authError
-        } catch let error as SdkError<ConfirmForgotPasswordOutputError> {
+        } catch let error as AuthErrorConvertible {
             throw error.authError
         } catch let error as AuthError {
             throw error

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResendSignUpCodeTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResendSignUpCodeTask.swift
@@ -36,9 +36,7 @@ class AWSAuthResendSignUpCodeTask: AuthResendSignUpCodeTask, DefaultLogger {
             let details = try await resendSignUpCode()
             log.verbose("Received result")
             return details
-        } catch let error as ResendConfirmationCodeOutputError {
-            throw error.authError
-        } catch let error as SdkError<ResendConfirmationCodeOutputError> {
+        } catch let error as AuthErrorConvertible {
             throw error.authError
         } catch let error as AuthError {
             throw error

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResetPasswordTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResetPasswordTask.swift
@@ -36,9 +36,7 @@ class AWSAuthResetPasswordTask: AuthResetPasswordTask, DefaultLogger {
             let result = try await resetPassword()
             log.verbose("Received result")
             return result
-        } catch let error as ForgotPasswordOutputError {
-            throw error.authError
-        } catch let error as SdkError<ForgotPasswordOutputError> {
+        } catch let error as AuthErrorConvertible {
             throw error.authError
         } catch let error as AuthError {
             throw error

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthFetchDevicesTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthFetchDevicesTask.swift
@@ -36,9 +36,7 @@ class AWSAuthFetchDevicesTask: AuthFetchDevicesTask {
             let accessToken = try await taskHelper.getAccessToken()
             let devices = try await fetchDevices(with: accessToken)
             return devices
-        } catch let error as ListDevicesOutputError {
-            throw error.authError
-        } catch let error as SdkError<ListDevicesOutputError> {
+        } catch let error as AuthErrorConvertible {
             throw error.authError
         } catch let error as AuthError {
             throw error

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthForgetDeviceTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthForgetDeviceTask.swift
@@ -38,9 +38,7 @@ class AWSAuthForgetDeviceTask: AuthForgetDeviceTask {
             let accessToken = try await taskHelper.getAccessToken()
             let username = try await getCurrentUsername()
             try await forgetDevice(with: accessToken, username: username)
-        } catch let error as ForgetDeviceOutputError {
-            throw error.authError
-        } catch let error as SdkError<ForgetDeviceOutputError> {
+        } catch let error as AuthErrorConvertible {
             throw error.authError
         } catch let error as AuthError {
             throw error

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthRememberDeviceTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthRememberDeviceTask.swift
@@ -37,9 +37,7 @@ class AWSAuthRememberDeviceTask: AuthRememberDeviceTask {
             let accessToken = try await taskHelper.getAccessToken()
             let username = try await getCurrentUsername()
             try await rememberDevice(with: accessToken, username: username)
-        } catch let error as UpdateDeviceStatusOutputError {
-            throw error.authError
-        } catch let error as SdkError<UpdateDeviceStatusOutputError> {
+        } catch let error as AuthErrorConvertible {
             throw error.authError
         } catch let error as AuthError {
             throw error

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthAttributeResendConfirmationCodeTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthAttributeResendConfirmationCodeTask.swift
@@ -35,7 +35,7 @@ class AWSAuthAttributeResendConfirmationCodeTask: AuthAttributeResendConfirmatio
             let accessToken = try await taskHelper.getAccessToken()
             let devices = try await initiateGettingVerificationCode(with: accessToken)
             return devices
-        } catch let error as GetUserAttributeVerificationCodeOutputError {
+        } catch let error as AuthErrorConvertible {
             throw error.authError
         } catch let error as AuthError {
             throw error

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthConfirmUserAttributeTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthConfirmUserAttributeTask.swift
@@ -35,7 +35,7 @@ class AWSAuthConfirmUserAttributeTask: AuthConfirmUserAttributeTask {
             await taskHelper.didStateMachineConfigured()
             let accessToken = try await taskHelper.getAccessToken()
             try await confirmUserAttribute(with: accessToken)
-        } catch let error as VerifyUserAttributeOutputError {
+        } catch let error as AuthErrorConvertible {
             throw error.authError
         } catch let error as AuthError {
             throw error

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthFetchUserAttributeTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthFetchUserAttributeTask.swift
@@ -35,7 +35,7 @@ class AWSAuthFetchUserAttributeTask: AuthFetchUserAttributeTask {
             await taskHelper.didStateMachineConfigured()
             let accessToken = try await taskHelper.getAccessToken()
             return try await getUserAttributes(with: accessToken)
-        } catch let error as GetUserOutputError {
+        } catch let error as AuthErrorConvertible {
             throw error.authError
         } catch let error as AuthError {
             throw error

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthUpdateUserAttributeTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthUpdateUserAttributeTask.swift
@@ -34,10 +34,9 @@ class AWSAuthUpdateUserAttributeTask: AuthUpdateUserAttributeTask {
             await taskHelper.didStateMachineConfigured()
             let accessToken = try await taskHelper.getAccessToken()
             return try await updateUserAttribute(with: accessToken)
-        } catch let error as UpdateUserAttributesOutputError {
+        } catch let error as AuthErrorConvertible {
             throw error.authError
         } catch let error as AuthError {
-            dispatch(result: .failure(error))
             throw error
         } catch let error {
             let error = AuthError.unknown("Unable to execute auth task", error)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthUpdateUserAttributesTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthUpdateUserAttributesTask.swift
@@ -34,7 +34,7 @@ class AWSAuthUpdateUserAttributesTask: AuthUpdateUserAttributesTask {
             await taskHelper.didStateMachineConfigured()
             let accessToken = try await taskHelper.getAccessToken()
             return try await updateUserAttribute(with: accessToken)
-        } catch let error as UpdateUserAttributesOutputError {
+        } catch let error as AuthErrorConvertible {
             throw error.authError
         } catch let error as AuthError {
             throw error

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthConfirmSignUpAPITests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthConfirmSignUpAPITests.swift
@@ -171,7 +171,10 @@ class AWSAuthConfirmSignUpAPITests: BasePluginTest {
 
         self.mockIdentityProvider = MockIdentityProvider(
             mockConfirmSignUpResponse: { _ in
-                throw ConfirmSignUpOutputError.internalErrorException(.init())
+                throw SdkError.service(
+                    ConfirmSignUpOutputError.internalErrorException(
+                        .init()),
+                    .init(body: .empty, statusCode: .accepted))
             }
         )
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthResendSignUpCodeAPITests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthResendSignUpCodeAPITests.swift
@@ -12,6 +12,7 @@ import AWSCognitoIdentity
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 import AWSCognitoIdentityProvider
+import ClientRuntime
 
 class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
 
@@ -147,7 +148,10 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
 
         mockIdentityProvider = MockIdentityProvider(
             mockResendConfirmationCodeOutputResponse: { _ in
-                throw ResendConfirmationCodeOutputError.codeDeliveryFailureException(CodeDeliveryFailureException(message: "Code delivery failure"))
+                throw SdkError.service(
+                    ResendConfirmationCodeOutputError.codeDeliveryFailureException(
+                        .init()),
+                    .init(body: .empty, statusCode: .accepted))
             }
         )
         do {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthSignUpAPITests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSAuthSignUpAPITests.swift
@@ -186,7 +186,10 @@ class AWSAuthSignUpAPITests: BasePluginTest {
 
         self.mockIdentityProvider = MockIdentityProvider(
             mockSignUpResponse: { _ in
-                throw SignUpOutputError.internalErrorException(.init())
+                throw SdkError.service(
+                    SignUpOutputError.internalErrorException(
+                        .init()),
+                    .init(body: .empty, statusCode: .accepted))
             }
         )
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/ClientBehaviorConfirmResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/ClientBehaviorConfirmResetPasswordTests.swift
@@ -13,6 +13,7 @@ import AWSCognitoIdentityProvider
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 @testable import AWSPluginsTestCommon
+import ClientRuntime
 
 class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
 
@@ -244,7 +245,10 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithInvalidLambdaResponseException() async throws {
         mockIdentityProvider = MockIdentityProvider(
             mockConfirmForgotPasswordOutputResponse: { _ in
-                throw ConfirmForgotPasswordOutputError.invalidLambdaResponseException(InvalidLambdaResponseException(message: "invalid lambda"))
+                throw SdkError.service(
+                    ConfirmForgotPasswordOutputError.invalidLambdaResponseException(
+                        .init()),
+                    .init(body: .empty, statusCode: .accepted))
             }
         )
         do {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/ClientBehaviorResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/ClientBehaviorResetPasswordTests.swift
@@ -12,6 +12,7 @@ import AWSCognitoIdentity
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 import AWSCognitoIdentityProvider
+import ClientRuntime
 
 class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
 
@@ -170,7 +171,10 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
 
         mockIdentityProvider = MockIdentityProvider(
             mockForgotPasswordOutputResponse: { _ in
-                throw ForgotPasswordOutputError.internalErrorException(InternalErrorException(message: "internal error"))
+                throw SdkError.service(
+                    ForgotPasswordOutputError.internalErrorException(
+                        .init()),
+                    .init(body: .empty, statusCode: .accepted))
             }
         )
         do {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorFetchDevicesTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorFetchDevicesTests.swift
@@ -12,6 +12,7 @@ import AWSCognitoIdentityProvider
 import Amplify
 @testable import AWSCognitoAuthPlugin
 @testable import AWSPluginsTestCommon
+import ClientRuntime
 
 class DeviceBehaviorFetchDevicesTests: BasePluginTest {
 
@@ -123,7 +124,10 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
 
         mockIdentityProvider = MockIdentityProvider(
             mockListDevicesOutputResponse: { _ in
-                throw ListDevicesOutputError.internalErrorException(InternalErrorException(message: "internal error"))
+                throw SdkError.service(
+                    ListDevicesOutputError.internalErrorException(
+                        .init()),
+                    .init(body: .empty, statusCode: .accepted))
             }
         )
         do {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorForgetDeviceTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorForgetDeviceTests.swift
@@ -12,6 +12,7 @@ import AWSCognitoIdentityProvider
 import Amplify
 @testable import AWSCognitoAuthPlugin
 @testable import AWSPluginsTestCommon
+import ClientRuntime
 
 class DeviceBehaviorForgetDeviceTests: BasePluginTest {
 
@@ -134,7 +135,10 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
 
         mockIdentityProvider = MockIdentityProvider(
             mockForgetDeviceResponse: { _ in
-                throw ForgetDeviceOutputError.invalidParameterException(InvalidParameterException(message: "invalid parameter"))
+                throw SdkError.service(
+                    ForgetDeviceOutputError.invalidParameterException(
+                        .init()),
+                    .init(body: .empty, statusCode: .accepted))
             }
         )
         do {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorRememberDeviceTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorRememberDeviceTests.swift
@@ -12,6 +12,7 @@ import AWSCognitoIdentityProvider
 import Amplify
 @testable import AWSCognitoAuthPlugin
 @testable import AWSPluginsTestCommon
+import ClientRuntime
 
 class DeviceBehaviorRememberDeviceTests: BasePluginTest {
 
@@ -136,7 +137,10 @@ class DeviceBehaviorRememberDeviceTests: BasePluginTest {
 
         mockIdentityProvider = MockIdentityProvider(
             mockRememberDeviceResponse: { _ in
-                throw UpdateDeviceStatusOutputError.invalidUserPoolConfigurationException(InvalidUserPoolConfigurationException(message: "invalid user pool configuration"))
+                throw SdkError.service(
+                    UpdateDeviceStatusOutputError.invalidUserPoolConfigurationException(
+                        .init()),
+                    .init(body: .empty, statusCode: .accepted))
             }
         )
         do {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorChangePasswordTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorChangePasswordTests.swift
@@ -11,6 +11,7 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 import AWSCognitoIdentityProvider
+import ClientRuntime
 
 class UserBehaviorChangePasswordTests: BasePluginTest {
 
@@ -126,7 +127,10 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
     func testChangePasswordWithLimitExceededException() async throws {
 
         self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutputResponse: { _ in
-            throw ChangePasswordOutputError.limitExceededException(.init(message: "limit exceeded exception"))
+            throw SdkError.service(
+                ChangePasswordOutputError.limitExceededException(
+                    .init()),
+                .init(body: .empty, statusCode: .accepted))
         })
         do {
             try await plugin.update(oldPassword: "old password", to: "new password")

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorConfirmAttributeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorConfirmAttributeTests.swift
@@ -9,6 +9,7 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 import AWSCognitoIdentityProvider
+import ClientRuntime
 
 class UserBehaviorConfirmAttributeTests: BasePluginTest {
 
@@ -97,7 +98,10 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
     func testcConfirmUpdateUserAttributesWithInternalErrorException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutputResponse: { _ in
-            throw VerifyUserAttributeOutputError.internalErrorException(.init())
+            throw SdkError.service(
+                VerifyUserAttributeOutputError.internalErrorException(
+                    .init()),
+                .init(body: .empty, statusCode: .accepted))
         })
         do {
             try await plugin.confirm(userAttribute: .email, confirmationCode: "code")

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorFetchAttributeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorFetchAttributeTests.swift
@@ -9,6 +9,7 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 import AWSCognitoIdentityProvider
+import ClientRuntime
 
 class UserBehaviorFetchAttributesTests: BasePluginTest {
 
@@ -128,7 +129,10 @@ class UserBehaviorFetchAttributesTests: BasePluginTest {
     func testFetchUserAttributesWithNotAuthorizedException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeResponse: { _ in
-            throw GetUserOutputError.notAuthorizedException(.init())
+            throw SdkError.service(
+                GetUserOutputError.notAuthorizedException(
+                    .init()),
+                .init(body: .empty, statusCode: .accepted))
         })
 
         do {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorResendCodeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorResendCodeTests.swift
@@ -11,6 +11,7 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 import AWSCognitoIdentityProvider
+import ClientRuntime
 
 class UserBehaviorResendCodeTests: BasePluginTest {
 
@@ -75,7 +76,10 @@ class UserBehaviorResendCodeTests: BasePluginTest {
     func testResendConfirmationCodeWithCodeMismatchException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutputResponse: { _ in
-            throw GetUserAttributeVerificationCodeOutputError.codeDeliveryFailureException(.init())
+            throw SdkError.service(
+                GetUserAttributeVerificationCodeOutputError.codeDeliveryFailureException(
+                    .init()),
+                .init(body: .empty, statusCode: .accepted))
         })
         do {
             _ = try await plugin.resendConfirmationCode(forUserAttributeKey: .email)

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorUpdateAttributeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorUpdateAttributeTests.swift
@@ -9,6 +9,7 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 import AWSCognitoIdentityProvider
+import ClientRuntime
 
 class UserBehaviorUpdateAttributesTests: BasePluginTest {
 
@@ -66,7 +67,10 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
     func testUpdateUserAttributesWithAliasExistsException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(mockUpdateUserAttributeResponse: { _ in
-            throw UpdateUserAttributesOutputError.aliasExistsException(.init())
+            throw SdkError.service(
+                UpdateUserAttributesOutputError.aliasExistsException(
+                    .init()),
+                    .init(body: .empty, statusCode: .accepted))
         })
         do {
             _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,21 @@
 {
   "pins" : [
     {
+      "identity" : "amplify-swift-utils-notifications",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/aws-amplify/amplify-swift-utils-notifications.git",
+      "state" : {
+        "revision" : "d4fd3c17e8d40efc821f448d3d6cff75b8f3b0dd",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "aws-appsync-realtime-client-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
       "state" : {
-        "revision" : "da88cf1cab82e281e7277cd9feb9efc87a057041",
-        "version" : "2.1.1"
+        "revision" : "3de274c68a3cb60c8aec18b5bc0a8c07860219cd",
+        "version" : "3.0.0"
       }
     },
     {
@@ -23,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "c54c028cfc3ee70fde8c077547a1a1f6ef1137d9",
-        "version" : "0.6.0"
+        "revision" : "30649be4b9d0788f987ae851c48d48ac6d00f2c2",
+        "version" : "0.6.1"
       }
     },
     {
@@ -50,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/smithy-swift.git",
       "state" : {
-        "revision" : "f59ed07c29d4e03f91ea8324edf7a2486bd86a9c",
-        "version" : "0.6.0"
+        "revision" : "3e9e420f69c28dee260c03b19c3e93b392128d42",
+        "version" : "0.6.1"
       }
     },
     {


### PR DESCRIPTION
## Issue \#
#2857 

## Description
Some of the Auth Tasks were not catching the SdkErrors correctly. Added correct handling and tests. 

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
