### PR TITLE
feat(datastore): Add Lazy reference types to Amplify core

### DIFF
--- a/Amplify.xcodeproj/project.pbxproj
+++ b/Amplify.xcodeproj/project.pbxproj
@@ -8,9 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		061FD5B1AF28D70F20D52407 /* Pods_Amplify_AmplifyTestConfigs_AmplifyTestCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAE4710DB0051BDB010053AA /* Pods_Amplify_AmplifyTestConfigs_AmplifyTestCommon.framework */; };
-		2104FE60284E7288007CF949 /* SchemaDrift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2104FE5D284E7288007CF949 /* SchemaDrift.swift */; };
-		2104FE61284E7288007CF949 /* SchemaDrift+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2104FE5E284E7288007CF949 /* SchemaDrift+Schema.swift */; };
-		2104FE62284E7288007CF949 /* EnumDrift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2104FE5F284E7288007CF949 /* EnumDrift.swift */; };
 		2104FE4728490338007CF949 /* Blog8+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2104FE3F28490337007CF949 /* Blog8+Schema.swift */; };
 		2104FE4828490338007CF949 /* MyNestedModel8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2104FE4028490337007CF949 /* MyNestedModel8.swift */; };
 		2104FE4928490338007CF949 /* MyCustomModel8+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2104FE4128490338007CF949 /* MyCustomModel8+Schema.swift */; };
@@ -21,6 +18,9 @@
 		2104FE4E28490338007CF949 /* Post8+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2104FE4628490338007CF949 /* Post8+Schema.swift */; };
 		2104FE562849115B007CF949 /* Comment8+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2104FE542849115B007CF949 /* Comment8+Schema.swift */; };
 		2104FE572849115B007CF949 /* Comment8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2104FE552849115B007CF949 /* Comment8.swift */; };
+		2104FE60284E7288007CF949 /* SchemaDrift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2104FE5D284E7288007CF949 /* SchemaDrift.swift */; };
+		2104FE61284E7288007CF949 /* SchemaDrift+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2104FE5E284E7288007CF949 /* SchemaDrift+Schema.swift */; };
+		2104FE62284E7288007CF949 /* EnumDrift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2104FE5F284E7288007CF949 /* EnumDrift.swift */; };
 		210922502359634C00CEC295 /* AnalyticsProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210922492359634B00CEC295 /* AnalyticsProfile.swift */; };
 		210922522359634C00CEC295 /* AnalyticsPropertyValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2109224B2359634C00CEC295 /* AnalyticsPropertyValue.swift */; };
 		210922572359693900CEC295 /* BasicAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210922562359693800CEC295 /* BasicAnalyticsEvent.swift */; };
@@ -549,6 +549,11 @@
 		B46884182460A92900221268 /* AuthFetchDevicesRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46884172460A92900221268 /* AuthFetchDevicesRequest.swift */; };
 		B468841A2460A98E00221268 /* AuthForgetDeviceRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46884192460A98E00221268 /* AuthForgetDeviceRequest.swift */; };
 		B468841C2460A9CC00221268 /* AuthRememberDeviceRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B468841B2460A9CC00221268 /* AuthRememberDeviceRequest.swift */; };
+		B46E7B982A0C1B9F00246315 /* PropertyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46E7B972A0C1B9F00246315 /* PropertyPath.swift */; };
+		B46E7B9B2A0C1C8A00246315 /* DefaultModelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46E7B9A2A0C1C8A00246315 /* DefaultModelProvider.swift */; };
+		B46E7B9D2A0C1CA100246315 /* LazyReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46E7B9C2A0C1CA100246315 /* LazyReference.swift */; };
+		B46E7B9F2A0C1D0500246315 /* ModelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46E7B9E2A0C1D0500246315 /* ModelProvider.swift */; };
+		B46E7BA12A0C1D4000246315 /* ModelProviderDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46E7BA02A0C1D4000246315 /* ModelProviderDecoder.swift */; };
 		B473B53E245DE8E100C45C72 /* AuthConfirmSignInOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B473B53D245DE8E100C45C72 /* AuthConfirmSignInOperation.swift */; };
 		B473B540245DE93100C45C72 /* AuthConfirmSignInRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B473B53F245DE93100C45C72 /* AuthConfirmSignInRequest.swift */; };
 		B473B548245E097600C45C72 /* AuthSignOutOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B473B547245E097600C45C72 /* AuthSignOutOperation.swift */; };
@@ -973,10 +978,6 @@
 		0671E539A66859A57E071091 /* Pods-Amplify-AmplifyTestConfigs-AmplifyTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AmplifyTestConfigs-AmplifyTests.release.xcconfig"; path = "Target Support Files/Pods-Amplify-AmplifyTestConfigs-AmplifyTests/Pods-Amplify-AmplifyTestConfigs-AmplifyTests.release.xcconfig"; sourceTree = "<group>"; };
 		09D90ABD9EDED6D6B1780253 /* Pods-Amplify-AWSPluginsCore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AWSPluginsCore.release.xcconfig"; path = "Target Support Files/Pods-Amplify-AWSPluginsCore/Pods-Amplify-AWSPluginsCore.release.xcconfig"; sourceTree = "<group>"; };
 		1FA86170C161C5E46E57A5F9 /* Pods-Amplify-AWSPluginsCore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Amplify-AWSPluginsCore.debug.xcconfig"; path = "Target Support Files/Pods-Amplify-AWSPluginsCore/Pods-Amplify-AWSPluginsCore.debug.xcconfig"; sourceTree = "<group>"; };
-		2104FE5D284E7288007CF949 /* SchemaDrift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchemaDrift.swift; sourceTree = "<group>"; };
-		2104FE5E284E7288007CF949 /* SchemaDrift+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SchemaDrift+Schema.swift"; sourceTree = "<group>"; };
-		2104FE5F284E7288007CF949 /* EnumDrift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumDrift.swift; sourceTree = "<group>"; };
-		2104FE3D2849010D007CF949 /* schema.graphql */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = schema.graphql; sourceTree = "<group>"; };
 		2104FE3F28490337007CF949 /* Blog8+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Blog8+Schema.swift"; sourceTree = "<group>"; };
 		2104FE4028490337007CF949 /* MyNestedModel8.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyNestedModel8.swift; sourceTree = "<group>"; };
 		2104FE4128490338007CF949 /* MyCustomModel8+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MyCustomModel8+Schema.swift"; sourceTree = "<group>"; };
@@ -987,6 +988,9 @@
 		2104FE4628490338007CF949 /* Post8+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post8+Schema.swift"; sourceTree = "<group>"; };
 		2104FE542849115B007CF949 /* Comment8+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Comment8+Schema.swift"; sourceTree = "<group>"; };
 		2104FE552849115B007CF949 /* Comment8.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment8.swift; sourceTree = "<group>"; };
+		2104FE5D284E7288007CF949 /* SchemaDrift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchemaDrift.swift; sourceTree = "<group>"; };
+		2104FE5E284E7288007CF949 /* SchemaDrift+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SchemaDrift+Schema.swift"; sourceTree = "<group>"; };
+		2104FE5F284E7288007CF949 /* EnumDrift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumDrift.swift; sourceTree = "<group>"; };
 		210922492359634B00CEC295 /* AnalyticsProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsProfile.swift; sourceTree = "<group>"; };
 		2109224B2359634C00CEC295 /* AnalyticsPropertyValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsPropertyValue.swift; sourceTree = "<group>"; };
 		210922562359693800CEC295 /* BasicAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicAnalyticsEvent.swift; sourceTree = "<group>"; };
@@ -1530,6 +1534,11 @@
 		B46884172460A92900221268 /* AuthFetchDevicesRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFetchDevicesRequest.swift; sourceTree = "<group>"; };
 		B46884192460A98E00221268 /* AuthForgetDeviceRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthForgetDeviceRequest.swift; sourceTree = "<group>"; };
 		B468841B2460A9CC00221268 /* AuthRememberDeviceRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRememberDeviceRequest.swift; sourceTree = "<group>"; };
+		B46E7B972A0C1B9F00246315 /* PropertyPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyPath.swift; sourceTree = "<group>"; };
+		B46E7B9A2A0C1C8A00246315 /* DefaultModelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultModelProvider.swift; sourceTree = "<group>"; };
+		B46E7B9C2A0C1CA100246315 /* LazyReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyReference.swift; sourceTree = "<group>"; };
+		B46E7B9E2A0C1D0500246315 /* ModelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelProvider.swift; sourceTree = "<group>"; };
+		B46E7BA02A0C1D4000246315 /* ModelProviderDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelProviderDecoder.swift; sourceTree = "<group>"; };
 		B473B53D245DE8E100C45C72 /* AuthConfirmSignInOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthConfirmSignInOperation.swift; sourceTree = "<group>"; };
 		B473B53F245DE93100C45C72 /* AuthConfirmSignInRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthConfirmSignInRequest.swift; sourceTree = "<group>"; };
 		B473B547245E097600C45C72 /* AuthSignOutOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSignOutOperation.swift; sourceTree = "<group>"; };
@@ -1965,16 +1974,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		2104FE5C284E7263007CF949 /* SchemaDrift */ = {
-			isa = PBXGroup;
-			children = (
-				2104FE5F284E7288007CF949 /* EnumDrift.swift */,
-				2104FE5D284E7288007CF949 /* SchemaDrift.swift */,
-				2104FE5E284E7288007CF949 /* SchemaDrift+Schema.swift */,
-			);
-			path = SchemaDrift;
-			sourceTree = "<group>";
-		};
 		2104FE3B28490087007CF949 /* OptionalAssociations */ = {
 			isa = PBXGroup;
 			children = (
@@ -1990,6 +1989,16 @@
 				2104FE4628490338007CF949 /* Post8+Schema.swift */,
 			);
 			path = OptionalAssociations;
+			sourceTree = "<group>";
+		};
+		2104FE5C284E7263007CF949 /* SchemaDrift */ = {
+			isa = PBXGroup;
+			children = (
+				2104FE5F284E7288007CF949 /* EnumDrift.swift */,
+				2104FE5D284E7288007CF949 /* SchemaDrift.swift */,
+				2104FE5E284E7288007CF949 /* SchemaDrift+Schema.swift */,
+			);
+			path = SchemaDrift;
 			sourceTree = "<group>";
 		};
 		21092258235969D000CEC295 /* Event */ = {
@@ -2549,6 +2558,8 @@
 				FA8EE77C238627350097E4F1 /* Model+Subscript.swift */,
 				21644B7A2588258100C548A5 /* ModelListDecoder.swift */,
 				21A4ED4A259CD21700E1047D /* ModelListProvider.swift */,
+				B46E7B9E2A0C1D0500246315 /* ModelProvider.swift */,
+				B46E7BA02A0C1D4000246315 /* ModelProviderDecoder.swift */,
 				B92E03A92367CE7A006CEB8D /* ModelRegistry.swift */,
 				FA5D4CF2238AFD7B00D2F54A /* ModelRegistry+Syncable.swift */,
 				FA8EE780238628490097E4F1 /* Persistable.swift */,
@@ -3044,6 +3055,15 @@
 			path = AuthPluginBehavior;
 			sourceTree = "<group>";
 		};
