### PR TITLE
ci(v1): read CocoaPods token before publishing

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,15 +35,6 @@ platform :ios do
 
   desc "Create a release version by building and committing a changelog, pushing a tag to GitHub, and pushing pods to CocoaPods"
   lane :release do
-    # Define `COCOAPODS_TRUNK_TOKEN` env var for trunk authentication
-    # https://github.com/CocoaPods/cocoapods-trunk/commit/9e6ec1c1faf96fa837dc2ed70b5f54006b181ed6
-    secret = sh(
-        command: 'aws secretsmanager get-secret-value --secret-id ${COCOAPODS_SECRET_ARN}',
-        log: false
-    )
-
-    ENV['COCOAPODS_TRUNK_TOKEN'] = JSON.parse(secret)["SecretString"]
-
     next_version, commits = calculate_next_release_version(version_limit:'v2.0.0')
     if next_version >= '2.0.0'
       UI.message("Received version: #{next_version}, exiting lane because version is larger than 2.0.0")
@@ -116,6 +107,15 @@ platform :ios do
 
   desc "Release pods"
   private_lane :release_pods do
+    # Define `COCOAPODS_TRUNK_TOKEN` env var for trunk authentication
+    # https://github.com/CocoaPods/cocoapods-trunk/commit/9e6ec1c1faf96fa837dc2ed70b5f54006b181ed6
+    secret = sh(
+        command: 'aws secretsmanager get-secret-value --secret-id ${COCOAPODS_SECRET_ARN}',
+        log: false
+    )
+
+    ENV['COCOAPODS_TRUNK_TOKEN'] = JSON.parse(secret)["SecretString"]
+
     AmplifyPods.pods.each do |pod|
       if pod[:no_push]
         UI.message "Skipping pushing pod #{pod[:spec]}"


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
related issue: https://github.com/aws-amplify/amplify-swift/pull/2990

## Description
<!-- Why is this change required? What problem does it solve? -->
This PR moves the procedure the process of retrieving the CocoaPods trunk token from AWS SecretManager to the fastlane `release_pods` function, allowing it to be used for both `unstable` and `stable` releases.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
