### PR TITLE
feat(api): Add async protocol implementation for token request interceptors

### DIFF
--- a/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
+++ b/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
@@ -25,8 +25,20 @@ open class APIAuthProviderFactory {
 }
 
 public protocol AmplifyAuthTokenProvider {
+
     typealias AuthToken = String
+
     func getLatestAuthToken() -> Result<AuthToken, Error>
+
+    func getLatestAuthToken(completion: @escaping (Result<AuthToken, Error>) -> Void)
+}
+
+public extension AmplifyAuthTokenProvider {
+
+    func getLatestAuthToken(completion: @escaping (Result<AuthToken, Error>) -> Void) {
+        let result = getLatestAuthToken()
+        completion(result)
+    }
 }
 
 /// Amplify OIDC Auth Provider

--- a/AmplifyPlugins.podspec
+++ b/AmplifyPlugins.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'AWSAPIPlugin' do |ss|
     ss.source_files = 'AmplifyPlugins/API/AWSAPICategoryPlugin/**/*.swift'
-    ss.dependency 'AppSyncRealTimeClient', "~> 3.0"
+    ss.dependency 'AppSyncRealTimeClient', "~> 3.1"
   end
 
   s.subspec 'AWSCognitoAuthPlugin' do |ss|

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
@@ -29,4 +29,19 @@ class AuthTokenProviderWrapper: AuthTokenProvider {
         }
     }
 
+    func getToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+        wrappedAuthTokenProvider.getLatestAuthToken { result in
+            switch result {
+            case .success(let token):
+                completion(.success(token))
+                return
+            case .failure(let error):
+                completion(.failure(AuthError.service("Unable to get latest auth token",
+                                                      "",
+                                                      error)))
+                return
+            }
+        }
+    }
+
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
@@ -28,6 +28,14 @@ class IAMAuthInterceptor: AuthInterceptor {
         self.region = region
     }
 
+    func interceptMessage(_ message: AppSyncMessage, for endpoint: URL, completion: @escaping (AppSyncMessage) -> Void) {
+
+    }
+
+    func interceptConnection(_ request: AppSyncConnectionRequest, for endpoint: URL, completion: @escaping (AppSyncConnectionRequest) -> Void) {
+
+    }
+
     func interceptMessage(_ message: AppSyncMessage, for endpoint: URL) -> AppSyncMessage {
         switch message.messageType {
         case .subscribe:

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
@@ -28,14 +28,6 @@ class IAMAuthInterceptor: AuthInterceptor {
         self.region = region
     }
 
-    func interceptMessage(_ message: AppSyncMessage, for endpoint: URL, completion: @escaping (AppSyncMessage) -> Void) {
-
-    }
-
-    func interceptConnection(_ request: AppSyncConnectionRequest, for endpoint: URL, completion: @escaping (AppSyncConnectionRequest) -> Void) {
-
-    }
-
     func interceptMessage(_ message: AppSyncMessage, for endpoint: URL) -> AppSyncMessage {
         switch message.messageType {
         case .subscribe:

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/OIDCAuthProviderWrapper.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Interceptor/SubscriptionInterceptor/OIDCAuthProviderWrapper.swift
@@ -20,4 +20,8 @@ class OIDCAuthProviderWrapper: OIDCAuthProvider {
     func getLatestAuthToken() -> Result<String, Error> {
         return authTokenProvider.getLatestAuthToken()
     }
+
+    func getLatestAuthToken(completion: @escaping (Result<String, Error>) -> Void ) {
+        authTokenProvider.getLatestAuthToken(completion: completion)
+    }
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -126,6 +126,10 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
         func getToken() -> Result<String, AuthError> {
             .success("token")
         }
+
+        func getToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+            completion(.success("token"))
+        }
     }
 
 }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -37,5 +37,9 @@ extension AuthTokenURLRequestInterceptorTests {
         func getToken() -> Result<String, AuthError> {
             .success(authorizationToken)
         }
+
+        func getToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+            completion(.success(authorizationToken))
+        }
     }
 }

--- a/AmplifyPlugins/API/Podfile
+++ b/AmplifyPlugins/API/Podfile
@@ -8,7 +8,7 @@ include_build_tools!
 target 'AWSAPICategoryPlugin' do
 	pod 'Amplify', :path => '../../'
   pod 'AWSPluginsCore', :path => '../../'
-  pod "AppSyncRealTimeClient", :git => 'https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git', :branch => 'main'
+  pod "AppSyncRealTimeClient", "~> 3.1"
 
   target "AWSAPICategoryPluginTests" do
     inherit! :complete

--- a/AmplifyPlugins/API/Podfile
+++ b/AmplifyPlugins/API/Podfile
@@ -8,7 +8,7 @@ include_build_tools!
 target 'AWSAPICategoryPlugin' do
 	pod 'Amplify', :path => '../../'
   pod 'AWSPluginsCore', :path => '../../'
