### PR TITLE
fix(datastore): stop datastore plugin only stops syncEngine

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngineBehavior.swift
@@ -17,12 +17,18 @@ enum StorageEngineEvent {
     case readyEvent
 }
 
+enum SyncEngineInitResult {
+    case alreadyInitialized
+    case successfullyInitialized
+    case failure(DataStoreError)
+}
+
 protocol StorageEngineBehavior: AnyObject, ModelStorageBehavior {
 
     var publisher: AnyPublisher<StorageEngineEvent, DataStoreError> { get }
 
     /// start remote sync, based on if sync is enabled and/or authentication is required
-    func startSync(completion: @escaping DataStoreCallback<Void>)
+    func startSync() -> Result<SyncEngineInitResult, DataStoreError>
     func stopSync(completion: @escaping DataStoreCallback<Void>)
     func clear(completion: @escaping DataStoreCallback<Void>)
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
@@ -229,6 +229,13 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         stateMachine.notify(action: .finished)
     }
 
+    func isSyncing() -> Bool {
+        if case .notStarted = stateMachine.state {
+            return false
+        }
+        return true
+    }
+
     func terminate() {
         remoteSyncTopicPublisher.send(completion: .finished)
         cleanup()

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngineBehavior.swift
@@ -45,6 +45,8 @@ protocol RemoteSyncEngineBehavior: AnyObject {
 
     func stop(completion: @escaping DataStoreCallback<Void>)
 
+    func isSyncing() -> Bool
+
     /// Submits a new mutation for synchronization to the remote API. The response will be handled by the appropriate
     /// reconciliation queue
     func submit(_ mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>)->Void)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockRemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockRemoteSyncEngine.swift
@@ -16,6 +16,8 @@ import Combine
 typealias OnSubmitCallBack = (MutationEvent, @escaping (Result<MutationEvent, DataStoreError>) -> Void) -> Void
 
 class MockRemoteSyncEngine: RemoteSyncEngineBehavior {
+    var syncing = false
+
     func submit(_ mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>) -> Void) {
         if let callback = callbackOnSubmit {
             callback(mutationEvent, completion)
@@ -36,11 +38,16 @@ class MockRemoteSyncEngine: RemoteSyncEngineBehavior {
         self.remoteSyncTopicPublisher = PassthroughSubject<RemoteSyncEngineEvent, DataStoreError>()
     }
     func start(api: APICategoryGraphQLBehaviorExtended, auth: AuthCategoryBehavior?) {
-
+        syncing = true
     }
 
     func stop(completion: @escaping DataStoreCallback<Void>) {
+        syncing = false
+        completion(.successfulVoid)
+    }
 
+    func isSyncing() -> Bool {
+        return syncing
     }
 
     func setCallbackOnSubmit(callbackOnSubmit: @escaping OnSubmitCallBack) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario6Tests.swift
@@ -205,7 +205,7 @@ class DataStoreConnectionScenario6Tests: SyncEngineIntegrationTestBase {
         let post2 = try await savePost(title: "title", blog: blog2)
         _ = try await saveComment(id: commentId2, post: post2, content: "content")
 
-        await waitForExpectations(timeout: 10)
+        await fulfillment(of: [remoteEventReceived], timeout: 30)
 
         let outboxMutationProcessed = expectation(description: "received outboxMutationProcessed")
         var processedSoFar = 0
@@ -239,7 +239,7 @@ class DataStoreConnectionScenario6Tests: SyncEngineIntegrationTestBase {
         
         try await Amplify.DataStore.delete(Blog6.self, where: QueryPredicateConstant.all)
         
-        await waitForExpectations(timeout: 10)
+        await fulfillment(of: [outboxMutationProcessed], timeout: 30)
     }
 
     func saveBlog(id: String = UUID().uuidString, name: String) async throws -> Blog6 {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -570,7 +570,70 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
         XCTAssertEqual(expectedResult, Set(posts.map(\.title)))
     }
 
+    func testStop_whenSavingInProgress() async throws {
+        let startTime = Temporal.DateTime.now()
+        let syncExpression = DataStoreSyncExpression(modelSchema: Post.schema) {
+            Post.keys.createdAt >= startTime
+        }
+        await setUp(
+            withModels: TestModelRegistration(),
+            dataStoreConfiguration: .custom(syncExpressions: [syncExpression])
+        )
+        try await startAmplifyAndWaitForSync()
+
+        let postCount = 1_000
+        let posts = (0 ..< postCount).map { _ in
+            Post(title: UUID().uuidString, content: UUID().uuidString, createdAt: .now())
+        }
+
+        let saveFinished = expectation(description: "Posts are saved")
+        saveFinished.expectedFulfillmentCount = postCount
+        let stopped = expectation(description: "DataStore plugin stopped")
+
+        let queryLocalFinished = expectation(description: "Query local finished")
+        queryLocalFinished.expectedFulfillmentCount = postCount
+
+        for post in posts {
+            Task {
+                try await sleepMill(UInt64.random(in: 50 ..< 150))
+                do {
+                    let savedPost = try await Amplify.DataStore.save(post)
+                    XCTAssertEqual(post, savedPost)
+                } catch {
+                    log.info("Failed to save post \(post)")
+                }
+                saveFinished.fulfill()
+            }
+        }
+
+        Task {
+            try await sleepMill(100)
+            try await Amplify.DataStore.stop()
+            stopped.fulfill()
+        }
+
+        await fulfillment(of: [saveFinished, stopped], timeout: 30)
+
+        var localSuccess = 0
+        for post in posts {
+            do {
+                let queriedPost = try await Amplify.DataStore.query(Post.self, byId: post.id)
+                XCTAssertEqual(post, queriedPost)
+                localSuccess += 1
+            } catch {
+                log.info("Failed to query post \(post)")
+            }
+            queryLocalFinished.fulfill()
+        }
+        await fulfillment(of: [queryLocalFinished], timeout: 30)
+        XCTAssertEqual(localSuccess, postCount)
+    }
+
     // MARK: - Helpers
+
+    private func sleepMill(_ milliseconds: UInt64) async throws {
+        try await Task.sleep(nanoseconds: milliseconds * NSEC_PER_MSEC)
+    }
 
     func validateSavePost() async throws {
         let date = Temporal.DateTime.now()

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
@@ -294,7 +294,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         let receivedPost = asyncExpectation(description: "received Post")
         try await savePostAndWaitForSync(Post(title: "title", content: "content", createdAt: .now()),
                                          postSyncedExpctation: receivedPost)
-        await waitForExpectations([snapshotWithIsSynced, receivedPost], timeout: 100)
+        await waitForExpectations([snapshotWithIsSynced, receivedPost], timeout: 30)
         XCTAssertTrue(snapshots.count >= 2)
         XCTAssertFalse(snapshots[0].isSynced)
         XCTAssertTrue(snapshots.last!.isSynced)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift.git",
       "state" : {
-        "revision" : "afe23a2a2f6cf78e6d8803d7c9e0c8e6f50b6915",
-        "version" : "0.4.0"
+        "revision" : "6feec6c3787877807aa9a00fad09591b96752376",
+        "version" : "0.6.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "30649be4b9d0788f987ae851c48d48ac6d00f2c2",
-        "version" : "0.6.1"
+        "revision" : "24bae88a2391fe75da8a940a544d1ef6441f5321",
+        "version" : "0.13.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/smithy-swift.git",
       "state" : {
-        "revision" : "3e9e420f69c28dee260c03b19c3e93b392128d42",
-        "version" : "0.6.1"
+        "revision" : "7b28da158d92cd06a3549140d43b8fbcf64a94a6",
+        "version" : "0.15.0"
       }
     },
     {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
This is the ported fix for v1 https://github.com/aws-amplify/amplify-swift/pull/2863
## Description
<!-- Why is this change required? What problem does it solve? -->

In the current implementation, if the customer triggers DataStore.stop, it's possible that the local DB connection may not be closed immediately. If the customer attempts to perform another DataStore operation while this connection is still open, a second connection to the database may be initiated from a different process. This could cause conflicts with the [SQLite locking system](https://www.sqlite.org/lockingv3.html) and potentially result in a failed write operation.

This PR is to address the issue with minimal changes. Specifically, when the `DataStore.stop` API is called, only the `SyncEngine` is stopped and set to nil, while the `StorageEngine` remains active to preserve the connection to local database.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
