### PR TITLE
chore(core): Added AmplifyAWSServiceConfiguration.frameworkMetaDataWithOS

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -7,19 +7,55 @@
 
 import Foundation
 import AWSClientRuntime
+import Amplify
 
+/// Convenience class that is used by Amplify to include metadata such as values for a "User-Agent" during
+/// server interactions.
+///
+/// - Tag: AmplifyAWSServiceConfiguration
 public class AmplifyAWSServiceConfiguration {
 
+    /// - Tag: AmplifyAWSServiceConfiguration.amplifyVersion
     public static let amplifyVersion = "2.10.0"
+
+    /// - Tag: AmplifyAWSServiceConfiguration.platformName
     public static let platformName = "amplify-swift"
 
-    public static func frameworkMetaData() -> FrameworkMetadata {
-
+    /// Returns basic amount of metadata that includes both
+    /// [AmplifyAWSServiceConfiguration.amplifyVersion](x-source-tag://AmplifyAWSServiceConfiguration.amplifyVersion)
+    /// and
+    /// [AmplifyAWSServiceConfiguration.platformName](x-source-tag://AmplifyAWSServiceConfiguration.platformName)
+    /// in addition to the operating system version if `includesOS` is set to `true`.
+    ///
+    /// - Tag: AmplifyAWSServiceConfiguration.frameworkMetaDataWithOS
+    public static func frameworkMetaData(includeOS: Bool = false) -> FrameworkMetadata {
+        let osKey = "os"
         guard let flutterVersion = platformMapping[Platform.flutter] else {
+            if includeOS {
+                return FrameworkMetadata(
+                    name: platformName,
+                    version: amplifyVersion,
+                    extras: [osKey: frameworkOS()]
+                )
+            }
             return FrameworkMetadata(name: platformName, version: amplifyVersion)
+        }
+        var extras = [platformName: amplifyVersion]
+        if includeOS {
+            extras[osKey] = frameworkOS()
         }
         return FrameworkMetadata(name: Platform.flutter.rawValue,
                                  version: flutterVersion,
-                                 extras: [platformName: amplifyVersion])
+                                 extras: extras)
+    }
+
+    private static func frameworkOS() -> String {
+        // Please note that because the value returned by this function will be
+        // sanitized by FrameworkMetadata by removing anything not in a special
+        // character set that does NOT include the forward slash (/), the
+        // backslash (\) is used as a separator instead.
+        let separator = "\\"
+        let operatingSystem = DeviceInfo.current.operatingSystem
+        return [operatingSystem.name, operatingSystem.version].joined(separator: separator)
     }
 }

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginBasicIntegrationTests.swift
@@ -40,6 +40,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// - Tag: SdkUserAgentComponent
     private enum URLUserAgentComponent: String, CaseIterable {
         case lib = "lib/amplify-swift"
+        case os = "os/iOS"
     }
 
     override func setUp() async throws {


### PR DESCRIPTION
## Description
<!-- Why is this change required? What problem does it solve? -->

Added `AmplifyAWSServiceConfiguration.frameworkMetaDataWithOS` and is used for the AWSS3StoragePlugin's `User-Agent`.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
~~- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)~~
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~~
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