-  pod "AppSyncRealTimeClient", "~> 3.0"
+  pod "AppSyncRealTimeClient", :git => 'https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git', :branch => 'main'
 
   target "AWSAPICategoryPluginTests" do
     inherit! :complete

--- a/AmplifyPlugins/API/Podfile.lock
+++ b/AmplifyPlugins/API/Podfile.lock
@@ -54,7 +54,7 @@ DEPENDENCIES:
   - Amplify (from `../../`)
   - AmplifyPlugins/AWSCognitoAuthPlugin (from `../../`)
   - AmplifyTestCommon (from `../../`)
-  - AppSyncRealTimeClient (~> 3.0)
+  - AppSyncRealTimeClient (from `https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git`, branch `main`)
   - AWSPluginsCore (from `../../`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `2.1.0`)
   - SwiftFormat/CLI (= 0.44.17)
@@ -62,7 +62,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - AppSyncRealTimeClient
     - AWSAuthCore
     - AWSCognitoIdentityProvider
     - AWSCognitoIdentityProviderASF
@@ -83,6 +82,9 @@ EXTERNAL SOURCES:
     :path: "../../"
   AmplifyTestCommon:
     :path: "../../"
+  AppSyncRealTimeClient:
+    :branch: main
+    :git: https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git
   AWSPluginsCore:
     :path: "../../"
   CwlPreconditionTesting:
@@ -90,6 +92,9 @@ EXTERNAL SOURCES:
     :tag: 2.1.0
 
 CHECKOUT OPTIONS:
+  AppSyncRealTimeClient:
+    :commit: 814d7a42a99371949732fc1e0fd72ad0edfcf6a9
+    :git: https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git
   CwlPreconditionTesting:
     :git: https://github.com/mattgallagher/CwlPreconditionTesting.git
     :tag: 2.1.0
@@ -114,6 +119,6 @@ SPEC CHECKSUMS:
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
 
-PODFILE CHECKSUM: 5170578806036f2ba018abb8868d56e448fb0ada
+PODFILE CHECKSUM: ed8a1897b59148645b469aec7b84a6aa25e10fd2
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.0

--- a/AmplifyPlugins/API/Podfile.lock
+++ b/AmplifyPlugins/API/Podfile.lock
@@ -19,7 +19,7 @@ PODS:
     - AWSMobileClient (~> 2.30.1)
     - AWSPluginsCore (= 1.29.2)
     - CwlPreconditionTesting (~> 2.0)
-  - AppSyncRealTimeClient (3.0.0):
+  - AppSyncRealTimeClient (3.1.0):
     - Starscream (~> 4.0.4)
   - AWSAuthCore (2.30.4):
     - AWSCore (= 2.30.4)
@@ -54,7 +54,7 @@ DEPENDENCIES:
   - Amplify (from `../../`)
   - AmplifyPlugins/AWSCognitoAuthPlugin (from `../../`)
   - AmplifyTestCommon (from `../../`)
-  - AppSyncRealTimeClient (from `https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git`, branch `main`)
+  - AppSyncRealTimeClient (~> 3.1)
   - AWSPluginsCore (from `../../`)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `2.1.0`)
   - SwiftFormat/CLI (= 0.44.17)
@@ -62,6 +62,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - AppSyncRealTimeClient
     - AWSAuthCore
     - AWSCognitoIdentityProvider
     - AWSCognitoIdentityProviderASF
@@ -82,9 +83,6 @@ EXTERNAL SOURCES:
     :path: "../../"
   AmplifyTestCommon:
     :path: "../../"
-  AppSyncRealTimeClient:
-    :branch: main
-    :git: https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git
   AWSPluginsCore:
     :path: "../../"
   CwlPreconditionTesting:
@@ -92,9 +90,6 @@ EXTERNAL SOURCES:
     :tag: 2.1.0
 
 CHECKOUT OPTIONS:
-  AppSyncRealTimeClient:
-    :commit: 814d7a42a99371949732fc1e0fd72ad0edfcf6a9
-    :git: https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git
   CwlPreconditionTesting:
     :git: https://github.com/mattgallagher/CwlPreconditionTesting.git
     :tag: 2.1.0
@@ -103,7 +98,7 @@ SPEC CHECKSUMS:
   Amplify: 955400b4b5f29832357f682e15c659d049028306
   AmplifyPlugins: 9ce2e86f2051f0ec38fcf4376efb936b6c617cce
   AmplifyTestCommon: 9b452352797cd82faa67e296669bb94bd531a5eb
