### PR TITLE
ci: add option in github action to use latest xcode

### DIFF
--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -8,6 +8,9 @@ inputs:
   project_path:
     required: false
     type: string
+  xcode_path:
+    required: false
+    type: string
   destination:
     required: false
     type: string
@@ -28,7 +31,12 @@ runs:
       env:
         SCHEME: ${{ inputs.scheme }}
         PROJECT_PATH: ${{ inputs.project_path }}
+        XCODE_PATH: ${{ inputs.xcode_path }}
       run: |
         cd $PROJECT_PATH
-        xcodebuild test -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}        
-      shell: bash 
+        if [ ! -z "$XCODE_PATH" ]; then
+          sudo xcode-select -s $XCODE_PATH
+        fi
+        xcodebuild -version
+        xcodebuild test -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
+      shell: bash

--- a/.github/workflows/integ_test_datastore.yml
+++ b/.github/workflows/integ_test_datastore.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
     id-token: write
-    contents: read 
+    contents: read
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   prepare-for-test:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,7 +32,7 @@ jobs:
   datastore-integration-test:
     timeout-minutes: 30
     needs: prepare-for-test
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -55,5 +55,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginIntegrationTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
- 
+

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
     id-token: write
-    contents: read 
+    contents: read
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -56,4 +56,4 @@ jobs:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginV2Tests
 
- 
+

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario2Tests.swift
@@ -46,8 +46,8 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
         try await startAmplifyAndWaitForSync()
         let team = Team2(name: "name1")
         let project = Project2(teamID: team.id, team: team)
-        let syncedTeamReceived = asyncExpectation(description: "received team from sync event")
-        let syncProjectReceived = asyncExpectation(description: "received project from sync event")
+        let syncedTeamReceived = expectation(description: "received team from sync event")
+        let syncProjectReceived = expectation(description: "received project from sync event")
         let hubListener = Amplify.Hub.listen(to: .dataStore,
                                              eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
             guard let mutationEvent = payload.data as? MutationEvent else {
@@ -57,16 +57,10 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
 
             if let syncedTeam = try? mutationEvent.decodeModel() as? Team2,
                syncedTeam == team {
-                Task {
-                    await syncedTeamReceived.fulfill()
-                }
-                
+                syncedTeamReceived.fulfill()
             } else if let syncedProject = try? mutationEvent.decodeModel() as? Project2,
                       syncedProject == project {
-                Task {
-                    await syncProjectReceived.fulfill()
-                }
-                
+                syncProjectReceived.fulfill()
             }
         }
         guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
@@ -75,11 +69,11 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
         }
 
         _ = try await Amplify.DataStore.save(team)
-        await waitForExpectations([syncedTeamReceived], timeout: networkTimeout)
+        await fulfillment(of: [syncedTeamReceived], timeout: networkTimeout)
         
         _ = try await Amplify.DataStore.save(project)
 
-        await waitForExpectations([syncProjectReceived], timeout: networkTimeout)
+        await fulfillment(of: [syncProjectReceived], timeout: networkTimeout)
 
         let queriedProject = try await Amplify.DataStore.query(Project2.self, byId: project.id)
         XCTAssertEqual(queriedProject, project)
