### PR TITLE
chore(test): target specific coverage reporting

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/AWSAPIPlugin.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AWSAPIPlugin.xcscheme
@@ -26,7 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSAPIPlugin"
+            BuildableName = "AWSAPIPlugin"
+            BlueprintName = "AWSAPIPlugin"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/AWSCognitoAuthPlugin.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AWSCognitoAuthPlugin.xcscheme
@@ -26,7 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSCognitoAuthPlugin"
+            BuildableName = "AWSCognitoAuthPlugin"
+            BlueprintName = "AWSCognitoAuthPlugin"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/AWSDataStorePlugin.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AWSDataStorePlugin.xcscheme
@@ -26,7 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSDataStorePlugin"
+            BuildableName = "AWSDataStorePlugin"
+            BlueprintName = "AWSDataStorePlugin"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/AWSPinpointAnalyticsPlugin.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AWSPinpointAnalyticsPlugin.xcscheme
@@ -26,7 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSPinpointAnalyticsPlugin"
+            BuildableName = "AWSPinpointAnalyticsPlugin"
+            BlueprintName = "AWSPinpointAnalyticsPlugin"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/AWSPinpointPushNotificationsPlugin.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AWSPinpointPushNotificationsPlugin.xcscheme
@@ -26,7 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSPinpointPushNotificationsPlugin"
+            BuildableName = "AWSPinpointPushNotificationsPlugin"
+            BlueprintName = "AWSPinpointPushNotificationsPlugin"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/AWSPluginsCore.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AWSPluginsCore.xcscheme
@@ -26,7 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSPluginsCore"
+            BuildableName = "AWSPluginsCore"
+            BlueprintName = "AWSPluginsCore"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/AWSPredictionsPlugin.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AWSPredictionsPlugin.xcscheme
@@ -40,7 +40,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSPredictionsPlugin"
+            BuildableName = "AWSPredictionsPlugin"
+            BlueprintName = "AWSPredictionsPlugin"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/AWSS3StoragePlugin.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AWSS3StoragePlugin.xcscheme
@@ -27,7 +27,17 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSS3StoragePlugin"
+            BuildableName = "AWSS3StoragePlugin"
+            BlueprintName = "AWSS3StoragePlugin"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
@@ -404,7 +404,88 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSAPIPlugin"
+            BuildableName = "AWSAPIPlugin"
+            BlueprintName = "AWSAPIPlugin"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSCognitoAuthPlugin"
+            BuildableName = "AWSCognitoAuthPlugin"
+            BlueprintName = "AWSCognitoAuthPlugin"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSDataStorePlugin"
+            BuildableName = "AWSDataStorePlugin"
+            BlueprintName = "AWSDataStorePlugin"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSLocationGeoPlugin"
+            BuildableName = "AWSLocationGeoPlugin"
+            BlueprintName = "AWSLocationGeoPlugin"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSPinpointAnalyticsPlugin"
+            BuildableName = "AWSPinpointAnalyticsPlugin"
+            BlueprintName = "AWSPinpointAnalyticsPlugin"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSPinpointPushNotificationsPlugin"
+            BuildableName = "AWSPinpointPushNotificationsPlugin"
+            BlueprintName = "AWSPinpointPushNotificationsPlugin"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSPluginsCore"
+            BuildableName = "AWSPluginsCore"
+            BlueprintName = "AWSPluginsCore"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSPredictionsPlugin"
+            BuildableName = "AWSPredictionsPlugin"
+            BlueprintName = "AWSPredictionsPlugin"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSS3StoragePlugin"
+            BuildableName = "AWSS3StoragePlugin"
+            BlueprintName = "AWSS3StoragePlugin"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Amplify"
+            BuildableName = "Amplify"
+            BlueprintName = "Amplify"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CoreMLPredictionsPlugin"
+            BuildableName = "CoreMLPredictionsPlugin"
+            BlueprintName = "CoreMLPredictionsPlugin"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify.xcscheme
@@ -26,7 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Amplify"
+            BuildableName = "Amplify"
+            BlueprintName = "Amplify"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/CoreMLPredictionsPlugin.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/CoreMLPredictionsPlugin.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,23 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AWSLocationGeoPlugin"
-               BuildableName = "AWSLocationGeoPlugin"
-               BlueprintName = "AWSLocationGeoPlugin"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AWSLocationGeoPluginTests"
-               BuildableName = "AWSLocationGeoPluginTests"
-               BlueprintName = "AWSLocationGeoPluginTests"
+               BlueprintIdentifier = "CoreMLPredictionsPlugin"
+               BuildableName = "CoreMLPredictionsPlugin"
+               BlueprintName = "CoreMLPredictionsPlugin"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
@@ -46,23 +32,13 @@
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "AWSLocationGeoPlugin"
-            BuildableName = "AWSLocationGeoPlugin"
-            BlueprintName = "AWSLocationGeoPlugin"
+            BlueprintIdentifier = "CoreMLPredictionsPlugin"
+            BuildableName = "CoreMLPredictionsPlugin"
+            BlueprintName = "CoreMLPredictionsPlugin"
             ReferencedContainer = "container:">
          </BuildableReference>
       </CodeCoverageTargets>
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AWSLocationGeoPluginTests"
-               BuildableName = "AWSLocationGeoPluginTests"
-               BlueprintName = "AWSLocationGeoPluginTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -85,9 +61,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "AWSLocationGeoPlugin"
-            BuildableName = "AWSLocationGeoPlugin"
-            BlueprintName = "AWSLocationGeoPlugin"
+            BlueprintIdentifier = "CoreMLPredictionsPlugin"
+            BuildableName = "CoreMLPredictionsPlugin"
+            BlueprintName = "CoreMLPredictionsPlugin"
             ReferencedContainer = "container:">
          </BuildableReference>
       </MacroExpansion>

--- a/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/DependencyTests/CoreMLVisionAdapterTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/DependencyTests/CoreMLVisionAdapterTests.swift
@@ -20,7 +20,7 @@ class CoreMLVisionAdapterTests: XCTestCase {
         let url = try XCTUnwrap(
             Bundle.module.url(forResource: "people", withExtension: "jpg", subdirectory: "TestImages")
         )
-        let result = coreMLVisionAdapter.detectLabels(url)
+        let result = try coreMLVisionAdapter.detectLabels(url)
         XCTAssertNotNil(result, "The result should be nil")
     }
 
@@ -28,7 +28,7 @@ class CoreMLVisionAdapterTests: XCTestCase {
         let url = try XCTUnwrap(
             Bundle.module.url(forResource: "screenshotWithText", withExtension: "png", subdirectory: "TestImages")
         )
-        let result = coreMLVisionAdapter.detectText(url)
+        let result = try coreMLVisionAdapter.detectText(url)
         XCTAssertNotNil(result, "The result should be nil")
     }
 
@@ -36,7 +36,7 @@ class CoreMLVisionAdapterTests: XCTestCase {
         let url = try XCTUnwrap(
             Bundle.module.url(forResource: "people", withExtension: "jpg", subdirectory: "TestImages")
         )
-        let result = coreMLVisionAdapter.detectEntities(url)
+        let result = try coreMLVisionAdapter.detectEntities(url)
         XCTAssertNotNil(result, "The result should be nil")
         XCTAssertTrue(result?.entities.isEmpty != true, "The result should contain values for the image provided.")
     }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
Adds test coverage reporting (in Xcode) for each target.

<img width="859" alt="Screenshot 2023-06-06 at 2 39 17 PM" src="https://github.com/aws-amplify/amplify-swift/assets/52051793/533533e3-34ba-4dd5-b4ad-2e3b2c0087bc">

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