+		B46E7B992A0C1C6E00246315 /* Lazy */ = {
+			isa = PBXGroup;
+			children = (
+				B46E7B9A2A0C1C8A00246315 /* DefaultModelProvider.swift */,
+				B46E7B9C2A0C1CA100246315 /* LazyReference.swift */,
+			);
+			path = Lazy;
+			sourceTree = "<group>";
+		};
 		B4944D1F251C06D300BF0BFE /* JSONHelper */ = {
 			isa = PBXGroup;
 			children = (
@@ -3271,14 +3291,16 @@
 		B92E03A62367CE7A006CEB8D /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				B4944D1F251C06D300BF0BFE /* JSONHelper */,
-				B92E03A72367CE7A006CEB8D /* Model.swift */,
-				7674E5252798DD8F008F58F4 /* ModelIdentifiable.swift */,
-				FA8EE778238627040097E4F1 /* Model+ModelName.swift */,
 				2129BE502395A66F006363A1 /* AmplifyModelRegistration.swift */,
-				902AE04B281304B800CD12CA /* Temporal */,
+				B92E03A72367CE7A006CEB8D /* Model.swift */,
+				FA8EE778238627040097E4F1 /* Model+ModelName.swift */,
+				7674E5252798DD8F008F58F4 /* ModelIdentifiable.swift */,
+				B46E7B972A0C1B9F00246315 /* PropertyPath.swift */,
 				B9FAA1232388BE2B009414B4 /* Collection */,
 				21AD424A249BEC440016FE95 /* Internal */,
+				B4944D1F251C06D300BF0BFE /* JSONHelper */,
+				B46E7B992A0C1C6E00246315 /* Lazy */,
+				902AE04B281304B800CD12CA /* Temporal */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -5275,6 +5297,7 @@
 				FAD393712381FD3C00463F5E /* DataStoreCategory+Subscribe.swift in Sources */,
 				FAA64FC32397294600B9C3C6 /* ModelSchema+Attributes.swift in Sources */,
 				FAC0A2AF22B4400100B50912 /* LoggingCategory+ClientBehavior.swift in Sources */,
+				B46E7BA12A0C1D4000246315 /* ModelProviderDecoder.swift in Sources */,
 				95DAAB28237E63370028544F /* Celebrity.swift in Sources */,
 				FA0933812384749A00C2FD5F /* LoggingCategory+Logger.swift in Sources */,
 				97DC3D5024C1FCEE00D79E24 /* LogEntryRow.swift in Sources */,
@@ -5319,6 +5342,7 @@
 				FAAFAF37239051E6002CF932 /* AtomicDictionary.swift in Sources */,
 				95DAAB2F237E63370028544F /* LanguageType.swift in Sources */,
 				B4D3852E236C97360014653D /* PredictionsIdentifyOperation.swift in Sources */,
+				B46E7B982A0C1B9F00246315 /* PropertyPath.swift in Sources */,
 				5C3324932772BD3D00F2C47B /* AuthDeleteUserRequest.swift in Sources */,
 				FA09B9412321BB78000E064D /* JSONValue.swift in Sources */,
 				B9A6A4E024452E0D00AC2792 /* AccessLevel.swift in Sources */,
@@ -5384,6 +5408,7 @@
 				2129BE512395A66F006363A1 /* AmplifyModelRegistration.swift in Sources */,
 				210922572359693900CEC295 /* BasicAnalyticsEvent.swift in Sources */,
 				9091FF8A2820771C0021D8E1 /* Date+Operation.swift in Sources */,
+				B46E7B9F2A0C1D0500246315 /* ModelProvider.swift in Sources */,
 				FAC2353F227A055200424678 /* PluginError.swift in Sources */,
 				974FF18724B54E590050D01B /* DeviceInfoItem.swift in Sources */,
 				97CB860624ABA023000C65FB /* LongPressGestureRecognizer.swift in Sources */,
@@ -5394,6 +5419,7 @@
 				FA09B9332321A305000E064D /* HubCategory+CategoryConfigurable.swift in Sources */,
 				B4B5CC9A2457B7FA0019C783 /* AuthUpdateUserAttributeOperation.swift in Sources */,
 				B92E03B02367CE7A006CEB8D /* DataStoreCallback.swift in Sources */,
+				B46E7B9D2A0C1CA100246315 /* LazyReference.swift in Sources */,
 				B92E03BA2367CE7A006CEB8D /* Model+Codable.swift in Sources */,
 				210B3E34245CB73400F43848 /* AuthRule.swift in Sources */,
 				974FF13324B043E60050D01B /* DevMenuBehavior.swift in Sources */,
@@ -5444,6 +5470,7 @@
 				9091FF9228207B8D0021D8E1 /* Temporal+Cache.swift in Sources */,
 				B4FA76082416E87E006F59CE /* AuthFetchSessionOperation.swift in Sources */,
 				B49A02F92410BEBE00B42A25 /* AuthCategory+CategoryConfigurable.swift in Sources */,
+				B46E7B9B2A0C1C8A00246315 /* DefaultModelProvider.swift in Sources */,
 				5C763DA426F2CCDF006650E7 /* CLocationCoordinate2D+Geo.Coordinates.swift in Sources */,
 				B92E03B12367CE7A006CEB8D /* DataStoreError.swift in Sources */,
 				95DAAB48237E639E0028544F /* IdentifyCelebritiesResult.swift in Sources */,

--- a/Amplify/Categories/DataStore/Model/Collection/ArrayLiteralListProvider.swift
+++ b/Amplify/Categories/DataStore/Model/Collection/ArrayLiteralListProvider.swift
@@ -31,4 +31,8 @@ public struct ArrayLiteralListProvider<Element: Model>: ModelListProvider {
                                                        "Don't call this method",
                                                        nil)))
     }
+
+    public func encode(to encoder: Encoder) throws {
+        try elements.encode(to: encoder)
+    }
 }

--- a/Amplify/Categories/DataStore/Model/Internal/ModelProvider.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelProvider.swift
@@ -74,6 +74,7 @@ public struct AnyModelProvider<Element: Model>: ModelProvider {
         self.encodeClosure = provider.encode
     }
 
+    @available(iOS 13.0.0, *)
     public func load() async throws -> Element? {
         try await loadAsync?()
     }