-  AppSyncRealTimeClient: ec19a24f635611b193eb98a2da573abcf98b793b
+  AppSyncRealTimeClient: 49901c6f21e541bec09281854c5695a6c1309bf7
   AWSAuthCore: 42e2d4927d94e5e323b63b2ae885f287c51b5889
   AWSCognitoIdentityProvider: 2331f5f4c8c1775c6a228bb2dae2d353198401e8
   AWSCognitoIdentityProviderASF: d905c2acab3d2e7016b643d53ba553d5217fa929
@@ -119,6 +114,6 @@ SPEC CHECKSUMS:
   SwiftFormat: 3b5caa6389b2b9adbc00e133b3ccc8c6e687a6a4
   SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
 
-PODFILE CHECKSUM: ed8a1897b59148645b469aec7b84a6aa25e10fd2
+PODFILE CHECKSUM: f542a7a3bf7a7e882e6ea4799c9722d5b6495208
 
 COCOAPODS: 1.12.0

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift
@@ -15,6 +15,14 @@ public protocol AuthTokenProvider {
     func getToken(completion: @escaping (Result<String, AuthError>) -> Void)
 }
 
+public extension AuthTokenProvider {
+
+    func getToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+        let result = getToken()
+        completion(result)
+    }
+}
+
 public struct BasicUserPoolTokenProvider: AuthTokenProvider {
 
     let authService: AWSAuthServiceBehavior

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AuthTokenProvider.swift
@@ -9,7 +9,10 @@ import Foundation
 import Amplify
 
 public protocol AuthTokenProvider {
+
     func getToken() -> Result<String, AuthError>
+
+    func getToken(completion: @escaping (Result<String, AuthError>) -> Void)
 }
 
 public struct BasicUserPoolTokenProvider: AuthTokenProvider {
@@ -22,5 +25,9 @@ public struct BasicUserPoolTokenProvider: AuthTokenProvider {
 
     public func getToken() -> Result<String, AuthError> {
         return authService.getToken()
+    }
+
+    public func getToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+        authService.getUserPoolAccessToken(completion: completion)
     }
 }

--- a/AmplifyPlugins/DataStore/Podfile.lock
+++ b/AmplifyPlugins/DataStore/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - Amplify/Default (= 1.29.2)
   - Amplify/Default (1.29.2)
   - AmplifyPlugins/AWSAPIPlugin (1.29.2):
-    - AppSyncRealTimeClient (~> 3.0)
+    - AppSyncRealTimeClient (~> 3.1)
     - AWSCore (~> 2.30.1)
     - AWSPluginsCore (= 1.29.2)
   - AmplifyPlugins/AWSCognitoAuthPlugin (1.29.2):
@@ -23,7 +23,7 @@ PODS:
     - AWSMobileClient (~> 2.30.1)
     - AWSPluginsCore (= 1.29.2)
     - CwlPreconditionTesting (~> 2.0)
-  - AppSyncRealTimeClient (3.0.0):
+  - AppSyncRealTimeClient (3.1.0):
     - Starscream (~> 4.0.4)
   - AWSAuthCore (2.30.4):
     - AWSCore (= 2.30.4)
@@ -106,9 +106,9 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Amplify: 955400b4b5f29832357f682e15c659d049028306
-  AmplifyPlugins: 9ce2e86f2051f0ec38fcf4376efb936b6c617cce
+  AmplifyPlugins: a82d1c5ddb2b5a8fcd23dd447f84b04f93dc00c2
   AmplifyTestCommon: 9b452352797cd82faa67e296669bb94bd531a5eb
-  AppSyncRealTimeClient: ec19a24f635611b193eb98a2da573abcf98b793b
+  AppSyncRealTimeClient: 49901c6f21e541bec09281854c5695a6c1309bf7
   AWSAuthCore: 42e2d4927d94e5e323b63b2ae885f287c51b5889
   AWSCognitoIdentityProvider: 2331f5f4c8c1775c6a228bb2dae2d353198401e8
   AWSCognitoIdentityProviderASF: d905c2acab3d2e7016b643d53ba553d5217fa929

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
         "state": {
           "branch": null,
-          "revision": "3de274c68a3cb60c8aec18b5bc0a8c07860219cd",
-          "version": "3.0.0"
+          "revision": "b036e83716789c13a3480eeb292b70caa54114f2",
+          "version": "3.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "AWSiOSSDKV2", url: "https://github.com/aws-amplify/aws-sdk-ios-spm.git", .upToNextMinor(from: "2.30.1")),
-        .package(name: "AppSyncRealTimeClient", url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git", from: "3.0.0"),
+        .package(name: "AppSyncRealTimeClient", url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git", from: "3.1.0"),
         .package(url: "https://github.com/stephencelis/SQLite.swift.git", .exact("0.13.2"))
     ],
     targets: [


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
- Adds async version of protocol `AmplifyAuthTokenProvider`
- Adds async version of protocol `AuthTokenProvider`
- Depends on `AppSyncRealTimeClient` >= 3.1.0
- All changes are backward compatible and should not break existing behavior

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
