### PR TITLE
feat(auth): deprecate AWSAuthSignInOptions.validationData

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignInOptions.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/Options/AWSAuthSignInOptions.swift
@@ -11,11 +11,21 @@ public struct AWSAuthSignInOptions {
 
     public let authFlowType: AuthFlowType?
 
-    /// You can pass data to your Lambda function using validation data during sign in
-    public let validationData: [String: String]?
-
     public let metadata: [String: String]?
 
+    public init(
+        metadata: [String: String]? = nil,
+        authFlowType: AuthFlowType? = nil
+    ) {
+        self.metadata = metadata
+        self.authFlowType = authFlowType
+    }
+
+    /// You can pass data to your Lambda function using validation data during sign in
+    @available(*, deprecated, renamed: "metadata")
+    public var validationData: [String: String]?
+
+    @available(*, deprecated, renamed: "init(metadata:authFlowType:)")
     public init(validationData: [String: String]? = nil,
                 metadata: [String: String]? = nil,
                 authFlowType: AuthFlowType? = nil) {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift
@@ -165,7 +165,7 @@ class AWSAuthSignInTask: AuthSignInTask, DefaultLogger {
             // in vNext, the `validationData` property will be removed
             // and we'll use only the `metadata` property.
             pluginOptions?.validationData ?? [:],
-            uniquingKeysWith: { current, _ in current }
+            uniquingKeysWith: { _, new in new }
         )
 
         return clientMetadata

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift
@@ -158,10 +158,16 @@ class AWSAuthSignInTask: AuthSignInTask, DefaultLogger {
 
         // Since InitiateAuth API explicitly doesn't accept validationData,
         // we can pass this data to the Lambda function by using the ClientMetadata parameter
-        var clientMetadata = pluginOptions?.metadata ?? [:]
-        for (key, value) in pluginOptions?.validationData ?? [:] {
-            clientMetadata[key] = value
-        }
+
+        let clientMetadata = (pluginOptions?.metadata ?? [:]).merging(
+            // we're adding `validationData` to the `clientMetadata` here
+            // to prevent breaking behavioral changes.
+            // in vNext, the `validationData` property will be removed
+            // and we'll use only the `metadata` property.
+            pluginOptions?.validationData ?? [:],
+            uniquingKeysWith: { current, _ in current }
+        )
+
         return clientMetadata
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/HubEventTests/AuthHubEventHandlerTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/HubEventTests/AuthHubEventHandlerTests.swift
@@ -29,8 +29,7 @@ class AuthHubEventHandlerTests: XCTestCase {
 
         configurePluginForSignInEvent()
 
-        let pluginOptions = AWSAuthSignInOptions(validationData: ["somekey": "somevalue"],
-                                                 metadata: ["somekey": "somevalue"])
+        let pluginOptions = AWSAuthSignInOptions(metadata: ["somekey": "somevalue"])
         let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
 
         let hubEventExpectation = expectation(description: "Should receive the hub event")

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInOptionsTestCase.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInOptionsTestCase.swift
@@ -102,7 +102,11 @@ class AWSAuthSignInOptionsTestCase: BasePluginTest {
     /// - Given: A sign in task
     /// - When: `metadata` and deprecated `validationData` is included in the `AWSAuthSignInOptions`
     ///  with the same key.
-    /// - Then: The value from `metadata` should be included in the event's `clientMetadata`
+    /// - Then: The value from `metadata` should be included in the event's `validationData`
+    ///
+    /// - Note:`validationData` overriding `metadata` seems a bit counterintuintive because
+    /// `validationData` is now deprecated. However this is necessary to ensure we don't break the implicit
+    /// contract consumers may be (knowlingly or unknowlingly) depending on.
     @available(*, deprecated)
     func test_clientMetadata_sameKey() async throws {
         let signInOptions = AWSAuthSignInOptions(
@@ -128,7 +132,7 @@ class AWSAuthSignInOptionsTestCase: BasePluginTest {
             .first(where: { _ in true })?
             .clientMetadata
 
-        XCTAssertEqual(clientMetadata, ["someKey": "metadataValue"])
+        XCTAssertEqual(clientMetadata, ["someKey": "validationValue"])
     }
 
     /// - Given: A sign in task

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInOptionsTestCase.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInOptionsTestCase.swift
@@ -1,0 +1,189 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AWSCognitoIdentity
+@testable import Amplify
+@testable import AWSCognitoAuthPlugin
+import AWSCognitoIdentityProvider
+import ClientRuntime
+
+class AWSAuthSignInOptionsTestCase: BasePluginTest {
+    override var initialState: AuthState {
+        AuthState.configured(.signedOut(.init(lastKnownUserName: nil)), .configured)
+    }
+
+    override func setUp() {
+        super.setUp()
+        mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            InitiateAuthOutputResponse(
+                authenticationResult: .none,
+                challengeName: .passwordVerifier,
+                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                session: "someSession")
+        }, mockRespondToAuthChallengeResponse: { _ in
+            RespondToAuthChallengeOutputResponse(
+                authenticationResult: .init(
+                    accessToken: Defaults.validAccessToken,
+                    expiresIn: 300,
+                    idToken: "idToken",
+                    newDeviceMetadata: nil,
+                    refreshToken: "refreshToken",
+                    tokenType: ""),
+                challengeName: .none,
+                challengeParameters: [:],
+                session: "session")
+        })
+    }
+
+    /// - Given: A sign in task
+    /// - When: `metadata` is included in the `AWSAuthSignInOptions`
+    /// - Then: That `metadata` should be included in the event's `clientMetadata`
+    func test_clientMetadata_noValidationData() async throws {
+        let signInOptions = AWSAuthSignInOptions(
+            metadata: ["someKey": "metadataValue"]
+        )
+        let options = AuthSignInRequest.Options(pluginOptions: signInOptions)
+        let request = AuthSignInRequest(username: "username", password: "password", options: options)
+
+        let stateMachine = try XCTUnwrap(plugin.authStateMachine)
+        let signInTask = AWSAuthSignInTask(
+            request,
+            authStateMachine: stateMachine,
+            configuration: plugin.authConfiguration
+        )
+
+        let states = await stateMachine.listen()
+        _ = try await signInTask.execute()
+
+        let clientMetadata = await states
+            .compactMap(\.authenticationState)
+            .compactMap(\.signInEvent)
+            .first(where: { _ in true })?
+            .clientMetadata
+
+        XCTAssertEqual(clientMetadata, ["someKey": "metadataValue"])
+    }
+
+    /// - Given: A sign in task
+    /// - When: Deprecated `validationData` is included in the `AWSAuthSignInOptions`
+    /// - Then: That `validationData` should be included in the event's `clientMetadata`
+    @available(*, deprecated)
+    func test_clientMetadata_noMetadata() async throws {
+        let signInOptions = AWSAuthSignInOptions(
+            validationData: ["someKey": "validationValue"]
+        )
+        let options = AuthSignInRequest.Options(pluginOptions: signInOptions)
+        let request = AuthSignInRequest(username: "username", password: "password", options: options)
+
+        let stateMachine = try XCTUnwrap(plugin.authStateMachine)
+        let signInTask = AWSAuthSignInTask(
+            request,
+            authStateMachine: stateMachine,
+            configuration: plugin.authConfiguration
+        )
+
+        let states = await stateMachine.listen()
+        _ = try await signInTask.execute()
+
+        let clientMetadata = await states
+            .compactMap(\.authenticationState)
+            .compactMap(\.signInEvent)
+            .first(where: { _ in true })?
+            .clientMetadata
+
+        XCTAssertEqual(clientMetadata, ["someKey": "validationValue"])
+    }
+
+    /// - Given: A sign in task
+    /// - When: `metadata` and deprecated `validationData` is included in the `AWSAuthSignInOptions`
+    ///  with the same key.
+    /// - Then: The value from `metadata` should be included in the event's `clientMetadata`
+    @available(*, deprecated)
+    func test_clientMetadata_sameKey() async throws {
+        let signInOptions = AWSAuthSignInOptions(
+            validationData: ["someKey": "validationValue"],
+            metadata: ["someKey": "metadataValue"]
+        )
+        let options = AuthSignInRequest.Options(pluginOptions: signInOptions)
+        let request = AuthSignInRequest(username: "username", password: "password", options: options)
+
+        let stateMachine = try XCTUnwrap(plugin.authStateMachine)
+        let signInTask = AWSAuthSignInTask(
+            request,
+            authStateMachine: stateMachine,
+            configuration: plugin.authConfiguration
+        )
+
+        let states = await stateMachine.listen()
+        _ = try await signInTask.execute()
+
+        let clientMetadata = await states
+            .compactMap(\.authenticationState)
+            .compactMap(\.signInEvent)
+            .first(where: { _ in true })?
+            .clientMetadata
+
+        XCTAssertEqual(clientMetadata, ["someKey": "metadataValue"])
+    }
+
+    /// - Given: A sign in task
+    /// - When: `metadata` and deprecated `validationData` is included in the `AWSAuthSignInOptions`
+    ///  with the different keys.
+    /// - Then: The values from `metadata` and the deprecated `validationData`  should be included in the event's `clientMetadata`
+    @available(*, deprecated)
+    func test_clientMetadata_differentKeys() async throws {
+        let signInOptions = AWSAuthSignInOptions(
+            validationData: ["validationKey": "validationValue"],
+            metadata: ["metadataKey": "metadataValue"]
+        )
+        let options = AuthSignInRequest.Options(pluginOptions: signInOptions)
+        let request = AuthSignInRequest(username: "username", password: "password", options: options)
+
+        let stateMachine = try XCTUnwrap(plugin.authStateMachine)
+        let signInTask = AWSAuthSignInTask(
+            request,
+            authStateMachine: stateMachine,
+            configuration: plugin.authConfiguration
+        )
+
+        let states = await stateMachine.listen()
+        _ = try await signInTask.execute()
+
+        let clientMetadata = await states
+            .compactMap(\.authenticationState)
+            .compactMap(\.signInEvent)
+            .first(where: { _ in true })?
+            .clientMetadata
+
+        XCTAssertEqual(
+            clientMetadata,
+            [
+                "validationKey": "validationValue",
+                "metadataKey": "metadataValue"
+            ]
+        )
+    }
+}
+
+fileprivate extension AuthState {
+    var authenticationState: AuthenticationState? {
+        if case .configured(let authenticationState, _) = self {
+            return authenticationState
+        }
+        return nil
+    }
+}
+
+fileprivate extension AuthenticationState {
+    var signInEvent: SignInEventData? {
+        if case .signingIn(.signingInWithSRP(_, let eventData)) = self {
+            return eventData
+        }
+        return nil
+    }
+}

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
@@ -49,8 +49,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
                 session: "session")
         })
 
-        let pluginOptions = AWSAuthSignInOptions(validationData: ["somekey": "somevalue"],
-                                                 metadata: ["somekey": "somevalue"])
+        let pluginOptions = AWSAuthSignInOptions(metadata: ["somekey": "somevalue"])
         let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
 
         do {
@@ -96,9 +95,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
                 session: "session")
         })
 