--- a/Amplify/Categories/DataStore/Model/Internal/ModelProvider.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelProvider.swift
@@ -1,0 +1,91 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// Protocol used as a marker to detect when the type is a `LazyReference`.
+/// Used to retrieve either the `reference` or the `identifiers` of the Model directly, without having load a not
+/// loaded LazyReference. This is useful when translating the model object over to the payload required for the
+/// underlying storage, such as storing the values in DataStore's local database or AppSync GraphQL request payload.
+///
+///
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
+/// directly by host applications. The behavior of this may change without warning. Though it is not used by host
+/// application making any change to these `public` types should be backward compatible, otherwise it will be a breaking
+/// change.
+public protocol LazyReferenceValue {
+    var state: LazyReferenceValueState { get }
+}
+
+public enum LazyReferenceValueState {
+    case notLoaded(identifiers: [LazyReferenceIdentifier]?)
+    case loaded(model: Model?)
+}
+
+/// State of the ModelProvider
+///
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
+/// directly by host applications. The behavior of this may change without warning. Though it is not used by host
+/// application making any change to these `public` types should be backward compatible, otherwise it will be a breaking
+/// change.
+public enum ModelProviderState<Element: Model> {
+    case notLoaded(identifiers: [LazyReferenceIdentifier]?)
+    case loaded(model: Element?)
+}
+
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
+/// directly by host applications. The behavior of this may change without warning. Though it is not used by host
+/// application making any change to these `public` types should be backward compatible, otherwise it will be a breaking
+/// change.
+public protocol ModelProvider {
+    associatedtype Element: Model
+
+    func load() async throws -> Element?
+
+    func getState() -> ModelProviderState<Element>
+
+    func encode(to encoder: Encoder) throws
+}
+
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
+/// directly by host applications. The behavior of this may change without warning. Though it is not used by host
+/// application making any change to these `public` types should be backward compatible, otherwise it will be a breaking
+/// change.
+public struct AnyModelProvider<Element: Model>: ModelProvider {
+
+    private let loadAsync: () async throws -> Element?
+    private let getStateClosure: () -> ModelProviderState<Element>
+    private let encodeClosure: (Encoder) throws -> Void
+
+    public init<Provider: ModelProvider>(provider: Provider) where Provider.Element == Self.Element {
+        self.loadAsync = provider.load
+        self.getStateClosure = provider.getState
+        self.encodeClosure = provider.encode
+    }
+
+    public func load() async throws -> Element? {
+        try await loadAsync()
+    }
+
+    public func getState() -> ModelProviderState<Element> {
+        getStateClosure()
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        try encodeClosure(encoder)
+    }
+}
+
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
+/// directly by host applications. The behavior of this may change without warning. Though it is not used by host
+/// application making any change to these `public` types should be backward compatible, otherwise it will be a breaking
+/// change.
+public extension ModelProvider {
+    func eraseToAnyModelProvider() -> AnyModelProvider<Element> {
+        AnyModelProvider(provider: self)
+    }
+}

--- a/Amplify/Categories/DataStore/Model/Internal/ModelProvider.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelProvider.swift
@@ -17,11 +17,12 @@ import Foundation
 /// directly by host applications. The behavior of this may change without warning. Though it is not used by host
 /// application making any change to these `public` types should be backward compatible, otherwise it will be a breaking
 /// change.
