### PR TITLE
fix(Auth): Pass client metadata to password verifier during SRP sign in

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/InitiateAuthSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/InitiateAuthSRP.swift
@@ -104,7 +104,7 @@ struct InitiateAuthSRP: Action {
                 parameters: parameters)
             return SignInEvent(eventType: .receivedChallenge(respondToAuthChallenge))
         }
-        return SignInEvent(eventType: .respondPasswordVerifier(srpStateData, response))
+        return SignInEvent(eventType: .respondPasswordVerifier(srpStateData, response, clientMetadata))
     }
 }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/VerifyPasswordSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/VerifyPasswordSRP.swift
@@ -14,11 +14,14 @@ struct VerifyPasswordSRP: Action {
 
     let stateData: SRPStateData
     let authResponse: InitiateAuthOutputResponse
+    let clientMetadata: ClientMetadata
 
     init(stateData: SRPStateData,
-         authResponse: InitiateAuthOutputResponse) {
+         authResponse: InitiateAuthOutputResponse,
+         clientMetadata: ClientMetadata) {
         self.stateData = stateData
         self.authResponse = authResponse
+        self.clientMetadata = clientMetadata
     }
 
     func execute(withDispatcher dispatcher: EventDispatcher,
@@ -60,6 +63,7 @@ struct VerifyPasswordSRP: Action {
                 session: authResponse.session,
                 secretBlock: secretBlockString,
                 signature: signature,
+                clientMetadata: clientMetadata,
                 deviceMetadata: deviceMetadata,
                 asfDeviceId: asfDeviceId,
                 environment: userPoolEnv)
@@ -83,7 +87,7 @@ struct VerifyPasswordSRP: Action {
             logVerbose("\(#fileID) Received device not found \(error)", environment: environment)
             // Remove the saved device details and retry password verify
             await DeviceMetadataHelper.removeDeviceMetaData(for: username, with: environment)
-            let event = SignInEvent(eventType: .retryRespondPasswordVerifier(stateData, authResponse))
+            let event = SignInEvent(eventType: .retryRespondPasswordVerifier(stateData, authResponse, clientMetadata))
             logVerbose("\(#fileID) Sending event \(event)",
                        environment: environment)
             await dispatcher.send(event)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInEvent.swift
@@ -28,7 +28,7 @@ struct SignInEvent: StateMachineEvent {
 
         case initiateMigrateAuth(SignInEventData, DeviceMetadata)
 
-        case respondPasswordVerifier(SRPStateData, InitiateAuthOutputResponse)
+        case respondPasswordVerifier(SRPStateData, InitiateAuthOutputResponse, ClientMetadata)
 
         case retryRespondPasswordVerifier(SRPStateData, InitiateAuthOutputResponse, ClientMetadata)
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInEvent.swift
@@ -10,6 +10,7 @@ import AWSCognitoIdentityProvider
 
 typealias Username = String
 typealias Password = String
+typealias ClientMetadata = [String: String]
 
 struct SignInEvent: StateMachineEvent {
 
@@ -29,7 +30,7 @@ struct SignInEvent: StateMachineEvent {
 
         case respondPasswordVerifier(SRPStateData, InitiateAuthOutputResponse)
 
-        case retryRespondPasswordVerifier(SRPStateData, InitiateAuthOutputResponse)
+        case retryRespondPasswordVerifier(SRPStateData, InitiateAuthOutputResponse, ClientMetadata)
 
         case initiateDeviceSRP(Username, SignInResponseBehavior)
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SRP/SRPSignInState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SRP/SRPSignInState+Resolver.swift
@@ -35,8 +35,7 @@ extension SRPSignInState {
             case .initiatingSRPA(let signInEventData):
                 return resolveInitiatingSRPA(
                     byApplying: srpSignInEvent,
-                    from: oldState,
-                    with: signInEventData)
+                    from: oldState)
             case .respondingPasswordVerifier(let srpStateData):
                 return resolveRespondingVerifyPassword(
                     srpStateData: srpStateData,
@@ -85,15 +84,14 @@ extension SRPSignInState {
 
         private func resolveInitiatingSRPA(
             byApplying signInEvent: SignInEvent,
-            from oldState: SRPSignInState,
-            with signInEventData: SignInEventData)
+            from oldState: SRPSignInState)
         -> StateResolution<SRPSignInState> {
             switch signInEvent.eventType {
-            case .respondPasswordVerifier(let srpStateData, let authResponse):
+            case .respondPasswordVerifier(let srpStateData, let authResponse, let clientMetadata):
                 let action = VerifyPasswordSRP(
                     stateData: srpStateData,
                     authResponse: authResponse,
-                    clientMetadata: signInEventData.clientMetadata)
+                    clientMetadata: clientMetadata)
                 return StateResolution(
                     newState: SRPSignInState.respondingPasswordVerifier(srpStateData),
                     actions: [action]

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SRP/SRPSignInState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SRP/SRPSignInState+Resolver.swift
@@ -32,10 +32,15 @@ extension SRPSignInState {
             switch oldState {
             case .notStarted:
                 return resolveNotStarted(byApplying: srpSignInEvent)
-            case .initiatingSRPA:
-                return resolveInitiatingSRPA(byApplying: srpSignInEvent, from: oldState)
+            case .initiatingSRPA(let signInEventData):
+                return resolveInitiatingSRPA(
+                    byApplying: srpSignInEvent,
+                    from: oldState,
+                    with: signInEventData)
             case .respondingPasswordVerifier(let srpStateData):
-                return resolveRespondingVerifyPassword(srpStateData: srpStateData, byApplying: srpSignInEvent)
+                return resolveRespondingVerifyPassword(
+                    srpStateData: srpStateData,
+                    byApplying: srpSignInEvent)
             case .signedIn, .error:
                 return .from(oldState)
             case .cancelling:
@@ -80,12 +85,15 @@ extension SRPSignInState {
 
         private func resolveInitiatingSRPA(
             byApplying signInEvent: SignInEvent,
-            from oldState: SRPSignInState)
+            from oldState: SRPSignInState,
+            with signInEventData: SignInEventData)
         -> StateResolution<SRPSignInState> {
             switch signInEvent.eventType {
             case .respondPasswordVerifier(let srpStateData, let authResponse):
-                let action = VerifyPasswordSRP(stateData: srpStateData,
-                                               authResponse: authResponse)
+                let action = VerifyPasswordSRP(
+                    stateData: srpStateData,
+                    authResponse: authResponse,
+                    clientMetadata: signInEventData.clientMetadata)
                 return StateResolution(
                     newState: SRPSignInState.respondingPasswordVerifier(srpStateData),
                     actions: [action]
@@ -102,9 +110,11 @@ extension SRPSignInState {
             byApplying signInEvent: SignInEvent)
         -> StateResolution<SRPSignInState> {
             switch signInEvent.eventType {
-            case .retryRespondPasswordVerifier(let srpStateData, let authResponse):
-                let action = VerifyPasswordSRP(stateData: srpStateData,
-                                               authResponse: authResponse)
+            case .retryRespondPasswordVerifier(let srpStateData, let authResponse, let clientMetadata):
+                let action = VerifyPasswordSRP(
+                    stateData: srpStateData,
+                    authResponse: authResponse,
+                    clientMetadata: clientMetadata)
                 return StateResolution(
                     newState: SRPSignInState.respondingPasswordVerifier(srpStateData),
                     actions: [action]

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/RespondToAuthChallengeInput+Amplify.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/RespondToAuthChallengeInput+Amplify.swift
@@ -15,6 +15,7 @@ extension RespondToAuthChallengeInput {
                                  session: String?,
                                  secretBlock: String,
                                  signature: String,
+                                 clientMetadata: ClientMetadata,
                                  deviceMetadata: DeviceMetadata,
                                  asfDeviceId: String?,
                                  environment: UserPoolEnvironment) -> RespondToAuthChallengeInput {
@@ -29,7 +30,7 @@ extension RespondToAuthChallengeInput {
             challengeType: .passwordVerifier,
             challengeResponses: challengeResponses,
             session: session,
-            clientMetadata: [:],
+            clientMetadata: clientMetadata,
             asfDeviceId: asfDeviceId,
             deviceMetadata: deviceMetadata,
             environment: environment)
@@ -119,7 +120,7 @@ extension RespondToAuthChallengeInput {
         challengeType: CognitoIdentityProviderClientTypes.ChallengeNameType,
         challengeResponses: [String: String],
         session: String?,
-        clientMetadata: [String: String],
+        clientMetadata: ClientMetadata,
         asfDeviceId: String?,
         deviceMetadata: DeviceMetadata,
         environment: UserPoolEnvironment) -> RespondToAuthChallengeInput {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/InitiateAuthSRPTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/InitiateAuthSRPTests.swift
@@ -95,7 +95,7 @@ class InitiateAuthSRPTests: XCTestCase {
                 return
             }
 
-            if case let .respondPasswordVerifier(_, authResponse) = event.eventType {
+            if case let .respondPasswordVerifier(_, authResponse, _) = event.eventType {
                 XCTAssertNotNil(authResponse)
                 successEventSent.fulfill()
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyPasswordSRPTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyPasswordSRPTests.swift
@@ -39,7 +39,8 @@ class VerifyPasswordSRPTests: XCTestCase {
 
         let data = InitiateAuthOutputResponse.validTestData
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
-                                       authResponse: data)
+                                       authResponse: data,
+                                       clientMetadata: [:])
 
         await action.execute(
             withDispatcher: MockDispatcher { _ in },
@@ -71,7 +72,8 @@ class VerifyPasswordSRPTests: XCTestCase {
 
         let data = InitiateAuthOutputResponse.validTestData
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
-                                       authResponse: data)
+                                       authResponse: data,
+                                       clientMetadata: [:])
 
         let passwordVerifierError = expectation(description: "passwordVerifierError")
 
@@ -118,7 +120,8 @@ class VerifyPasswordSRPTests: XCTestCase {
 
         let data = InitiateAuthOutputResponse.invalidChallenge
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
-                                       authResponse: data)
+                                       authResponse: data,
+                                       clientMetadata: [:])
 
         let passwordVerifierError = expectation(
             description: "passwordVerifierError")
@@ -165,7 +168,8 @@ class VerifyPasswordSRPTests: XCTestCase {
 
         let data = InitiateAuthOutputResponse.invalidTestDataWithNoSalt
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
-                                       authResponse: data)
+                                       authResponse: data,
+                                       clientMetadata: [:])
 
         let passwordVerifierError = expectation(
             description: "passwordVerifierError")
@@ -212,7 +216,8 @@ class VerifyPasswordSRPTests: XCTestCase {
 
         let data = InitiateAuthOutputResponse.invalidTestDataWithNoSecretBlock
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
-                                       authResponse: data)
+                                       authResponse: data,
+                                       clientMetadata: [:])
 
         let passwordVerifierError = expectation(
             description: "passwordVerifierError")
@@ -259,7 +264,8 @@ class VerifyPasswordSRPTests: XCTestCase {
 
         let data = InitiateAuthOutputResponse.invalidTestDataWithNoSRPB
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
-                                       authResponse: data)
+                                       authResponse: data,
+                                       clientMetadata: [:])
 
         let passwordVerifierError = expectation(
             description: "passwordVerifierError")
@@ -306,7 +312,8 @@ class VerifyPasswordSRPTests: XCTestCase {
 
         let data = InitiateAuthOutputResponse.invalidTestDataForException
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
-                                       authResponse: data)
+                                       authResponse: data,
+                                       clientMetadata: [:])
 
         let passwordVerifierError = expectation(
             description: "passwordVerifierError")
@@ -352,7 +359,8 @@ class VerifyPasswordSRPTests: XCTestCase {
 
         let data = InitiateAuthOutputResponse.validTestData
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
-                                       authResponse: data)
+                                       authResponse: data,
+                                       clientMetadata: [:])
 
         let passwordVerifierCompletion = expectation(
             description: "passwordVerifierCompletion")
@@ -394,7 +402,8 @@ class VerifyPasswordSRPTests: XCTestCase {
 
         let data = InitiateAuthOutputResponse.validTestData
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
-                                       authResponse: data)
+                                       authResponse: data,
+                                       clientMetadata: [:])
 
         let passwordVerifierError = expectation(
             description: "passwordVerifierError")
@@ -443,7 +452,8 @@ class VerifyPasswordSRPTests: XCTestCase {
 
         let data = InitiateAuthOutputResponse.validTestData
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
-                                       authResponse: data)
+                                       authResponse: data,
+                                       clientMetadata: [:])
 
         let passwordVerifierError = expectation(description: "passwordVerifierError")
 
@@ -487,7 +497,8 @@ class VerifyPasswordSRPTests: XCTestCase {
 
         let data = InitiateAuthOutputResponse.validTestData
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
-                                       authResponse: data)
+                                       authResponse: data,
+                                       clientMetadata: [:])
 
         let passwordVerifierCompletion = expectation(
             description: "passwordVerifierCompletion")
@@ -529,7 +540,8 @@ class VerifyPasswordSRPTests: XCTestCase {
 
         let data = InitiateAuthOutputResponse.validTestData
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
-                                       authResponse: data)
+                                       authResponse: data,
+                                       clientMetadata: [:])
 
         let passwordVerifierCompletion = expectation(
             description: "passwordVerifierCompletion")

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/SRPTestData.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/SRPTestData.swift
@@ -134,7 +134,7 @@ extension SignInEvent {
 
     static let respondPasswordVerifierEvent = SignInEvent(
         id: "respondPasswordVerifierEvent",
-        eventType: .respondPasswordVerifier(.testData, InitiateAuthOutputResponse.testData)
+        eventType: .respondPasswordVerifier(.testData, InitiateAuthOutputResponse.testData, [:])
     )
 
     static func finalizeSRPSignInEvent(signedInData: SignedInData) -> SignInEvent {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignUpState/RespondToAuthInputTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignUpState/RespondToAuthInputTests.swift
@@ -88,6 +88,7 @@ class RespondToAuthInputTests: XCTestCase {
             session: "session",
             secretBlock: "secret",
             signature: "signature",
+            clientMetadata: ["test": "test"],
             deviceMetadata: .metadata(.init(deviceKey: "", deviceGroupKey: "")),
             asfDeviceId: "asfDeviceId",
             environment: environment)

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
@@ -310,14 +310,17 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///
     func testCustomAuthWithAdditionalInfo() async {
 
-        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+        let clientMetadata = ["somekey": "somevalue"]
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
+            XCTAssertEqual(clientMetadata, input.clientMetadata)
+            return InitiateAuthOutputResponse(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
                 challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
                 session: "someSession")
-        }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+        }, mockRespondToAuthChallengeResponse: { input in
+            XCTAssertEqual([clientMetadata], input.clientMetadata)
+            return RespondToAuthChallengeOutputResponse(
                 authenticationResult: .none,
                 challengeName: .customChallenge,
                 challengeParameters: ["paramKey": "value"],
@@ -325,7 +328,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
         })
 
         let pluginOptions = AWSAuthSignInOptions(
-            metadata: ["somekey": "somevalue"],
+            metadata: clientMetadata,
             authFlowType: .customWithSRP
         )
         let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AWSAuthSignInPluginTests.swift
@@ -28,15 +28,17 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     ///    - I should get a .done response
     ///
     func testSuccessfulSignIn() async {
-
-        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+        let clientMetadata = ["somekey": "somevalue"]
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
+            XCTAssertEqual(clientMetadata, input.clientMetadata)
+            return InitiateAuthOutputResponse(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
                 challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
                 session: "someSession")
-        }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+        }, mockRespondToAuthChallengeResponse: { input in
+            XCTAssertEqual(clientMetadata, input.clientMetadata)
+            return RespondToAuthChallengeOutputResponse(
                 authenticationResult: .init(
                     accessToken: Defaults.validAccessToken,
                     expiresIn: 300,
@@ -49,7 +51,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
                 session: "session")
         })
 
-        let pluginOptions = AWSAuthSignInOptions(metadata: ["somekey": "somevalue"])
+        let pluginOptions = AWSAuthSignInOptions(metadata: clientMetadata)
         let options = AuthSignInRequest.Options(pluginOptions: pluginOptions)
 
         do {
@@ -319,7 +321,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
                 challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { input in
-            XCTAssertEqual([clientMetadata], input.clientMetadata)
+            XCTAssertEqual(clientMetadata, input.clientMetadata)
             return RespondToAuthChallengeOutputResponse(
                 authenticationResult: .none,
                 challengeName: .customChallenge,

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "fbff345ef06eac131c41da21d765edeedbd52ba1",
-        "version" : "0.11.0"
+        "revision" : "24bae88a2391fe75da8a940a544d1ef6441f5321",
+        "version" : "0.13.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/smithy-swift.git",
       "state" : {
-        "revision" : "1f80a308de05f3805ee6bee3914dc0859dfe37e6",
-        "version" : "0.13.0"
+        "revision" : "7b28da158d92cd06a3549140d43b8fbcf64a94a6",
+        "version" : "0.15.0"
       }
     },
     {


### PR DESCRIPTION
## Issue \#
#2983 

## Description
Adding the missing implementation of passing client metadata for RespondToAuthChallenge cases with Cognito. 

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
