### PR TITLE
test: Fix CwlPreconditionTesting to build in Geo and Predictions

### DIFF
--- a/AmplifyPlugins/Geo/Podfile.lock
+++ b/AmplifyPlugins/Geo/Podfile.lock
@@ -37,8 +37,8 @@ PODS:
   - AWSPluginsCore (1.29.2):
     - Amplify (= 1.29.2)
     - AWSCore (~> 2.30.1)
-  - CwlCatchException (2.1.2):
-    - CwlCatchExceptionSupport (~> 2.1.2)
+  - CwlCatchException (2.1.1):
+    - CwlCatchExceptionSupport (~> 2.1.1)
   - CwlCatchExceptionSupport (2.1.2)
   - CwlMachBadInstructionHandler (2.1.2)
   - CwlPosixPreconditionTesting (2.1.2)
@@ -55,6 +55,7 @@ DEPENDENCIES:
   - AmplifyTestCommon (from `../../`)
   - AWSLocation (~> 2.30.1)
   - AWSPluginsCore (from `../../`)
+  - CwlCatchException (= 2.1.1)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `2.1.0`)
   - SwiftFormat/CLI (= 0.44.17)
   - SwiftLint (= 0.49.1)
@@ -94,7 +95,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Amplify: 955400b4b5f29832357f682e15c659d049028306
-  AmplifyPlugins: 9ce2e86f2051f0ec38fcf4376efb936b6c617cce
+  AmplifyPlugins: a82d1c5ddb2b5a8fcd23dd447f84b04f93dc00c2
   AmplifyTestCommon: 9b452352797cd82faa67e296669bb94bd531a5eb
   AWSAuthCore: 42e2d4927d94e5e323b63b2ae885f287c51b5889
   AWSCognitoIdentityProvider: 2331f5f4c8c1775c6a228bb2dae2d353198401e8
@@ -103,7 +104,7 @@ SPEC CHECKSUMS:
   AWSLocation: 3bf8506963f52f15d12d979690147ba04d407375
   AWSMobileClient: 7d9c81e47ef27c6b5604858477006548eb1db342
   AWSPluginsCore: 787b6199af91f6662171cbd66ad9a876530aed50
-  CwlCatchException: 76542d5ea479c79ce16ddd6e7bc9d42c7ec63300
+  CwlCatchException: 86760545af2a490a23e964d76d7c77442dbce79b
   CwlCatchExceptionSupport: 42bf8c5e4e5e663f51100ddfa68caf7cfcf64ab6
   CwlMachBadInstructionHandler: b982c7e3e44fcfa1c680e8046f6bba35f3476d65
   CwlPosixPreconditionTesting: 4011f0660c0be460b088d10bcfdf351c7e036ac4
@@ -113,4 +114,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: eac71f2c18215703baf5648bacac93d4641c2d87
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.0

--- a/AmplifyPlugins/Predictions/Podfile.lock
+++ b/AmplifyPlugins/Predictions/Podfile.lock
@@ -47,8 +47,8 @@ PODS:
     - AWSCore (= 2.30.4)
   - AWSTranslate (2.30.4):
     - AWSCore (= 2.30.4)
-  - CwlCatchException (2.1.2):
-    - CwlCatchExceptionSupport (~> 2.1.2)
+  - CwlCatchException (2.1.1):
+    - CwlCatchExceptionSupport (~> 2.1.1)
   - CwlCatchExceptionSupport (2.1.2)
   - CwlMachBadInstructionHandler (2.1.2)
   - CwlPosixPreconditionTesting (2.1.2)
@@ -70,6 +70,7 @@ DEPENDENCIES:
   - AWSTextract (~> 2.30.1)
   - AWSTranscribeStreaming (~> 2.30.1)
   - AWSTranslate (~> 2.30.1)
+  - CwlCatchException (= 2.1.1)
   - CwlPreconditionTesting (from `https://github.com/mattgallagher/CwlPreconditionTesting.git`, tag `2.1.0`)
   - SwiftFormat/CLI (= 0.44.17)
   - SwiftLint (= 0.49.1)
@@ -114,7 +115,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Amplify: 955400b4b5f29832357f682e15c659d049028306
-  AmplifyPlugins: 9ce2e86f2051f0ec38fcf4376efb936b6c617cce
+  AmplifyPlugins: a82d1c5ddb2b5a8fcd23dd447f84b04f93dc00c2
   AmplifyTestCommon: 9b452352797cd82faa67e296669bb94bd531a5eb
   AWSAuthCore: 42e2d4927d94e5e323b63b2ae885f287c51b5889
   AWSCognitoIdentityProvider: 2331f5f4c8c1775c6a228bb2dae2d353198401e8
@@ -128,7 +129,7 @@ SPEC CHECKSUMS:
   AWSTextract: 5adbfe57a4dbbf60573203006323c00eec740630
   AWSTranscribeStreaming: dda8f6ee1acaf5de39710aff9b2dde33e77604de
   AWSTranslate: 094f154abdb802ec7078c21806aabd059c868739
-  CwlCatchException: 76542d5ea479c79ce16ddd6e7bc9d42c7ec63300
+  CwlCatchException: 86760545af2a490a23e964d76d7c77442dbce79b
   CwlCatchExceptionSupport: 42bf8c5e4e5e663f51100ddfa68caf7cfcf64ab6
   CwlMachBadInstructionHandler: b982c7e3e44fcfa1c680e8046f6bba35f3476d65
   CwlPosixPreconditionTesting: 4011f0660c0be460b088d10bcfdf351c7e036ac4
@@ -138,4 +139,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: f96d753f1be77936c8d187f6834c2082b94be4f4
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.0

--- a/build-support/dependencies.rb
+++ b/build-support/dependencies.rb
@@ -24,4 +24,6 @@ def include_test_utilities!
   pod 'CwlPreconditionTesting',
     git: 'https://github.com/mattgallagher/CwlPreconditionTesting.git',
     tag: '2.1.0'
+
+  pod 'CwlCatchException', '2.1.1' 
 end


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
Test build were failing with iOS mismatch error. Looks like `CwlCatchException` increased the iOS version support, this PR pins the version so that `CwlPreconditionTesting` will pick the supported version.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
