### PR TITLE
fix(Auth): Fixing throwing of AuthError when Authorization fails during signIn

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/HostedUISignInHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/HostedUISignInHelper.swift
@@ -94,19 +94,13 @@ struct HostedUISignInHelper: DefaultLogger {
                 }
 
             case .error(let error):
-                await waitForSignInCancel()
                 throw error.authError
 
             case .signingIn(let signInState):
-                do {
-                    guard let result = try UserPoolSignInHelper.checkNextStep(signInState) else {
-                        continue
-                    }
-                    return result
-                } catch {
-                    await waitForSignInCancel()
-                    throw error
+                guard let result = try UserPoolSignInHelper.checkNextStep(signInState) else {
+                    continue
                 }
+                return result
             default:
                 continue
             }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/HostedUISignInHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/HostedUISignInHelper.swift
@@ -26,8 +26,15 @@ struct HostedUISignInHelper: DefaultLogger {
 
     func initiateSignIn() async throws -> AuthSignInResult {
         try await isValidState()
-        log.verbose("Start signIn flow")
-        return try await doSignIn()
+        do {
+            log.verbose("Start signIn flow")
+            let result = try await doSignIn()
+            log.verbose("Received result")
+            return result
+        } catch {
+            await waitForSignInCancel()
+            throw error
+        }
     }
 
     func isValidState() async throws {
@@ -80,7 +87,10 @@ struct HostedUISignInHelper: DefaultLogger {
             switch authNState {
             case .signedIn:
                 if case .sessionEstablished = authZState {
-                   return AuthSignInResult(nextStep: .done)
+                    return AuthSignInResult(nextStep: .done)
+                } else if case .error(let error) = authZState {
+                    log.verbose("Authorization reached an error state \(error)")
+                    throw error.authError
                 }
 
             case .error(let error):
@@ -143,6 +153,10 @@ struct HostedUISignInHelper: DefaultLogger {
             switch authenticationState {
             case .signedOut:
                 return
+            case .signingOut(let signingOutState):
+                if case .error = signingOutState {
+                    return
+                }
             default: continue
             }
         }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Errors/AuthorizationError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Errors/AuthorizationError.swift
@@ -26,14 +26,13 @@ extension AuthorizationError: AuthErrorConvertible {
         case .configuration(let message):
             return .configuration(message, "")
         case .service(let error):
-            if let getIdOutputError = error as? SdkError<GetIdOutputError> {
-                return getIdOutputError.authError
-            } else if let getCredentialForIdentityError = error as? SdkError<GetCredentialsForIdentityOutputError> {
-                return getCredentialForIdentityError.authError
-            } else if let authError = error as? AuthError {
-                return authError
+            if let convertibleError = error as? AuthErrorConvertible {
+                return convertibleError.authError
             } else {
-                return AuthError.unknown("", error)
+                return .service(
+                    "Service error occurred",
+                    AmplifyErrorMessages.reportBugToAWS(),
+                    error)
             }
         case .invalidState(let message):
             return .invalidState(message, AuthPluginErrorConstants.invalidStateError, nil)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Errors/FetchSessionError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Errors/FetchSessionError.swift
@@ -79,10 +79,14 @@ extension FetchSessionError: AuthErrorConvertible {
             return .unknown(
                 "Refreshing credentials from federationToIdentityPool is not supported \(AmplifyErrorMessages.reportBugToAWS())")
         case .service(let error):
-            return .service(
-                "Service error occurred",
-                AmplifyErrorMessages.reportBugToAWS(),
-                error)
+            if let convertibleError = error as? AuthErrorConvertible {
+                return convertibleError.authError
+            } else {
+                return .service(
+                    "Service error occurred",
+                    AmplifyErrorMessages.reportBugToAWS(),
+                    error)
+            }
         }
     }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/Authentication/AuthenticationState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/Authentication/AuthenticationState+Resolver.swift
@@ -202,6 +202,16 @@ extension AuthenticationState {
                 )
                 return resolution
 
+            case .cancelSignIn:
+                let action = InitiateSignOut(
+                    signedInData: currentSignedInData,
+                    signOutEventData: .init(globalSignOut: false))
+                let signOutState = SignOutState.notStarted
+                let resolution = StateResolution(
+                    newState: AuthenticationState.signingOut(signOutState),
+                    actions: [action]
+                )
+                return resolution
             default:
                 return .from(.signedIn(currentSignedInData))
             }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/UserPoolSignInHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/UserPoolSignInHelper.swift
@@ -81,7 +81,7 @@ struct UserPoolSignInHelper: DefaultLogger {
 
             let client = try environment.cognitoUserPoolFactory()
             let response = try await client.respondToAuthChallenge(input: request)
-            let event = try self.parseResponse(response, for: username, signInMethod: signInMethod)
+            let event = self.parseResponse(response, for: username, signInMethod: signInMethod)
             return event
         }
 
@@ -90,7 +90,7 @@ struct UserPoolSignInHelper: DefaultLogger {
     static func parseResponse(
         _ response: SignInResponseBehavior,
         for username: String,
-        signInMethod: SignInMethod) throws -> StateMachineEvent {
+        signInMethod: SignInMethod) -> StateMachineEvent {
 
             if let authenticationResult = response.authenticationResult,
                let idToken = authenticationResult.idToken,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift
@@ -45,7 +45,7 @@ class AWSAuthSignInTask: AuthSignInTask, DefaultLogger {
         let authflowType = authFlowType(userPoolConfiguration: userPoolConfiguration)
         do {
             log.verbose("Signing with \(authflowType)")
-           let result = try await doSignIn(authflowType: authflowType)
+            let result = try await doSignIn(authflowType: authflowType)
             log.verbose("Received result")
             return result
         } catch {
@@ -95,8 +95,7 @@ class AWSAuthSignInTask: AuthSignInTask, DefaultLogger {
                     return AuthSignInResult(nextStep: .done)
                 } else if case .error(let error) = authZState {
                     log.verbose("Authorization reached an error state \(error)")
-                    let error = AuthError.unknown("Sign in reached an error state", error)
-                    throw error
+                    throw error.authError
                 }
             case .error(let error):
                 throw error.authError

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
@@ -29,6 +29,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSuccessfulSignIn() async {
 
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
                 authenticationResult: .none,
@@ -75,6 +79,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .done response
     ///
     func testSuccessfulSignInWithAuthFlow() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
@@ -124,6 +132,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithEmptyUsername() async {
 
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider()
 
         let options = AuthSignInRequest.Options()
@@ -149,6 +161,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a valid response
     ///
     func testSignInWithEmptyPassword() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
@@ -194,6 +210,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithInvalidResult() async {
 
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse()
         })
@@ -219,6 +239,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get signed in
     ///
     func testSecondSignInAfterSignInWithInvalidResult() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse()
@@ -267,6 +291,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .confirmSignInWithSMSMFACode
     ///
     func testSignInWithNextStepSMS() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
@@ -352,6 +380,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSMSMFAWithAdditionalInfo() async {
 
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
                 authenticationResult: .none,
@@ -395,6 +427,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithNextStepNewPassword() async {
 
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
                 authenticationResult: .none,
@@ -433,6 +469,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a the info in next step
     ///
     func testNewPasswordWithAdditionalInfo() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
@@ -477,6 +517,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithNextStepCustomChallenge() async {
 
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
                 authenticationResult: .none,
@@ -515,6 +559,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .unknown error
     ///
     func testSignInWithNextStepUnknown() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
@@ -596,6 +644,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithCustomAuthIncorrectCode() async {
 
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
                 authenticationResult: .none,
@@ -647,6 +699,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithInternalErrorException() async {
 
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.internalErrorException(.init())
         })
@@ -674,6 +730,11 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .service error with .lambda error
     ///
     func testSignInWithInvalidLambdaResponseException() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.invalidLambdaResponseException(.init())
         })
@@ -702,6 +763,11 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .service error with .invalidParameter error
     ///
     func testSignInWithInvalidParameterException() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.invalidParameterException(.init())
         })
@@ -730,6 +796,11 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .configuration error
     ///
     func testSignInWithInvalidUserPoolConfigurationException() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.invalidUserPoolConfigurationException(.init())
         })
@@ -757,6 +828,11 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .notAuthorized error
     ///
     func testSignInWithNotAuthorizedException() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.notAuthorizedException(.init())
         })
@@ -784,6 +860,11 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .resetPassword as next step
     ///
     func testSignInWithPasswordResetRequiredException() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.passwordResetRequiredException(.init())
         })
@@ -812,6 +893,11 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .resetPassword as next step
     ///
     func testSignInWithPasswordResetRequiredException2() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             let serviceError = SdkError<InitiateAuthOutputError>
                 .service(.passwordResetRequiredException(PasswordResetRequiredException()),
@@ -843,6 +929,11 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .service error with .resourceNotFound error
     ///
     func testSignInWithResourceNotFoundException() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.resourceNotFoundException(.init())
         })
@@ -871,6 +962,11 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .service error with .requestLimitExceeded error
     ///
     func testSignInWithTooManyRequestsException() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.tooManyRequestsException(.init())
         })
