### PR TITLE
feat(datastore): Add `Int` based `.page(_:limit:)` overload

### DIFF
--- a/Amplify/Categories/DataStore/Query/QueryPaginationInput.swift
+++ b/Amplify/Categories/DataStore/Query/QueryPaginationInput.swift
@@ -35,6 +35,23 @@ extension QueryPaginationInput {
         return QueryPaginationInput(page: page, limit: limit)
     }
 
+	/// Creates a `QueryPaginationInput` in an expressive way, enabling a short
+	/// and developer friendly access to an instance of `QueryPaginationInput`.
+	///
+	/// - Parameters:
+	///   - page: the page number (starting at 0)
+	///   - limit: the page size (defaults to `QueryPaginationInput.defaultLimit`)
+	/// - Precondition: `page` and `limit` must be greater than or equal to `0`
+	/// - Returns: a new instance of `QueryPaginationInput`
+	public static func page(
+		_ page: Int,
+		limit: Int = Int(QueryPaginationInput.defaultLimit)
+	) -> QueryPaginationInput {
+		assert(page >= 0, "Page number must be >= 0")
+		assert(limit >= 0, "Page limit must be >= 0")
+		return QueryPaginationInput(page: UInt(page), limit: UInt(limit))
+	}
+
     /// Utility that created a `QueryPaginationInput` with `page` 0 and `limit` 1
     public static var firstResult: QueryPaginationInput {
         .page(0, limit: 1)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/QueryPaginationInputTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/QueryPaginationInputTests.swift
@@ -6,9 +6,9 @@
 //
 
 import XCTest
-
 @testable import Amplify
 @testable import AWSDataStorePlugin
+import AmplifyTestCommon
 
 class QueryPaginationInputTests: XCTestCase {
 
@@ -76,4 +76,34 @@ class QueryPaginationInputTests: XCTestCase {
         XCTAssertEqual(paginationInput.sqlStatement, "limit 1 offset 0")
     }
 
+	/// - Given:  `page` and `limit` local variables inferred to be of type `Int`
+	/// - When: Calling `.page(_:limit:)`
+	/// - Then: The example should compile by using the `Int` based overload
+	func test_queryPaginationInput_inferredInt() {
+		let page = 0
+		let limit = 42
+		let paginationInput = QueryPaginationInput.page(page, limit: limit)
+		XCTAssertEqual(paginationInput.sqlStatement, "limit 42 offset 0")
+	}
+
+	/// - Given:  `page` and `limit` local variables explicitly typed as `UInt`
+	/// - When: Calling `.page(_:limit:)`
+	/// - Then: The example should compile by using the `UInt` based overload
+	func test_queryPaginationInput_explicitUInt() {
+		let page: UInt = 0
+		let limit: UInt = 42
+		let paginationInput = QueryPaginationInput.page(page, limit: limit)
+		XCTAssertEqual(paginationInput.sqlStatement, "limit 42 offset 0")
+	}
+
+	/// - Given:  A local `page` variable with a negative value of type `Int`
+	/// - When: Calling `.page(_:limit:)`
+	/// - Then: An assertion failure should be thrown.
+	func test_queryPaginationInput_negativeIntOverload_assertionFailure() throws {
+		let page = -1
+		let limit = 42
+		try XCTAssertThrowFatalError {
+			_ = QueryPaginationInput.page(page, limit: limit)
+		}
+	}
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
- https://github.com/aws-amplify/amplify-swift/issues/1114

## Description
<!-- Why is this change required? What problem does it solve? -->
This change adds an `Int` based overload to `QueryPaginationInput.page(_:limit:)` and a few tests to ensure this isn't breaking.

See issue for "Why is this change required?"

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
