### PR TITLE
chore: fix internal pinpoint tests that were broken by latest swift concurrency updates and enable them to run in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,6 +338,13 @@ workflows:
           requires:
             - build_amplify_ios_spm
       - unit_test:
+          name: ios_unit_test_internal_pinpoint
+          scheme: InternalAWSPinpointUnitTests
+          sdk: iphonesimulator
+          destination: << pipeline.parameters.ios-destination >>
+          requires:
+            - build_amplify_ios_spm
+      - unit_test:
           name: ios_unit_test_push_notifications
           scheme: AWSPinpointPushNotificationsPlugin
           sdk: iphonesimulator
@@ -396,6 +403,13 @@ workflows:
       - unit_test:
           name: macos_unit_test_geo
           scheme: AWSLocationGeoPlugin
+          sdk: macosx
+          destination: << pipeline.parameters.macos-destination >>
+          requires:
+            - build_amplify_macos_spm
+      - unit_test:
+          name: macos_unit_test_internal_pinpoint
+          scheme: InternalAWSPinpointUnitTests
           sdk: macosx
           destination: << pipeline.parameters.macos-destination >>
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,6 +260,7 @@ deploy_requires: &deploy_requires
     - ios_unit_test_auth
     - ios_unit_test_datastore
     - ios_unit_test_geo
+    - ios_unit_test_internal_pinpoint
     - ios_unit_test_push_notifications
     - ios_unit_test_storage
     - macos_unit_test_amplify
@@ -269,6 +270,7 @@ deploy_requires: &deploy_requires
     - macos_unit_test_auth
     - macos_unit_test_datastore
     - macos_unit_test_geo
+    - macos_unit_test_internal_pinpoint
     - macos_unit_test_push_notifications
     - macos_unit_test_storage
     - fortify_scan

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockAnalyticsClient.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockAnalyticsClient.swift
@@ -9,6 +9,7 @@ import AWSPinpoint
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 import StoreKit
 import XCTest
+import AmplifyAsyncTesting
 
 actor MockAnalyticsClient: AnalyticsClientBehaviour {
     let pinpointClient: PinpointClientProtocol = MockPinpointClient()
@@ -72,10 +73,10 @@ actor MockAnalyticsClient: AnalyticsClientBehaviour {
 
     }
 
-    private var recordExpectation: XCTestExpectation?
-    func setRecordExpectation(_ expectation: XCTestExpectation, count: Int = 1) {
+    private var recordExpectation: AsyncExpectation?
+    func setRecordExpectation(_ expectation: AsyncExpectation, count: Int = 1) async {
         recordExpectation = expectation
-        recordExpectation?.expectedFulfillmentCount = count
+        await recordExpectation?.setExpectedFulfillmentCount(count)
     }
 
     var recordCount = 0
@@ -85,19 +86,23 @@ actor MockAnalyticsClient: AnalyticsClientBehaviour {
         recordCount += 1
         lastRecordedEvent = event
         recordedEvents.append(event)
-        recordExpectation?.fulfill()
+        Task {
+            await recordExpectation?.fulfill()
+        }
     }
 
-    private var submitEventsExpectation: XCTestExpectation?
-    func setSubmitEventsExpectation(_ expectation: XCTestExpectation, count: Int = 1) {
+    private var submitEventsExpectation: AsyncExpectation?
+    func setSubmitEventsExpectation(_ expectation: AsyncExpectation, count: Int = 1) async {
         submitEventsExpectation = expectation
-        submitEventsExpectation?.expectedFulfillmentCount = count
+        await submitEventsExpectation?.setExpectedFulfillmentCount(count)
     }
 
     var submitEventsCount = 0
     func submitEvents() async throws -> [PinpointEvent] {
         submitEventsCount += 1
-        submitEventsExpectation?.fulfill()
+        Task {
+            await submitEventsExpectation?.fulfill()
+        }
         return []
     }
 

--- a/Package.swift
+++ b/Package.swift
@@ -280,7 +280,8 @@ let internalPinpointTargets: [Target] = [
         name: "InternalAWSPinpointUnitTests",
         dependencies: [
             "InternalAWSPinpoint",
-            "AmplifyTestCommon"
+            "AmplifyTestCommon",
+            "AmplifyAsyncTesting"
         ],
         path: "AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests"
     )


### PR DESCRIPTION
## Description
fix internal pinpoint tests that were broken by latest swift concurrency updates and enable them to run in CI

## General Checklist
<!-- Check or cross out if not relevant -->

- ~~[ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
- ~~[ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~~
- ~~[ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