@@ -131,13 +125,13 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
     func testDeleteAndGetProjectReturnsNilWithSync() async throws {
         await setUp(withModels: TestModelRegistration())
         try await startAmplifyAndWaitForSync()
-        let team = try await saveTeam(name: "name")
-        let project = try await saveProject(teamID: team.id, team: team)
+        let team = Team2(id: UUID().uuidString, name: UUID().uuidString)
+        let project = Project2(id: UUID().uuidString, name: UUID().uuidString, teamID: team.id, team: team)
 
-        let createReceived = asyncExpectation(description: "received created items from cloud",
-                                              expectedFulfillmentCount: 2) // 1 project and 1 team
-        let deleteReceived = asyncExpectation(description: "Delete notification received",
-                                              expectedFulfillmentCount: 2) // 1 project and 1 team
+        let createReceived = expectation(description: "received created items from cloud")
+        createReceived.expectedFulfillmentCount = 2 // 1 project and 1 team
+        let deleteReceived = expectation(description: "Delete notification received")
+        deleteReceived.expectedFulfillmentCount = 2 // 1 project and 1 team
         let hubListener = Amplify.Hub.listen(to: .dataStore,
                                              eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
             guard let mutationEvent = payload.data as? MutationEvent else {
@@ -149,17 +143,17 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
                projectEvent.id == project.id {
                 if mutationEvent.mutationType == GraphQLMutationType.create.rawValue {
                     XCTAssertEqual(mutationEvent.version, 1)
-                    Task { await createReceived.fulfill() }
+                    createReceived.fulfill()
                 } else if mutationEvent.mutationType == GraphQLMutationType.delete.rawValue {
-                    Task { await deleteReceived.fulfill() }
+                    deleteReceived.fulfill()
                 }
 
             } else if let teamEvent = try? mutationEvent.decodeModel() as? Team2, teamEvent.id == team.id {
                 if mutationEvent.mutationType == GraphQLMutationType.create.rawValue {
                     XCTAssertEqual(mutationEvent.version, 1)
-                    Task { await createReceived.fulfill() }
+                    createReceived.fulfill()
                 } else if mutationEvent.mutationType == GraphQLMutationType.delete.rawValue {
-                    Task { await deleteReceived.fulfill() }
+                    deleteReceived.fulfill()
                 }
             }
 
@@ -168,14 +162,16 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
             XCTFail("Listener not registered for hub")
             return
         }
-        await waitForExpectations([createReceived], timeout: TestCommonConstants.networkTimeout)
+        try await Amplify.DataStore.save(team)
+        try await Amplify.DataStore.save(project)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         try await Amplify.DataStore.delete(project)
 
         // TODO: Delete Team should not be necessary, cascade delete should delete the team when deleting the project.
         // Once cascade works for hasOne, the following code can be removed.
         try await Amplify.DataStore.delete(team)
-        await waitForExpectations([deleteReceived], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
         let project2 = try await Amplify.DataStore.query(Project2.self, byId: project.id)
         XCTAssertNil(project2)
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario3Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario3Tests.swift
@@ -46,8 +46,8 @@ class DataStoreConnectionScenario3Tests: SyncEngineIntegrationTestBase {
         try await startAmplifyAndWaitForSync()
         let post = Post3(title: "title")
         let comment = Comment3(postID: post.id, content: "content")
-        let syncedPostReceived = asyncExpectation(description: "received post from sync event")
-        let syncCommentReceived = asyncExpectation(description: "received comment from sync event")
+        let syncedPostReceived = expectation(description: "received post from sync event")
+        let syncCommentReceived = expectation(description: "received comment from sync event")
         let hubListener = Amplify.Hub.listen(to: .dataStore,
                                              eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
             guard let mutationEvent = payload.data as? MutationEvent else {
@@ -57,10 +57,10 @@ class DataStoreConnectionScenario3Tests: SyncEngineIntegrationTestBase {
 
             if let syncedPost = try? mutationEvent.decodeModel() as? Post3,
                syncedPost == post {
-                Task { await syncedPostReceived.fulfill() }
+                syncedPostReceived.fulfill()
             } else if let syncComment = try? mutationEvent.decodeModel() as? Comment3,
                       syncComment == comment {
-                Task { await syncCommentReceived.fulfill() }
+                syncCommentReceived.fulfill()
             }
         }
         guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
@@ -68,9 +68,9 @@ class DataStoreConnectionScenario3Tests: SyncEngineIntegrationTestBase {
             return
         }
         _ = try await Amplify.DataStore.save(post)
-        await waitForExpectations([syncedPostReceived], timeout: networkTimeout)
+        await fulfillment(of: [syncedPostReceived], timeout: networkTimeout)
         _ = try await Amplify.DataStore.save(comment)
-        await waitForExpectations([syncCommentReceived], timeout: networkTimeout)
+        await fulfillment(of: [syncCommentReceived], timeout: networkTimeout)
         
         let queriedComment = try await Amplify.DataStore.query(Comment3.self, byId: comment.id)
         XCTAssertEqual(queriedComment, comment)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreConsecutiveUpdatesTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreConsecutiveUpdatesTests.swift
@@ -156,8 +156,7 @@ class DataStoreConsecutiveUpdatesTests: SyncEngineIntegrationTestBase {
         // query the deleted post immediately
         let queryResult = try await queryPost(byId: newPost.id)
         XCTAssertNil(queryResult)
-
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [deleteSyncReceived], timeout: networkTimeout)
 
         // query the deleted post in eventual consistent state
         let queryResultAfterSync = try await queryPost(byId: newPost.id)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -147,7 +147,7 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
         }
 
         _ = try await Amplify.DataStore.save(newPost)
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [createReceived], timeout: networkTimeout)
 
         let updateReceived = expectation(description: "Update notification received")
         hubListener = Amplify.Hub.listen(
@@ -177,7 +177,7 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
             return
         }
         _ = try await Amplify.DataStore.save(updatedPost)
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [updateReceived], timeout: networkTimeout)
         
         let deleteReceived = expectation(description: "Delete notification received")
         hubListener = Amplify.Hub.listen(
@@ -207,7 +207,7 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
             return
         }
         try await Amplify.DataStore.delete(updatedPost)
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: networkTimeout)
     }
 
     /// - Given: A post that has been saved

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreHubEventsTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreHubEventsTests.swift
@@ -82,7 +82,13 @@ class DataStoreHubEventTests: HubEventsIntegrationTestBase {
 
         await startAmplify(withModels: TestModelRegistration())
 
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [
+            networkStatusReceived,
+            subscriptionsEstablishedReceived,
+            syncQueriesStartedReceived,
+            outboxStatusReceived
+        ], timeout: networkTimeout)
+
         hubListener.cancel()
     }
 
@@ -134,7 +140,7 @@ class DataStoreHubEventTests: HubEventsIntegrationTestBase {
         await startAmplify(withModels: TestModelRegistration())
         _ = try await Amplify.DataStore.save(post)
 
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [outboxMutationEnqueuedReceived, outboxMutationProcessedReceived], timeout: networkTimeout)
         hubListener.cancel()
     }
 
@@ -179,7 +185,7 @@ class DataStoreHubEventTests: HubEventsIntegrationTestBase {
 
         await startAmplify(withModels: TestModelRegistration())
 
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [modelSyncedReceived, syncQueriesReadyReceived], timeout: networkTimeout)
         hubListener.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
@@ -112,7 +112,7 @@ class SyncEngineIntegrationTestBase: DataStoreTestBase {
         }
 
         try await Amplify.DataStore.start()
-        await waitForExpectations(timeout: 10.0)
+        await fulfillment(of: [eventReceived], timeout: 10)
 
         try await deleteMutationEvents()
     }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
With the recent release of [Xcode v14.3](https://developer.apple.com/documentation/xcode-release-notes/xcode-14_3-release-notes), awaiting expectations requires the use of the new [fulfillment API](https://developer.apple.com/documentation/xctest/xctestcase/4109476-fulfillment). However, our current GitHub integration workflows do not provide an option to utilize this feature.

## Description
<!-- Why is this change required? What problem does it solve? -->

- add new option `xcode_path` to choose the expected Xcode version
- change datastore integration test workflow to use the latest runner macos-13 with the latest Xcode 14.3.
- fix some integration test cases to use the fulfillment API.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