-        let pluginOptions = AWSAuthSignInOptions(validationData: ["somekey": "somevalue"],
-                                                 metadata: ["somekey": "somevalue"],
-                                                 authFlowType: .userSRP)
+        let pluginOptions = AWSAuthSignInOptions(
+            metadata: ["somekey": "somevalue"],
+            authFlowType: .userSRP
+        )
         let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
 
         do {
@@ -324,9 +324,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
                 session: "session")
         })
 
-        let pluginOptions = AWSAuthSignInOptions(validationData: ["somekey": "somevalue"],
-                                                 metadata: ["somekey": "somevalue"],
-                                                 authFlowType: .customWithSRP)
+        let pluginOptions = AWSAuthSignInOptions(
+            metadata: ["somekey": "somevalue"],
+            authFlowType: .customWithSRP
+        )
         let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
         do {
             let result = try await plugin.signIn(username: "username", password: "password", options: options)
@@ -571,9 +572,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
                 session: "session")
         })
 
-        let pluginOptions = AWSAuthSignInOptions(validationData: ["somekey": "somevalue"],
-                                                 metadata: ["somekey": "somevalue"],
-                                                 authFlowType: .userPassword)
+        let pluginOptions = AWSAuthSignInOptions(
+            metadata: ["somekey": "somevalue"],
+            authFlowType: .userPassword
+        )
         let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
         do {
             let result = try await plugin.signIn(
@@ -614,9 +616,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
                 session: "session")
         })
 
