### PR TITLE
chore(predictions): Simplifying amplifyconfig.json setup

### DIFF
--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/.gitignore
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/.gitignore
@@ -18,3 +18,4 @@ amplifytools.xcconfig
 .secret-*
 **.sample
 #amplify-do-not-edit-end
+

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/AWSPredictionsPluginIntegrationTests/AWSPredictionsPluginTestBase.swift
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/AWSPredictionsPluginIntegrationTests/AWSPredictionsPluginTestBase.swift
@@ -15,7 +15,6 @@ class AWSPredictionsPluginTestBase: XCTestCase {
 
     // 20 seconds to wait before network timeouts
     let networkTimeout = TimeInterval(20)
-    let amplifyConfigurationFile = "testconfiguration/AWSPredictionsPluginIntegrationTests-amplifyconfiguration"
 
     override func setUp() {
         super.setUp()
@@ -23,24 +22,9 @@ class AWSPredictionsPluginTestBase: XCTestCase {
         continueAfterFailure = false
 
         do {
-            guard let path = Bundle.init(for: type(of: self)).path(
-                forResource: amplifyConfigurationFile,
-                ofType: "json"
-            ) else {
-                fatalError("❌ Could not retrieve configuration file: \(amplifyConfigurationFile)")
-            }
-
-            let url = URL(fileURLWithPath: path)
-            let data = try Data(contentsOf: url)
-            let jsonDecoder = JSONDecoder()
-            let configuration = try jsonDecoder.decode(
-                AmplifyConfiguration.self,
-                from: data
-            )
-
             try Amplify.add(plugin: AWSCognitoAuthPlugin())
             try Amplify.add(plugin: AWSPredictionsPlugin())
-            try Amplify.configure(configuration)
+            try Amplify.configure()
         } catch {
             XCTFail(String(describing: error))
             return

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/AWSPredictionsPluginIntegrationTests/IdentifyBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/AWSPredictionsPluginIntegrationTests/IdentifyBasicIntegrationTests.swift
@@ -33,8 +33,8 @@ class IdentifyBasicIntegrationTests: AWSPredictionsPluginTestBase {
         let electronicsLabel = try XCTUnwrap(
             result.labels.first(where: { $0.name == "Electronics" })?.metadata
         )
-        let isConfidentImageContainsElectronics = electronicsLabel.confidence >= 99
         XCTAssertNotNil(result)
+        XCTAssertGreaterThanOrEqual(electronicsLabel.confidence, 99)
     }
 
     func testIdentifyModerationLabels() async throws {

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/PredictionsHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/PredictionsHostApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03B3827B1594333F4C40DCFC /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 77D412CE71D4C36343815DC9 /* amplifyconfiguration.json */; };
 		902830062914027000897087 /* PredictionsHostAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902830052914027000897087 /* PredictionsHostAppApp.swift */; };
 		902830082914027000897087 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902830072914027000897087 /* ContentView.swift */; };
 		9028300A2914027100897087 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 902830092914027100897087 /* Assets.xcassets */; };
@@ -56,6 +57,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		77D412CE71D4C36343815DC9 /* amplifyconfiguration.json */ = {isa = PBXFileReference; explicitFileType = text.json; path = amplifyconfiguration.json; sourceTree = "<group>"; };
 		902830022914027000897087 /* PredictionsHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PredictionsHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		902830052914027000897087 /* PredictionsHostAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictionsHostAppApp.swift; sourceTree = "<group>"; };
 		902830072914027000897087 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -117,6 +119,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		7D09EFAF27FE586FBA9A9B2D /* AmplifyConfig */ = {
+			isa = PBXGroup;
+			children = (
+				77D412CE71D4C36343815DC9 /* amplifyconfiguration.json */,
+			);
+			name = AmplifyConfig;
+			sourceTree = "<group>";
+		};
 		90282FF92914027000897087 = {
 			isa = PBXGroup;
 			children = (
@@ -126,6 +136,7 @@
 				90283041291402E600897087 /* AWSPredictionsPluginIntegrationTests */,
 				902830032914027000897087 /* Products */,
 				9028304A2914042800897087 /* Frameworks */,
+				7D09EFAF27FE586FBA9A9B2D /* AmplifyConfig */,
 			);
 			sourceTree = "<group>";
 		};
@@ -228,6 +239,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 902830262914027200897087 /* Build configuration list for PBXNativeTarget "PredictionsHostApp" */;
 			buildPhases = (
+				56CF7FEF2A0016100073F364 /* ShellScript */,
 				90282FFE2914027000897087 /* Sources */,
 				90282FFF2914027000897087 /* Frameworks */,
 				902830002914027000897087 /* Resources */,
@@ -272,7 +284,6 @@
 				903555F429141355004B83C2 /* Sources */,
 				903555F529141355004B83C2 /* Frameworks */,
 				903555F629141355004B83C2 /* Resources */,
-				90F5B34529FB404E0036138A /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -342,6 +353,7 @@
 			files = (
 				9028300D2914027100897087 /* Preview Assets.xcassets in Resources */,
 				9028300A2914027100897087 /* Assets.xcassets in Resources */,
+				03B3827B1594333F4C40DCFC /* amplifyconfiguration.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -373,7 +385,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		90F5B34529FB404E0036138A /* ShellScript */ = {
+		56CF7FEF2A0016100073F364 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -388,7 +400,8 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "TEMP_FILE=$HOME/.aws-amplify/amplify-ios/testconfiguration/.\nDEST_PATH=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/testconfiguration/\"\n\nif [[ ! -d $TEMP_FILE ]] ; then\n    echo \"${TEMP_FILE} does not exist. Using empty configuration.\"\n    exit 0\nfi\n      \nif [[ -f $DEST_PATH ]] ; then\n    rm $DEST_PATH\nfi\n      \ncp -r $TEMP_FILE $DEST_PATH\n";
+			shellScript = "set -e\n\nSOURCE_DIR=$HOME/.aws-amplify/amplify-ios/testconfiguration\nDESTINATION_DIR=\"$SOURCE_ROOT\"\n\nif [ -d \"$AMPLIFY_CONFIGURATION_PATH\" ]; then\n    echo \"Found AMPLIFY_CONFIGURATION_PATH - copying\"\n    mkdir -p \"$DESTINATION_DIR\"\n    ditto \"$AMPLIFY_CONFIGURATION_PATH\" \"$DESTINATION_DIR\"\n    exit 0\nfi\n\nif [ ! -d \"$SOURCE_DIR\" ]; then\n    echo \"error: Test configuration directory does not exist: ${SOURCE_DIR}\" && exit 1\nfi\n\nmkdir -p \"$DESTINATION_DIR\"\n\nif [ ! -f \"$SOURCE_DIR/AWSPredictionsPluginIntegrationTests-amplifyconfiguration.json\" ]; then\n    echo \"error: Missing AWSPredictionsPluginIntegrationTests-amplifyconfiguration.json from: ${SOURCE_DIR}\" && exit 1\nfi\n\nditto \"$SOURCE_DIR/AWSPredictionsPluginIntegrationTests-amplifyconfiguration.json\" \"$DESTINATION_DIR/amplifyconfiguration.json\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
## Issue \#

https://github.com/aws-amplify/amplify-swift/issues/2916

## Description

This updates the Prediction integration test harness in order to:

1. Make it compatible with `amplify pull`
2. Retain compatibility with `$HOME/.aws-amplify/amplify-ios/testconfiguration`
3. Make it compatible with running under new CICD system.

## General Checklist
<!-- Check or cross out if not relevant -->

~~- [ ] Added new tests to cover change, if needed~~
~~- [ ] Build succeeds with all target using Swift Package Manager~~
~~- [ ] All unit tests pass~~
- [x] All integration tests pass
~~- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~~
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
