### PR TITLE
fix(predictions): plugin public init

### DIFF
--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin.swift
@@ -30,7 +30,7 @@ final public class AWSPredictionsPlugin: PredictionsCategoryPlugin {
         predictionsService.getEscapeHatch(client: key)
     }
 
-    init() {}
+    public init() {}
 }
 
 extension AWSPredictionsPlugin: AmplifyVersionable { }

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/PredictionsPluginInit.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/PredictionsPluginInit.swift
@@ -1,0 +1,24 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+// This import statement needs to stay as it is.
+// Do not add @testable
+import AWSPredictionsPlugin
+
+class PredictionsPluginInitTestCase: XCTest {
+    /// Given: A non @testable import of the `AWSPredictionsPlugin` module
+    /// When:  Initializing the `AWSPredictionsPlugin` class
+    /// Then: The init should not result in a compiler error
+    ///
+    /// - Note: The assertion here is that the plugin's init remains
+    /// public. In the case of a regression (i.e. making the init private / internal),
+    /// the test target will fail to build.
+    func testPublicInitializer() {
+        _ = AWSPredictionsPlugin()
+    }
+}


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/3009

## Description
<!-- Why is this change required? What problem does it solve? -->
`AWSPredictionsPlugin` init was made internal to prevent configuring it in v2 for the time period that the target was added (for liveness support) and predictions v2 was released. The plugin initializer needs to be public now.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