-        let pluginOptions = AWSAuthSignInOptions(validationData: ["somekey": "somevalue"],
-                                                 metadata: ["somekey": "somevalue"],
-                                                 authFlowType: .customWithoutSRP)
+        let pluginOptions = AWSAuthSignInOptions(
+            metadata: ["somekey": "somevalue"],
+            authFlowType: .customWithoutSRP
+        )
         let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
         do {
             let result = try await plugin.signIn(
@@ -1144,8 +1147,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
                 session: "session")
         })
 
-        let pluginOptions = AWSAuthSignInOptions(validationData: ["somekey": "somevalue"],
-                                                 metadata: ["somekey": "somevalue"])
+        let pluginOptions = AWSAuthSignInOptions(metadata: ["somekey": "somevalue"])
         let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
 
         do {
@@ -1226,8 +1228,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
                 session: "session")
         })
 
-        let pluginOptions = AWSAuthSignInOptions(validationData: ["somekey": "somevalue"],
-                                                 metadata: ["somekey": "somevalue"])
+        let pluginOptions = AWSAuthSignInOptions(metadata: ["somekey": "somevalue"])
         let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
 
         do {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
@@ -257,8 +257,7 @@ class AWSAuthHostedUISignInTests: XCTestCase {
                 session: "session")
         })
 