-public protocol LazyReferenceValue {
-    var state: LazyReferenceValueState { get }
+public protocol _LazyReferenceValue {
+    var state: _LazyReferenceValueState { get }
 }
 
-public enum LazyReferenceValueState {
+// swiftlint:disable type_name
+public enum _LazyReferenceValueState {
     case notLoaded(identifiers: [LazyReferenceIdentifier]?)
     case loaded(model: Model?)
 }

--- a/Amplify/Categories/DataStore/Model/Internal/ModelProviderDecoder.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/ModelProviderDecoder.swift
@@ -1,0 +1,40 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// Registry of `ModelProviderDecoder`'s used to retrieve decoders that can create `ModelProvider`s to perform
+/// LazyReference functionality.
+///
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
+/// directly by host applications. The behavior of this may change without warning. Though it is not used by host
+/// application making any change to these `public` types should be backward compatible, otherwise it will be a breaking
+/// change.
+public struct ModelProviderRegistry {
+    static var decoders = AtomicValue(initialValue: [ModelProviderDecoder.Type]())
+
+    /// Register a decoder during plugin configuration time, to allow runtime retrievals of model providers.
+    public static func registerDecoder(_ decoder: ModelProviderDecoder.Type) {
+        decoders.append(decoder)
+    }
+}
+
+extension ModelProviderRegistry {
+    static func reset() {
+        decoders.set([ModelProviderDecoder.Type]())
+    }
+}
+
+/// `ModelProviderDecoder` provides decoding and lazy reference functionality.
+///
+/// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
+/// directly by host applications. The behavior of this may change without warning. Though it is not used by host
+/// application making any change to these `public` types should be backward compatible, otherwise it will be a breaking
+/// change.
+public protocol ModelProviderDecoder {
+    static func decode<ModelType: Model>(modelType: ModelType.Type, decoder: Decoder) -> AnyModelProvider<ModelType>?
+}

--- a/Amplify/Categories/DataStore/Model/Lazy/DefaultModelProvider.swift
+++ b/Amplify/Categories/DataStore/Model/Lazy/DefaultModelProvider.swift
@@ -20,12 +20,13 @@ public struct DefaultModelProvider<Element: Model>: ModelProvider {
         self.loadedState = .notLoaded(identifiers: identifiers)
     }
 
-    public func load(completion: (Result<Element?, Error>) -> Void) {
+    @available(iOS 13.0.0, *)
+    public func load() async throws -> Element? {
         switch loadedState {
         case .notLoaded:
-            completion(.success(nil))
+            return nil
         case .loaded(let model):
-            completion(.success(model))
+            return model
         }
     }
 

--- a/Amplify/Categories/DataStore/Model/Lazy/DefaultModelProvider.swift
+++ b/Amplify/Categories/DataStore/Model/Lazy/DefaultModelProvider.swift
@@ -20,6 +20,7 @@ public struct DefaultModelProvider<Element: Model>: ModelProvider {
         self.loadedState = .notLoaded(identifiers: identifiers)
     }
 
+    @available(iOS 13.0.0, *)
     public func load() async throws -> Element? {
         switch loadedState {
         case .notLoaded:

--- a/Amplify/Categories/DataStore/Model/Lazy/DefaultModelProvider.swift
+++ b/Amplify/Categories/DataStore/Model/Lazy/DefaultModelProvider.swift
@@ -20,13 +20,12 @@ public struct DefaultModelProvider<Element: Model>: ModelProvider {
         self.loadedState = .notLoaded(identifiers: identifiers)
     }
 
-    @available(iOS 13.0.0, *)
-    public func load() async throws -> Element? {
+    public func load(completion: (Result<Element?, Error>) -> Void) {
         switch loadedState {
         case .notLoaded:
-            return nil
+            completion(.success(nil))
         case .loaded(let model):
-            return model
+            completion(.success(model))
         }
     }
 

--- a/Amplify/Categories/DataStore/Model/Lazy/DefaultModelProvider.swift
+++ b/Amplify/Categories/DataStore/Model/Lazy/DefaultModelProvider.swift
@@ -23,7 +23,7 @@ public struct DefaultModelProvider<Element: Model>: ModelProvider {
     public func load() async throws -> Element? {
         switch loadedState {
         case .notLoaded:
-            throw CoreError.clientValidation("DefaultModelProvider does not provide loading capabilities", "")
+            return nil
         case .loaded(let model):
             return model
         }

--- a/Amplify/Categories/DataStore/Model/Lazy/DefaultModelProvider.swift
+++ b/Amplify/Categories/DataStore/Model/Lazy/DefaultModelProvider.swift
@@ -1,0 +1,45 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+// MARK: - DefaultModelProvider
+public struct DefaultModelProvider<Element: Model>: ModelProvider {
+
+    var loadedState: ModelProviderState<Element>
+
+    public init(element: Element? = nil) {
+        self.loadedState = .loaded(model: element)
+    }
+
+    public init(identifiers: [LazyReferenceIdentifier]?) {
+        self.loadedState = .notLoaded(identifiers: identifiers)
+    }
+
+    public func load() async throws -> Element? {
+        switch loadedState {
+        case .notLoaded:
+            throw CoreError.clientValidation("DefaultModelProvider does not provide loading capabilities", "")
+        case .loaded(let model):
+            return model
+        }
+    }
+
+    public func getState() -> ModelProviderState<Element> {
+        loadedState
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        switch loadedState {
+        case .notLoaded(let identifiers):
+            var container = encoder.singleValueContainer()
+            try container.encode(identifiers)
+        case .loaded(let element):
+            try element.encode(to: encoder)
+        }
+    }
+}

--- a/Amplify/Categories/DataStore/Model/Lazy/LazyReference.swift
+++ b/Amplify/Categories/DataStore/Model/Lazy/LazyReference.swift
@@ -39,7 +39,7 @@ struct LazyReferenceModelIdentifier: ModelIdentifierProtocol {
 ///
 /// The default implementation `DefaultModelProvider` only handles in-memory data, therefore `get()` and
 /// `require()` will simply return the current `reference`.
-public class LazyReference<ModelType: Model>: Codable, LazyReferenceValue {
+public class LazyReference<ModelType: Model>: Codable, _LazyReferenceValue {
 
     /// Represents the data state of the `LazyModel`.
     enum LoadedState {
@@ -50,7 +50,7 @@ public class LazyReference<ModelType: Model>: Codable, LazyReferenceValue {
     var loadedState: LoadedState
 
     @_spi(LazyReference)
-    public var state: LazyReferenceValueState {
+    public var state: _LazyReferenceValueState {
         switch loadedState {
         case .notLoaded(let identifiers):
             return .notLoaded(identifiers: identifiers)

--- a/Amplify/Categories/DataStore/Model/Lazy/LazyReference.swift
+++ b/Amplify/Categories/DataStore/Model/Lazy/LazyReference.swift
@@ -1,0 +1,152 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Combine
+
+/// A Codable struct to hold key value pairs representing the identifier's field name and value.
+/// Useful for maintaining order for key-value pairs when used as an Array type.
+public struct LazyReferenceIdentifier: Codable {
+    public let name: String
+    public let value: String
+
+    public init(name: String, value: String) {
+        self.name = name
+        self.value = value
+    }
+}
+
+extension Array where Element == LazyReferenceIdentifier {
+    public var stringValue: String {
+        var fields = [(String, Persistable)]()
+        for id in self {
+            fields.append((id.name, id.value))
+        }
+        return LazyReferenceModelIdentifier(fields: fields).stringValue
+    }
+}
+
+struct LazyReferenceModelIdentifier: ModelIdentifierProtocol {
+    var fields: [(name: String, value: Persistable)]
+}
+
+/// This class represents a lazy reference to a `Model`, meaning that the reference
+/// may or may not exist at instantiation time.
+///
+/// The default implementation `DefaultModelProvider` only handles in-memory data, therefore `get()` and
+/// `require()` will simply return the current `reference`.
+public class LazyReference<ModelType: Model>: Codable, LazyReferenceValue {
+
+    /// Represents the data state of the `LazyModel`.
+    enum LoadedState {
+        case notLoaded(identifiers: [LazyReferenceIdentifier]?)
+        case loaded(ModelType?)
+    }
+
+    var loadedState: LoadedState
+
+    @_spi(LazyReference)
+    public var state: LazyReferenceValueState {
+        switch loadedState {
+        case .notLoaded(let identifiers):
+            return .notLoaded(identifiers: identifiers)
+        case .loaded(let model):
+            return .loaded(model: model)
+        }
+    }
+
+    /// The provider for fulfilling list behaviors
+    let modelProvider: AnyModelProvider<ModelType>
+
+    public init(modelProvider: AnyModelProvider<ModelType>) {
+        self.modelProvider = modelProvider
+        switch self.modelProvider.getState() {
+        case .loaded(let element):
+            self.loadedState = .loaded(element)
+        case .notLoaded(let identifiers):
+            self.loadedState = .notLoaded(identifiers: identifiers)
+        }
+    }
+
+    // MARK: - Initializers
+    public convenience init(_ reference: ModelType?) {
+        let modelProvider = DefaultModelProvider(element: reference).eraseToAnyModelProvider()
+        self.init(modelProvider: modelProvider)
+    }
+
+    public convenience init(identifiers: [LazyReferenceIdentifier]?) {
+        let modelProvider = DefaultModelProvider<ModelType>(identifiers: identifiers).eraseToAnyModelProvider()
+        self.init(modelProvider: modelProvider)
+    }
+
+    // MARK: - Codable implementation
+    /// Decodable implementation is delegated to the ModelProviders.
+    required convenience public init(from decoder: Decoder) throws {
+        for modelDecoder in ModelProviderRegistry.decoders.get() {
+            if let modelProvider = modelDecoder.decode(modelType: ModelType.self, decoder: decoder) {
+                self.init(modelProvider: modelProvider)
+                return
+            }
+        }
+        let json = try JSONValue(from: decoder)
+        switch json {
+        case .object:
+            if let element = try? ModelType(from: decoder) {
+                self.init(element)
+                return
+            }
+        default:
+            break
+        }
+        self.init(identifiers: nil)
+    }
+
+    /// Encodable implementation is delegated to the underlying ModelProviders.
+    public func encode(to encoder: Encoder) throws {
+        try modelProvider.encode(to: encoder)
+    }
+
+    // MARK: - APIs
+    /// This function is responsible for retrieving the model reference. In the default
+    /// implementation this means simply returning the existing `reference`, but different
+    /// storage mechanisms can implement their own logic to fetch data,
+    /// e.g. from DataStore's SQLite or AppSync.
+    ///
+    /// - Returns: the model `reference`, if it exists.
+    public func get() async throws -> ModelType? {
+        switch loadedState {
+        case .notLoaded:
+            let element = try await modelProvider.load()
+            loadedState = .loaded(element)
+            return element
+        case .loaded(let element):
+            return element
+        }
+    }
+
+    /// The equivalent of `get()` but aimed to retrieve references that are considered
+    /// non-optional. However, referential integrity issues and/or availability constraints
+    /// might affect how required data is fetched. In such scenarios the implementation
+    /// must throw an error to communicate to developers why required data could not be fetched.
+    ///
+    /// - Throws: an error of type `DataError` when the data marked as required cannot be retrieved.
+    public func require() async throws -> ModelType {
+        switch loadedState {
+        case .notLoaded:
+            guard let element = try await modelProvider.load() else {
+                throw CoreError.clientValidation("Data is required but underlying data source successfully loaded no data. ", "")
+            }
+            loadedState = .loaded(element)
+            return element
+        case .loaded(let element):
+            guard let element = element else {
+                throw CoreError.clientValidation("Data is required but containing LazyReference is loaded with no data.", "")
+            }
+            return element
+        }
+    }
+}

--- a/Amplify/Categories/DataStore/Model/Lazy/LazyReference.swift
+++ b/Amplify/Categories/DataStore/Model/Lazy/LazyReference.swift
@@ -117,6 +117,7 @@ public class LazyReference<ModelType: Model>: Codable, _LazyReferenceValue {
     /// e.g. from DataStore's SQLite or AppSync.
     ///
     /// - Returns: the model `reference`, if it exists.
+    @available(iOS 13.0.0, *)
     public func get() async throws -> ModelType? {
         switch loadedState {
         case .notLoaded:
@@ -134,17 +135,24 @@ public class LazyReference<ModelType: Model>: Codable, _LazyReferenceValue {
     /// must throw an error to communicate to developers why required data could not be fetched.
     ///
     /// - Throws: an error of type `DataError` when the data marked as required cannot be retrieved.
+    @available(iOS 13.0.0, *)
     public func require() async throws -> ModelType {
         switch loadedState {
         case .notLoaded:
             guard let element = try await modelProvider.load() else {
-                throw CoreError.clientValidation("Data is required but underlying data source successfully loaded no data. ", "")
+                throw CoreError.clientValidation(
+                    """
+                    Data is required but underlying data source successfully loaded no data.
+                    """, "")
             }
             loadedState = .loaded(element)
             return element
         case .loaded(let element):
             guard let element = element else {
-                throw CoreError.clientValidation("Data is required but containing LazyReference is loaded with no data.", "")
+                throw CoreError.clientValidation(
+                    """
+                    Data is required but containing LazyReference is loaded with no data.
+                    """, "")
             }
             return element
         }

--- a/Amplify/Categories/DataStore/Model/PropertyPath.swift
+++ b/Amplify/Categories/DataStore/Model/PropertyPath.swift
@@ -1,0 +1,126 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// Runtime information about a property. Its `name` and `parent` property reference,
+/// as well as whether the property represents a collection of the type or not.
+public struct PropertyPathMetadata {
+    public let name: String
+    public let isCollection: Bool
+    public let parent: PropertyPath?
+}
+
+/// Represents a property of a `Model`. PropertyPath is a way of representing the
+/// structure of a model with static typing, so developers can reference model
+/// properties in queries and other functionality that require them.
+public protocol PropertyPath {
+
+    /// Access the property metadata.
+    ///
+    /// **Implementation note:** this function is in place over an implicit accessor over
+    /// a property named `metadata` in order to avoid name conflict with the actual property
+    /// names that will get generate from the `Model`.
+    ///
+    /// - Returns the property metadata, that contains the name and a reference to its parent.
+    func getMetadata() -> PropertyPathMetadata
+}
+
+/// This is a specialized protocol to indicate the property is a container of other properties,
+/// i.e. a `struct` representing another `Model`.
+///
+/// - SeeAlso: `ModelPath`
+public protocol PropertyContainerPath: PropertyPath {
+
+    ///
+    func getKeyPath() -> String
+
+    /// Must return a reference to the type containing the properties
+    func getModelType() -> Model.Type
+
+}
+
+extension PropertyContainerPath {
+
+    public func getKeyPath() -> String {
+        var metadata = getMetadata()
+        var path = [String]()
+        while let parent = metadata.parent {
+            path.insert(metadata.name, at: 0)
+            metadata = parent.getMetadata()
+        }
+        return path.joined(separator: ".")
+    }
+}
+
+/// Represents a scalar (i.e. data type) of a model property.
+public struct FieldPath<ValueType>: PropertyPath {
+    private let metadata: PropertyPathMetadata
+
+    init(name: String, parent: PropertyPath? = nil) {
+        self.metadata = PropertyPathMetadata(name: name, isCollection: false, parent: parent)
+    }
+
+    public func getMetadata() -> PropertyPathMetadata {
+        return metadata
+    }
+}
+
+/// Represents the `Model` structure itself, a container of property references.
+///
+/// - Example:
+/// ```swift
+/// class PostModelPath : ModelPath<Post> {}
+///
+/// extension ModelPath where ModelType == Post {
+///   var id: FieldPath<String> { id() }
+///   var title: FieldPath<String> { string("title") }
+///   var blog: ModelPath<Blog> { BlogModelPath(name: "blog", parent: self) }
+/// }
+/// ```
+open class ModelPath<ModelType: Model>: PropertyContainerPath {
+
+    private let metadata: PropertyPathMetadata
+
+    public init(name: String = "root", isCollection: Bool = false, parent: PropertyPath? = nil) {
+        self.metadata = PropertyPathMetadata(name: name, isCollection: isCollection, parent: parent)
+    }
+
+    public func getMetadata() -> PropertyPathMetadata {
+        return metadata
+    }
+
+    public func getModelType() -> Model.Type {
+        return ModelType.self
+    }
+
+    public func isRoot() -> Bool {
+        return metadata.parent == nil
+    }
+
+    public func id(_ name: String = "id") -> FieldPath<String> {
+        FieldPath(name: name, parent: self)
+    }
+
+    public func string(_ name: String) -> FieldPath<String> {
+        FieldPath(name: name, parent: self)
+    }
+
+    public func bool(_ name: String) -> FieldPath<Bool> {
+        FieldPath(name: name, parent: self)
+    }
+
+    public func date(_ name: String) -> FieldPath<Temporal.Date> {
+        FieldPath(name: name, parent: self)
+    }
+
+    public func datetime(_ name: String) -> FieldPath<Temporal.DateTime> {
+        FieldPath(name: name, parent: self)
+    }
+
+    public func time(_ name: String) -> FieldPath<Temporal.Time> {
+        FieldPath(name: name, parent: self)
+    }
+}

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Core/AppSyncListProvider.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Core/AppSyncListProvider.swift
@@ -19,13 +19,13 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
 
     /// The current state of lazily loaded list
     enum LoadedState {
-        /// If the list represents an association between two models, the `associatedIdentifiers` will
+        /// If the list represents an association between two models, the `associatedId` will
         /// hold the information necessary to query the associated elements (e.g. comments of a post)
         ///
         /// The associatedField represents the field to which the owner of the `List` is linked to.
         /// For example, if `Post.comments` is associated with `Comment.post` the `List<Comment>`
         /// of `Post` will have a reference to the `post` field in `Comment`.
-        case notLoaded(associatedIdentifiers: [String],
+        case notLoaded(associatedId: Model.Identifier,
                        associatedField: String)
 
         /// If the list is retrieved directly, this state holds the underlying data, nextToken used to create
@@ -41,8 +41,8 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
 
     convenience init(payload: AppSyncListPayload) throws {
         let listResponse = try AppSyncListResponse.initWithMetadata(type: Element.self,
-                                                                    graphQLData: payload.graphQLData,
-                                                                    apiName: payload.apiName)
+                                                                       graphQLData: payload.graphQLData,
+                                                                       apiName: payload.apiName)
 
         self.init(elements: listResponse.items,
                   nextToken: listResponse.nextToken,
@@ -57,7 +57,9 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
     }
 
     convenience init(metadata: AppSyncModelMetadata) {
-        fatalError("To be implemented")
+        self.init(associatedId: metadata.appSyncAssociatedId,
+                  associatedField: metadata.appSyncAssociatedField,
+                  apiName: metadata.apiName)
     }
 
     // Internal initializer for testing
@@ -72,35 +74,25 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
     }
 
     // Internal initializer for testing
-    init(associatedIdentifiers: [String], associatedField: String, apiName: String? = nil) {
-        self.loadedState = .notLoaded(
-            associatedIdentifiers: associatedIdentifiers,
-            associatedField: associatedField)
+    init(associatedId: String, associatedField: String, apiName: String? = nil) {
+        self.loadedState = .notLoaded(associatedId: associatedId,
+                                      associatedField: associatedField)
         self.apiName = apiName
     }
 
     // MARK: APIs
 
-    public func getState() -> ModelListProviderState<Element> {
-        switch loadedState {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
-            return .notLoaded(associatedIdentifiers: associatedIdentifiers, associatedField: associatedField)
-        case .loaded(let elements, _, _):
-            return .loaded(elements)
-        }
-    }
-
     public func load() -> Result<[Element], CoreError> {
         switch loadedState {
         case .loaded(let elements, _, _):
             return .success(elements)
-        case .notLoaded(let associatedIdentifiers, let associatedField):
+        case .notLoaded(let associatedId, let associatedField):
             let semaphore = DispatchSemaphore(value: 0)
             var loadResult: Result<[Element], CoreError> = .failure(
                 .listOperation("API query failed to complete.",
                                AmplifyErrorMessages.reportBugToAWS(),
                                nil))
-            load(associatedIdentifiers: associatedIdentifiers, associatedField: associatedField) { result in
+            load(associatedId: associatedId, associatedField: associatedField) { result in
                 defer {
                     semaphore.signal()
                 }
@@ -121,32 +113,17 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
         switch loadedState {
         case .loaded(let elements, _, _):
             completion(.success(elements))
-        case .notLoaded(let associatedIdentifiers, let associatedField):
-            load(associatedIdentifiers: associatedIdentifiers, associatedField: associatedField, completion: completion)
+        case .notLoaded(let associatedId, let associatedField):
+            load(associatedId: associatedId, associatedField: associatedField, completion: completion)
         }
     }
 
     //// Internal `load` to perform the retrieval of the first page and storing it in memory
-    func load(associatedIdentifiers: [String],
+    func load(associatedId: String,
               associatedField: String,
               completion: @escaping (Result<[Element], CoreError>) -> Void ) {
-        let filter: GraphQLFilter
-        if associatedIdentifiers.count == 1, let associatedId = associatedIdentifiers.first {
-            let predicate: QueryPredicate = field(associatedField) == associatedId
-            filter = predicate.graphQLFilter(for: Element.schema)
-        } else {
-            var queryPredicates: [QueryPredicateOperation] = []
-            let columnNames = columnNames(field: associatedField, Element.schema)
-
-            let predicateValues = zip(columnNames, associatedIdentifiers)
-            for (identifierName, identifierValue) in predicateValues {
-                queryPredicates.append(QueryPredicateOperation(field: identifierName,
-                                                               operator: .equals(identifierValue)))
-            }
-            let groupedQueryPredicates = QueryPredicateGroup(type: .and, predicates: queryPredicates)
-            filter = groupedQueryPredicates.graphQLFilter(for: Element.schema)
-        }
-
+        let predicate: QueryPredicate = field(associatedField) == associatedId
+        let filter = predicate.graphQLFilter(for: Element.schema)
         let request = GraphQLRequest<JSONValue>.listQuery(responseType: JSONValue.self,
                                                           modelSchema: Element.schema,
                                                           filter: filter,
@@ -174,9 +151,9 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
                 case .failure(let graphQLError):
                     Amplify.API.log.error(error: graphQLError)
                     completion(.failure(.listOperation(
-                        "The AppSync response returned successfully with GraphQL errors.",
-                        "Check the underlying error for the failed GraphQL response.",
-                        graphQLError)))
+                                            "The AppSync response returned successfully with GraphQL errors.",
+                                            "Check the underlying error for the failed GraphQL response.",
+                                            graphQLError)))
                 }
             case .failure(let apiError):
                 Amplify.API.log.error(error: apiError)
@@ -244,29 +221,4 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
             }
         }
     }
-    public func encode(to encoder: Encoder) throws {
-        fatalError("To be implemented")
-    }
-
-    // MARK: - Helpers
-    /// Retrieve the column names for the specified field `field` for this schema.
-    func columnNames(field: String, _ modelSchema: ModelSchema) -> [String] {
-        guard let modelField = modelSchema.field(withName: field) else {
-            return [field]
-        }
-        let defaultFieldName = modelSchema.name.camelCased() + field.pascalCased() + "Id"
-        switch modelField.association {
-        case .belongsTo(_, let targetNames), .hasOne(_, let targetNames):
-            guard !targetNames.isEmpty else {
-                return [defaultFieldName]
-
-            }
-            return targetNames
-        default:
-            return [field]
-        }
-    }
-
 }
-
-extension AppSyncListProvider: DefaultLogger { }

--- a/AmplifyPlugins/API/AWSAPICategoryPlugin/Core/AppSyncListProvider.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPlugin/Core/AppSyncListProvider.swift
@@ -19,13 +19,13 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
 
     /// The current state of lazily loaded list
     enum LoadedState {
-        /// If the list represents an association between two models, the `associatedId` will
+        /// If the list represents an association between two models, the `associatedIdentifiers` will
         /// hold the information necessary to query the associated elements (e.g. comments of a post)
         ///
         /// The associatedField represents the field to which the owner of the `List` is linked to.
         /// For example, if `Post.comments` is associated with `Comment.post` the `List<Comment>`
         /// of `Post` will have a reference to the `post` field in `Comment`.
-        case notLoaded(associatedId: Model.Identifier,
+        case notLoaded(associatedIdentifiers: [String],
                        associatedField: String)
 
         /// If the list is retrieved directly, this state holds the underlying data, nextToken used to create
@@ -57,9 +57,7 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
     }
 
     convenience init(metadata: AppSyncModelMetadata) {
-        self.init(associatedId: metadata.appSyncAssociatedId,
-                  associatedField: metadata.appSyncAssociatedField,
-                  apiName: metadata.apiName)
+        fatalError("To be implemented")
     }
 
     // Internal initializer for testing
@@ -74,25 +72,34 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
     }
 
     // Internal initializer for testing
-    init(associatedId: String, associatedField: String, apiName: String? = nil) {
-        self.loadedState = .notLoaded(associatedId: associatedId,
+    init(associatedIdentifiers: [String], associatedField: String, apiName: String? = nil) {
+        self.loadedState = .notLoaded(associatedIdentifiers: associatedIdentifiers,
                                       associatedField: associatedField)
         self.apiName = apiName
     }
 
     // MARK: APIs
 
+    public func getState() -> ModelListProviderState<Element> {
+        switch loadedState {
+        case .notLoaded(let associatedIdentifiers, let associatedField):
+            return .notLoaded(associatedIdentifiers: associatedIdentifiers, associatedField: associatedField)
+        case .loaded(let elements, _, _):
+            return .loaded(elements)
+        }
+    }
+
     public func load() -> Result<[Element], CoreError> {
         switch loadedState {
         case .loaded(let elements, _, _):
             return .success(elements)
-        case .notLoaded(let associatedId, let associatedField):
+        case .notLoaded(let associatedIdentifiers, let associatedField):
             let semaphore = DispatchSemaphore(value: 0)
             var loadResult: Result<[Element], CoreError> = .failure(
                 .listOperation("API query failed to complete.",
                                AmplifyErrorMessages.reportBugToAWS(),
                                nil))
-            load(associatedId: associatedId, associatedField: associatedField) { result in
+            load(associatedIdentifiers: associatedIdentifiers, associatedField: associatedField) { result in
                 defer {
                     semaphore.signal()
                 }
@@ -113,17 +120,32 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
         switch loadedState {
         case .loaded(let elements, _, _):
             completion(.success(elements))
-        case .notLoaded(let associatedId, let associatedField):
-            load(associatedId: associatedId, associatedField: associatedField, completion: completion)
+        case .notLoaded(let associatedIdentifiers, let associatedField):
+            load(associatedIdentifiers: associatedIdentifiers, associatedField: associatedField, completion: completion)
         }
     }
 
     //// Internal `load` to perform the retrieval of the first page and storing it in memory
-    func load(associatedId: String,
+    func load(associatedIdentifiers: [String],
               associatedField: String,
               completion: @escaping (Result<[Element], CoreError>) -> Void ) {
-        let predicate: QueryPredicate = field(associatedField) == associatedId
-        let filter = predicate.graphQLFilter(for: Element.schema)
+        let filter: GraphQLFilter
+        if associatedIdentifiers.count == 1, let associatedId = associatedIdentifiers.first {
+            let predicate: QueryPredicate = field(associatedField) == associatedId
+            filter = predicate.graphQLFilter(for: Element.schema)
+        } else {
+            var queryPredicates: [QueryPredicateOperation] = []
+            let columnNames = columnNames(field: associatedField, Element.schema)
+
+            let predicateValues = zip(columnNames, associatedIdentifiers)
+            for (identifierName, identifierValue) in predicateValues {
+                queryPredicates.append(QueryPredicateOperation(field: identifierName,
+                                                               operator: .equals(identifierValue)))
+            }
+            let groupedQueryPredicates = QueryPredicateGroup(type: .and, predicates: queryPredicates)
+            filter = groupedQueryPredicates.graphQLFilter(for: Element.schema)
+        }
+
         let request = GraphQLRequest<JSONValue>.listQuery(responseType: JSONValue.self,
                                                           modelSchema: Element.schema,
                                                           filter: filter,
@@ -221,4 +243,47 @@ public class AppSyncListProvider<Element: Model>: ModelListProvider {
             }
         }
     }
-}
+
+    public func encode(to encoder: Encoder) throws {
+            switch loadedState {
+            case .notLoaded(let associatedIdentifiers, let associatedField):
+                fatalError("To be implemented")
+//                let metadata = AppSyncListDecoder.Metadata.init(
+//                    appSyncAssociatedIdentifiers: associatedIdentifiers,
+//                    appSyncAssociatedField: associatedField,
+//                    apiName: apiName)
+//                var container = encoder.singleValueContainer()
+//                try container.encode(metadata)
+            case .loaded(let elements, _, _):
+                // This does not encode the `nextToken` or `filter`, which means the data is essentially dropped.
+                // If the encoded list is later decoded, the existing `elements` will be available but will be missing
+                // the metadata to reflect whether there's a next page or not. Encoding the metadata is rather difficult
+                // with the filter being `Any` type and is not a call pattern that is recommended/supported. The extent
+                // of this supported flow is to allow encoding and decoding of the `elements`. To get the
+                // latest data, make the call to your data source directly through **Amplify.API**.
+                try elements.encode(to: encoder)
+            }
+        }
+
+        // MARK: - Helpers
+        /// Retrieve the column names for the specified field `field` for this schema.
+        func columnNames(field: String, _ modelSchema: ModelSchema) -> [String] {
+            guard let modelField = modelSchema.field(withName: field) else {
+                return [field]
+            }
+            let defaultFieldName = modelSchema.name.camelCased() + field.pascalCased() + "Id"
+            switch modelField.association {
+            case .belongsTo(_, let targetNames), .hasOne(_, let targetNames):
+                guard !targetNames.isEmpty else {
+                    return [defaultFieldName]
+
+                }
+                return targetNames
+            default:
+                return [field]
+            }
+        }
+
+    }
+
+    extension AppSyncListProvider: DefaultLogger { }

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListDecoderTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListDecoderTests.swift
@@ -99,11 +99,11 @@ class AppSyncListDecoderTests: XCTestCase {
             XCTFail("Could get AppSyncListProvider")
             return
         }
-        guard case .notLoaded(let associatedId, let associatedField) = provider.loadedState else {
+        guard case .notLoaded(let associatedIds, let associatedField) = provider.loadedState else {
             XCTFail("Should be in not loaded state")
             return
         }
-        XCTAssertEqual(associatedId, "postId")
+        XCTAssertEqual(associatedIds, ["postId"])
         XCTAssertEqual(associatedField, "post")
     }
 

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListProviderPaginationTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListProviderPaginationTests.swift
@@ -159,7 +159,7 @@ extension AppSyncListProviderTests {
         wait(for: [getNextPageComplete], timeout: 1)
     }
 
-    func testNotLoadedStateGetNextPageFailure() {
+    func testNotLoadedStateGetNextPageFailure() throws {
         let modelMetadata = AppSyncModelMetadata(appSyncAssociatedId: "postId",
                                                  appSyncAssociatedField: "post",
                                                  apiName: "apiName")

--- a/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListProviderTests.swift
+++ b/AmplifyPlugins/API/AWSAPICategoryPluginTests/Core/AppSyncListProviderTests.swift
@@ -98,11 +98,11 @@ class AppSyncListProviderTests: XCTestCase {
                                                  appSyncAssociatedField: "post",
                                                  apiName: "apiName")
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
-        guard case .notLoaded(let associatedId, let associatedField) = provider.loadedState else {
+        guard case .notLoaded(let associatedIds, let associatedField) = provider.loadedState else {
             XCTFail("Should be in not loaded state")
             return
         }
-        XCTAssertEqual(associatedId, "postId")
+        XCTAssertEqual(associatedIds, ["postId"])
         XCTAssertEqual(associatedField, "post")
     }
 

--- a/AmplifyPlugins/API/Podfile.lock
+++ b/AmplifyPlugins/API/Podfile.lock
@@ -21,19 +21,19 @@ PODS:
     - CwlPreconditionTesting (~> 2.0)
   - AppSyncRealTimeClient (3.1.0):
     - Starscream (~> 4.0.4)
-  - AWSAuthCore (2.31.0):
-    - AWSCore (= 2.31.0)
-  - AWSCognitoIdentityProvider (2.31.0):
-    - AWSCognitoIdentityProviderASF (= 2.31.0)
-    - AWSCore (= 2.31.0)
-  - AWSCognitoIdentityProviderASF (2.31.0):
-    - AWSCore (= 2.31.0)
-  - AWSCore (2.31.0)
-  - AWSMobileClient (2.31.0):
-    - AWSAuthCore (= 2.31.0)
-    - AWSCognitoIdentityProvider (= 2.31.0)
-    - AWSCognitoIdentityProviderASF (= 2.31.0)
-    - AWSCore (= 2.31.0)
+  - AWSAuthCore (2.31.1):
+    - AWSCore (= 2.31.1)
+  - AWSCognitoIdentityProvider (2.31.1):
+    - AWSCognitoIdentityProviderASF (= 2.31.1)
+    - AWSCore (= 2.31.1)
+  - AWSCognitoIdentityProviderASF (2.31.1):
+    - AWSCore (= 2.31.1)
+  - AWSCore (2.31.1)
+  - AWSMobileClient (2.31.1):
+    - AWSAuthCore (= 2.31.1)
+    - AWSCognitoIdentityProvider (= 2.31.1)
+    - AWSCognitoIdentityProviderASF (= 2.31.1)
+    - AWSCore (= 2.31.1)
   - AWSPluginsCore (1.30.0):
     - Amplify (= 1.30.0)
     - AWSCore (~> 2.31.0)
@@ -100,11 +100,11 @@ SPEC CHECKSUMS:
   AmplifyPlugins: 93ac2c18c87b4f1dc408eb9492d1aa3bfdd23012
   AmplifyTestCommon: 02ad3e6e87abecac479ae7142ecb96b9bf0aaac2
   AppSyncRealTimeClient: 49901c6f21e541bec09281854c5695a6c1309bf7
-  AWSAuthCore: 889db67d5c6a5325c4314ad7f689ccc3841da530
-  AWSCognitoIdentityProvider: 41f2f1c2bd0ca188ec6869003bbd1fa4a6bfb0c7
-  AWSCognitoIdentityProviderASF: e48fb68d9aa42f9bc5f095c6db0e1d519b006ce1
-  AWSCore: 7db143a63c31d330c58b390d3e1bb0b795ee213d
-  AWSMobileClient: 4c1db471a0473a1f0c3559ffd25100479c402780
+  AWSAuthCore: efed26af355360a00b84fc9251ce3e3beeecac92
+  AWSCognitoIdentityProvider: 63dda7bea693a2b0e76229c40a82a8a4199e4487
+  AWSCognitoIdentityProviderASF: a7323a914ab660c625b71a05d338230dcfee3d2e
+  AWSCore: 3fa19af1810d4430cfb735cc5323b68d8674fb5b
+  AWSMobileClient: 5605350f3e9c0ee6d1f2b2a1a0b8aa2954aef6cb
   AWSPluginsCore: 9f6380f0e88e97c7350b8993cad23c480f18e4c4
   CwlCatchException: 86760545af2a490a23e964d76d7c77442dbce79b
   CwlCatchExceptionSupport: a004322095d7101b945442c86adc7cec0650f676
@@ -117,4 +117,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: f542a7a3bf7a7e882e6ea4799c9722d5b6495208
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.0

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Core/DataStoreListDecoder.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Core/DataStoreListDecoder.swift
@@ -53,7 +53,7 @@ public struct DataStoreListDecoder: ModelListDecoder {
         case .object(let associationData):
             if case let .string(associatedId) = associationData["associatedId"],
                case let .string(associatedField) = associationData["associatedField"] {
-                return DataStoreListProvider<ModelType>(associatedIdentifiers: [associatedId],
+                return DataStoreListProvider<ModelType>(associatedId: associatedId,
                                                         associatedField: associatedField)
             }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Core/DataStoreListDecoder.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Core/DataStoreListDecoder.swift
@@ -53,7 +53,7 @@ public struct DataStoreListDecoder: ModelListDecoder {
         case .object(let associationData):
             if case let .string(associatedId) = associationData["associatedId"],
                case let .string(associatedField) = associationData["associatedField"] {
-                return DataStoreListProvider<ModelType>(associatedId: associatedId,
+                return DataStoreListProvider<ModelType>(associatedIdentifiers: [associatedId],
                                                         associatedField: associatedField)
             }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Core/DataStoreListProvider.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Core/DataStoreListProvider.swift
@@ -18,29 +18,26 @@ import Combine
 /// of the associated `id` and `field` and fetches the associated data on demand.
 public class DataStoreListProvider<Element: Model>: ModelListProvider {
 
-    /// The current state of lazily loaded list
-    enum LoadedState {
-        /// If the list represents an association between two models, the `associatedId` will
-        /// hold the information necessary to query the associated elements (e.g. comments of a post)
-        ///
-        /// The associatedField represents the field to which the owner of the `List` is linked to.
-        /// For example, if `Post.comments` is associated with `Comment.post` the `List<Comment>`
-        /// of `Post` will have a reference to the `post` field in `Comment`.
-        case notLoaded(associatedId: Model.Identifier, associatedField: String)
+    var loadedState: ModelListProviderState<Element>
 
-        case loaded([Element])
-    }
-
-    var loadedState: LoadedState
-
-    init(associatedId: Model.Identifier,
+    init(associatedIdentifiers: [String],
          associatedField: String) {
-        self.loadedState = .notLoaded(associatedId: associatedId,
-                                      associatedField: associatedField)
+        self.loadedState = .notLoaded(
+            associatedIdentifiers: associatedIdentifiers,
+            associatedField: associatedField)
     }
 
     init(_ elements: [Element]) {
         self.loadedState = .loaded(elements)
+    }
+
+    public func getState() -> ModelListProviderState<Element> {
+        switch loadedState {
+        case .notLoaded(let associatedIdentifiers, let associatedField):
+            return .notLoaded(associatedIdentifiers: associatedIdentifiers, associatedField: associatedField)
+        case .loaded(let elements):
+            return .loaded(elements)
+        }
     }
 
     public func load() -> Result<[Element], CoreError> {
@@ -70,7 +67,14 @@ public class DataStoreListProvider<Element: Model>: ModelListProvider {
         switch loadedState {
         case .loaded(let elements):
             completion(.success(elements))
-        case .notLoaded(let associatedId, let associatedField):
+        case .notLoaded(let associatedIdentifiers, let associatedField):
+            guard let associatedId = associatedIdentifiers.first else {
+                let error = CoreError.listOperation("Unexpected identifiers.",
+                                                    "See underlying DataStoreError for more details.", nil)
+                completion(.failure(error))
+                return
+            }
+            log.verbose("Loading List of \(Element.schema.name) by \(associatedField) == \(associatedId) ")
             let predicate: QueryPredicate = field(associatedField) == associatedId
             Amplify.DataStore.query(Element.self, where: predicate) {
                 switch $0 {
@@ -96,4 +100,10 @@ public class DataStoreListProvider<Element: Model>: ModelListProvider {
                                                        "Only call `getNextPage()` when `hasNextPage()` is true.",
                                                        nil)))
     }
+
+    public func encode(to encoder: Encoder) throws {
+        fatalError("To be implemented")
+    }
 }
+
+extension DataStoreListProvider: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Core/DataStoreListProvider.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Core/DataStoreListProvider.swift
@@ -18,30 +18,30 @@ import Combine
 /// of the associated `id` and `field` and fetches the associated data on demand.
 public class DataStoreListProvider<Element: Model>: ModelListProvider {
 
-    var loadedState: ModelListProviderState<Element>
+    /// The current state of lazily loaded list
+    enum LoadedState {
+        /// If the list represents an association between two models, the `associatedId` will
+        /// hold the information necessary to query the associated elements (e.g. comments of a post)
+        ///
+        /// The associatedField represents the field to which the owner of the `List` is linked to.
+        /// For example, if `Post.comments` is associated with `Comment.post` the `List<Comment>`
+        /// of `Post` will have a reference to the `post` field in `Comment`.
+        case notLoaded(associatedId: Model.Identifier, associatedField: String)
 
-    init(associatedIdentifiers: [String],
+        case loaded([Element])
+    }
+
+    var loadedState: LoadedState
+
+    init(associatedId: Model.Identifier,
          associatedField: String) {
-        self.loadedState = .notLoaded(
-            associatedIdentifiers: associatedIdentifiers,
-            associatedField: associatedField)
+        self.loadedState = .notLoaded(associatedId: associatedId,
+                                      associatedField: associatedField)
     }
 
     init(_ elements: [Element]) {
         self.loadedState = .loaded(elements)
     }
-
-    public func getState() -> ModelListProviderState<Element> {
-        switch loadedState {
-        case .notLoaded(let associatedIdentifiers, let associatedField):
-            return .notLoaded(
-                associatedIdentifiers: associatedIdentifiers,
-                associatedField: associatedField)
-        case .loaded(let elements):
-            return .loaded(elements)
-        }
-    }
-
 
     public func load() -> Result<[Element], CoreError> {
         let semaphore = DispatchSemaphore(value: 0)
@@ -70,15 +70,7 @@ public class DataStoreListProvider<Element: Model>: ModelListProvider {
         switch loadedState {
         case .loaded(let elements):
             completion(.success(elements))
-        case .notLoaded(let associatedIdentifiers, let associatedField):
-            guard let associatedId = associatedIdentifiers.first else {
-                let error = CoreError.listOperation(
-                    "Unexpected identifiers.",
-                    "See underlying DataStoreError for more details.", nil)
-                completion(.failure(error))
-                return
-            }
-            log.verbose("Loading List of \(Element.schema.name) by \(associatedField) == \(associatedId) ")
+        case .notLoaded(let associatedId, let associatedField):
             let predicate: QueryPredicate = field(associatedField) == associatedId
             Amplify.DataStore.query(Element.self, where: predicate) {
                 switch $0 {
@@ -87,10 +79,9 @@ public class DataStoreListProvider<Element: Model>: ModelListProvider {
                     completion(.success(elements))
                 case .failure(let error):
                     Amplify.DataStore.log.error(error: error)
-                    completion(.failure(CoreError.listOperation(
-                        "Failed to Query DataStore.",
-                        "See underlying DataStoreError for more details.",
-                        error)))
+                    completion(.failure(CoreError.listOperation("Failed to Query DataStore.",
+                                                                "See underlying DataStoreError for more details.",
+                                                                error)))
                 }
             }
         }
@@ -105,10 +96,4 @@ public class DataStoreListProvider<Element: Model>: ModelListProvider {
                                                        "Only call `getNextPage()` when `hasNextPage()` is true.",
                                                        nil)))
     }
-
-    public func encode(to encoder: Encoder) throws {
-        fatalError("To be implemented")
-    }
 }
-
-extension DataStoreListProvider: DefaultLogger { }

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/DataStoreListDecoderTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/DataStoreListDecoderTests.swift
@@ -73,11 +73,11 @@ class DataStoreListDecoderTests: BaseDataStoreTests {
             XCTFail("Could get AppSyncListProvider")
             return
         }
-        guard case .notLoaded(let associatedId, let associatedField) = provider.loadedState else {
+        guard case .notLoaded(let associatedIds, let associatedField) = provider.loadedState else {
             XCTFail("Should be in loaded state")
             return
         }
-        XCTAssertEqual(associatedId, "postId")
+        XCTAssertEqual(associatedIds, ["postId"])
         XCTAssertEqual(associatedField, "post")
     }
 

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/DataStoreListProviderFunctionalTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/DataStoreListProviderFunctionalTests.swift
@@ -16,7 +16,7 @@ class DataStoreListProviderFunctionalTests: BaseDataStoreTests {
 
     func testDataStoreListProviderWithAssociationDataShouldLoad() {
         let postId = preparePost4DataForTest()
-        let provider = DataStoreListProvider<Comment4>(associatedId: postId, associatedField: "post")
+        let provider = DataStoreListProvider<Comment4>(associatedIdentifiers: [postId], associatedField: "post")
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
             return
@@ -35,7 +35,7 @@ class DataStoreListProviderFunctionalTests: BaseDataStoreTests {
 
     func testDataStoreListProviderWithAssociationDataShouldLoadWithCompletion() {
         let postId = preparePost4DataForTest()
-        let provider = DataStoreListProvider<Comment4>(associatedId: postId, associatedField: "post")
+        let provider = DataStoreListProvider<Comment4>(associatedIdentifiers: [postId], associatedField: "post")
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
             return

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/DataStoreListProviderTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Core/DataStoreListProviderTests.swift
@@ -48,7 +48,7 @@ class DataStoreListProviderTests: XCTestCase {
     }
 
     func testInitWithAssociationDataShouldBeInNotLoadedState() {
-        let provider = DataStoreListProvider<Post4>(associatedId: "id", associatedField: "field")
+        let provider = DataStoreListProvider<Post4>(associatedIdentifiers: ["id"], associatedField: "field")
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
             return
@@ -77,7 +77,7 @@ class DataStoreListProviderTests: XCTestCase {
                                  Comment4(content: "content")])
             }
 
-        let provider = DataStoreListProvider<Comment4>(associatedId: "postId", associatedField: "post")
+        let provider = DataStoreListProvider<Comment4>(associatedIdentifiers: ["postId"], associatedField: "post")
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
             return
@@ -101,7 +101,7 @@ class DataStoreListProviderTests: XCTestCase {
                 return .failure(DataStoreError.internalOperation("", "", nil))
             }
 
-        let provider = DataStoreListProvider<Comment4>(associatedId: "postId", associatedField: "post")
+        let provider = DataStoreListProvider<Comment4>(associatedIdentifiers: ["postId"], associatedField: "post")
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
             return
@@ -137,7 +137,7 @@ class DataStoreListProviderTests: XCTestCase {
                 return .failure(DataStoreError.internalOperation("", "", nil))
             }
 
-        let provider = DataStoreListProvider<Comment4>(associatedId: "postId", associatedField: "post")
+        let provider = DataStoreListProvider<Comment4>(associatedIdentifiers: ["postId"], associatedField: "post")
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
             return

--- a/AmplifyPlugins/DataStore/Podfile.lock
+++ b/AmplifyPlugins/DataStore/Podfile.lock
@@ -25,19 +25,19 @@ PODS:
     - CwlPreconditionTesting (~> 2.0)
   - AppSyncRealTimeClient (3.1.0):
     - Starscream (~> 4.0.4)
-  - AWSAuthCore (2.31.0):
-    - AWSCore (= 2.31.0)
-  - AWSCognitoIdentityProvider (2.31.0):
-    - AWSCognitoIdentityProviderASF (= 2.31.0)
-    - AWSCore (= 2.31.0)
-  - AWSCognitoIdentityProviderASF (2.31.0):
-    - AWSCore (= 2.31.0)
-  - AWSCore (2.31.0)
-  - AWSMobileClient (2.31.0):
-    - AWSAuthCore (= 2.31.0)
-    - AWSCognitoIdentityProvider (= 2.31.0)
-    - AWSCognitoIdentityProviderASF (= 2.31.0)
-    - AWSCore (= 2.31.0)
+  - AWSAuthCore (2.31.1):
+    - AWSCore (= 2.31.1)
+  - AWSCognitoIdentityProvider (2.31.1):
+    - AWSCognitoIdentityProviderASF (= 2.31.1)
+    - AWSCore (= 2.31.1)
+  - AWSCognitoIdentityProviderASF (2.31.1):
+    - AWSCore (= 2.31.1)
+  - AWSCore (2.31.1)
+  - AWSMobileClient (2.31.1):
+    - AWSAuthCore (= 2.31.1)
+    - AWSCognitoIdentityProvider (= 2.31.1)
+    - AWSCognitoIdentityProviderASF (= 2.31.1)
+    - AWSCore (= 2.31.1)
   - AWSPluginsCore (1.30.0):
     - Amplify (= 1.30.0)
     - AWSCore (~> 2.31.0)
@@ -110,11 +110,11 @@ SPEC CHECKSUMS:
   AmplifyPlugins: 93ac2c18c87b4f1dc408eb9492d1aa3bfdd23012
   AmplifyTestCommon: 02ad3e6e87abecac479ae7142ecb96b9bf0aaac2
   AppSyncRealTimeClient: 49901c6f21e541bec09281854c5695a6c1309bf7
-  AWSAuthCore: 889db67d5c6a5325c4314ad7f689ccc3841da530
-  AWSCognitoIdentityProvider: 41f2f1c2bd0ca188ec6869003bbd1fa4a6bfb0c7
-  AWSCognitoIdentityProviderASF: e48fb68d9aa42f9bc5f095c6db0e1d519b006ce1
-  AWSCore: 7db143a63c31d330c58b390d3e1bb0b795ee213d
-  AWSMobileClient: 4c1db471a0473a1f0c3559ffd25100479c402780
+  AWSAuthCore: efed26af355360a00b84fc9251ce3e3beeecac92
+  AWSCognitoIdentityProvider: 63dda7bea693a2b0e76229c40a82a8a4199e4487
+  AWSCognitoIdentityProviderASF: a7323a914ab660c625b71a05d338230dcfee3d2e
+  AWSCore: 3fa19af1810d4430cfb735cc5323b68d8674fb5b
+  AWSMobileClient: 5605350f3e9c0ee6d1f2b2a1a0b8aa2954aef6cb
   AWSPluginsCore: 9f6380f0e88e97c7350b8993cad23c480f18e4c4
   CwlCatchException: 86760545af2a490a23e964d76d7c77442dbce79b
   CwlCatchExceptionSupport: a004322095d7101b945442c86adc7cec0650f676

--- a/AmplifyTests/CategoryTests/DataStore/Model/ListTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/Model/ListTests.swift
@@ -45,6 +45,10 @@ class ListTests: XCTestCase {
     }
 
     class MockListProvider<Element: Model>: ModelListProvider {
+        func encode(to encoder: Encoder) throws {
+            try elements.encode(to: encoder)
+        }
+
         let elements: [Element]
         var error: CoreError?
         var nextPage: List<Element>?

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/aws-amplify/aws-sdk-ios-spm.git",
         "state": {
           "branch": null,
-          "revision": "86213ad94e6d0c0658197d29cdb5b60b1bda311e",
-          "version": "2.31.0"
+          "revision": "2879d48d55104753c0635d4e5f29e8ae1c773742",
+          "version": "2.31.1"
         }
       },
       {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AWSCore (2.31.0)
+  - AWSCore (2.31.1)
   - CwlCatchException (2.1.1):
     - CwlCatchExceptionSupport (~> 2.1.1)
   - CwlCatchExceptionSupport (2.1.1)
@@ -40,7 +40,7 @@ CHECKOUT OPTIONS:
     :tag: 2.1.0
 
 SPEC CHECKSUMS:
-  AWSCore: 7db143a63c31d330c58b390d3e1bb0b795ee213d
+  AWSCore: 3fa19af1810d4430cfb735cc5323b68d8674fb5b
   CwlCatchException: 86760545af2a490a23e964d76d7c77442dbce79b
   CwlCatchExceptionSupport: a004322095d7101b945442c86adc7cec0650f676
   CwlMachBadInstructionHandler: aa1fe9f2d08b29507c150d099434b2890247e7f8


### PR DESCRIPTION
## Description
- Picks Lazy reference models from the PR https://github.com/aws-amplify/amplify-swift/pull/2711/, originally authored by @lawmicha 
- These changes are similar to the implementation that we have in v2 of datastore https://github.com/aws-amplify/amplify-swift/pull/2583

### Changes from v2
- Adds `@available(iOS 13.0.0, *)` for `async` functions

---

This PR introduces the LazyReference type. The post reference in the Comment type is replaced with an instance of LazyReference<Post>.

Before:

```
struct Comment: Model {
  let id: String
  var content: String?
  var post: Post
}
```

After:
```
struct Comment: Model {
  let _post: LazyReference<Post>
  public let post: Post { 
     get async throws {
         try await _post.require()
     }
  }
}
```

The computed property `post` is backed by the internal `_post` of type `LazyReference`. The computed property allows the developer to make an async call to lazy load the post. With the computed property and internal property, the developer call pattern becomes:

```
let post = try await comment.post
```

When the association is required, the underlying API used is `_post.require()`, if the association is optional, then `_post.get()`.` _post.require()` will throw if the model cannot be loaded, while get() will return nil. The LazyReference type allows the data payloads to include all fields (eager loaded) or include only the primary keys of post (lazy loaded), used for decoding to the type into one of the two states.

When a LazyReference instance is created during data decoding, a model provider is created using the registered plugin's model provider registry.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
