### PR TITLE
feat(predictions): add category request supporting types

### DIFF
--- a/Amplify/Categories/Predictions/PredictionsCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Predictions/PredictionsCategory+ClientBehavior.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 extension PredictionsCategory: PredictionsCategoryBehavior {
-
     public func identify<Output>(
         _ request: Predictions.Identify.Request<Output>,
         in image: URL,

--- a/Amplify/Categories/Predictions/Request/Convert/Convert+SpeechToText+Options.swift
+++ b/Amplify/Categories/Predictions/Request/Convert/Convert+SpeechToText+Options.swift
@@ -1,0 +1,33 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Convert.SpeechToText {
+    public struct Options {
+        /// The default NetworkPolicy for the operation. The default value will be `auto`.
+        public let defaultNetworkPolicy: DefaultNetworkPolicy
+
+        /// The language of the audio file you are transcribing
+        public let language: Predictions.Language?
+
+        /// Extra plugin specific options, only used in special circumstances when the existing options do not
+        /// provide a way to utilize the underlying storage system's functionality. See plugin documentation for
+        /// expected key/values
+        public let pluginOptions: Any?
+
+        public init(
+            defaultNetworkPolicy: DefaultNetworkPolicy = .auto,
+            language: Predictions.Language? = nil,
+            pluginOptions: Any? = nil
+        ) {
+            self.defaultNetworkPolicy = defaultNetworkPolicy
+            self.language = language
+            self.pluginOptions = pluginOptions
+        }
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Convert/Convert+SpeechToText+Request.swift
+++ b/Amplify/Categories/Predictions/Request/Convert/Convert+SpeechToText+Request.swift
@@ -1,0 +1,23 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Convert.SpeechToText {
+    public struct Request {
+        /// The text to synthesize to speech
+        public let speechToText: URL
+
+        /// Options to adjust the behavior of this request, including plugin options
+        public let options: Options
+
+        public init(speechToText: URL, options: Options) {
+            self.speechToText = speechToText
+            self.options = options
+        }
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Convert/Convert+SpeechToText+Result.swift
+++ b/Amplify/Categories/Predictions/Request/Convert/Convert+SpeechToText+Result.swift
@@ -1,0 +1,21 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Convert.SpeechToText {
+    /// Results are mapped to SpeechToTextResult when convert() API is
+    /// called to convert a text to audio
+    public struct Result {
+        /// Resulting string from speech to text conversion
+        public let transcription: String
+
+        public init(transcription: String) {
+            self.transcription = transcription
+        }
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Convert/Convert+SpeechToText.swift
+++ b/Amplify/Categories/Predictions/Request/Convert/Convert+SpeechToText.swift
@@ -1,0 +1,22 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Convert {
+    public enum SpeechToText {}
+}
+
+extension Predictions.Convert.Request where
+Input == URL,
+Options == Predictions.Convert.SpeechToText.Options,
+Output == AsyncThrowingStream<Predictions.Convert.SpeechToText.Result, Error> {
+
+    public static func speechToText(url: URL) -> Self {
+        .init(input: url, kind: .speechToText(.lift))
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Convert/Convert+TextToSpeech+Options.swift
+++ b/Amplify/Categories/Predictions/Request/Convert/Convert+TextToSpeech+Options.swift
@@ -1,0 +1,33 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Convert.TextToSpeech {
+    public struct Options {
+        /// The default NetworkPolicy for the operation. The default value will be `auto`.
+        public let defaultNetworkPolicy: DefaultNetworkPolicy
+
+        /// The voice type selected for synthesizing text to speech
+        public let voice: Predictions.Voice?
+
+        /// Extra plugin specific options, only used in special circumstances when the existing options do not provide
+        /// a way to utilize the underlying storage system's functionality. See plugin documentation for expected
+        /// key/values
+        public let pluginOptions: Any?
+
+        public init(
+            defaultNetworkPolicy: DefaultNetworkPolicy = .auto,
+            voice: Predictions.Voice? = nil,
+            pluginOptions: Any? = nil
+        ) {
+            self.defaultNetworkPolicy = defaultNetworkPolicy
+            self.pluginOptions = pluginOptions
+            self.voice = voice
+        }
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Convert/Convert+TextToSpeech+Request.swift
+++ b/Amplify/Categories/Predictions/Request/Convert/Convert+TextToSpeech+Request.swift
@@ -1,0 +1,23 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Convert.TextToSpeech {
+    public struct Request {
+        /// The text to synthesize to speech
+        public let textToSpeech: String
+
+        /// Options to adjust the behavior of this request, including plugin options
+        public let options: Options
+
+        public init(textToSpeech: String, options: Options) {
+            self.textToSpeech = textToSpeech
+            self.options = options
+        }
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Convert/Convert+TextToSpeech+Result.swift
+++ b/Amplify/Categories/Predictions/Request/Convert/Convert+TextToSpeech+Result.swift
@@ -1,0 +1,21 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Convert.TextToSpeech {
+    /// Results are mapped to TextToSpeechResult when convert() API is
+    /// called to convert a text to audio
+    public struct Result {
+        /// Resulting audio from text to speech conversion
+        public let audioData: Data
+
+        public init(audioData: Data) {
+            self.audioData = audioData
+        }
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Convert/Convert+TextToSpeech.swift
+++ b/Amplify/Categories/Predictions/Request/Convert/Convert+TextToSpeech.swift
@@ -1,0 +1,22 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Convert {
+    public enum TextToSpeech {}
+}
+
+extension Predictions.Convert.Request where
+Input == String,
+Options == Predictions.Convert.TextToSpeech.Options,
+Output == Predictions.Convert.TextToSpeech.Result {
+
+    public static func textToSpeech(_ text: String) -> Self {
+        .init(input: text, kind: .textToSpeech(.lift))
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Convert/Convert+TranslateText+Options.swift
+++ b/Amplify/Categories/Predictions/Request/Convert/Convert+TranslateText+Options.swift
@@ -1,0 +1,28 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Convert.TranslateText {
+    public struct Options {
+        /// The default NetworkPolicy for the operation. The default value will be `auto`.
+        public let defaultNetworkPolicy: DefaultNetworkPolicy
+
+        /// Extra plugin specific options, only used in special circumstances when the existing options do not provide
+        /// a way to utilize the underlying storage system's functionality. See plugin documentation for expected
+        /// key/values
+        public let pluginOptions: Any?
+
+        public init(
+            defaultNetworkPolicy: DefaultNetworkPolicy = .auto,
+            pluginOptions: Any? = nil
+        ) {
+            self.defaultNetworkPolicy = defaultNetworkPolicy
+            self.pluginOptions = pluginOptions
+        }
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Convert/Convert+TranslateText+Request.swift
+++ b/Amplify/Categories/Predictions/Request/Convert/Convert+TranslateText+Request.swift
@@ -1,0 +1,36 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Convert.TranslateText {
+    public struct Request {
+        /// The text to translate.
+        public let textToTranslate: String
+
+        /// The language to translate
+        public let targetLanguage: Predictions.Language?
+
+        /// Source language of the text given.
+        public let language: Predictions.Language?
+
+        /// Options to adjust the behavior of this request, including plugin options
+        public let options: Options
+
+        public init(
+            textToTranslate: String,
+            targetLanguage: Predictions.Language?,
+            language: Predictions.Language?,
+            options: Options
+        ) {
+            self.textToTranslate = textToTranslate
+            self.language = language
+            self.targetLanguage = targetLanguage
+            self.options = options
+        }
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Convert/Convert+TranslateText+Result.swift
+++ b/Amplify/Categories/Predictions/Request/Convert/Convert+TranslateText+Result.swift
@@ -1,0 +1,23 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+extension Predictions.Convert.TranslateText {
+    /// Results are mapped to TranslateTextResult when convert() API is
+    /// called to translate a text into another language
+    public struct Result {
+        /// Translated text
+        public let text: String
+
+        /// Language to which the text was translated.
+        public let targetLanguage: Predictions.Language
+
+        public init(text: String, targetLanguage: Predictions.Language) {
+            self.text = text
+            self.targetLanguage = targetLanguage
+        }
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Convert/Convert+TranslateText.swift
+++ b/Amplify/Categories/Predictions/Request/Convert/Convert+TranslateText.swift
@@ -1,0 +1,29 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Convert {
+    public enum TranslateText {}
+}
+
+extension Predictions.Convert.Request where
+Input == (String, Predictions.Language?, Predictions.Language?),
+Options == Predictions.Convert.TranslateText.Options,
+Output == Predictions.Convert.TranslateText.Result {
+
+    public static func textToTranslate(
+        _ text: String,
+        from: Predictions.Language? = nil,
+        to: Predictions.Language? = nil
+    ) -> Self {
+        .init(
+            input: (text, from, to),
+            kind: .textToTranslate(.lift)
+        )
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Convert/Convert.swift
+++ b/Amplify/Categories/Predictions/Request/Convert/Convert.swift
@@ -22,6 +22,28 @@ extension Predictions.Convert.Request {
     public enum Kind {
         public typealias BidirectionalLift<T, U> = ((T) -> U, (U) -> T)
 
-        // TODO: Add request kind cases
+        case textToSpeech(
+            Lift<
+            String, Input,
+            Predictions.Convert.TextToSpeech.Options?, Options?,
+            Predictions.Convert.TextToSpeech.Result, Output
+            >
+        )
+
+        case speechToText(
+            Lift<
+            URL, Input,
+            Predictions.Convert.SpeechToText.Options?, Options?,
+            AsyncThrowingStream<Predictions.Convert.SpeechToText.Result, Error>, Output
+            >
+        )
+
+        case textToTranslate(
+            Lift<
+            (String, Predictions.Language?, Predictions.Language?), Input,
+            Predictions.Convert.TranslateText.Options?, Options?,
+            Predictions.Convert.TranslateText.Result, Output
+            >
+        )
     }
 }

--- a/Amplify/Categories/Predictions/Request/Identify/Identify+Celebrities+Result.swift
+++ b/Amplify/Categories/Predictions/Request/Identify/Identify+Celebrities+Result.swift
@@ -1,0 +1,18 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+extension Predictions.Identify.Celebrities {
+    /// Results are mapped to IdentifyCelebritiesResult when .detectCelebrity in passed in the type: field
+    /// in identify() API
+    public struct Result {
+        public let celebrities: [Predictions.Celebrity]
+
+        public init(celebrities: [Predictions.Celebrity]) {
+            self.celebrities = celebrities
+        }
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Identify/Identify+Celebrities.swift
+++ b/Amplify/Categories/Predictions/Request/Identify/Identify+Celebrities.swift
@@ -1,0 +1,18 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Identify {
+    public enum Celebrities {}
+}
+
+extension Predictions.Identify.Request where Output == Predictions.Identify.Celebrities.Result {
+    public static let celebrities = Self(
+        kind: .detectCelebrities(.lift)
+    )
+}

--- a/Amplify/Categories/Predictions/Request/Identify/Identify+Document.swift
+++ b/Amplify/Categories/Predictions/Request/Identify/Identify+Document.swift
@@ -1,0 +1,18 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Identify {
+    public enum DocumentText {}
+}
+
+extension Predictions.Identify.Request where Output == Predictions.Identify.DocumentText.Result {
+    public static func textInDocument(textFormatType: Predictions.TextFormatType) -> Self {
+        .init(kind: .detectTextInDocument(textFormatType, .lift))
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Identify/Identify+DocumentText+Result.swift
+++ b/Amplify/Categories/Predictions/Request/Identify/Identify+DocumentText+Result.swift
@@ -1,0 +1,39 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+extension Predictions.Identify.DocumentText {
+    /// Results are mapped to IdentifyDocumentTextResult when .form, .table
+    /// or .all is passed for .detectText in the type: field
+    /// in identify() API
+    public struct Result {
+        public let fullText: String
+        public let words: [Predictions.IdentifiedWord]
+        public let rawLineText: [String]
+        public let identifiedLines: [Predictions.IdentifiedLine]
+        public let selections: [Predictions.Selection]
+        public let tables: [Predictions.Table]
+        public let keyValues: [Predictions.BoundedKeyValue]
+
+        public init(
+            fullText: String,
+            words: [Predictions.IdentifiedWord],
+            rawLineText: [String],
+            identifiedLines: [Predictions.IdentifiedLine],
+            selections: [Predictions.Selection],
+            tables: [Predictions.Table],
+            keyValues: [Predictions.BoundedKeyValue]
+        ) {
+            self.fullText = fullText
+            self.words = words
+            self.rawLineText = rawLineText
+            self.identifiedLines = identifiedLines
+            self.selections = selections
+            self.tables = tables
+            self.keyValues = keyValues
+        }
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Identify/Identify+Entities+Result.swift
+++ b/Amplify/Categories/Predictions/Request/Identify/Identify+Entities+Result.swift
@@ -1,0 +1,20 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+extension Predictions.Identify.Entities {
+    /// Results are mapped to IdentifyEntitiesResult when .detectEntities is
+    /// passed to type: field in identify() API and general entities like facial features, landmarks etc.
+    /// are needed to be detected
+    public struct Result {
+        /// List of 'Entity' as a result of Identify query
+        public let entities: [Predictions.Entity]
+
+        public init(entities: [Predictions.Entity]) {
+            self.entities = entities
+        }
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Identify/Identify+Entities.swift
+++ b/Amplify/Categories/Predictions/Request/Identify/Identify+Entities.swift
@@ -1,0 +1,18 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Identify {
+    public enum Entities {}
+}
+
+extension Predictions.Identify.Request where Output == Predictions.Identify.Entities.Result {
+    public static let entities = Self(
+        kind: .detectEntities(.lift)
+    )
+}

--- a/Amplify/Categories/Predictions/Request/Identify/Identify+EntityMatches+Result.swift
+++ b/Amplify/Categories/Predictions/Request/Identify/Identify+EntityMatches+Result.swift
@@ -1,0 +1,20 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+extension Predictions.Identify.EntityMatches {
+    /// Results are mapped to IdentifyEntityMatchesResult when .detectEntities is
+    /// passed to type: field in identify() API and matches from your Rekognition Collection
+    /// need to be identified
+    public struct Result {
+        /// List of matched `Entity.Match`
+        public let entities: [Predictions.Entity.Match]
+
+        public init(entities: [Predictions.Entity.Match]) {
+            self.entities = entities
+        }
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Identify/Identify+EntityMatches.swift
+++ b/Amplify/Categories/Predictions/Request/Identify/Identify+EntityMatches.swift
@@ -1,0 +1,18 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Identify {
+    public enum EntityMatches {}
+}
+
+extension Predictions.Identify.Request where Output == Predictions.Identify.EntityMatches.Result {
+    public static func entitiesFromCollection(withID collectionID: String) -> Self {
+        .init(kind: .detectEntitiesCollection(collectionID, .lift))
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Identify/Identify+Labels+Result.swift
+++ b/Amplify/Categories/Predictions/Request/Identify/Identify+Labels+Result.swift
@@ -1,0 +1,61 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import CoreGraphics
+
+extension Predictions.Identify.Labels {
+    /// Results are mapped to IdentifyLabelsResult when .labels in passed to .detectLabels
+    /// in the type: field in identify() API
+    public struct Result {
+        public let labels: [Predictions.Label]
+        public let unsafeContent: Bool?
+
+        public init(labels: [Predictions.Label], unsafeContent: Bool? = nil) {
+            self.labels = labels
+            self.unsafeContent = unsafeContent
+        }
+    }
+}
+
+extension Predictions {
+    /// Describes a real world object (e.g., chair, desk) identified in an image
+    public struct Label {
+        public let name: String
+        public let metadata: Metadata?
+        public let boundingBoxes: [CGRect]?
+
+        public init(
+            name: String,
+            metadata: Metadata? = nil,
+            boundingBoxes: [CGRect]? = nil
+        ) {
+            self.name = name
+            self.metadata = metadata
+            self.boundingBoxes = boundingBoxes
+        }
+    }
+
+    public struct Parent {
+        public let name: String
+
+        public init(name: String) {
+            self.name = name
+        }
+    }
+}
+
+extension Predictions.Label {
+    public struct Metadata {
+        public let confidence: Double
+        public let parents: [Predictions.Parent]?
+
+        public init(confidence: Double, parents: [Predictions.Parent]? = nil) {
+            self.confidence = confidence
+            self.parents = parents
+        }
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Identify/Identify+Labels.swift
+++ b/Amplify/Categories/Predictions/Request/Identify/Identify+Labels.swift
@@ -1,0 +1,18 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Identify {
+    public enum Labels {}
+}
+
+extension Predictions.Identify.Request where Output == Predictions.Identify.Labels.Result {
+    public static func labels(type: Predictions.LabelType = .labels) -> Self {
+        .init(kind: .detectLabels(type, .lift))
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Identify/Identify+Text+Result.swift
+++ b/Amplify/Categories/Predictions/Request/Identify/Identify+Text+Result.swift
@@ -1,0 +1,29 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+extension Predictions.Identify.Text {
+    /// Results are mapped to IdentifyTextResult when .plain is passed for .detectText in the type: field
+    /// in identify() API
+    public struct Result {
+        public let fullText: String?
+        public let words: [Predictions.IdentifiedWord]?
+        public let rawLineText: [String]?
+        public let identifiedLines: [Predictions.IdentifiedLine]?
+        
+        public init(
+            fullText: String?,
+            words: [Predictions.IdentifiedWord]?,
+            rawLineText: [String]?,
+            identifiedLines: [Predictions.IdentifiedLine]?
+        ) {
+            self.fullText = fullText
+            self.words = words
+            self.rawLineText = rawLineText
+            self.identifiedLines = identifiedLines
+        }
+    }
+}

--- a/Amplify/Categories/Predictions/Request/Identify/Identify+Text.swift
+++ b/Amplify/Categories/Predictions/Request/Identify/Identify+Text.swift
@@ -1,0 +1,18 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension Predictions.Identify {
+    public enum Text {}
+}
+
+extension Predictions.Identify.Request where Output == Predictions.Identify.Text.Result {
+    public static let text = Self(
+        kind: .detectText(.lift)
+    )
+}

--- a/Amplify/Categories/Predictions/Request/Identify/Identify.swift
+++ b/Amplify/Categories/Predictions/Request/Identify/Identify.swift
@@ -42,6 +42,31 @@ extension Predictions.Identify.Request {
     public enum Kind {
         public typealias Lifting<T> = ((T) -> Output, (Output) -> T)
 
-        // TODO: Add request kind cases
+        case detectCelebrities(
+            Lift<Predictions.Identify.Celebrities.Result, Output>
+        )
+
+        case detectEntities(
+            Lift<Predictions.Identify.Entities.Result, Output>
+        )
+
+        case detectEntitiesCollection(
+            String,
+            Lift<Predictions.Identify.EntityMatches.Result, Output>
+        )
+
+        case detectLabels(
+            Predictions.LabelType,
+            Lift<Predictions.Identify.Labels.Result, Output>
+        )
+
+        case detectTextInDocument(
+            Predictions.TextFormatType,
+            Lift<Predictions.Identify.DocumentText.Result, Output>
+        )
+
+        case detectText(
+            Lift<Predictions.Identify.Text.Result, Output>
+        )
     }
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
- adds category supporting types for requests / responses

<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [ ] ~Build succeeds with all target using Swift Package Manager~
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