-        let pluginOptions = AWSAuthSignInOptions(validationData: ["somekey": "somevalue"],
-                                                 metadata: ["somekey": "somevalue"])
+        let pluginOptions = AWSAuthSignInOptions(metadata: ["somekey": "somevalue"])
         let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
 
         do {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
- https://github.com/aws-amplify/amplify-swift/issues/2595

## Description
<!-- Why is this change required? What problem does it solve? -->
- Deprecates `AWSAuthSignInOptions.validationData` and `AWSSignInOptions.init(validationData:metadata:authFlowType:)`.
- Changes the (now) deprecated `validationData` to a var to avoid the deprecation warning in the new `init`.
- Updates tests to not use the deprecated property / `init`.
```swift
// ✅ no warning
let signInOptions = AWSAuthSignInOptions()

// ✅ no warning
let signInOptions = AWSAuthSignInOptions(
    metadata: [:]
)

// ✅ no warning
let signInOptions = AWSAuthSignInOptions(
    authFlowType: nil
)

// ✅ no warning
let signInOptions = AWSAuthSignInOptions(
    metadata: [:],
    authFlowType: nil
)

// ⚠️ 'init(validationData:metadata:authFlowType:)' is deprecated: replaced by 'init(metadata:authFlowType:)'
let signInOptions = AWSAuthSignInOptions(
    validationData: [:]
)

// ⚠️ 'init(validationData:metadata:authFlowType:)' is deprecated: replaced by 'init(metadata:authFlowType:)'
let signInOptions = AWSAuthSignInOptions(
    validationData: [:],
    metadata: [:],
    authFlowType: nil
)

// ⚠️ 'validationData' is deprecated: renamed to 'metadata'
// Use 'metadata' instead [Fix]
_ = AWSAuthSignInOptions().validationData 
```


## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
