### PR TITLE
ci(v1): add oidc context to unstable release lane

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,6 +469,7 @@ workflows:
             - fortify_scan
       - deploy:
           name: deploy unstable
+          context: amplify-swift-aws-oidc
           <<: *deploy_requires
           filters:
             branches:


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
The final step of publishing a new unstable version in the unstable release CircleCI job failed due to the absence of OIDC context necessary for retrieving the CocoaPod Trunk Token.


## Description
<!-- Why is this change required? What problem does it solve? -->
- add OIDC context for unstable release lane.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
