### PR TITLE
chore(storage): Added User-Agent to upload and download URLRequests

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+Configure.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+Configure.swift
@@ -42,7 +42,9 @@ extension AWSS3StoragePlugin {
 
             let storageService = try AWSS3StorageService(authService: authService,
                                                          region: region,
-                                                         bucket: bucket)
+                                                         bucket: bucket,
+                                                         httpClientEngineProxy: self.httpClientEngineProxy)
+            storageService.urlRequestDelegate = self.urlRequestDelegate
 
             configure(storageService: storageService, authService: authService, defaultAccessLevel: defaultAccessLevel)
         } catch let storageError as StorageError {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
@@ -37,6 +37,12 @@ final public class AWSS3StoragePlugin: StorageCategoryPlugin {
     /// The storage plugin configuration
     let storageConfiguration: AWSS3StoragePluginConfiguration
 
+    /// See [HttpClientEngineProxy](x-source-tag://HttpClientEngineProxy)
+    internal var httpClientEngineProxy: HttpClientEngineProxy?
+
+    /// See [URLRequestDelegate](x-source-tag://URLRequestDelegate)
+    internal weak var urlRequestDelegate: URLRequestDelegate?
+
     /// Instantiates an instance of the AWSS3StoragePlugin.
     ///
     /// - Tag: AWSS3StoragePlugin.init

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+DownloadBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+DownloadBehavior.swift
@@ -44,15 +44,12 @@ extension AWSS3StorageService {
         var request = URLRequest(url: preSignedURL)
         request.cachePolicy = .reloadIgnoringLocalCacheData
         request.httpMethod = "GET"
-
-        /*
-         let userAgent = AWSServiceConfiguration.baseUserAgent()
-         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-         */
-
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
         request.setHTTPRequestHeaders(transferTask: transferTask)
 
+        urlRequestDelegate?.willSend(request: request)
         let downloadTask = urlSession.downloadTask(with: request)
+        urlRequestDelegate?.didSend(request: request)
         transferTask.sessionTask = downloadTask
 
         // log task identifier?

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+UploadBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+UploadBehavior.swift
@@ -60,15 +60,13 @@ extension AWSS3StorageService {
         request.networkServiceType = .responsiveData
 
         request.setValue(contentType, forHTTPHeaderField: "Content-Type")
-
-        /*
-        let userAgent = AWSServiceConfiguration.baseUserAgent()
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-         */
 
         request.setHTTPRequestHeaders(transferTask: transferTask)
 
+        urlRequestDelegate?.willSend(request: request)
         let uploadTask = urlSession.uploadTask(with: request, fromFile: fileURL)
+        urlRequestDelegate?.didSend(request: request)
         transferTask.sessionTask = uploadTask
 
         // log task identifier?

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
@@ -102,12 +102,17 @@ class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
             request.httpMethod = "PUT"
             request.networkServiceType = .responsiveData
 
-            /*
-            let userAgent = AWSServiceConfiguration.baseUserAgent().appending(" MultiPart")
+            // Because this request represents an
+            // [UploadPart](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html)
+            // operation, the "MultiPart/UploadPart" suffix is added to the
+            // user agent.
+            let userAgent = serviceProxy.userAgent.appending(" MultiPart/UploadPart")
             request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-             */
 
+            self.serviceProxy?.urlRequestDelegate?.willSend(request: request)
             let uploadTask = serviceProxy.urlSession.uploadTask(with: request, fromFile: partialFileURL)
+            self.serviceProxy?.urlRequestDelegate?.didSend(request: request)
+
             subTask.sessionTask = uploadTask
             subTask.uploadPart = multipartUpload.part(for: partNumber)
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageServiceProxy.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageServiceProxy.swift
@@ -12,6 +12,8 @@ protocol StorageServiceProxy: AnyObject {
     var preSignedURLBuilder: AWSS3PreSignedURLBuilderBehavior! { get }
     var awsS3: AWSS3Behavior! { get }
     var urlSession: URLSession { get }
+    var userAgent: String { get }
+    var urlRequestDelegate: URLRequestDelegate? { get }
 
     func register(task: StorageTransferTask)
     func unregister(task: StorageTransferTask)

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Utils/HttpClientEngineProxy.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Utils/HttpClientEngineProxy.swift
@@ -1,0 +1,31 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import ClientRuntime
+import Foundation
+
+/// Internal protocol that may be to inspect or decorate
+/// [ClientRuntime requests](x-source-tag://SdkHttpRequest).
+///
+/// NOTE: This protocol exists in other categories such as **Auth** and used by higher-level modules via
+/// the `@_spi(InternalAmplifyPluginExtension)`. At the time of this writing, no usage outside
+/// the AWSS3StoragePlugin is necessary so this protocol is not exposed via the SPI.
+///
+/// See:
+/// 
+/// * [URLRequestDelegate](x-source-tag://URLRequestDelegate)
+/// * [CommonRuntime.HttpClientEngine](x-source-tag://HttpClientEngine)
+///
+/// - Tag: HttpClientEngineProxy
+protocol HttpClientEngineProxy: HttpClientEngine {
+
+    /// The actual engine performing the requests. This must be set before the receiver gets its first call to
+    /// `execute(request:)`.
+    ///
+    /// - Tag: HttpClientEngineProxy.target
+    var target: HttpClientEngine? { get set }
+}

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Utils/URLRequestDelegate.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Utils/URLRequestDelegate.swift
@@ -1,0 +1,31 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// Internal protocol that may be to inspect or decorate instances of
+/// [URLRequest](x-source-tag://URLRequest) created through the AWSS3StoragePlugin.
+///
+/// See:
+///
+/// * [HttpClientEngineProxy](x-source-tag://HttpClientEngineProxy)
+///
+/// - Tag: URLRequestDelegate
+protocol URLRequestDelegate: AnyObject {
+
+    /// Called **before** a [NSURLSessionTask](x-source-tag://NSURLSessionTask) for the
+    /// request is created.
+    ///
+    /// - Tag: URLRequestDelegate.willSend
+    func willSend(request: URLRequest)
+
+    /// Called **after** a [NSURLSessionTask](x-source-tag://NSURLSessionTask) for the
+    /// request is created.
+    ///
+    /// - Tag: URLRequestDelegate.didSend
+    func didSend(request: URLRequest)
+}

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginRequestRecorder.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginRequestRecorder.swift
@@ -1,0 +1,36 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AWSS3StoragePlugin
+
+import ClientRuntime
+import Foundation
+
+class AWSS3StoragePluginRequestRecorder {
+    var target: HttpClientEngine? = nil
+    var sdkRequests: [SdkHttpRequest] = []
+    var urlRequests: [URLRequest] = []
+    init() {
+    }
+}
+
+extension AWSS3StoragePluginRequestRecorder: HttpClientEngineProxy {
+    func execute(request: SdkHttpRequest) async throws -> HttpResponse {
+        guard let target = target  else {
+            throw ClientError.unknownError("HttpClientEngine is not set")
+        }
+        sdkRequests.append(request)
+        return try await target.execute(request: request)
+   }
+}
+
+extension AWSS3StoragePluginRequestRecorder: URLRequestDelegate {
+    func willSend(request: URLRequest) {}
+    func didSend(request: URLRequest) {
+        urlRequests.append(request)
+    }
+}

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		0311113528EBED6500D58441 /* Tests.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 0311113428EBED6500D58441 /* Tests.xcconfig */; };
 		031BC3F328EC9B2C0047B2E8 /* AppIcon.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 031BC3F228EC9B2C0047B2E8 /* AppIcon.xcassets */; };
 		56043E9329FC4D33003E3424 /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = D5C0382101A0E23943FDF4CB /* amplifyconfiguration.json */; };
+		562B9AA42A0D703700A96FC6 /* AWSS3StoragePluginRequestRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562B9AA32A0D703700A96FC6 /* AWSS3StoragePluginRequestRecorder.swift */; };
+		562B9AA52A0D734E00A96FC6 /* AWSS3StoragePluginRequestRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562B9AA32A0D703700A96FC6 /* AWSS3StoragePluginRequestRecorder.swift */; };
 		681DFEB228E748270000C36A /* AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEAF28E748270000C36A /* AsyncTesting.swift */; };
 		681DFEB328E748270000C36A /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEB028E748270000C36A /* AsyncExpectation.swift */; };
 		681DFEB428E748270000C36A /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEB128E748270000C36A /* XCTestCase+AsyncTesting.swift */; };
