### PR TITLE
chore(storage): Conditionally copying AWSAmplifyStressTests and AWSS3StoragePluginTests

### DIFF
--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/copy_configuration.sh
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/copy_configuration.sh
@@ -17,6 +17,16 @@ if [ ! -d "$SOURCE_DIR" ]; then
 fi
 
 mkdir -p "$DESTINATION_DIR"
-cp "$SOURCE_DIR/AWSS3StoragePluginTests-amplifyconfiguration.json" "$DESTINATION_DIR/amplifyconfiguration.json"
+
+if [ -f "$SOURCE_DIR/AWSAmplifyStressTests-amplifyconfiguration.json" ]; then
+    cp "$SOURCE_DIR/AWSAmplifyStressTests-amplifyconfiguration.json" "$DESTINATION_DIR/amplifyconfiguration.json"
+    exit 0
+fi
+
+if [ -f "$SOURCE_DIR/AWSS3StoragePluginTests-amplifyconfiguration.json" ]; then
+    cp "$SOURCE_DIR/AWSS3StoragePluginTests-amplifyconfiguration.json" "$DESTINATION_DIR/amplifyconfiguration.json"
+    exit 0
+fi
 
 exit 0
+


### PR DESCRIPTION
## Issue \#

https://github.com/aws-amplify/amplify-swift/issues/2916

## Description

In order to keep backend configurations separate, conditionally copying AWSAmplifyStressTests and AWSS3StoragePluginTests

## General Checklist
<!-- Check or cross out if not relevant -->

~~- [ ] Added new tests to cover change, if needed~~
~~- [ ] Build succeeds with all target using Swift Package Manager~~
~~- [ ] All unit tests pass~~
- [x] All integration tests pass
~~- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~~
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
