### PR TITLE
test(datastore): fix integration test errors for AWSDataStorePluginV2Tests

### DIFF
--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   datastore-integration-v2-test:
     timeout-minutes: 30
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -33,3 +33,6 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginV2Tests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
+

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
@@ -114,10 +114,9 @@ class SyncEngineIntegrationTestBase: DataStoreTestBase {
             return
         }
 
-        try await Amplify.DataStore.start()
-        await fulfillment(of: [eventReceived], timeout: 10)
-
         try await deleteMutationEvents()
+
+        await fulfillment(of: [eventReceived], timeout: 10)
     }
     
     func deleteMutationEvents() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TestSupport/SyncEngineIntegrationV2TestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TestSupport/SyncEngineIntegrationV2TestBase.swift
@@ -28,14 +28,22 @@ class SyncEngineIntegrationV2TestBase: DataStoreTestBase {
         let storageAdapter = storageEngine.storageAdapter as! SQLiteStorageEngineAdapter
         return storageAdapter
     }
+
+    override func setUp() {
+        continueAfterFailure = true
+    }
+
+    override func tearDown() async throws {
+        try await Amplify.DataStore.clear()
+        await Amplify.reset()
+        try await Task.sleep(seconds: 1)
+    }
+
     // swiftlint:enable force_try
     // swiftlint:enable force_cast
 
     func setUp(withModels models: AmplifyModelRegistration, logLevel: LogLevel = .error) async {
 
-        continueAfterFailure = false
-
-        await Amplify.reset()
         Amplify.Logging.logLevel = logLevel
 
         do {
@@ -98,6 +106,6 @@ class SyncEngineIntegrationV2TestBase: DataStoreTestBase {
         let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: Self.amplifyConfigurationFile)
         try Amplify.configure(amplifyConfig)
         try await Amplify.DataStore.start()
-        await waitForExpectations(timeout: 100.0)
+        await fulfillment(of: [eventReceived], timeout: 100)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionOptionalAssociations.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionOptionalAssociations.swift
@@ -242,7 +242,7 @@ class DataStoreConnectionOptionalAssociations: SyncEngineIntegrationV2TestBase {
 
     func testQueryAllPost() async throws {
         await setUp(withModels: TestModelRegistration())
-        try await startAmplifyAndWaitForSync()
+        try await startAmplifyAndWaitForReady()
         let queriedPosts = try await Amplify.DataStore.query(Post8.self)
         XCTAssertTrue(!queriedPosts.isEmpty)
     }
@@ -255,13 +255,13 @@ class DataStoreConnectionOptionalAssociations: SyncEngineIntegrationV2TestBase {
             commentToSave = Comment8(content: "content", post: post)
         }
 
-        let waitForSync = asyncExpectation(description: "synced")
+        let waitForSync = expectation(description: "synced")
         token = Amplify.Hub.listen(to: .dataStore) { payload in
             let event = DataStoreHubEvent(payload: payload)
             switch event {
             case .syncReceived(let mutationEvent):
                 if mutationEvent.modelId == commentToSave.id {
-                    Task { await waitForSync.fulfill() }
+                    waitForSync.fulfill()
                     if let token = self.token {
                         Amplify.Hub.removeListener(token)
                     }
@@ -271,7 +271,7 @@ class DataStoreConnectionOptionalAssociations: SyncEngineIntegrationV2TestBase {
             }
         }
         let savedComment = try await Amplify.DataStore.save(commentToSave)
-        await waitForExpectations([waitForSync], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [waitForSync], timeout: TestCommonConstants.networkTimeout)
         return savedComment
     }
 
@@ -283,13 +283,13 @@ class DataStoreConnectionOptionalAssociations: SyncEngineIntegrationV2TestBase {
             postToSave = Post8(name: "name", randomId: "randomId", blog: blog)
         }
 
-        let waitForSync = asyncExpectation(description: "synced")
+        let waitForSync = expectation(description: "synced")
         token = Amplify.Hub.listen(to: .dataStore) { payload in
             let event = DataStoreHubEvent(payload: payload)
             switch event {
             case .syncReceived(let mutationEvent):
                 if mutationEvent.modelId == postToSave.id {
-                    Task { await waitForSync.fulfill() }
+                    waitForSync.fulfill()
                     if let token = self.token {
                         Amplify.Hub.removeListener(token)
                     }
@@ -299,7 +299,7 @@ class DataStoreConnectionOptionalAssociations: SyncEngineIntegrationV2TestBase {
             }
         }
         let savedPost = try await Amplify.DataStore.save(postToSave)
-        await waitForExpectations([waitForSync], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [waitForSync], timeout: TestCommonConstants.networkTimeout)
         return savedPost
     }
 
@@ -318,13 +318,13 @@ class DataStoreConnectionOptionalAssociations: SyncEngineIntegrationV2TestBase {
             blogToSave = Blog8(name: "name", customs: [customModel], notes: ["notes1", "notes2"])
         }
 
-        let waitForSync = asyncExpectation(description: "synced")
+        let waitForSync = expectation(description: "synced")
         token = Amplify.Hub.listen(to: .dataStore) { payload in
             let event = DataStoreHubEvent(payload: payload)
             switch event {
             case .syncReceived(let mutationEvent):
                 if mutationEvent.modelId == blogToSave.id {
-                    Task { await waitForSync.fulfill() }
+                    waitForSync.fulfill()
                     if let token = self.token {
                         Amplify.Hub.removeListener(token)
                     }
@@ -335,7 +335,7 @@ class DataStoreConnectionOptionalAssociations: SyncEngineIntegrationV2TestBase {
             }
         }
         let savedBlog = try await Amplify.DataStore.save(blogToSave)
-        await waitForExpectations([waitForSync], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [waitForSync], timeout: TestCommonConstants.networkTimeout)
         return savedBlog
     }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario1V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario1V2Tests.swift
@@ -65,7 +65,7 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         }
 
         _ = try await Amplify.DataStore.save(team)
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [syncedTeamReceived], timeout: TestCommonConstants.networkTimeout)
         
         let syncProjectReceived = expectation(description: "received project from sync path")
         hubListener = Amplify.Hub.listen(to: .dataStore,
@@ -89,7 +89,7 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         }
         
         _ = try await Amplify.DataStore.save(project)
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [syncProjectReceived], timeout: TestCommonConstants.networkTimeout)
 
         let queriedProjectOptional = try await Amplify.DataStore.query(Project1V2.self, byId: project.id)
         guard let queriedProject = queriedProjectOptional else {
@@ -137,7 +137,7 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
 
         project.project1V2TeamId = anotherTeam.id
         _ = try await Amplify.DataStore.save(project)
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [syncUpdatedProjectReceived], timeout: TestCommonConstants.networkTimeout)
 
         let queriedProjectOptional = try await Amplify.DataStore.query(Project1V2.self, byId: project.id)
         XCTAssertNotNil(queriedProjectOptional)
@@ -188,7 +188,7 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         _ = try await Amplify.DataStore.save(team)
         _ = try await Amplify.DataStore.save(project)
 
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
         let updateReceived = expectation(description: "received update project from sync path")
         hubListener = Amplify.Hub.listen(to: .dataStore,
                                              eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
@@ -212,7 +212,7 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         
         project.name = "updatedName"
         _ = try await Amplify.DataStore.save(project)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [updateReceived], timeout: TestCommonConstants.networkTimeout)
         
         let deleteReceived = expectation(description: "Delete notification received")
         deleteReceived.expectedFulfillmentCount = 2 // 1 project and 1 team
@@ -244,7 +244,7 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         // TODO: Delete Team should not be necessary, cascade delete should delete the team when deleting the project.
         // Once cascade works for hasOne, the following code can be removed.
         _ = try await Amplify.DataStore.delete(team)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
         let queriedProject = try await Amplify.DataStore.query(Project1V2.self, byId: project.id)
         XCTAssertNil(queriedProject)
 
@@ -290,7 +290,7 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         _ = try await Amplify.DataStore.save(team)
         _ = try await Amplify.DataStore.save(project)
 
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
         
         let deleteReceived = expectation(description: "Delete notification received")
         deleteReceived.expectedFulfillmentCount = 2 // 1 project and 1 team
@@ -322,7 +322,7 @@ class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
         // TODO: Delete Team should not be necessary, cascade delete should delete the team when deleting the project.
         // Once cascade works for hasOne, the following code can be removed.
         _ = try await Amplify.DataStore.delete(team)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
         let queriedProject = try await Amplify.DataStore.query(Project1V2.self, byId: project.id)
         XCTAssertNil(queriedProject)
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario2V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario2V2Tests.swift
@@ -66,7 +66,7 @@ class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
         }
         
         _ = try await Amplify.DataStore.save(team)
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [syncedTeamReceived], timeout: TestCommonConstants.networkTimeout)
         
         let syncProjectReceived = expectation(description: "received project from sync event")
         hubListener = Amplify.Hub.listen(to: .dataStore,
@@ -84,7 +84,7 @@ class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
         }
         
         _ = try await Amplify.DataStore.save(project)
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [syncProjectReceived], timeout: TestCommonConstants.networkTimeout)
 
         let queriedProjectOptional = try await Amplify.DataStore.query(Project2V2.self, byId: project.id)
         guard let queriedProject = queriedProjectOptional else {
@@ -128,7 +128,7 @@ class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
         project.teamID = anotherTeam.id
         project.team = anotherTeam
         _ = try await Amplify.DataStore.save(project)
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [syncUpdatedProjectReceived], timeout: TestCommonConstants.networkTimeout)
 
         let queriedProjectOptional = try await Amplify.DataStore.query(Project2V2.self, byId: project.id)
         XCTAssertNotNil(queriedProjectOptional)
