### PR TITLE
chore(storage): Renamed AWSS3StorageServiceBehaviour to AWSS3StorageServiceBehavior

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+Configure.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+Configure.swift
@@ -67,7 +67,7 @@ extension AWSS3StoragePlugin {
     ///   - authService: The authentication service object.
     ///   - defaultAccessLevel: The access level to be used for all API calls by default.
     ///   - queue: The queue which operations are stored and dispatched for asychronous processing.
-    func configure(storageService: AWSS3StorageServiceBehaviour,
+    func configure(storageService: AWSS3StorageServiceBehavior,
                    authService: AWSAuthServiceBehavior,
                    defaultAccessLevel: StorageAccessLevel,
                    queue: OperationQueue = OperationQueue()) {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
@@ -13,7 +13,7 @@ import AWSPluginsCore
 final public class AWSS3StoragePlugin: StorageCategoryPlugin {
 
     /// An instance of the S3 storage service.
-    var storageService: AWSS3StorageServiceBehaviour!
+    var storageService: AWSS3StorageServiceBehavior!
 
     /// An instance of the authentication service.
     var authService: AWSAuthServiceBehavior!

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadDataOperation.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadDataOperation.swift
@@ -22,7 +22,7 @@ class AWSS3StorageDownloadDataOperation: AmplifyInProcessReportingOperation<
 >, StorageDownloadDataOperation {
 
     let storageConfiguration: AWSS3StoragePluginConfiguration
-    let storageService: AWSS3StorageServiceBehaviour
+    let storageService: AWSS3StorageServiceBehavior
     let authService: AWSAuthServiceBehavior
 
     var storageTaskReference: StorageTaskReference?
@@ -32,7 +32,7 @@ class AWSS3StorageDownloadDataOperation: AmplifyInProcessReportingOperation<
 
     init(_ request: StorageDownloadDataRequest,
          storageConfiguration: AWSS3StoragePluginConfiguration,
-         storageService: AWSS3StorageServiceBehaviour,
+         storageService: AWSS3StorageServiceBehavior,
          authService: AWSAuthServiceBehavior,
          progressListener: InProcessListener? = nil,
          resultListener: ResultListener? = nil) {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadFileOperation.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageDownloadFileOperation.swift
@@ -25,7 +25,7 @@ class AWSS3StorageDownloadFileOperation: AmplifyInProcessReportingOperation<
 >, StorageDownloadFileOperation {
 
     let storageConfiguration: AWSS3StoragePluginConfiguration
-    let storageService: AWSS3StorageServiceBehaviour
+    let storageService: AWSS3StorageServiceBehavior
     let authService: AWSAuthServiceBehavior
 
     var storageTaskReference: StorageTaskReference?
@@ -35,7 +35,7 @@ class AWSS3StorageDownloadFileOperation: AmplifyInProcessReportingOperation<
 
     init(_ request: StorageDownloadFileRequest,
          storageConfiguration: AWSS3StoragePluginConfiguration,
-         storageService: AWSS3StorageServiceBehaviour,
+         storageService: AWSS3StorageServiceBehavior,
          authService: AWSAuthServiceBehavior,
          progressListener: InProcessListener? = nil,
          resultListener: ResultListener? = nil) {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageRemoveOperation.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageRemoveOperation.swift
@@ -21,12 +21,12 @@ class AWSS3StorageRemoveOperation: AmplifyOperation<
 >, StorageRemoveOperation {
 
     let storageConfiguration: AWSS3StoragePluginConfiguration
-    let storageService: AWSS3StorageServiceBehaviour
+    let storageService: AWSS3StorageServiceBehavior
     let authService: AWSAuthServiceBehavior
 
     init(_ request: StorageRemoveRequest,
          storageConfiguration: AWSS3StoragePluginConfiguration,
-         storageService: AWSS3StorageServiceBehaviour,
+         storageService: AWSS3StorageServiceBehavior,
          authService: AWSAuthServiceBehavior,
          resultListener: ResultListener? = nil) {
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadDataOperation.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadDataOperation.swift
@@ -22,7 +22,7 @@ class AWSS3StorageUploadDataOperation: AmplifyInProcessReportingOperation<
 >, StorageUploadDataOperation {
 
     let storageConfiguration: AWSS3StoragePluginConfiguration
-    let storageService: AWSS3StorageServiceBehaviour
+    let storageService: AWSS3StorageServiceBehavior
     let authService: AWSAuthServiceBehavior
 
     var storageTaskReference: StorageTaskReference?
@@ -32,7 +32,7 @@ class AWSS3StorageUploadDataOperation: AmplifyInProcessReportingOperation<
 
     init(_ request: StorageUploadDataRequest,
          storageConfiguration: AWSS3StoragePluginConfiguration,
-         storageService: AWSS3StorageServiceBehaviour,
+         storageService: AWSS3StorageServiceBehavior,
          authService: AWSAuthServiceBehavior,
          progressListener: InProcessListener? = nil,
          resultListener: ResultListener? = nil) {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadFileOperation.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadFileOperation.swift
@@ -22,7 +22,7 @@ class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation<
 >, StorageUploadFileOperation {
 
     let storageConfiguration: AWSS3StoragePluginConfiguration
-    let storageService: AWSS3StorageServiceBehaviour
+    let storageService: AWSS3StorageServiceBehavior
     let authService: AWSAuthServiceBehavior
 
     var storageTaskReference: StorageTaskReference?
@@ -32,7 +32,7 @@ class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation<
 
     init(_ request: StorageUploadFileRequest,
          storageConfiguration: AWSS3StoragePluginConfiguration,
-         storageService: AWSS3StorageServiceBehaviour,
+         storageService: AWSS3StorageServiceBehavior,
          authService: AWSAuthServiceBehavior,
          progressListener: InProcessListener? = nil,
          resultListener: ResultListener? = nil) {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
@@ -12,7 +12,7 @@ import Amplify
 import AWSPluginsCore
 
 /// - Tag: AWSS3StorageService
-class AWSS3StorageService: AWSS3StorageServiceBehaviour, StorageServiceProxy {
+class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy {
 
     // resettable values
     private var authService: AWSAuthServiceBehavior?
@@ -152,9 +152,9 @@ class AWSS3StorageService: AWSS3StorageServiceBehaviour, StorageServiceProxy {
         self.urlSession = URLSession(configuration: sessionConfiguration, delegate: delegate, delegateQueue: delegateQueue)
     }
 
-    func attachEventHandlers(onUpload: AWSS3StorageServiceBehaviour.StorageServiceUploadEventHandler? = nil,
-                             onDownload: AWSS3StorageServiceBehaviour.StorageServiceDownloadEventHandler? = nil,
-                             onMultipartUpload: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler? = nil) {
+    func attachEventHandlers(onUpload: AWSS3StorageServiceBehavior.StorageServiceUploadEventHandler? = nil,
+                             onDownload: AWSS3StorageServiceBehavior.StorageServiceDownloadEventHandler? = nil,
+                             onMultipartUpload: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler? = nil) {
         storageTransferDatabase.attachEventHandlers(onUpload: onUpload, onDownload: onDownload, onMultipartUpload: onMultipartUpload)
     }
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageServiceBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageServiceBehavior.swift
@@ -9,7 +9,7 @@ import Foundation
 import Amplify
 import AWSS3
 
-protocol AWSS3StorageServiceBehaviour {
+protocol AWSS3StorageServiceBehavior {
     typealias StorageServiceDownloadEventHandler = (StorageServiceDownloadEvent) -> Void
     typealias StorageServiceDownloadEvent =
         StorageEvent<StorageTaskReference, Progress, Data?, StorageError>

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/DefaultStorageTransferDatabase.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/DefaultStorageTransferDatabase.swift
@@ -35,9 +35,9 @@ class DefaultStorageTransferDatabase {
         tasks.values.count
     }
 
-    private var uploadEventHandler: AWSS3StorageServiceBehaviour.StorageServiceUploadEventHandler?
-    private var downloadEventHandler: AWSS3StorageServiceBehaviour.StorageServiceDownloadEventHandler?
-    private var multipartUploadEventHandler: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler?
+    private var uploadEventHandler: AWSS3StorageServiceBehavior.StorageServiceUploadEventHandler?
+    private var downloadEventHandler: AWSS3StorageServiceBehavior.StorageServiceDownloadEventHandler?
+    private var multipartUploadEventHandler: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler?
 
     static let `default`: StorageTransferDatabase = {
         DefaultStorageTransferDatabase()
@@ -227,15 +227,15 @@ class DefaultStorageTransferDatabase {
         try load(fileURL: fileURL, type: StoragePersistableTransferTask.self)
     }
 
-    private func handleUploadEvent(event: AWSS3StorageServiceBehaviour.StorageServiceUploadEvent) {
+    private func handleUploadEvent(event: AWSS3StorageServiceBehavior.StorageServiceUploadEvent) {
         uploadEventHandler?(event)
     }
 
-    private func handleDownloadEvent(event: AWSS3StorageServiceBehaviour.StorageServiceDownloadEvent) {
+    private func handleDownloadEvent(event: AWSS3StorageServiceBehavior.StorageServiceDownloadEvent) {
         downloadEventHandler?(event)
     }
 
-    private func handleMultipartUploadEvent(event: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEvent) {
+    private func handleMultipartUploadEvent(event: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEvent) {
         multipartUploadEventHandler?(event)
     }
 
@@ -341,9 +341,9 @@ extension DefaultStorageTransferDatabase: StorageTransferDatabase {
         return transferType
     }
 
-    func attachEventHandlers(onUpload: AWSS3StorageServiceBehaviour.StorageServiceUploadEventHandler?,
-                             onDownload: AWSS3StorageServiceBehaviour.StorageServiceDownloadEventHandler?,
-                             onMultipartUpload: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler?) {
+    func attachEventHandlers(onUpload: AWSS3StorageServiceBehavior.StorageServiceUploadEventHandler?,
+                             onDownload: AWSS3StorageServiceBehavior.StorageServiceDownloadEventHandler?,
+                             onMultipartUpload: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler?) {
         queue.async { [weak self] in
             guard let self = self else { fatalError("self cannot be weak") }
             self.uploadEventHandler = onUpload

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadSession.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadSession.swift
@@ -40,7 +40,7 @@ class StorageMultipartUploadSession {
     private let id = UUID()
     private var multipartUpload: StorageMultipartUpload
     private let client: StorageMultipartUploadClient
-    private let onEvent: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler
+    private let onEvent: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler
 
     private let transferTask: StorageTransferTask
 
@@ -57,7 +57,7 @@ class StorageMultipartUploadSession {
          key: String,
          contentType: String? = nil,
          requestHeaders: RequestHeaders? = nil,
-         onEvent: @escaping AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler,
+         onEvent: @escaping AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler,
          behavior: StorageMultipartUploadBehavior = .progressive,
          fileSystem: FileSystem = .default,
          logger: Logger = storageLogger) {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageTransferDatabase.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageTransferDatabase.swift
@@ -29,9 +29,9 @@ protocol StorageTransferDatabase {
 
     func recover(urlSession: StorageURLSession, completionHandler: @escaping (Result<StorageTransferTaskPairs, Error>) -> Void)
 
-    func attachEventHandlers(onUpload: AWSS3StorageServiceBehaviour.StorageServiceUploadEventHandler?,
-                             onDownload: AWSS3StorageServiceBehaviour.StorageServiceDownloadEventHandler?,
-                             onMultipartUpload: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler?)
+    func attachEventHandlers(onUpload: AWSS3StorageServiceBehavior.StorageServiceUploadEventHandler?,
+                             onDownload: AWSS3StorageServiceBehavior.StorageServiceDownloadEventHandler?,
+                             onMultipartUpload: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler?)
 }
 
 extension StorageTransferDatabase {
@@ -39,9 +39,9 @@ extension StorageTransferDatabase {
         prepareForBackground(completion: nil)
     }
 
-    func attachEventHandlers(onUpload: AWSS3StorageServiceBehaviour.StorageServiceUploadEventHandler? = nil,
-                             onDownload: AWSS3StorageServiceBehaviour.StorageServiceDownloadEventHandler? = nil,
-                             onMultipartUpload: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler? = nil ) {
+    func attachEventHandlers(onUpload: AWSS3StorageServiceBehavior.StorageServiceUploadEventHandler? = nil,
+                             onDownload: AWSS3StorageServiceBehavior.StorageServiceDownloadEventHandler? = nil,
+                             onMultipartUpload: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler? = nil ) {
         attachEventHandlers(onUpload: onUpload, onDownload: onDownload, onMultipartUpload: onMultipartUpload)
     }
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageTransferType.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageTransferType.swift
@@ -21,13 +21,13 @@ enum StorageTransferType {
         case remove = 6
     }
 
-    case getPreSignedURL(onEvent: AWSS3StorageServiceBehaviour.StorageServiceGetPreSignedURLEventHandler)
-    case download(onEvent: AWSS3StorageServiceBehaviour.StorageServiceDownloadEventHandler)
-    case upload(onEvent: AWSS3StorageServiceBehaviour.StorageServiceUploadEventHandler)
-    case multiPartUpload(onEvent: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler)
+    case getPreSignedURL(onEvent: AWSS3StorageServiceBehavior.StorageServiceGetPreSignedURLEventHandler)
+    case download(onEvent: AWSS3StorageServiceBehavior.StorageServiceDownloadEventHandler)
+    case upload(onEvent: AWSS3StorageServiceBehavior.StorageServiceUploadEventHandler)
+    case multiPartUpload(onEvent: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler)
     case multiPartUploadPart(uploadId: UploadID, partNumber: PartNumber)
-    case list(onEvent: AWSS3StorageServiceBehaviour.StorageServiceListEventHandler)
-    case remove(onEvent: AWSS3StorageServiceBehaviour.StorageServiceDeleteEventHandler)
+    case list(onEvent: AWSS3StorageServiceBehavior.StorageServiceListEventHandler)
+    case remove(onEvent: AWSS3StorageServiceBehavior.StorageServiceDeleteEventHandler)
 
     var name: String {
         switch self {
@@ -151,11 +151,11 @@ enum StorageTransferType {
             return result
         }
 
-        private static var defaultGetPreSignedURLEvent: AWSS3StorageServiceBehaviour.StorageServiceGetPreSignedURLEventHandler = { _ in  }
-        private static var defaultDownloadEvent: AWSS3StorageServiceBehaviour.StorageServiceDownloadEventHandler = { _ in  }
-        private static var defaultUploadEvent: AWSS3StorageServiceBehaviour.StorageServiceUploadEventHandler = { _ in }
-        private static var defaultMultiPartUploadEvent: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler = { _ in }
-        private static var defaultListEvent: AWSS3StorageServiceBehaviour.StorageServiceListEventHandler = { _ in  }
-        private static var defaultRemoveEvent: AWSS3StorageServiceBehaviour.StorageServiceDeleteEventHandler = { _ in  }
+        private static var defaultGetPreSignedURLEvent: AWSS3StorageServiceBehavior.StorageServiceGetPreSignedURLEventHandler = { _ in  }
+        private static var defaultDownloadEvent: AWSS3StorageServiceBehavior.StorageServiceDownloadEventHandler = { _ in  }
+        private static var defaultUploadEvent: AWSS3StorageServiceBehavior.StorageServiceUploadEventHandler = { _ in }
+        private static var defaultMultiPartUploadEvent: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler = { _ in }
+        private static var defaultListEvent: AWSS3StorageServiceBehavior.StorageServiceListEventHandler = { _ in  }
+        private static var defaultRemoveEvent: AWSS3StorageServiceBehavior.StorageServiceDeleteEventHandler = { _ in  }
     }
 }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockAWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockAWSS3StorageService.swift
@@ -11,7 +11,7 @@ import Amplify
 import AWSS3
 @testable import AWSS3StoragePlugin
 
-public class MockAWSS3StorageService: AWSS3StorageServiceBehaviour {
+public class MockAWSS3StorageService: AWSS3StorageServiceBehavior {
 
     // MARK: method call counts
     var interactions: [String] = []

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/MockStorageTransferDatabase.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/MockStorageTransferDatabase.swift
@@ -16,9 +16,9 @@ class MockStorageTransferDatabase: StorageTransferDatabase {
                                       target: .global())
     private var tasks: [TransferID: StorageTransferTask] = [:]
 
-    private var uploadEventHandler: AWSS3StorageServiceBehaviour.StorageServiceUploadEventHandler?
-    private var downloadEventHandler: AWSS3StorageServiceBehaviour.StorageServiceDownloadEventHandler?
-    private var multipartUploadEventHandler: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler?
+    private var uploadEventHandler: AWSS3StorageServiceBehavior.StorageServiceUploadEventHandler?
+    private var downloadEventHandler: AWSS3StorageServiceBehavior.StorageServiceDownloadEventHandler?
+    private var multipartUploadEventHandler: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler?
 
     func insertTransferRequest(task: StorageTransferTask) {
         dispatchPrecondition(condition: .notOnQueue(queue))
@@ -79,9 +79,9 @@ class MockStorageTransferDatabase: StorageTransferDatabase {
     }
 
     // swiftlint:disable line_length
-    func attachEventHandlers(onUpload: AWSS3StorageServiceBehaviour.StorageServiceUploadEventHandler? = nil,
-                             onDownload: AWSS3StorageServiceBehaviour.StorageServiceDownloadEventHandler? = nil,
-                             onMultipartUpload: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler? = nil) {
+    func attachEventHandlers(onUpload: AWSS3StorageServiceBehavior.StorageServiceUploadEventHandler? = nil,
+                             onDownload: AWSS3StorageServiceBehavior.StorageServiceDownloadEventHandler? = nil,
+                             onMultipartUpload: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler? = nil) {
         queue.async { [weak self] in
             guard let self = self else { fatalError("self cannot be weak") }
             self.uploadEventHandler = onUpload
@@ -91,15 +91,15 @@ class MockStorageTransferDatabase: StorageTransferDatabase {
     }
     // swiftlint:enable line_length
 
-    private func handleUploadEvent(event: AWSS3StorageServiceBehaviour.StorageServiceUploadEvent) {
+    private func handleUploadEvent(event: AWSS3StorageServiceBehavior.StorageServiceUploadEvent) {
         uploadEventHandler?(event)
     }
 
-    private func handleDownloadEvent(event: AWSS3StorageServiceBehaviour.StorageServiceDownloadEvent) {
+    private func handleDownloadEvent(event: AWSS3StorageServiceBehavior.StorageServiceDownloadEvent) {
         downloadEventHandler?(event)
     }
 
-    private func handleMultipartUploadEvent(event: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEvent) {
+    private func handleMultipartUploadEvent(event: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEvent) {
         multipartUploadEventHandler?(event)
     }
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageMultipartUploadSessionTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageMultipartUploadSessionTests.swift
@@ -19,7 +19,7 @@ class StorageMultipartUploadSessionTests: XCTestCase {
     func testSessionCreation() throws {
         let bucket = "my-bucket"
         let key = "key.txt"
-        let onEvent: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler = { event in
+        let onEvent: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler = { event in
             switch event {
             case .initiated:
                 print("Initiated")
@@ -47,7 +47,7 @@ class StorageMultipartUploadSessionTests: XCTestCase {
 
         let bucket = "my-bucket"
         let key = "key.txt"
-        let onEvent: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler = { event in
+        let onEvent: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler = { event in
             switch event {
             case .initiated:
                 print("Initiated")
@@ -86,7 +86,7 @@ class StorageMultipartUploadSessionTests: XCTestCase {
         var closureSession: StorageMultipartUploadSession?
         let bucket = "my-bucket"
         let key = "key.txt"
-        let onEvent: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler = { event in
+        let onEvent: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler = { event in
             switch event {
             case .initiated:
                 print("Initiated")
@@ -135,7 +135,7 @@ class StorageMultipartUploadSessionTests: XCTestCase {
         var pauseCount = 0
         let bucket = "my-bucket"
         let key = "key.txt"
-        let onEvent: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler = { event in
+        let onEvent: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler = { event in
             switch event {
             case .initiated:
                 print("Initiated")
@@ -188,7 +188,7 @@ class StorageMultipartUploadSessionTests: XCTestCase {
         var failCount = 0
         let bucket = "my-bucket"
         let key = "key.txt"
-        let onEvent: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler = { event in
+        let onEvent: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler = { event in
             switch event {
             case .initiated:
                 print("Initiated")
@@ -238,7 +238,7 @@ class StorageMultipartUploadSessionTests: XCTestCase {
         var failCount = 0
         let bucket = "my-bucket"
         let key = "key.txt"
-        let onEvent: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler = { event in
+        let onEvent: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler = { event in
             switch event {
             case .initiated:
                 print("Initiated")

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageTransferDatabaseTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageTransferDatabaseTests.swift
@@ -297,8 +297,8 @@ class StorageTransferDatabaseTests: XCTestCase {
         UUID().uuidString + ".key"
     }
 
-    private var mockDownloadEvent: AWSS3StorageServiceBehaviour.StorageServiceDownloadEventHandler = { _ in  }
-    private var mockUploadEvent: AWSS3StorageServiceBehaviour.StorageServiceUploadEventHandler = { _ in }
-    private var mockMultiPartUploadEvent: AWSS3StorageServiceBehaviour.StorageServiceMultiPartUploadEventHandler = { _ in }
+    private var mockDownloadEvent: AWSS3StorageServiceBehavior.StorageServiceDownloadEventHandler = { _ in  }
+    private var mockUploadEvent: AWSS3StorageServiceBehavior.StorageServiceUploadEventHandler = { _ in }
+    private var mockMultiPartUploadEvent: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler = { _ in }
 
 }


### PR DESCRIPTION
## Description
<!-- Why is this change required? What problem does it solve? -->

In order to conform to our style guide, this PR renames the **internal** protocol `AWSS3StorageServiceBehaviour` to `AWSS3StorageServiceBehavior`

## General Checklist
<!-- Check or cross out if not relevant -->

~~- [ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
~~- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~~
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