@@ -63,6 +65,7 @@
 		0311113428EBED6500D58441 /* Tests.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Tests.xcconfig; sourceTree = "<group>"; };
 		0311113828EBEEA700D58441 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		031BC3F228EC9B2C0047B2E8 /* AppIcon.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = AppIcon.xcassets; sourceTree = "<group>"; };
+		562B9AA32A0D703700A96FC6 /* AWSS3StoragePluginRequestRecorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSS3StoragePluginRequestRecorder.swift; sourceTree = "<group>"; };
 		681DFEAF28E748270000C36A /* AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncTesting.swift; sourceTree = "<group>"; };
 		681DFEB028E748270000C36A /* AsyncExpectation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncExpectation.swift; sourceTree = "<group>"; };
 		681DFEB128E748270000C36A /* XCTestCase+AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AsyncTesting.swift"; sourceTree = "<group>"; };
@@ -198,6 +201,7 @@
 				684FB07F28BEAF8E00C8A6EB /* AWSS3StoragePluginPrefixKeyResolverTests.swift */,
 				684FB08C28BEAF8E00C8A6EB /* AWSS3StoragePluginProgressTests.swift */,
 				684FB07E28BEAF8E00C8A6EB /* AWSS3StoragePluginTestBase.swift */,
+				562B9AA32A0D703700A96FC6 /* AWSS3StoragePluginRequestRecorder.swift */,
 				684FB08728BEAF8E00C8A6EB /* ResumabilityTests */,
 			);
 			path = AWSS3StoragePluginIntegrationTests;
