### PR TITLE
fix(datastore): extract mutation events handling out of periodic snapshot generate logic

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStoreObserveQueryOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStoreObserveQueryOperation.swift
@@ -226,6 +226,7 @@ class ObserveQueryTaskRunner<M: Model>: InternalTaskRunner, InternalTaskAsyncThr
                 .filter { _ in !self.dispatchedModelSyncedEvent.get() }
                 .filter(self.filterByModelName(mutationEvent:))
                 .filter(self.filterByPredicateMatch(mutationEvent:))
+                .handleEvents(receiveOutput: self.onItemChangeDuringSync(mutationEvent:) )
                 .collect(.byTimeOrCount(self.serialQueue, self.itemsChangedPeriodicPublishTimeInSeconds, self.itemsChangedMaxSize))
                 .sink(receiveCompletion: self.onReceiveCompletion(completed:),
                       receiveValue: self.onItemsChangeDuringSync(mutationEvents:))
@@ -238,7 +239,7 @@ class ObserveQueryTaskRunner<M: Model>: InternalTaskRunner, InternalTaskAsyncThr
                       receiveValue: self.onItemChangeAfterSync(mutationEvent:))
         }
     }
-    
+
     func subscribeToModelSyncedEvent() {
         modelSyncedEventSink = Amplify.Hub.publisher(for: .dataStore).sink { event in
             if event.eventName == HubPayload.EventName.DataStore.modelSynced,
@@ -271,6 +272,16 @@ class ObserveQueryTaskRunner<M: Model>: InternalTaskRunner, InternalTaskAsyncThr
         }
     }
 
+    func onItemChangeDuringSync(mutationEvent: MutationEvent) {
+        serialQueue.async { [weak self] in
+            guard let self = self, self.observeQueryStarted else {
+                return
+            }
+
+            self.apply(itemsChanged: [mutationEvent])
+        }
+    }
+
     func onItemsChangeDuringSync(mutationEvents: [MutationEvent]) {
         serialQueue.async {
             guard self.observeQueryStarted, !mutationEvents.isEmpty else {
@@ -278,7 +289,6 @@ class ObserveQueryTaskRunner<M: Model>: InternalTaskRunner, InternalTaskAsyncThr
             }
 
             self.startSnapshotStopWatch()
-            self.apply(itemsChanged: mutationEvents)
             self.sendSnapshot()
         }
     }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStoreObserveQueryOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStoreObserveQueryOperation.swift
@@ -283,10 +283,12 @@ class ObserveQueryTaskRunner<M: Model>: InternalTaskRunner, InternalTaskAsyncThr
     }
 
     func onItemsChangeDuringSync(mutationEvents: [MutationEvent]) {
-        serialQueue.async {
-            guard self.observeQueryStarted, !mutationEvents.isEmpty else {
-                return
-            }
+        serialQueue.async { [weak self] in
+            guard let self = self,
+                  self.observeQueryStarted,
+                  !mutationEvents.isEmpty,
+                  !self.dispatchedModelSyncedEvent.get()
+            else { return }
 
             self.startSnapshotStopWatch()
             self.sendSnapshot()

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
@@ -150,7 +150,6 @@ final class ModelSyncedEventEmitter {
             }
 
             modelSyncedEventTopic.send(.mutationEventApplied(event))
-
             if shouldSendModelSyncedEvent {
                 sendModelSyncedEvent()
             }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
@@ -301,6 +301,51 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         XCTAssertTrue(snapshots.last!.items.count > numberOfPosts)
     }
 
+
+    /// ObserveQuery with DataStore sync. Ensure datastore is cleared.
+    /// When ObserveQuery is called, it will start DataStore and perform a full sync on max records.
+    ///
+    /// - Given: DataStore is cleared.
+    /// - When:
+    ///    - ObserveQuery is called to do perform full sync
+    /// - Then:
+    ///    - The first snapshot should have the old data and `isSynced` false
+    ///    - The final snapshot should have all the latest models with `isSynced` true
+    ///
+    func testObserveQuery_withClearedDataStore_fullySyncedWithMaxRecords() async throws {
+        await setUp(withModels: TestModelRegistration())
+        try await startAmplifyAndWaitForReady()
+        try await clearDataStore()
+
+        let snapshotWithIsSynced = asyncExpectation(description: "query snapshot with isSynced true")
+        var snapshots = [DataStoreQuerySnapshot<Post>]()
+
+        Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self)).sink { completed in
+            switch completed {
+            case .finished:
+                break
+            case .failure(let error):
+                XCTFail("\(error)")
+            }
+        } receiveValue: { querySnapshot in
+            snapshots.append(querySnapshot)
+            if querySnapshot.isSynced {
+                Task { await snapshotWithIsSynced.fulfill() }
+            }
+        }.store(in: &cancellables)
+
+        let newPost = Post(title: "title", content: "content", createdAt: .now())
+        let receivedPost = asyncExpectation(description: "received Post")
+        try await savePostAndWaitForSync(newPost,
+                                         postSyncedExpctation: receivedPost)
+
+        await waitForExpectations([snapshotWithIsSynced, receivedPost], timeout: 30)
+        XCTAssertTrue(snapshots.count >= 2)
+        XCTAssertFalse(snapshots[0].isSynced)
+        XCTAssertTrue(snapshots.last!.isSynced)
+        XCTAssertTrue(snapshots.last!.items.contains(newPost))
+    }
+
     /// ObserveQuery is set up with a query predicate.
     /// Sync is completed and actions are applied after sync to observe expected snapshots.
     ///

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
@@ -342,8 +342,11 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         await waitForExpectations([snapshotWithIsSynced, receivedPost], timeout: 30)
         XCTAssertTrue(snapshots.count >= 2)
         XCTAssertFalse(snapshots[0].isSynced)
