### PR TITLE
fix(predictions): public error inits + config error handling

### DIFF
--- a/Amplify/Categories/Predictions/Error/PredictionsError.swift
+++ b/Amplify/Categories/Predictions/Error/PredictionsError.swift
@@ -19,12 +19,34 @@ public enum PredictionsError {
         public let recoverySuggestion: RecoverySuggestion
         public let httpStatusCode: Int?
         public let underlyingError: Error?
+
+        public init(
+            description: ErrorDescription,
+            recoverySuggestion: RecoverySuggestion,
+            httpStatusCode: Int? = nil,
+            underlyingError: Error? = nil
+        ) {
+            self.description = description
+            self.recoverySuggestion = recoverySuggestion
+            self.httpStatusCode = httpStatusCode
+            self.underlyingError = underlyingError
+        }
     }
 
     public struct ClientError {
         public let description: ErrorDescription
         public let recoverySuggestion: RecoverySuggestion
         public let underlyingError: Error?
+
+        public init(
+            description: ErrorDescription,
+            recoverySuggestion: RecoverySuggestion,
+            underlyingError: Error? = nil
+        ) {
+            self.description = description
+            self.recoverySuggestion = recoverySuggestion
+            self.underlyingError = underlyingError
+        }
     }
 }
 

--- a/Amplify/Categories/Predictions/PredictionsCategory.swift
+++ b/Amplify/Categories/Predictions/PredictionsCategory.swift
@@ -53,18 +53,24 @@ final public class PredictionsCategory: Category {
         let key = plugin.key
         guard !key.isEmpty else {
             let pluginDescription = String(describing: plugin)
-            let error = PredictionsError.configuration("Plugin \(pluginDescription) has an empty `key`.",
-                "Set the `key` property for \(String(describing: plugin))")
-            throw error
+            throw PredictionsError.client(
+                .init(
+                    description: "Plugin \(pluginDescription) has an empty `key`.",
+                    recoverySuggestion: "Set the `key` property for \(pluginDescription)",
+                    underlyingError: nil
+                )
+            )
         }
 
         guard !isConfigured else {
             let pluginDescription = String(describing: plugin)
-            let error = ConfigurationError.amplifyAlreadyConfigured(
-                "\(pluginDescription) cannot be added after `Amplify.configure()`.",
-                "Do not add plugins after calling `Amplify.configure()`."
+            throw PredictionsError.client(
+                .init(
+                    description: "\(pluginDescription) cannot be added after `Amplify.configure()`.",
+                    recoverySuggestion: "Do not add plugins after calling `Amplify.configure()`.",
+                    underlyingError: nil
+                )
             )
-            throw error
         }
 
         plugins[plugin.key] = plugin
@@ -77,9 +83,13 @@ final public class PredictionsCategory: Category {
     public func getPlugin(for key: PluginKey) throws -> PredictionsCategoryPlugin {
         guard let plugin = plugins[key] else {
             let keys = plugins.keys.joined(separator: ", ")
-            let error = PredictionsError.configuration("No plugin has been added for '\(key)'.",
-                "Either add a plugin for '\(key)', or use one of the known keys: \(keys)")
-            throw error
+            throw PredictionsError.client(
+                .init(
+                    description: "No plugin has been added for '\(key)'.",
+                    recoverySuggestion: "Either add a plugin for '\(key)', or use one of the known keys: \(keys)",
+                    underlyingError: nil
+                )
+            )
         }
         return plugin
     }

--- a/Amplify/Categories/Predictions/Request/Interpret/Interpret+Result.swift
+++ b/Amplify/Categories/Predictions/Request/Interpret/Interpret+Result.swift
@@ -12,5 +12,19 @@ extension Predictions.Interpret {
         public let entities: [Predictions.Entity.DetectionResult]?
         public let language: Predictions.Language.DetectionResult?
         public let syntax: [Predictions.SyntaxToken]?
+
+        public init(
+            keyPhrases: [Predictions.KeyPhrase]?,
+            sentiment: Predictions.Sentiment?,
+            entities: [Predictions.Entity.DetectionResult]?,
+            language: Predictions.Language.DetectionResult?,
+            syntax: [Predictions.SyntaxToken]?
+        ) {
+            self.keyPhrases = keyPhrases
+            self.sentiment = sentiment
+            self.entities = entities
+            self.language = language
+            self.syntax = syntax
+        }
     }
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
- makes `ClientError` and `ServiceError` inits public
- fixes errors thrown during configuration

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [ ] ~Build succeeds with all target using Swift Package Manager~
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