@@ -425,6 +429,7 @@
 				68828E4528C26D2D006E7C0A /* AWSS3StoragePluginPrefixKeyResolverTests.swift in Sources */,
 				684FB0B328BEB08900C8A6EB /* AWSS3StoragePluginTestBase.swift in Sources */,
 				68828E3F28C1549B006E7C0A /* AWSS3StoragePluginUploadFileResumabilityTests.swift in Sources */,
+				562B9AA42A0D703700A96FC6 /* AWSS3StoragePluginRequestRecorder.swift in Sources */,
 				68828E3E28C1546F006E7C0A /* AWSS3StoragePluginConfigurationTests.swift in Sources */,
 				68828E4728C27745006E7C0A /* AWSS3StoragePluginPutDataResumabilityTests.swift in Sources */,
 				68828E4128C154E5006E7C0A /* AWSS3StoragePluginNegativeTests.swift in Sources */,
@@ -445,6 +450,7 @@
 				97914BA32955798D002000EA /* AsyncTesting.swift in Sources */,
 				97914BA52955798D002000EA /* AsyncExpectation.swift in Sources */,
 				97914BB02955798D002000EA /* XCTestCase+AsyncTesting.swift in Sources */,
+				562B9AA52A0D734E00A96FC6 /* AWSS3StoragePluginRequestRecorder.swift in Sources */,
 				97914BB22955798D002000EA /* TestConfigHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "amplify-swift-utils-notifications",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/aws-amplify/amplify-swift-utils-notifications.git",
+      "state" : {
+        "revision" : "d4fd3c17e8d40efc821f448d3d6cff75b8f3b0dd",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "aws-appsync-realtime-client-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
@@ -14,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift.git",
       "state" : {
-        "revision" : "afe23a2a2f6cf78e6d8803d7c9e0c8e6f50b6915",
-        "version" : "0.4.0"
+        "revision" : "6feec6c3787877807aa9a00fad09591b96752376",
+        "version" : "0.6.1"
       }
     },
     {
@@ -23,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "c54c028cfc3ee70fde8c077547a1a1f6ef1137d9",
-        "version" : "0.6.0"
+        "revision" : "24bae88a2391fe75da8a940a544d1ef6441f5321",
+        "version" : "0.13.0"
       }
     },
     {
@@ -50,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/smithy-swift.git",
       "state" : {
-        "revision" : "f59ed07c29d4e03f91ea8324edf7a2486bd86a9c",
-        "version" : "0.6.0"
+        "revision" : "7b28da158d92cd06a3549140d43b8fbcf64a94a6",
+        "version" : "0.15.0"
       }
     },
     {


### PR DESCRIPTION
## Description
<!-- Why is this change required? What problem does it solve? -->

This PR supersedes https://github.com/aws-amplify/amplify-swift/pull/2363 - it also adds the User-Agent header to upload and download URLRequests but also includes tests to ensure the header is as expected for both corresponding URLRequests and each SDK operation.

## General Checklist
<!-- Check or cross out if not relevant -->

~~- [ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
~~- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~~
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<img width="565" alt="Screenshot 2023-05-11 at 5 16 34 PM" src="https://github.com/aws-amplify/amplify-swift/assets/1117904/686cd1b8-c5ab-448c-9af7-2277c4835f22">