@@ -175,7 +175,7 @@ class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
 
         _ = try await Amplify.DataStore.save(team)
         _ = try await Amplify.DataStore.save(project)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
         
         let updateReceived = expectation(description: "received update project from sync path")
         hubListener = Amplify.Hub.listen(to: .dataStore,
@@ -200,7 +200,7 @@ class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
         
         project.name = "updatedName"
         _ = try await Amplify.DataStore.save(project)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [updateReceived], timeout: TestCommonConstants.networkTimeout)
         
         let deleteReceived = expectation(description: "received deleted project from sync path")
         deleteReceived.expectedFulfillmentCount = 2 // 1 project and 1 team
@@ -231,7 +231,7 @@ class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
         // TODO: Delete Team should not be necessary, cascade delete should delete the team when deleting the project.
         // Once cascade works for hasOne, the following code can be removed.
         _ = try await Amplify.DataStore.delete(team)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
         
         let queriedProject = try await Amplify.DataStore.query(Project2V2.self, byId: project.id)
         XCTAssertNil(queriedProject)
@@ -277,7 +277,7 @@ class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
         
         _ = try await Amplify.DataStore.save(team)
         _ = try await Amplify.DataStore.save(project)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
         
         let deleteReceived = expectation(description: "Delete notification received")
         deleteReceived.expectedFulfillmentCount = 2 // 1 project and 1 team
