### PR TITLE
fix(Auth): Use correct queries when getting and setting keychain items

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStore.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStore.swift
@@ -99,7 +99,7 @@ public struct KeychainStore: KeychainStoreBehavior {
     /// - Parameter key: A String key use to look up the value in the Keychain
     /// - Returns: A data value
     public func _getData(_ key: String) throws -> Data {
-        var query = attributes.query()
+        var query = attributes.defaultGetQuery()
 
         query[Constants.MatchLimit] = Constants.MatchLimitOne
         query[Constants.ReturnData] = kCFBooleanTrue
@@ -142,7 +142,7 @@ public struct KeychainStore: KeychainStoreBehavior {
     ///   - value: A data value to store in Keychain
     ///   - key: A String key for the value to store in the Keychain
     public func _set(_ value: Data, key: String) throws {
-        var query = attributes.query()
+        var query = attributes.defaultSetQuery()
         query[Constants.AttributeAccount] = key
 
         let fetchStatus = SecItemCopyMatching(query as CFDictionary, nil)
@@ -173,7 +173,7 @@ public struct KeychainStore: KeychainStoreBehavior {
     /// This System Programming Interface (SPI) may have breaking changes in future updates.
     /// - Parameter key: A String key to delete the key-value pair
     public func _remove(_ key: String) throws {
-        var query = attributes.query()
+        var query = attributes.defaultGetQuery()
         query[Constants.AttributeAccount] = key
 
         let status = SecItemDelete(query as CFDictionary)
@@ -186,7 +186,7 @@ public struct KeychainStore: KeychainStoreBehavior {
     /// Removes all key-value pair in the Keychain.
     /// This System Programming Interface (SPI) may have breaking changes in future updates.
     public func _removeAll() throws {
-        var query = attributes.query()
+        var query = attributes.defaultGetQuery()
 #if !os(iOS) && !os(watchOS) && !os(tvOS)
         query[Constants.MatchLimit] = Constants.MatchLimitAll
 #endif

--- a/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStoreAttributes.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStoreAttributes.swift
@@ -19,7 +19,7 @@ struct KeychainStoreAttributes {
 
 extension KeychainStoreAttributes {
 
-    func query() -> [String: Any] {
+    func defaultGetQuery() -> [String: Any] {
         var query: [String: Any] = [
             KeychainStore.Constants.Class: itemClass,
             KeychainStore.Constants.AttributeService: service
@@ -27,6 +27,11 @@ extension KeychainStoreAttributes {
         if let accessGroup = accessGroup {
             query[KeychainStore.Constants.AttributeAccessGroup] = accessGroup
         }
+        return query
+    }
+
+    func defaultSetQuery() -> [String: Any] {
+        var query: [String: Any] = defaultGetQuery()
         query[KeychainStore.Constants.AttributeAccessible] = KeychainStore.Constants.AttributeAccessibleAfterFirstUnlockThisDeviceOnly
         query[KeychainStore.Constants.UseDataProtectionKeyChain] = kCFBooleanTrue
         return query
@@ -37,7 +42,7 @@ extension KeychainStoreAttributes {
         var attributes: [String: Any]
 
         if key != nil {
-            attributes = query()
+            attributes = defaultGetQuery()
             attributes[KeychainStore.Constants.AttributeAccount] = key
         } else {
             attributes = [String: Any]()

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Keychain/KeychainStoreAttributesTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Keychain/KeychainStoreAttributesTests.swift
@@ -1,0 +1,71 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+@testable import AWSPluginsCore
+
+class KeychainStoreAttributesTests: XCTestCase {
+
+    var keychainStoreAttribute: KeychainStoreAttributes!
+
+    /// Given: an instance of `KeychainStoreAttributes`
+    /// When: `keychainStoreAttribute.defaultGetQuery()` is invoked with a required service param
+    /// Then: Validate if the attributes contain the correct get query params
+    ///     - AttributeService
+    ///     - Class
+    func testDefaultGetQuery() {
+        keychainStoreAttribute = KeychainStoreAttributes(service: "someService")
+
+        let defaultGetAttributes = keychainStoreAttribute.defaultGetQuery()
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.AttributeService] as? String, "someService")
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.Class] as? String, KeychainStore.Constants.ClassGenericPassword)
+        XCTAssertNil(defaultGetAttributes[KeychainStore.Constants.AttributeAccessGroup] as? String)
+        XCTAssertNil(defaultGetAttributes[KeychainStore.Constants.AttributeAccessible] as? String)
+        XCTAssertNil(defaultGetAttributes[KeychainStore.Constants.UseDataProtectionKeyChain] as? String)
+    }
+
+    /// Given: an instance of `KeychainStoreAttributes`
+    /// When: `keychainStoreAttribute.defaultGetQuery()` is invoked with a required service param and access group
+    /// Then: Validate if the attributes contain the correct get query params
+    ///     - AttributeService
+    ///     - Class
+    ///     - AttributeAccessGroup
+    func testDefaultGetQueryWithAccessGroup() {
+        keychainStoreAttribute = KeychainStoreAttributes(service: "someService", accessGroup: "someAccessGroup")
+
+        let defaultGetAttributes = keychainStoreAttribute.defaultGetQuery()
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.AttributeService] as? String, "someService")
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.Class] as? String, KeychainStore.Constants.ClassGenericPassword)
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.AttributeAccessGroup] as? String, "someAccessGroup")
+        XCTAssertNil(defaultGetAttributes[KeychainStore.Constants.AttributeAccessible] as? String)
+        XCTAssertNil(defaultGetAttributes[KeychainStore.Constants.UseDataProtectionKeyChain] as? String)
+    }
+
+    /// Given: an instance of `KeychainStoreAttributes`
+    /// When: `keychainStoreAttribute.defaultSetQuery()` is invoked with a required service param and access group
+    /// Then: Validate if the attributes contain the correct get query params
+    ///     - AttributeService
+    ///     - Class
+    ///     - AttributeAccessGroup
+    ///     - AttributeAccessible
+    ///     - UseDataProtectionKeyChain
+    func testDefaultSetQueryWithAccessGroup() {
+        keychainStoreAttribute = KeychainStoreAttributes(service: "someService", accessGroup: "someAccessGroup")
+
+        let defaultGetAttributes = keychainStoreAttribute.defaultSetQuery()
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.AttributeService] as? String, "someService")
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.Class] as? String, KeychainStore.Constants.ClassGenericPassword)
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.AttributeAccessGroup] as? String, "someAccessGroup")
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.AttributeAccessible] as? String, KeychainStore.Constants.AttributeAccessibleAfterFirstUnlockThisDeviceOnly)
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.UseDataProtectionKeyChain] as? Bool, true)
+    }
+
+    override func tearDown() {
+        keychainStoreAttribute = nil
+    }
+}


### PR DESCRIPTION
## Issue \#
#2945 

## Description
Amplify V1 made a change to keychain accessibility to prevent Amplify keychain being backed up and restored on another device. Backing up and restoring Amplify keychain items is not a supported feature. The PR for the change is https://github.com/aws-amplify/aws-sdk-ios/pull/4159. 

Amplify V2 refactored the Keychain implementation and started using default queries to retrieve data from the keychain. This default query also has `kSecAttrAccessible` as a query parameter. Amplify V2 sets a default value to `AttributeAccessibleAfterFirstUnlockThisDeviceOnly` and is not customizable by the customer. 

Due to this, querying for keychain items from Amplify V1 which has `kSecAttrAccessible` set to `AWSUICKeyChainStoreAccessibilityAfterFirstUnlock` would fail, because `kSecAttrAccessible` doesn't match.

**Solution**: 
Separating out default query params for setting and getting of attributes. This would avoid legacy keychain items not getting carried over when upgrading to newer versions of Amplify. 

This will bring the implementation with parity to Amplify V1 which also has separate queries for setting and getting keychain items.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
