### PR TITLE
fix: liveness service error reporting

### DIFF
--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Events/LivenessEvent.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Events/LivenessEvent.swift
@@ -16,9 +16,15 @@ public struct LivenessEvent<T> {
 
 @_spi(PredictionsFaceLiveness)
 public enum LivenessEventKind {
-    public struct Server: Hashable {
-        public static let challenge = Server()
-        public static let disconnect = Server()
+    public struct Server: RawRepresentable, Hashable {
+        public var rawValue: String
+
+        public init(rawValue: String) {
+            self.rawValue = rawValue
+        }
+
+        public static let challenge = Self(rawValue: "ServerSessionInformationEvent")
+        public static let disconnect = Self(rawValue: "DisconnectionEvent")
     }
     case server(Server)
 
@@ -31,6 +37,22 @@ public enum LivenessEventKind {
         public static let final = Client(id: 3)
     }
     case client(Client)
+
+    public struct Exception: RawRepresentable, Equatable {
+        public var rawValue: String
+
+        public init(rawValue: String) {
+            self.rawValue = rawValue
+        }
+
+        public static let accessDenied = Self(rawValue: "AccessDeniedException")
+        public static let validation = Self(rawValue: "ValidationException")
+        public static let internalServer = Self(rawValue: "InternalServerException")
+        public static let throttling = Self(rawValue: "ThrottlingException")
+        public static let serviceQuotaExceeded = Self(rawValue: "ServiceQuotaExceededException")
+        public static let serviceUnavailable = Self(rawValue: "ServiceUnavailableException")
+        public static let sessionNotFound = Self(rawValue: "SessionNotFoundException")
+    }
 }
 
 extension LivenessEventKind: CustomDebugStringConvertible {

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/SPI/AWSPredictionsPlugin+Liveness.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/SPI/AWSPredictionsPlugin+Liveness.swift
@@ -39,6 +39,8 @@ extension AWSPredictionsPlugin {
             baseURL: url
         )
 
+        session.onServiceException = { completion(.failure($0)) }
+
         return session
     }
 }
@@ -54,8 +56,38 @@ extension FaceLivenessSession {
 public struct FaceLivenessSessionError: Swift.Error, Equatable {
     public let code: UInt8
 
-    public static let accessDenied = Self(code: 0)
-    public static let invalidRegion = Self(code: 1)
-    public static let invalidURL = Self(code: 2)
+    public static let unknown = Self(code: 0)
+    public static let validation = Self(code: 1)
+    public static let internalServer = Self(code: 2)
+    public static let throttling = Self(code: 3)
+    public static let serviceQuotaExceeded = Self(code: 4)
+    public static let serviceUnavailable = Self(code: 5)
+    public static let sessionNotFound = Self(code: 6)
+    public static let accessDenied = Self(code: 7)
+    public static let invalidRegion = Self(code: 8)
+    public static let invalidURL = Self(code: 9)
+}
+
+extension FaceLivenessSessionError {
+    init(event: LivenessEventKind.Exception) {
+        switch event {
+        case .accessDenied:
+            self = .accessDenied
+        case .validation:
+            self = .validation
+        case .internalServer:
+            self = .internalServer
+        case .throttling:
+            self = .throttling
+        case .serviceQuotaExceeded:
+            self = .serviceQuotaExceeded
+        case .serviceUnavailable:
+            self = .serviceUnavailable
+        case .sessionNotFound:
+            self = .sessionNotFound
+        default:
+            self = .unknown
+        }
+    }
 }
 

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/FaceLivenessSessionRepresentable.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/FaceLivenessSessionRepresentable.swift
@@ -15,6 +15,8 @@ public protocol LivenessService {
         eventDate: () -> Date
     )
 
+    var onServiceException: (FaceLivenessSessionError) -> Void { get set }
+
     func register(onComplete: @escaping (ServerDisconnection) -> Void)
 
     func initializeLivenessStream(withSessionID sessionID: String, userAgent: String) throws

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/WebSocketSession.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/WebSocketSession.swift
@@ -36,7 +36,11 @@ final class WebSocketSession {
     }
 
     func receive(shouldContinue: Bool) {
-        guard shouldContinue else { return }
+        guard shouldContinue else {
+            session.finishTasksAndInvalidate()
+            return
+        }
+
         task?.receive(completionHandler: { [weak self] result in
             if let shouldContinue = self?.receiveMessage?(result) {
                 self?.receive(shouldContinue: shouldContinue)


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
Some service exceptions are not properly being reported through the liveness session. Instead the session is defaulting to a fallback error, which isn't very helpful.

This update allows the liveness session to report applicable service exceptions to the callsite.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