@@ -899,6 +995,11 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .service error with .lambda error
     ///
     func testSignInWithUnexpectedLambdaException() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.unexpectedLambdaException(.init())
         })
@@ -927,6 +1028,11 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .service error with .lambda error
     ///
     func testSignInWithUserLambdaValidationException() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.userLambdaValidationException(.init())
         })
@@ -983,6 +1089,11 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .confirmSignUp as next step
     ///
     func testSignInWithUserNotConfirmedException2() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             let serviceError = SdkError<InitiateAuthOutputError>
                 .service(.userNotConfirmedException(UserNotConfirmedException()),
@@ -1014,6 +1125,11 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .service error with .userNotFound error
     ///
     func testSignInWithUserNotFoundException() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.userNotFoundException(.init())
         })
@@ -1044,6 +1160,11 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .service error with .aliasExists error
     ///
     func testSignInWithAliasExistsException() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
                 authenticationResult: .none,
@@ -1078,6 +1199,11 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .service error with .invalidPassword error
     ///
     func testSignInWithInvalidPasswordException() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
                 authenticationResult: .none,
@@ -1164,6 +1290,69 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             XCTAssertTrue(result2.isSignedIn)
         } catch {
             XCTFail("Received failure with error \(error)")
+        }
+    }
+
+    /// Test a signIn with valid inputs
+    ///
+    /// - Given: Given an auth plugin with mocked service.
+    ///
+    /// - When:
+    ///    - I invoke signIn with valid values
+    /// - Then:
+    ///    - I should get a .done response
+    ///
+    func testSuccessfulSignInWithFailingIdentity() async {
+
+        self.mockIdentity = MockIdentity(
+            mockGetIdResponse: { _ in
+                throw GetIdOutputError.invalidParameterException(.init(message: "Invalid parameter passed"))
+            },
+            mockGetCredentialsResponse: getCredentials)
+
+        self.mockIdentityProvider = MockIdentityProvider(mockRevokeTokenResponse: { _ in
+            RevokeTokenOutputResponse()
+        }, mockInitiateAuthResponse: { _ in
+            InitiateAuthOutputResponse(
+                authenticationResult: .none,
+                challengeName: .passwordVerifier,
+                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                session: "someSession")
+        }, mockRespondToAuthChallengeResponse: { _ in
+            RespondToAuthChallengeOutputResponse(
+                authenticationResult: .init(
+                    accessToken: Defaults.validAccessToken,
+                    expiresIn: 300,
+                    idToken: "idToken",
+                    newDeviceMetadata: nil,
+                    refreshToken: "refreshToken",
+                    tokenType: ""),
+                challengeName: .none,
+                challengeParameters: [:],
+                session: "session")
+        })
+
+        let pluginOptions = AWSAuthSignInOptions(validationData: ["somekey": "somevalue"],
+                                                 metadata: ["somekey": "somevalue"])
+        let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
+
+        do {
+            let result = try await plugin.signIn(username: "username", password: "password", options: options)
+            XCTFail("Sign In with failing authorization should throw an error")
+
+        } catch AuthError.service(_, _, let error) {
+            guard let cognitoError = error as? AWSCognitoAuthError else {
+                XCTFail("Underlying error should be of type AWSCognitoAuthError")
+                return
+            }
+
+            guard case AWSCognitoAuthError.invalidParameter = cognitoError else {
+                XCTFail("Error thrown should be an AWSCognitoAuthError.invalidParameter")
+                return
+            }
+
+        } catch {
+            XCTFail("Error thrown should be an AuthError but got:\n\(error)")
         }
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
@@ -29,10 +29,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSuccessfulSignIn() async {
 
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
-
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
                 authenticationResult: .none,
@@ -79,10 +75,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .done response
     ///
     func testSuccessfulSignInWithAuthFlow() async {
-
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
@@ -131,10 +123,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .validation error
     ///
     func testSignInWithEmptyUsername() async {
-
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider()
 
@@ -210,10 +198,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithInvalidResult() async {
 
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
-
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse()
         })
@@ -239,10 +223,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get signed in
     ///
     func testSecondSignInAfterSignInWithInvalidResult() async {
-
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse()
@@ -291,10 +271,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .confirmSignInWithSMSMFACode
     ///
     func testSignInWithNextStepSMS() async {
-
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
@@ -380,10 +356,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSMSMFAWithAdditionalInfo() async {
 
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
-
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
                 authenticationResult: .none,
@@ -427,10 +399,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithNextStepNewPassword() async {
 
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
-
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
                 authenticationResult: .none,
@@ -469,10 +437,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a the info in next step
     ///
     func testNewPasswordWithAdditionalInfo() async {
-
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
@@ -517,10 +481,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithNextStepCustomChallenge() async {
 
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
-
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
                 authenticationResult: .none,
@@ -559,10 +519,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .unknown error
     ///
     func testSignInWithNextStepUnknown() async {
-
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
@@ -644,10 +600,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithCustomAuthIncorrectCode() async {
 
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
-
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
                 authenticationResult: .none,
@@ -699,10 +651,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithInternalErrorException() async {
 
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
-
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.internalErrorException(.init())
         })
@@ -730,10 +678,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .service error with .lambda error
     ///
     func testSignInWithInvalidLambdaResponseException() async {
-
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.invalidLambdaResponseException(.init())
@@ -764,10 +708,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithInvalidParameterException() async {
 
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
-
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.invalidParameterException(.init())
         })
@@ -797,10 +737,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithInvalidUserPoolConfigurationException() async {
 
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
-
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.invalidUserPoolConfigurationException(.init())
         })
@@ -828,10 +764,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .notAuthorized error
     ///
     func testSignInWithNotAuthorizedException() async {
-
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.notAuthorizedException(.init())
@@ -861,10 +793,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithPasswordResetRequiredException() async {
 
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
-
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.passwordResetRequiredException(.init())
         })
@@ -893,10 +821,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .resetPassword as next step
     ///
     func testSignInWithPasswordResetRequiredException2() async {
-
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             let serviceError = SdkError<InitiateAuthOutputError>
@@ -930,10 +854,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithResourceNotFoundException() async {
 
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
-
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.resourceNotFoundException(.init())
         })
@@ -962,10 +882,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .service error with .requestLimitExceeded error
     ///
     func testSignInWithTooManyRequestsException() async {
-
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.tooManyRequestsException(.init())
@@ -996,10 +912,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithUnexpectedLambdaException() async {
 
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
-
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.unexpectedLambdaException(.init())
         })
@@ -1028,10 +940,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .service error with .lambda error
     ///
     func testSignInWithUserLambdaValidationException() async {
-
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.userLambdaValidationException(.init())
@@ -1090,10 +998,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithUserNotConfirmedException2() async {
 
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
-
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             let serviceError = SdkError<InitiateAuthOutputError>
                 .service(.userNotConfirmedException(UserNotConfirmedException()),
@@ -1126,10 +1030,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testSignInWithUserNotFoundException() async {
 
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
-
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             throw InitiateAuthOutputError.userNotFoundException(.init())
         })
@@ -1160,10 +1060,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .service error with .aliasExists error
     ///
     func testSignInWithAliasExistsException() async {
-
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
@@ -1199,10 +1095,6 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .service error with .invalidPassword error
     ///
     func testSignInWithInvalidPasswordException() async {
-
-        self.mockIdentity = MockIdentity(
-            mockGetIdResponse: getId,
-            mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
             InitiateAuthOutputResponse(
@@ -1298,9 +1190,11 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     /// - Given: Given an auth plugin with mocked service.
     ///
     /// - When:
-    ///    - I invoke signIn with valid values
+    ///    - I invoke signIn with valid values, and
+    ///      AuthN is success whereas AuthZ fails
+    ///      In This case, GetId throws an exception
     /// - Then:
-    ///    - I should get a .done response
+    ///    - I should get a service exception and should not be signed in
     ///
     func testSuccessfulSignInWithFailingIdentity() async {
 
@@ -1337,7 +1231,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
         let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
 
         do {
-            let result = try await plugin.signIn(username: "username", password: "password", options: options)
+            _ = try await plugin.signIn(username: "username", password: "password", options: options)
             XCTFail("Sign In with failing authorization should throw an error")
 
         } catch AuthError.service(_, _, let error) {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFederationToIdentityPoolTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFederationToIdentityPoolTests.swift
@@ -787,7 +787,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
 
         let getCredentials: MockIdentity.MockGetCredentialsResponse = { input in
             if shouldThrowError {
-                throw GetCredentialsForIdentityOutputError.internalErrorException(.init())
+                throw GetCredentialsForIdentityOutputError.invalidParameterException(.init())
             } else {
                 return .init(credentials: credentials, identityId: mockIdentityId)
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/BasePluginTest.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/BasePluginTest.swift
@@ -14,7 +14,11 @@ class BasePluginTest: XCTestCase {
 
     let apiTimeout = 2.0
     var mockIdentityProvider: CognitoUserPoolBehavior!
-    var mockIdentity: CognitoIdentityBehavior!
+    lazy var mockIdentity: CognitoIdentityBehavior = {
+        MockIdentity(
+            mockGetIdResponse: getId,
+            mockGetCredentialsResponse: getCredentials)
+    }()
     var plugin: AWSCognitoAuthPlugin!
 
     let getId: MockIdentity.MockGetIdResponse = { _ in


### PR DESCRIPTION
## Issue \#
#2864 

## Description
The changes are aimed at resolving Authorization Errors during sign in correctly. 

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