@@ -310,7 +310,7 @@ class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
         // TODO: Delete Team should not be necessary, cascade delete should delete the team when deleting the project.
         // Once cascade works for hasOne, the following code can be removed.
         _ = try await Amplify.DataStore.delete(team)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
         let queriedProject = try await Amplify.DataStore.query(Project2V2.self, byId: project.id)
         XCTAssertNil(queriedProject)
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario3V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario3V2Tests.swift
@@ -68,7 +68,7 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
         
         _ = try await Amplify.DataStore.save(post)
         _ = try await Amplify.DataStore.save(comment)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [syncedPostReceived, syncCommentReceived], timeout: TestCommonConstants.networkTimeout)
         
         let queriedComment = try await Amplify.DataStore.query(Comment3V2.self, byId: comment.id)
         XCTAssertEqual(queriedComment, comment)
@@ -166,7 +166,7 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.save(post)
-        await(waitForExpectations(timeout: TestCommonConstants.networkTimeout))
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let queriedPost = try await Amplify.DataStore.query(Post3V2.self, byId: post.id)
         XCTAssertEqual(queriedPost, post)
@@ -198,7 +198,7 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.save(post)
-        await(waitForExpectations(timeout: TestCommonConstants.networkTimeout))
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
         
         let updatedTitle = "updatedTitle"
         post.title = updatedTitle
@@ -220,7 +220,7 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
             }
         }
         _ = try await Amplify.DataStore.save(post)