-        XCTAssertTrue(snapshots.last!.isSynced)
-        XCTAssertTrue(snapshots.last!.items.contains(newPost))
+        XCTAssertEqual(1, snapshots.filter({ $0.isSynced }).count)
+
+        let theSyncedSnapshot = snapshots.first(where: { $0.isSynced })
+        XCTAssertNotNil(theSyncedSnapshot)
+        XCTAssertTrue(theSyncedSnapshot!.items.contains(newPost))
     }
 
     /// ObserveQuery is set up with a query predicate.

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
@@ -28,9 +28,9 @@
 		21182143289BFBC4001B5945 /* AWSAPIPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 21182142289BFBC4001B5945 /* AWSAPIPlugin */; };
 		21182145289BFBC4001B5945 /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 21182144289BFBC4001B5945 /* AWSCognitoAuthPlugin */; };
 		21182147289BFBC4001B5945 /* AWSDataStorePlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 21182146289BFBC4001B5945 /* AWSDataStorePlugin */; };
+		211F5094296DD4C30040EB62 /* AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211F5093296DD4C30040EB62 /* AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift */; };
 		2138482A2947ACCF00BBA647 /* AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213848292947ACCF00BBA647 /* AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift */; };
 		2138482C2947F89C00BBA647 /* AWSDataStoreLazyLoadingBlogPostCmment8V2SnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2138482B2947F89C00BBA647 /* AWSDataStoreLazyLoadingBlogPostCmment8V2SnapshotTests.swift */; };
-		211F5094296DD4C30040EB62 /* AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211F5093296DD4C30040EB62 /* AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift */; };
 		213DBB9C28A5743600B30280 /* ModelImplicitDefaultPk+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213DBB6228A5743200B30280 /* ModelImplicitDefaultPk+Schema.swift */; };
 		213DBB9D28A5743600B30280 /* ModelImplicitDefaultPk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213DBB6328A5743200B30280 /* ModelImplicitDefaultPk.swift */; };
 		213DBB9E28A5743600B30280 /* ModelExplicitDefaultPk+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213DBB6428A5743200B30280 /* ModelExplicitDefaultPk+Schema.swift */; };
@@ -759,7 +759,6 @@
 		21182131289BFB4B001B5945 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		21182133289BFB4F001B5945 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		21182136289BFB4F001B5945 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
-		2118213E289BFB63001B5945 /* amplify-ios-staging */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-ios-staging"; path = ../../../..; sourceTree = "<group>"; };
 		211F5093296DD4C30040EB62 /* AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift; sourceTree = "<group>"; };
 		213848292947ACCF00BBA647 /* AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift; sourceTree = "<group>"; };
 		2138482B2947F89C00BBA647 /* AWSDataStoreLazyLoadingBlogPostCmment8V2SnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadingBlogPostCmment8V2SnapshotTests.swift; sourceTree = "<group>"; };
@@ -1317,6 +1316,7 @@
 		21DFAE9D295F4E8600B4A883 /* PhoneCall.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneCall.swift; sourceTree = "<group>"; };
 		21DFAE9E295F4E8600B4A883 /* Transcript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transcript.swift; sourceTree = "<group>"; };
 		21DFAEA5295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadPhoneCallTests.swift; sourceTree = "<group>"; };
+		60CB6B3E2A1454F90051BAD2 /* amplify-swift */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-swift"; path = ../../../..; sourceTree = "<group>"; };
 		681DFE8028E746C10000C36A /* AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncTesting.swift; sourceTree = "<group>"; };
 		681DFE8128E746C10000C36A /* AsyncExpectation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncExpectation.swift; sourceTree = "<group>"; };
 		681DFE8228E746C10000C36A /* XCTestCase+AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AsyncTesting.swift"; sourceTree = "<group>"; };
@@ -1554,7 +1554,7 @@
 		2118213D289BFB63001B5945 /* Packages */ = {
 			isa = PBXGroup;
 			children = (
-				2118213E289BFB63001B5945 /* amplify-ios-staging */,
+				60CB6B3E2A1454F90051BAD2 /* amplify-swift */,
 			);
 			name = Packages;
 			sourceTree = "<group>";


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/2575

The ModelSynced snapshot is created using a buffered or periodic event. It is possible that the default buffer size is larger than the total size of the customer's observeQuery. 
In such cases, we temporarily hold the incoming MutationEvents and handle them until periodic time window is reached. If a snapshot is generated during this period, it will result in an empty array with isSynced set to true.

## Description
<!-- Why is this change required? What problem does it solve? -->

This PR separates the logic for handling mutation events from the logic responsible for generating periodic snapshots. With this change, the incoming mutation events will be promptly handled as soon as they are received.

## General Checklist
<!-- Check or cross out if not relevant -->

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
