### PR TITLE
fix(datastore): fix sync with lazy references

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Identifiers.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Identifiers.swift
@@ -1,0 +1,22 @@
+//
+//  ModelSchema+Identifiers.swift
+//  
+//
+//  Created by Sapir Muallem on 23/04/2023.
+//
+
+import Foundation
+
+extension ModelSchema {
+    func getModelIdentifiers(from modelObject: [String: JSONValue]) -> [LazyReferenceIdentifier] {
+        var identifiers = [LazyReferenceIdentifier]()
+
+        for identifierField in primaryKey.fields {
+            if case .string(let identifierValue) = modelObject[identifierField.name] {
+                identifiers.append(.init(name: identifierField.name, value: identifierValue))
+            }
+        }
+        
+        return identifiers
+    }
+}

--- a/Amplify/Categories/DataStore/Model/Lazy/LazyReference.swift
+++ b/Amplify/Categories/DataStore/Model/Lazy/LazyReference.swift
@@ -96,9 +96,13 @@ public class LazyReference<ModelType: Model>: Codable, _LazyReferenceValue {
         }
         let json = try JSONValue(from: decoder)
         switch json {
-        case .object:
+        case .object(let _json):
             if let element = try? ModelType(from: decoder) {
                 self.init(element)
+                return
+            }
+            else {
+                self.init(identifiers: ModelType.schema.getModelIdentifiers(from: _json))
                 return
             }
         default:

--- a/AmplifyTests/CategoryTests/DataStore/Model/LazyReferenceTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/Model/LazyReferenceTests.swift
@@ -84,4 +84,23 @@ final class LazyReferenceTests: XCTestCase {
         let json = try comment.toJSON()
         XCTAssertEqual(json, "{\"post\":[{\"name\":\"id\",\"value\":\"postId\"}],\"id\":\"commentId\",\"content\":\"content\",\"updatedAt\":null,\"createdAt\":null}")
     }
+    
+    func testDecodePrimaryKeysOnly() async throws {
+        let postIdentifierName = "id"
+        let postIdentifierValue = "postId"
+        
+        let commentWithLazyPostJSON = "{\"post\":{\"\(postIdentifierName)\":\"\(postIdentifierValue)\"},\"id\":\"commentId\",\"content\":\"c\",\"updatedAt\":null,\"createdAt\":null}"
+        
+        guard let decodedComment = try ModelRegistry.decode(modelName: LazyChildComment4V2.modelName, from: commentWithLazyPostJSON) as? LazyChildComment4V2 else {
+            XCTFail("Could not decode to comment from json")
+            return
+        }
+        switch decodedComment._post.loadedState {
+        case .notLoaded(let identifiers):
+            let id = identifiers?.first(where: { $0.name == postIdentifierName && $0.value == postIdentifierValue })
+            XCTAssertNotNil(id)
+        case .loaded:
+            XCTFail("Should be not loaded")
+        }
+    }
 }


### PR DESCRIPTION
## Issue \#

## Description
- The decoding logic of `LazyReference` relied on `ModelProviderRegistry.decoders` to handle the decoding process.
- In case the `ModelProviderRegistry.decoders` failed to decode, the logic attempted to decode it into a model instance.
- However, if required fields were missing from the JSON, the decode failed and returned nil.
- Handling this scenario by returning the unloaded model state instead of nil was missing.
- Fixed this issue by adding a logic that handles not fully loaded models.

## General Checklist
- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
