### PR TITLE
fix(predictions): add equatable conformance to errors

### DIFF
--- a/Amplify/Categories/Predictions/Error/PredictionsError+ClientError.swift
+++ b/Amplify/Categories/Predictions/Error/PredictionsError+ClientError.swift
@@ -8,7 +8,12 @@
 import Foundation
 
 extension PredictionsError {
-    public struct ClientError {
+    public struct ClientError: Equatable {
+        public static func == (lhs: PredictionsError.ClientError, rhs: PredictionsError.ClientError) -> Bool {
+            lhs.description == rhs.description
+            && lhs.recoverySuggestion == rhs.recoverySuggestion
+        }
+
         public let description: ErrorDescription
         public let recoverySuggestion: RecoverySuggestion
         public let underlyingError: Error?

--- a/Amplify/Categories/Predictions/Error/PredictionsError+ServiceError.swift
+++ b/Amplify/Categories/Predictions/Error/PredictionsError+ServiceError.swift
@@ -8,7 +8,12 @@
 import Foundation
 
 extension PredictionsError {
-    public struct ServiceError {
+    public struct ServiceError: Equatable {
+        public static func == (lhs: PredictionsError.ServiceError, rhs: PredictionsError.ServiceError) -> Bool {
+            lhs.description == rhs.description
+            && lhs.recoverySuggestion == rhs.recoverySuggestion
+        }
+
         public let description: ErrorDescription
         public let recoverySuggestion: RecoverySuggestion
         public let httpStatusCode: Int?

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/ErrorMapping/PollyErrorMappingTestCase.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/ErrorMapping/PollyErrorMappingTestCase.swift
@@ -1,0 +1,83 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AWSPolly
+import Amplify
+@testable import AWSPredictionsPlugin
+
+final class PollyErrorMappingTestCase: XCTestCase {
+    private func assertCatchVariations(
+        for sdkError: SynthesizeSpeechOutputError,
+        expecting expectedServiceError: PredictionsError.ServiceError,
+        label: String
+    ) {
+        let predictionsError = ServiceErrorMapping.synthesizeSpeech.map(sdkError)
+        let unexpected: (Error) -> String = {
+            "Expected PredictionsError.service(.\(label), received \($0)"
+        }
+
+        // catch variation 1.
+        do { throw predictionsError }
+        catch PredictionsError.service(expectedServiceError) {}
+        catch {
+            XCTFail(unexpected(error))
+        }
+
+        // catch variation 2.
+        do { throw predictionsError }
+        catch let error as PredictionsError {
+            guard case .service(expectedServiceError) = error else {
+                return XCTFail(unexpected(error))
+            }
+        } catch {
+            XCTFail(unexpected(error))
+        }
+
+        // catch variation 3.
+        do { throw predictionsError }
+        catch {
+            guard let error = error as? PredictionsError,
+                  case .service(expectedServiceError) = error
+            else {
+                return XCTFail(unexpected(error))
+            }
+        }
+    }
+
+    func testSynthesizeSpeech_invalidSampleRateException() throws {
+        assertCatchVariations(
+            for: .invalidSampleRateException(.init()),
+            expecting: .invalidSampleRate,
+            label: "invalidSampleRate"
+        )
+    }
+
+    func testSynthesizeSpeech_languageNotSupportedException() throws {
+        assertCatchVariations(
+            for: .languageNotSupportedException(.init()),
+            expecting: .unsupportedLanguage,
+            label: "unsupportedLanguage"
+        )
+    }
+
+    func testSynthesizeSpeech_serviceFailureException() throws {
+        assertCatchVariations(
+            for: .serviceFailureException(.init()),
+            expecting: .internalServerError,
+            label: "internalServerError"
+        )
+    }
+
+    func testSynthesizeSpeech_textLengthExceededException() throws {
+        assertCatchVariations(
+            for: .textLengthExceededException(.init()),
+            expecting: .textSizeLimitExceeded,
+            label: "textSizeLimitExceeded"
+        )
+    }
+}

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/ErrorMapping/TextractErrorMappingTestCase.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/ErrorMapping/TextractErrorMappingTestCase.swift
@@ -1,0 +1,75 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AWSTextract
+import Amplify
+@testable import AWSPredictionsPlugin
+
+final class TextractErrorMappingTestCase: XCTestCase {
+    private func assertCatchVariations(
+        for sdkError: AnalyzeDocumentOutputError,
+        expecting expectedServiceError: PredictionsError.ServiceError,
+        label: String
+    ) {
+        let predictionsError = ServiceErrorMapping.analyzeDocument.map(sdkError)
+        let unexpected: (Error) -> String = {
+            "Expected PredictionsError.service(.\(label), received \($0)"
+        }
+
+        // catch variation 1.
+        do { throw predictionsError }
+        catch PredictionsError.service(expectedServiceError) {}
+        catch {
+            XCTFail(unexpected(error))
+        }
+
+        // catch variation 2.
+        do { throw predictionsError }
+        catch let error as PredictionsError {
+            guard case .service(expectedServiceError) = error else {
+                return XCTFail(unexpected(error))
+            }
+        } catch {
+            XCTFail(unexpected(error))
+        }
+
+        // catch variation 3.
+        do { throw predictionsError }
+        catch {
+            guard let error = error as? PredictionsError,
+                  case .service(expectedServiceError) = error
+            else {
+                return XCTFail(unexpected(error))
+            }
+        }
+    }
+
+    func testAnalyzeDocument_internalServerError() throws {
+        assertCatchVariations(
+            for: .internalServerError(.init()),
+            expecting: .internalServerError,
+            label: "internalServerError"
+        )
+    }
+
+    func testAnalyzeDocument_accessDeniedException() throws {
+        assertCatchVariations(
+            for: .accessDeniedException(.init()),
+            expecting: .accessDenied,
+            label: "accessDenied"
+        )
+    }
+
+    func testAnalyzeDocument_throttlingException() throws {
+        assertCatchVariations(
+            for: .throttlingException(.init()),
+            expecting: .throttling,
+            label: "throttling"
+        )
+    }
+}


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
- adds `Equatable` conformance to errors.
- add some error mapping test cases

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