-        await(waitForExpectations(timeout: TestCommonConstants.networkTimeout))
+        await fulfillment(of: [updateReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeletePostWithSync() async throws {
@@ -250,7 +250,7 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.save(post)
-        await(waitForExpectations(timeout: TestCommonConstants.networkTimeout))
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let deleteReceived = expectation(description: "received deleted post from sync event")
         hubListener = Amplify.Hub.listen(to: .dataStore,
@@ -274,7 +274,7 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
         }
         
         _ = try await Amplify.DataStore.delete(post)
-        await(waitForExpectations(timeout: TestCommonConstants.networkTimeout))
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeletePostCascadeToComments() async throws {
@@ -313,7 +313,7 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
         }
         _ = try await Amplify.DataStore.save(post)
         _ = try await Amplify.DataStore.save(comment)
-        await(waitForExpectations(timeout: TestCommonConstants.networkTimeout))
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let deleteReceived = expectation(description: "received deleted from sync event")
         deleteReceived.expectedFulfillmentCount = 2 // 1 post and 1 comment
@@ -342,7 +342,7 @@ class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
         _ = try await Amplify.DataStore.delete(post)
         // TODO: Deleting the comment should not be necessary. Cascade delete is not working
         _ = try await Amplify.DataStore.delete(comment)
-        await(waitForExpectations(timeout: TestCommonConstants.networkTimeout))
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
 }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario3aV2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario3aV2Tests.swift
@@ -68,7 +68,7 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
         _ = try await Amplify.DataStore.save(post)
         _ = try await Amplify.DataStore.save(comment)
         
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [syncedPostReceived, syncCommentReceived], timeout: TestCommonConstants.networkTimeout)
         
         let queriedComment = try await Amplify.DataStore.query(Comment3aV2.self, byId: comment.id)
         XCTAssertEqual(queriedComment, comment)
@@ -174,7 +174,7 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
         }
         
         _ = try await Amplify.DataStore.save(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let queriedPost = try await Amplify.DataStore.query(Post3aV2.self, byId: post.id)
         XCTAssertEqual(queriedPost, post)
@@ -207,7 +207,7 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
         }
         
         _ = try await Amplify.DataStore.save(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let updateReceived = expectation(description: "received updated post from sync event")
         let updatedTitle = "updatedTitle"
@@ -235,7 +235,7 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
         
         post.title = updatedTitle
         _ = try await Amplify.DataStore.save(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [updateReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeletePostWithSync() async throws {
@@ -265,7 +265,7 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.save(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let deleteReceived = expectation(description: "received deleted post from sync event")
         hubListener = Amplify.Hub.listen(to: .dataStore,
@@ -290,7 +290,7 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
         }
         
         _ = try await Amplify.DataStore.delete(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
     
 
@@ -330,7 +330,7 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
         }
         _ = try await Amplify.DataStore.save(post)
         _ = try await Amplify.DataStore.save(comment)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let deleteReceived = expectation(description: "received deleted from sync event")
         deleteReceived.expectedFulfillmentCount = 2 // 1 post and 1 comment
@@ -363,7 +363,7 @@ class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
         _ = try await Amplify.DataStore.delete(post)
         // TODO: Deleting the comment should not be necessary. Cascade delete is not working
         _ = try await Amplify.DataStore.delete(comment)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
 }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario4V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario4V2Tests.swift
@@ -156,7 +156,7 @@ class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.save(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let queriedPost = try await Amplify.DataStore.query(Post4V2.self, byId: post.id)
         XCTAssertEqual(queriedPost, post)
@@ -188,7 +188,7 @@ class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.save(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let updatedTitle = "updatedTitle"
         let updateReceived = expectation(description: "received updated post from sync event")
@@ -215,7 +215,7 @@ class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
         
         post.title = updatedTitle
         _ = try await Amplify.DataStore.save(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [updateReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeletePostWithSync() async throws {
@@ -245,7 +245,7 @@ class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.save(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let deleteReceived = expectation(description: "received deleted post from sync event")
         hubListener = Amplify.Hub.listen(to: .dataStore,
@@ -269,7 +269,7 @@ class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.delete(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeletePostCascadeToComments() async throws {
@@ -308,7 +308,7 @@ class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
         }
         _ = try await Amplify.DataStore.save(post)
         _ = try await Amplify.DataStore.save(comment)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let deleteReceived = expectation(description: "received deleted from sync event")
         deleteReceived.expectedFulfillmentCount = 2 // 1 post and 1 comment
@@ -338,7 +338,7 @@ class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.delete(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
 }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario5V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario5V2Tests.swift
@@ -147,7 +147,7 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.save(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let queriedPost = try await Amplify.DataStore.query(Post5V2.self, byId: post.id)
         XCTAssertEqual(queriedPost, post)
@@ -179,7 +179,7 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.save(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let updateReceived = expectation(description: "received updated post from sync event")
         let updatedTitle = "updatedTitle"
@@ -202,7 +202,7 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
         }
         
         _ = try await Amplify.DataStore.save(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [updateReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeletePostWithSync() async throws {
@@ -231,7 +231,7 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.save(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let deleteReceived = expectation(description: "received deleted post from sync event")
         hubListener = Amplify.Hub.listen(to: .dataStore,
@@ -255,7 +255,7 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.delete(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeletePostCascadeToPostEditor() async throws {
@@ -302,7 +302,7 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
         _ = try await Amplify.DataStore.save(post)
         _ = try await Amplify.DataStore.save(user)
         _ = try await Amplify.DataStore.save(postEditor)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let deleteReceived = expectation(description: "received deleted from sync event")
         deleteReceived.expectedFulfillmentCount = 2 // 1 post, 1 postEditor
@@ -332,7 +332,7 @@ class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.delete(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
 }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario6V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario6V2Tests.swift
@@ -221,7 +221,7 @@ class DataStoreConnectionScenario6V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         XCTAssertEqual(queriedBlog.id, blog.id)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testSaveBlogPost() async throws {
@@ -289,7 +289,7 @@ class DataStoreConnectionScenario6V2Tests: SyncEngineIntegrationV2TestBase {
         }
         try await posts.fetch()
         XCTAssertEqual(posts.count, 2)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testSaveBlogPostComment() async throws {
@@ -369,7 +369,7 @@ class DataStoreConnectionScenario6V2Tests: SyncEngineIntegrationV2TestBase {
         XCTAssertTrue(comments.contains(where: { (commentFetched) -> Bool in
             commentFetched.id == comment.id
         }))
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testCascadeDeleteBlogDeletesPostAndComments() async throws {
@@ -415,7 +415,7 @@ class DataStoreConnectionScenario6V2Tests: SyncEngineIntegrationV2TestBase {
             XCTFail("Listener not registered for hub")
             return
         }
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let deleteReceived = expectation(description: "Delete notification received")
         deleteReceived.expectedFulfillmentCount = 3 // 3 models due to cascade delete behavior
@@ -450,7 +450,7 @@ class DataStoreConnectionScenario6V2Tests: SyncEngineIntegrationV2TestBase {
         }
         
         _ = try await Amplify.DataStore.delete(blog)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
 
     }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario7V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario7V2Tests.swift
@@ -215,8 +215,7 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         XCTAssertEqual(queriedBlog.id, blog.id)
-        
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testSaveBlogPost() async throws {
@@ -283,7 +282,7 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
         }
         try await posts.fetch()
         XCTAssertEqual(posts.count, 2)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testSaveBlogPostComment() async throws {
@@ -361,7 +360,7 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
         XCTAssertTrue(comments.contains(where: { (commentFetched) -> Bool in
             commentFetched.id == comment.id
         }))
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testUpdatePostWithSync() async throws {
@@ -394,7 +393,7 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
             XCTFail("Listener not registered for hub")
             return
         }
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let updateReceived = expectation(description: "received updated post from sync event")
         let updatedTitle = "updatedTitle"
@@ -420,7 +419,7 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.save(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [updateReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeletePostWithSync() async throws {
@@ -452,7 +451,7 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
             XCTFail("Listener not registered for hub")
             return
         }
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
         
         let deleteReceived = expectation(description: "received deleted post from sync event")
         hubListener = Amplify.Hub.listen(to: .dataStore,
@@ -475,7 +474,7 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.delete(post)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeleteBlogCascadeToPostAndComments() async throws {
@@ -522,7 +521,7 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
             XCTFail("Listener not registered for hub")
             return
         }
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
 
         let deleteReceived = expectation(description: "received deleted from sync event")
         deleteReceived.expectedFulfillmentCount = 3 // 1 blog, 1 post, 1 comment
@@ -557,7 +556,7 @@ class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         _ = try await Amplify.DataStore.delete(blog)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func saveBlog(id: String = UUID().uuidString, name: String) async -> Blog7V2? {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario8V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario8V2Tests.swift
@@ -96,7 +96,8 @@ class DataStoreConnectionScenario8V2Tests: SyncEngineIntegrationV2TestBase {
             XCTFail("Listener not registered for hub")
             return
         }
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
+
         let queriedAttendeeOptional = try await Amplify.DataStore.query(Attendee8V2.self, byId: attendee.id)
         guard let queriedAttendee = queriedAttendeeOptional else {
             XCTFail("Could not get attendee")
@@ -165,7 +166,7 @@ class DataStoreConnectionScenario8V2Tests: SyncEngineIntegrationV2TestBase {
             XCTFail("Listener not registered for hub")
             return
         }
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
         
         let updateReceived = expectation(description: "Update notification received")
         hubListener = Amplify.Hub.listen(
@@ -194,7 +195,7 @@ class DataStoreConnectionScenario8V2Tests: SyncEngineIntegrationV2TestBase {
         registration.attendee = attendee2
         let updatedRegistration = try await Amplify.DataStore.save(registration)
         XCTAssertEqual(updatedRegistration.attendee.id, attendee2.id)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [updateReceived], timeout: TestCommonConstants.networkTimeout)
         
         var queriedAttendeeOptional = try await Amplify.DataStore.query(Attendee8V2.self, byId: attendee.id)
         guard let queriedAttendee = queriedAttendeeOptional else {
@@ -261,7 +262,7 @@ class DataStoreConnectionScenario8V2Tests: SyncEngineIntegrationV2TestBase {
             XCTFail("Listener not registered for hub")
             return
         }
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
         
         let deleteRegistrationRecieved = expectation(description: "Delete registration received")
         hubListener = Amplify.Hub.listen(
@@ -285,7 +286,7 @@ class DataStoreConnectionScenario8V2Tests: SyncEngineIntegrationV2TestBase {
             return
         }
         let _ = try await Amplify.DataStore.delete(registration)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteRegistrationRecieved], timeout: TestCommonConstants.networkTimeout)
         
         let queriedAttendeeOptional = try await Amplify.DataStore.query(Attendee8V2.self, byId: attendee.id)
         guard let queriedAttendee = queriedAttendeeOptional else {
@@ -352,7 +353,7 @@ class DataStoreConnectionScenario8V2Tests: SyncEngineIntegrationV2TestBase {
             XCTFail("Listener not registered for hub")
             return
         }
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
         
         let deleteReceived = expectation(description: "Delete received")
         deleteReceived.expectedFulfillmentCount = 2 // attendee and registration
@@ -390,7 +391,7 @@ class DataStoreConnectionScenario8V2Tests: SyncEngineIntegrationV2TestBase {
         }
         
         _ = try await Amplify.DataStore.delete(attendee)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
         
         let queriedAttendeeOptional = try await Amplify.DataStore.query(Attendee8V2.self, byId: attendee.id)
         XCTAssertNil(queriedAttendeeOptional)
@@ -452,7 +453,7 @@ class DataStoreConnectionScenario8V2Tests: SyncEngineIntegrationV2TestBase {
             XCTFail("Listener not registered for hub")
             return
         }
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [createReceived], timeout: TestCommonConstants.networkTimeout)
         
         let deleteReceived = expectation(description: "Delete received")
         deleteReceived.expectedFulfillmentCount = 2 // meeting and registration
@@ -481,7 +482,7 @@ class DataStoreConnectionScenario8V2Tests: SyncEngineIntegrationV2TestBase {
         }
         
         _ = try await Amplify.DataStore.delete(meeting)
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: TestCommonConstants.networkTimeout)
         
         let queriedAttendeeOptional = try await Amplify.DataStore.query(Attendee8V2.self, byId: attendee.id)
         guard let queriedAttendee = queriedAttendeeOptional else {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "f504716c27d2e5d4144fa4794b12129301d17729",
-        "version" : "1.0.3"
+        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
+        "version" : "1.0.4"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MaxDesiatov/XMLCoder.git",
       "state" : {
-        "revision" : "ca932442d7481700f5434a7b138c47dd42d9902b",
-        "version" : "0.14.0"
+        "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
+        "version" : "0.17.1"
       }
     }
   ],


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
The concurrent test executions occtionally failed due to the mismatch of the registered model schemas.

## Description
<!-- Why is this change required? What problem does it solve? -->
- changed all async test cases to use new concurrency-safe API [`fulfillment`](https://developer.apple.com/documentation/xctest/xctestcase/4109476-fulfillment).

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
