### PR TITLE
chore(CoreMLPredictionsPlugin): Performing simulator work on CPU and surfacing errors

### DIFF
--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLVisionAdapter.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLVisionAdapter.swift
@@ -10,11 +10,14 @@ import Vision
 
 class CoreMLVisionAdapter: CoreMLVisionBehavior {
 
-    public func detectLabels(_ imageURL: URL) -> Predictions.Identify.Labels.Result? {
+    func detectLabels(_ imageURL: URL) throws -> Predictions.Identify.Labels.Result? {
         var labelsResult = [Predictions.Label]()
         let handler = VNImageRequestHandler(url: imageURL, options: [:])
         let request = VNClassifyImageRequest()
-        try? handler.perform([request])
+#if targetEnvironment(simulator)
+        request.usesCPUOnly = true
+#endif
+        try handler.perform([request])
         guard let observations = request.results else { return nil }
 
         let categories = observations.filter { $0.hasMinimumRecall(0.01, forPrecision: 0.9) }
@@ -26,11 +29,14 @@ class CoreMLVisionAdapter: CoreMLVisionBehavior {
         return Predictions.Identify.Labels.Result(labels: labelsResult)
     }
 
-    public func detectText(_ imageURL: URL) -> Predictions.Identify.Text.Result? {
+    public func detectText(_ imageURL: URL) throws -> Predictions.Identify.Text.Result? {
         let handler = VNImageRequestHandler(url: imageURL, options: [:])
         let request = VNRecognizeTextRequest()
+#if targetEnvironment(simulator)
+        request.usesCPUOnly = true
+#endif
         request.recognitionLevel = .accurate
-        try? handler.perform([request])
+        try handler.perform([request])
         guard let observations = request.results else { return nil }
 
         var identifiedLines = [Predictions.IdentifiedLine]()
@@ -62,10 +68,13 @@ class CoreMLVisionAdapter: CoreMLVisionBehavior {
         )
     }
 
-    func detectEntities(_ imageURL: URL) -> Predictions.Identify.Entities.Result? {
+    func detectEntities(_ imageURL: URL) throws -> Predictions.Identify.Entities.Result? {
         let handler = VNImageRequestHandler(url: imageURL, options: [:])
         let faceLandmarksRequest = VNDetectFaceLandmarksRequest()
-        try? handler.perform([faceLandmarksRequest])
+#if targetEnvironment(simulator)
+        faceLandmarksRequest.usesCPUOnly = true
+#endif
+        try handler.perform([faceLandmarksRequest])
         guard let observations = faceLandmarksRequest.results else { return nil }
 
         var entities: [Predictions.Entity] = []

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLVisionBehavior.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLVisionBehavior.swift
@@ -9,7 +9,7 @@ import Foundation
 import Amplify
 
 protocol CoreMLVisionBehavior: AnyObject {
-    func detectLabels(_ imageURL: URL) -> Predictions.Identify.Labels.Result?
-    func detectText(_ imageURL: URL) -> Predictions.Identify.Text.Result?
-    func detectEntities(_ imageURL: URL) -> Predictions.Identify.Entities.Result?
+    func detectLabels(_ imageURL: URL) throws -> Predictions.Identify.Labels.Result?
+    func detectText(_ imageURL: URL) throws -> Predictions.Identify.Text.Result?
+    func detectEntities(_ imageURL: URL) throws -> Predictions.Identify.Entities.Result?
 }

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/CoreMLPredictionsPluginIntegrationTests/CoreMLPredictionsPluginIntegrationTest.swift
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/CoreMLPredictionsPluginIntegrationTests/CoreMLPredictionsPluginIntegrationTest.swift
@@ -8,17 +8,44 @@
 import XCTest
 import Amplify
 import XCTest
+import AVFoundation
 
 class CoreMLPredictionsPluginIntegrationTest: AWSPredictionsPluginTestBase {
+
     func testIdentify() async throws {
         let testBundle = Bundle(for: type(of: self))
         let url = try XCTUnwrap(testBundle.url(forResource: "people", withExtension: "jpg"))
 
-        let result = try await Amplify.Predictions.identify(
+        let result: Predictions.Identify.Labels.Result = try await Amplify.Predictions.identify(
             .labels(type: .all),
             in: url
         )
 
-        XCTAssertNotNil(result, "Result should contain value")
+        XCTAssertEqual(result.labels.count, 0, String(describing: result))
+        XCTAssertNil(result.unsafeContent, String(describing: result))
+    }
+
+    func testConvertSpeechToText() async throws {
+        let testBundle = Bundle(for: type(of: self))
+        let url = try XCTUnwrap(testBundle.url(forResource: "audio", withExtension: "wav"))
+
+        let options = Predictions.Convert.SpeechToText.Options(
+            defaultNetworkPolicy: .auto,
+            language: .usEnglish
+        )
+
+        let result = try await Amplify.Predictions.convert(
+            .speechToText(url: url), options: options
+        )
+        let responses = result.map(\.transcription)
+
+        do {
+            for try await response in responses {
+                XCTFail("Expecting failure but got: \(response)")
+            }
+        } catch let error as NSError {
+            XCTAssertEqual(error.code, 201)
+            XCTAssertEqual(error.localizedDescription, "Siri and Dictation are disabled")
+        }
     }
 }


### PR DESCRIPTION
## Description
<!-- Why is this change required? What problem does it solve? -->

This change makes sure that the CoreMLPredictionsPlugin relinquishes control back to the caller when errors are encountered.

## General Checklist
<!-- Check or cross out if not relevant -->

~~- [ ] Added new tests to cover change, if needed~~
~~- [ ] Build succeeds with all target using Swift Package Manager~~
- [x] All unit tests pass
- [x] All integration tests pass
~~- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~~
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
