### PR TITLE
fix(api): wrap URLSession with validation state

### DIFF
--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
@@ -2190,7 +2190,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2215,7 +2215,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2362,7 +2362,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2394,7 +2394,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "amplify-swift-utils-notifications",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/aws-amplify/amplify-swift-utils-notifications.git",
+      "state" : {
+        "revision" : "d4fd3c17e8d40efc821f448d3d6cff75b8f3b0dd",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "aws-appsync-realtime-client-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
@@ -14,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift.git",
       "state" : {
-        "revision" : "afe23a2a2f6cf78e6d8803d7c9e0c8e6f50b6915",
-        "version" : "0.4.0"
+        "revision" : "6feec6c3787877807aa9a00fad09591b96752376",
+        "version" : "0.6.1"
       }
     },
     {
@@ -23,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "30649be4b9d0788f987ae851c48d48ac6d00f2c2",
-        "version" : "0.6.1"
+        "revision" : "24bae88a2391fe75da8a940a544d1ef6441f5321",
+        "version" : "0.13.0"
       }
     },
     {
@@ -50,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/smithy-swift.git",
       "state" : {
-        "revision" : "3e9e420f69c28dee260c03b19c3e93b392128d42",
-        "version" : "0.6.1"
+        "revision" : "7b28da158d92cd06a3549140d43b8fbcf64a94a6",
+        "version" : "0.15.0"
       }
     },
     {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreAuthBaseTest.swift
@@ -12,6 +12,7 @@ import AWSDataStorePlugin
 import AWSPluginsCore
 import AWSAPIPlugin
 import AWSCognitoAuthPlugin
+@testable import DataStoreHostApp
 
 @testable import Amplify
 
@@ -155,9 +156,11 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
 
     /// Setup DataStore with given models
     /// - Parameter models: DataStore models
-    func setup(withModels models: AmplifyModelRegistration,
-               testType: DataStoreAuthTestType,
-               apiPluginFactory: () -> AWSAPIPlugin = { AWSAPIPlugin() }) async throws {
+    func setup(
+        withModels models: AmplifyModelRegistration,
+        testType: DataStoreAuthTestType,
+        apiPluginFactory: () -> AWSAPIPlugin = { AWSAPIPlugin(sessionFactory: AmplifyURLSessionFactory()) }
+    ) async throws {
         do {
             setupCredentials(forAuthStrategy: testType)
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthIAMTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthIAMTests/AWSDataStoreAuthBaseTest.swift
@@ -13,6 +13,7 @@ import AWSPluginsCore
 import AWSAPIPlugin
 import AWSCognitoAuthPlugin
 
+@testable import DataStoreHostApp
 @testable import Amplify
 
 struct TestUser {
@@ -155,9 +156,11 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
 
     /// Setup DataStore with given models
     /// - Parameter models: DataStore models
-    func setup(withModels models: AmplifyModelRegistration,
-               testType: DataStoreAuthTestType,
-               apiPluginFactory: () -> AWSAPIPlugin = { AWSAPIPlugin() }) async {
+    func setup(
+        withModels models: AmplifyModelRegistration,
+        testType: DataStoreAuthTestType,
+        apiPluginFactory: () -> AWSAPIPlugin = { AWSAPIPlugin(sessionFactory: AmplifyURLSessionFactory()) }
+    ) async {
         do {
             setupCredentials(forAuthStrategy: testType)
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStorePrimaryKeyBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStorePrimaryKeyBaseTest.swift
@@ -10,6 +10,7 @@ import XCTest
 import Combine
 import AWSDataStorePlugin
 import AWSAPIPlugin
+@testable import DataStoreHostApp
 
 @testable import Amplify
 
@@ -35,7 +36,7 @@ class AWSDataStorePrimaryKeyBaseTest: XCTestCase {
             loadAmplifyConfig()
             try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models))
 
-            try Amplify.add(plugin: AWSAPIPlugin())
+            try Amplify.add(plugin: AWSAPIPlugin(sessionFactory: AmplifyURLSessionFactory()))
 
             Amplify.Logging.logLevel = .verbose
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SyncEngineFlutterIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SyncEngineFlutterIntegrationTestBase.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 import XCTest
+@testable import DataStoreHostApp
 @testable import Amplify
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
@@ -37,7 +38,10 @@ class SyncEngineFlutterIntegrationTestBase: XCTestCase {
         Amplify.Logging.logLevel = .verbose
 
         do {
-            try Amplify.add(plugin: AWSAPIPlugin(modelRegistration: TestFlutterModelRegistration()))
+            try Amplify.add(plugin: AWSAPIPlugin(
+                modelRegistration: TestFlutterModelRegistration(),
+                sessionFactory: AmplifyURLSessionFactory()
+            ))
             try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: TestFlutterModelRegistration()))
         } catch {
             XCTFail(String(describing: error))

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreHubEventsTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreHubEventsTests.swift
@@ -25,7 +25,7 @@ class DataStoreHubEventTests: HubEventsIntegrationTestBase {
 
     /// - Given:
     ///    - registered two models from `TestModelRegistration`
-    ///    - no pending MutationEvents in MutationEvent database
+    ///    - no pending MutationEvents in MutationEvent database by clearing the local datastore
     /// - When:
     ///    - DataStore's remote sync engine is initialized
     /// - Then:
@@ -38,6 +38,10 @@ class DataStoreHubEventTests: HubEventsIntegrationTestBase {
     ///    - syncQueriesReady received, payload should be nil
     func testDataStoreConfiguredDispatchesHubEvents() async throws {
         Amplify.Logging.logLevel = .verbose
+        try configureAmplify(withModels: TestModelRegistration())
+        try await Amplify.DataStore.clear()
+        await Amplify.reset()
+
         let networkStatusReceived = expectation(description: "networkStatus received")
         var networkStatusActive = false
         let subscriptionsEstablishedReceived = expectation(description: "subscriptionsEstablished received")

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
@@ -9,7 +9,7 @@ import XCTest
 
 import AWSAPIPlugin
 import AWSPluginsCore
-
+@testable import DataStoreHostApp
 @testable import Amplify
 @testable import AWSDataStorePlugin
 
@@ -45,17 +45,23 @@ class HubEventsIntegrationTestBase: XCTestCase {
         try await Task.sleep(seconds: 1)
     }
 
+    func configureAmplify(withModels models: AmplifyModelRegistration) throws {
+        let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: Self.amplifyConfigurationFile)
+
+        try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models))
+        try Amplify.add(plugin: AWSAPIPlugin(
+            modelRegistration: models,
+            sessionFactory: AmplifyURLSessionFactory()
+        ))
+        try Amplify.configure(amplifyConfig)
+    }
+
     func startAmplify(withModels models: AmplifyModelRegistration) async {
         do {
-            let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: Self.amplifyConfigurationFile)
-
-            try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models))
-            try Amplify.add(plugin: AWSAPIPlugin(modelRegistration: models))
-            try Amplify.configure(amplifyConfig)
+            try configureAmplify(withModels: models)
             try await Amplify.DataStore.start()
         } catch {
             XCTFail(String(describing: error))
-            return
         }
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
@@ -52,7 +52,10 @@ class SyncEngineIntegrationTestBase: DataStoreTestBase {
         Amplify.Logging.logLevel = logLevel
 
         do {
-            try Amplify.add(plugin: AWSAPIPlugin(modelRegistration: models))
+            try Amplify.add(plugin: AWSAPIPlugin(
+                modelRegistration: models,
+                sessionFactory: AmplifyURLSessionFactory()
+            ))
             try Amplify.add(
                 plugin: AWSDataStorePlugin(
                     modelRegistration: models,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationV2TestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationV2TestBase.swift
@@ -39,7 +39,10 @@ class SyncEngineIntegrationV2TestBase: DataStoreTestBase {
         Amplify.Logging.logLevel = logLevel
 
         do {
-            try Amplify.add(plugin: AWSAPIPlugin(modelRegistration: models))
+            try Amplify.add(plugin: AWSAPIPlugin(
+                modelRegistration: models,
+                sessionFactory: AmplifyURLSessionFactory()
+            ))
             try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models))
         } catch {
             XCTFail(String(describing: error))

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/AWSDataStoreLazyLoadBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/AWSDataStoreLazyLoadBaseTest.swift
@@ -12,6 +12,7 @@ import Combine
 import AWSPluginsCore
 import AWSAPIPlugin
 
+@testable import DataStoreHostApp
 @testable import Amplify
 
 class AWSDataStoreLazyLoadBaseTest: XCTestCase {
@@ -68,7 +69,7 @@ class AWSDataStoreLazyLoadBaseTest: XCTestCase {
             
             try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models,
                                                        configuration: .custom(syncMaxRecords: 100)))
-            try Amplify.add(plugin: AWSAPIPlugin())
+            try Amplify.add(plugin: AWSAPIPlugin(sessionFactory: AmplifyURLSessionFactory()))
             try Amplify.configure(amplifyConfig)
             
             try await deleteMutationEvents()
@@ -105,7 +106,7 @@ class AWSDataStoreLazyLoadBaseTest: XCTestCase {
         do {
             setupConfig()
             Amplify.Logging.logLevel = logLevel
-            try Amplify.add(plugin: AWSAPIPlugin(modelRegistration: models))
+            try Amplify.add(plugin: AWSAPIPlugin(modelRegistration: models, sessionFactory: AmplifyURLSessionFactory()))
             try Amplify.configure(amplifyConfig)
         } catch {
             XCTFail("Error during setup: \(error)")

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/TestConfigHelper.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/TestConfigHelper.swift
@@ -8,8 +8,6 @@
 import Foundation
 @testable import Amplify
 
-extension String: Error { }
-
 class TestConfigHelper {
 
     static func retrieveAmplifyConfiguration(forResource: String) throws -> AmplifyConfiguration {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreAuthBaseTest.swift
@@ -13,6 +13,7 @@ import AWSPluginsCore
 import AWSAPIPlugin
 import AWSCognitoAuthPlugin
 
+@testable import DataStoreHostApp
 @testable import Amplify
 
 struct TestUser {
@@ -155,9 +156,11 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
 
     /// Setup DataStore with given models
     /// - Parameter models: DataStore models
-    func setup(withModels models: AmplifyModelRegistration,
-               testType: DataStoreAuthTestType,
-               apiPluginFactory: () -> AWSAPIPlugin = { AWSAPIPlugin() }) async {
+    func setup(
+        withModels models: AmplifyModelRegistration,
+        testType: DataStoreAuthTestType,
+        apiPluginFactory: () -> AWSAPIPlugin = { AWSAPIPlugin(sessionFactory: AmplifyURLSessionFactory()) }
+    ) async {
         do {
             setupCredentials(forAuthStrategy: testType)
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TestSupport/SyncEngineIntegrationV2TestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TestSupport/SyncEngineIntegrationV2TestBase.swift
@@ -39,7 +39,10 @@ class SyncEngineIntegrationV2TestBase: DataStoreTestBase {
         Amplify.Logging.logLevel = logLevel
 
         do {
-            try Amplify.add(plugin: AWSAPIPlugin(modelRegistration: models))
+            try Amplify.add(plugin: AWSAPIPlugin(
+                modelRegistration: models,
+                sessionFactory: AmplifyURLSessionFactory()
+            ))
             try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models,
                                                        configuration: .custom(syncMaxRecords: 100)))
         } catch {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
@@ -546,6 +546,8 @@
 		21DFAEA3295F4E8600B4A883 /* PhoneCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAE9D295F4E8600B4A883 /* PhoneCall.swift */; };
 		21DFAEA4295F4E8600B4A883 /* Transcript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAE9E295F4E8600B4A883 /* Transcript.swift */; };
 		21DFAEA6295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAEA5295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift */; };
+		60040D982A18362400D123D6 /* AmplifyURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60040D962A18362400D123D6 /* AmplifyURLSession.swift */; };
+		60040D992A18362400D123D6 /* AmplifyURLSessionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60040D972A18362400D123D6 /* AmplifyURLSessionFactory.swift */; };
 		681DFE8328E746C10000C36A /* AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8028E746C10000C36A /* AsyncTesting.swift */; };
 		681DFE8428E746C10000C36A /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8128E746C10000C36A /* AsyncExpectation.swift */; };
 		681DFE8528E746C10000C36A /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8228E746C10000C36A /* XCTestCase+AsyncTesting.swift */; };
@@ -1316,6 +1318,8 @@
 		21DFAE9D295F4E8600B4A883 /* PhoneCall.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhoneCall.swift; sourceTree = "<group>"; };
 		21DFAE9E295F4E8600B4A883 /* Transcript.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transcript.swift; sourceTree = "<group>"; };
 		21DFAEA5295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadPhoneCallTests.swift; sourceTree = "<group>"; };
+		60040D962A18362400D123D6 /* AmplifyURLSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmplifyURLSession.swift; sourceTree = "<group>"; };
+		60040D972A18362400D123D6 /* AmplifyURLSessionFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmplifyURLSessionFactory.swift; sourceTree = "<group>"; };
 		60CB6B3E2A1454F90051BAD2 /* amplify-swift */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-swift"; path = ../../../..; sourceTree = "<group>"; };
 		681DFE8028E746C10000C36A /* AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncTesting.swift; sourceTree = "<group>"; };
 		681DFE8128E746C10000C36A /* AsyncExpectation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncExpectation.swift; sourceTree = "<group>"; };
@@ -1537,6 +1541,8 @@
 				213DBB6128A4172000B30280 /* Info.plist */,
 				2118212F289BFB4B001B5945 /* DataStoreHostAppApp.swift */,
 				21182131289BFB4B001B5945 /* ContentView.swift */,
+				60040D962A18362400D123D6 /* AmplifyURLSession.swift */,
+				60040D972A18362400D123D6 /* AmplifyURLSessionFactory.swift */,
 				21182133289BFB4F001B5945 /* Assets.xcassets */,
 				21182135289BFB4F001B5945 /* Preview Content */,
 			);
@@ -3454,6 +3460,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				60040D992A18362400D123D6 /* AmplifyURLSessionFactory.swift in Sources */,
+				60040D982A18362400D123D6 /* AmplifyURLSession.swift in Sources */,
 				21182132289BFB4B001B5945 /* ContentView.swift in Sources */,
 				213DBC6328A5841400B30280 /* HubListenerTestUtilities.swift in Sources */,
 				219B518628E3A7150080EDCC /* DataStoreHubEvent.swift in Sources */,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp/AmplifyURLSession.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp/AmplifyURLSession.swift
@@ -1,0 +1,77 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+import Amplify
+import AWSAPIPlugin
+
+enum AmplifyURLSessionState {
+    case active
+    case inactive
+}
+
+class AmplifyURLSessionNoOperationDataTask: URLSessionDataTaskBehavior {
+    var taskBehaviorIdentifier: Int
+
+    var taskBehaviorResponse: URLResponse?
+
+    init(taskBehaviorIdentifier: Int, taskBehaviorResponse: URLResponse? = nil) {
+        self.taskBehaviorIdentifier = taskBehaviorIdentifier
+        self.taskBehaviorResponse = taskBehaviorResponse
+    }
+
+    static let shared: AmplifyURLSessionNoOperationDataTask =
+        AmplifyURLSessionNoOperationDataTask(taskBehaviorIdentifier: -1)
+
+    func cancel() { }
+
+    func pause() { }
+
+    func resume() { }
+
+}
+
+class AmplifyURLSession {
+    private let queue = DispatchQueue(label: "AmplifyURLSession")
+    private var state: AmplifyURLSessionState
+    let session: URLSession
+
+    init(state: AmplifyURLSessionState, session: URLSession) {
+        self.state = state
+        self.session = session
+    }
+
+    convenience init(session: URLSession) {
+        self.init(state: .active, session: session)
+    }
+}
+
+extension AmplifyURLSession: URLSessionBehavior {
+    func cancelAndReset() async {
+        queue.sync {
+            state = .inactive
+        }
+        await session.cancelAndReset()
+    }
+
+    func dataTaskBehavior(with request: URLRequest) -> URLSessionDataTaskBehavior {
+        queue.sync {
+            switch state {
+            case .active:
+                return session.dataTask(with: request)
+            default:
+                return AmplifyURLSessionNoOperationDataTask.shared
+            }
+        }
+    }
+
+    var sessionBehaviorDelegate: URLSessionBehaviorDelegate? {
+        return session.sessionBehaviorDelegate
+    }
+
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp/AmplifyURLSessionFactory.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp/AmplifyURLSessionFactory.swift
@@ -1,0 +1,26 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+import AWSAPIPlugin
+
+class AmplifyURLSessionFactory: URLSessionBehaviorFactory {
+    func makeSession(withDelegate delegate: URLSessionBehaviorDelegate?) -> URLSessionBehavior {
+        let urlSessionDelegate = delegate?.asURLSessionDelegate
+        let configuration = URLSessionConfiguration.default
+        configuration.tlsMinimumSupportedProtocolVersion = .TLSv12
+        configuration.tlsMaximumSupportedProtocolVersion = .TLSv13
+        
+        let session = URLSession(configuration: configuration,
+                                 delegate: urlSessionDelegate,
+                                 delegateQueue: nil)
+        return AmplifyURLSession(session: session)
+    }
+
+
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressBaseTest.swift
@@ -29,7 +29,7 @@ class DataStoreStressBaseTest: XCTestCase {
         do {
             let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: Self.amplifyConfigurationFile)
             try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models, configuration: .custom(syncMaxRecords: 100)))
-            try Amplify.add(plugin: AWSAPIPlugin(modelRegistration: models))
+            try Amplify.add(plugin: AWSAPIPlugin(modelRegistration: models, sessionFactory: AmplifyURLSessionFactory()))
             try Amplify.configure(amplifyConfig)
         } catch {
             XCTFail(String(describing: error))


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

When performing `Amplify.reset`, th `URLSession` of the API plugin is also invalidated and reset. This means that any ongoing operations that utilize this `URLSession` to create new URL tasks may encounter an exception with the message `"Terminating app due to uncaught exception 'NSGenericException', reason: 'Task created in a session that has been invalidated'"` Unfortunately, `URLSession` does not provide a method to check if the current session has been invalidated.

## Description
<!-- Why is this change required? What problem does it solve? -->

- create a new class called `AmplifyURLSession` that acts as a wrapper for `URLSession` and also conforms to the `URLSessionBehavior` protocol.
- in the `AmplifyURLSession` class, include a variable that tracks the state of the `URLSession`.
- when attempting to generate a dataTask, check the state of the `URLSession` in `AmplifyURLSession` to ensure it is not already invalidated. If the session is invalidated, prevent the generation of the dataTask.

we can effectively manage the `URLSession` state and avoid generating data tasks when the session is already invalidated.



## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
