### PR TITLE
fix(datastore): support CPK with sortKey for GraphQL scalar types

### DIFF
--- a/.github/workflows/integ_test_datastore_cpk.yml
+++ b/.github/workflows/integ_test_datastore_cpk.yml
@@ -5,12 +5,12 @@ on:
 
 permissions:
     id-token: write
-    contents: read 
+    contents: read
 
 jobs:
   datastore-integration-cpk-test:
     timeout-minutes: 30
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -33,5 +33,6 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginCPKTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
- 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/SingleDirectiveGraphQLDocument.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/SingleDirectiveGraphQLDocument.swift
@@ -105,8 +105,8 @@ extension SingleDirectiveGraphQLDocument {
 
         var inputParameters = variableInputs.map { ($0.key, "$\($0.key)") }
         for input in inlineInputs {
-            if case .inline(let doucument)  = input.value.value {
-                inputParameters.append((input.key, doucument.graphQLInlineValue))
+            if case .inline(let document)  = input.value.value {
+                inputParameters.append((input.key, document.graphQLInlineValue))
             }
         }
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/GraphQLDocumentInputValue.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/GraphQLDocumentInputValue.swift
@@ -76,13 +76,3 @@ extension Double: GraphQLDocumentValueRepresentable {
         return "\(self)"
     }
 }
-
-extension Float: GraphQLDocumentValueRepresentable {
-    public var graphQLDocumentValue: String {
-        return "\(self)"
-    }
-
-    public var graphQLInlineValue: String {
-        return "\(self)"
-    }
-}

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/GraphQLDocumentnputValue.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/GraphQLDocumentnputValue.swift
@@ -10,16 +10,29 @@ import Foundation
 /// A container to hold either an object or a value, useful for storing document inputs and allowing manipulation at
 /// the first level of the object
 public enum GraphQLDocumentInputValue {
+    case inline(GraphQLDocumentValueRepresentable)
     case scalar(GraphQLDocumentValueRepresentable)
     case object([String: Any?])
+
+    public func isInline() -> Bool {
+        if case .inline = self {
+            return true
+        }
+        return false
+    }
 }
 
 public protocol GraphQLDocumentValueRepresentable {
     var graphQLDocumentValue: String { get }
+    var graphQLInlineValue: String { get }
 }
 
 extension Int: GraphQLDocumentValueRepresentable {
     public var graphQLDocumentValue: String {
+        return "\(self)"
+    }
+
+    public var graphQLInlineValue: String {
         return "\(self)"
     }
 }
@@ -28,16 +41,48 @@ extension String: GraphQLDocumentValueRepresentable {
     public var graphQLDocumentValue: String {
         return self
     }
+
+    public var graphQLInlineValue: String {
+        return "\"\(self)\""
+    }
 }
 
 extension Bool: GraphQLDocumentValueRepresentable {
     public var graphQLDocumentValue: String {
         return "\(self)"
     }
+
+    public var graphQLInlineValue: String {
+        return "\(self)"
+    }
 }
 
 extension Decimal: GraphQLDocumentValueRepresentable {
     public var graphQLDocumentValue: String {
+        return "\(self)"
+    }
+
+    public var graphQLInlineValue: String {
+        return "\(self)"
+    }
+}
+
+extension Double: GraphQLDocumentValueRepresentable {
+    public var graphQLDocumentValue: String {
+        return "\(self)"
+    }
+
+    public var graphQLInlineValue: String {
+        return "\(self)"
+    }
+}
+
+extension Float: GraphQLDocumentValueRepresentable {
+    public var graphQLDocumentValue: String {
+        return "\(self)"
+    }
+
+    public var graphQLInlineValue: String {
         return "\(self)"
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestSyncCustomPrimaryKeyTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestSyncCustomPrimaryKeyTests.swift
@@ -29,8 +29,8 @@ class GraphQLRequestSyncCustomPrimaryKeyTests: XCTestCase {
         documentBuilder.add(decorator: ConflictResolutionDecorator(graphQLType: .query))
         let document = documentBuilder.build()
         let documentStringValue = """
-        query GetCustomerOrder($id: ID!, $orderId: String!) {
-          getCustomerOrder(id: $id, orderId: $orderId) {
+        query GetCustomerOrder {
+          getCustomerOrder(id: "\(order.id)", orderId: "\(order.orderId)") {
             orderId
             id
             email
@@ -56,8 +56,7 @@ class GraphQLRequestSyncCustomPrimaryKeyTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(variables["id"] as? String, order.id)
-        XCTAssertEqual(variables["orderId"] as? String, order.orderId)
+        XCTAssertTrue(variables.isEmpty)
     }
 
     func testCreateMutationGraphQLRequest() throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/11/AWSDataStoreIntSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/11/AWSDataStoreIntSortKeyTest.swift
@@ -1,0 +1,113 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+import Combine
+import XCTest
+import AWSAPIPlugin
+import AWSDataStorePlugin
+
+@testable import Amplify
+@testable import DataStoreHostApp
+
+fileprivate struct TestModels: AmplifyModelRegistration {
+    func registerModels(registry: ModelRegistry.Type) {
+        ModelRegistry.register(modelType: Post11.self)
+    }
+
+    var version: String = "test"
+}
+
+class AWSDataStoreIntSortKeyTest: XCTestCase {
+    let configFile = "testconfiguration/AWSDataStoreCategoryPluginPrimaryKeyIntegrationTests-amplifyconfiguration"
+
+    override func setUp() async throws {
+        continueAfterFailure = true
+        let config = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: configFile)
+        try Amplify.add(plugin: AWSAPIPlugin(
+            sessionFactory: AmplifyURLSessionFactory())
+        )
+        try Amplify.add(plugin: AWSDataStorePlugin(
+            modelRegistration: TestModels(),
+            configuration: .custom(syncMaxRecords: 100)
+        ))
+        Amplify.Logging.logLevel = .verbose
+        try Amplify.configure(config)
+    }
+
+    override func tearDown() async throws {
+        try await Amplify.DataStore.clear()
+        await Amplify.reset()
+        try await Task.sleep(seconds: 1)
+    }
+
+    func waitDataStoreReady() async throws {
+        let ready = expectation(description: "DataStore is ready")
+        var requests: Set<AnyCancellable> = []
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.ready }
+            .sink { _ in
+                ready.fulfill()
+            }
+            .store(in: &requests)
+
+        try await Amplify.DataStore.start()
+        await fulfillment(of: [ready], timeout: 60)
+    }
+
+    func testCreateModel_withSortKeyInIntegerType_success() async throws {
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+        let post = Post11(postId: UUID().uuidString, sk: 15)
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+    }
+
+    func testQueryCreatedModel_withSortKeyInIntegerType_success() async throws {
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+        let post = Post11(postId: UUID().uuidString, sk: 15)
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+
+        let queryResult = try await Amplify.API.query(
+            request: .get(
+                Post11.self,
+                byIdentifier: .identifier(postId: post.postId, sk: post.sk)
+            )
+        )
+
+        switch queryResult {
+        case .success(let queriedPost):
+            XCTAssertEqual(post.identifier, queriedPost!.identifier)
+        case .failure(let error):
+            XCTFail("Failed to query comment \(error)")
+        }
+    }
+
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/11/Post11+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/11/Post11+Schema.swift
@@ -1,0 +1,46 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post11 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case postId
+    case sk
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post11 = Post11.keys
+    
+    model.pluralName = "Post11s"
+    
+    model.attributes(
+      .index(fields: ["postId", "sk"], name: nil),
+      .primaryKey(fields: [post11.postId, post11.sk])
+    )
+    
+    model.fields(
+      .field(post11.postId, is: .required, ofType: .string),
+      .field(post11.sk, is: .required, ofType: .int),
+      .field(post11.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post11.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension Post11: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Post11.IdentifierProtocol {
+  public static func identifier(postId: String,
+      sk: Int) -> Self {
+    .make(fields:[(name: "postId", value: postId), (name: "sk", value: sk)])
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/11/Post11.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/11/Post11.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post11: Model {
+  public let postId: String
+  public let sk: Int
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(postId: String,
+      sk: Int) {
+    self.init(postId: postId,
+      sk: sk,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(postId: String,
+      sk: Int,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.postId = postId
+      self.sk = sk
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/12/AWSDataStoreFloatSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/12/AWSDataStoreFloatSortKeyTest.swift
@@ -1,0 +1,115 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+import Combine
+import XCTest
+import AWSAPIPlugin
+import AWSDataStorePlugin
+
+@testable import Amplify
+@testable import DataStoreHostApp
+
+fileprivate struct TestModels: AmplifyModelRegistration {
+    func registerModels(registry: ModelRegistry.Type) {
+        ModelRegistry.register(modelType: Post12.self)
+    }
+
+    var version: String = "test"
+}
+
+class AWSDataStoreFloatSortKeyTest: XCTestCase {
+    let configFile = "testconfiguration/AWSDataStoreCategoryPluginPrimaryKeyIntegrationTests-amplifyconfiguration"
+
+    override func setUp() async throws {
+        continueAfterFailure = true
+        let config = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: configFile)
+        try Amplify.add(plugin: AWSAPIPlugin(
+            sessionFactory: AmplifyURLSessionFactory())
+        )
+        try Amplify.add(plugin: AWSDataStorePlugin(
+            modelRegistration: TestModels(),
+            configuration: .custom(syncMaxRecords: 100)
+        ))
+        Amplify.Logging.logLevel = .verbose
+        try Amplify.configure(config)
+    }
+
+    override func tearDown() async throws {
+        try await Amplify.DataStore.clear()
+        await Amplify.reset()
+        try await Task.sleep(seconds: 1)
+    }
+
+    func waitDataStoreReady() async throws {
+        let ready = expectation(description: "DataStore is ready")
+        var requests: Set<AnyCancellable> = []
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.ready }
+            .sink { _ in
+                ready.fulfill()
+            }
+            .store(in: &requests)
+
+        try await Amplify.DataStore.start()
+        await fulfillment(of: [ready], timeout: 60)
+    }
+
+    func testCreateModel_withSortKeyInDoubleType_success() async throws {
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+        let post = Post12(postId: UUID().uuidString, sk: 3.1415)
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+    }
+
+    func testQueryCreatedModel_withSortKeyInDoubleType_success() async throws {
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+        let post = Post12(postId: UUID().uuidString, sk: 3.1415)
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+
+        let queryResult = try await Amplify.API.query(
+            request: .get(
+                Post12.self,
+                byIdentifier: .identifier(postId: post.postId, sk: post.sk)
+            )
+        )
+
+        switch queryResult {
+        case .success(let queriedPost):
+            XCTAssertEqual(post.identifier, queriedPost!.identifier)
+        case .failure(let error):
+            XCTFail("Failed to query comment \(error)")
+        }
+    }
+
+}
+
+

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/12/Post12+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/12/Post12+Schema.swift
@@ -1,0 +1,46 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post12 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case postId
+    case sk
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post12 = Post12.keys
+    
+    model.pluralName = "Post12s"
+    
+    model.attributes(
+      .index(fields: ["postId", "sk"], name: nil),
+      .primaryKey(fields: [post12.postId, post12.sk])
+    )
+    
+    model.fields(
+      .field(post12.postId, is: .required, ofType: .string),
+      .field(post12.sk, is: .required, ofType: .double),
+      .field(post12.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post12.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension Post12: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Post12.IdentifierProtocol {
+  public static func identifier(postId: String,
+      sk: Double) -> Self {
+    .make(fields:[(name: "postId", value: postId), (name: "sk", value: sk)])
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/12/Post12.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/12/Post12.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post12: Model {
+  public let postId: String
+  public let sk: Double
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(postId: String,
+      sk: Double) {
+    self.init(postId: postId,
+      sk: sk,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(postId: String,
+      sk: Double,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.postId = postId
+      self.sk = sk
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/9/AWSDataStoreCompositeSortKeyIdentifierTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/9/AWSDataStoreCompositeSortKeyIdentifierTest.swift
@@ -1,0 +1,130 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import XCTest
+import Combine
+import AWSAPIPlugin
+import AWSDataStorePlugin
+
+@testable import Amplify
+@testable import DataStoreHostApp
+
+fileprivate struct TestModels: AmplifyModelRegistration {
+    func registerModels(registry: ModelRegistry.Type) {
+        ModelRegistry.register(modelType: Post9.self)
+        ModelRegistry.register(modelType: Comment9.self)
+    }
+
+    public let version: String = "test"
+}
+
+class AWSDataStoreCompositeSortKeyIdentifierTest: XCTestCase {
+    let configFile = "testconfiguration/AWSDataStoreCategoryPluginPrimaryKeyIntegrationTests-amplifyconfiguration"
+
+    override func setUp() async throws {
+        continueAfterFailure = true
+        let config = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: configFile)
+        try Amplify.add(plugin: AWSAPIPlugin(
+            sessionFactory: AmplifyURLSessionFactory())
+        )
+        try Amplify.add(plugin: AWSDataStorePlugin(
+            modelRegistration: TestModels(),
+            configuration: .custom(syncMaxRecords: 100)
+        ))
+        Amplify.Logging.logLevel = .verbose
+        try Amplify.configure(config)
+    }
+
+    override func tearDown() async throws {
+        try await Amplify.DataStore.clear()
+        await Amplify.reset()
+        try await Task.sleep(seconds: 1)
+    }
+
+    func waitDataStoreReady() async throws {
+        let ready = expectation(description: "DataStore is ready")
+        var requests: Set<AnyCancellable> = []
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.ready }
+            .sink { _ in
+                ready.fulfill()
+            }
+            .store(in: &requests)
+
+        try await Amplify.DataStore.start()
+        await fulfillment(of: [ready], timeout: 60)
+    }
+
+    func testCreateModel_withSortKeyInIdType_success() async throws {
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+        let post = Post9(postId: UUID().uuidString)
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+
+        let comment = Comment9(commentId: UUID().uuidString, postId: post.postId)
+        let commentCreated = expectation(description: "Comment is created")
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == comment.identifier }
+            .sink { _ in
+                commentCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(comment)
+        await fulfillment(of: [commentCreated], timeout: 5)
+    }
+
+    func testQueryCreatedModel_withSortKeyInIdType_success() async throws {
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+        let post = Post9(postId: UUID().uuidString)
+        try await Amplify.DataStore.save(post)
+        let comment = Comment9(commentId: UUID().uuidString, postId: post.postId)
+
+        let commentCreated = expectation(description: "Comment is created")
+        commentCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == comment.identifier }
+            .sink { _ in
+                commentCreated.fulfill()
+            }.store(in: &requests)
+        try await Amplify.DataStore.save(comment)
+        await fulfillment(of: [commentCreated], timeout: 5)
+
+        let queryResult = try await Amplify.API.query(
+            request: .get(
+                Comment9.self,
+                byIdentifier: .identifier(commentId: comment.commentId, postId: comment.postId)
+            )
+        )
+
+        switch queryResult {
+        case .success(let queriedComment):
+            XCTAssertEqual(comment.identifier, queriedComment!.identifier)
+        case .failure(let error):
+            XCTFail("Failed to query comment \(error)")
+        }
+    }
+
+}
+
+

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/9/Comment9+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/9/Comment9+Schema.swift
@@ -1,0 +1,49 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Comment9 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case commentId
+    case postId
+    case content
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let comment9 = Comment9.keys
+    
+    model.pluralName = "Comment9s"
+    
+    model.attributes(
+      .index(fields: ["commentId", "postId"], name: nil),
+      .index(fields: ["postId"], name: "byPost9"),
+      .primaryKey(fields: [comment9.commentId, comment9.postId])
+    )
+    
+    model.fields(
+      .field(comment9.commentId, is: .required, ofType: .string),
+      .field(comment9.postId, is: .required, ofType: .string),
+      .field(comment9.content, is: .optional, ofType: .string),
+      .field(comment9.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(comment9.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension Comment9: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Comment9.IdentifierProtocol {
+  public static func identifier(commentId: String,
+      postId: String) -> Self {
+    .make(fields:[(name: "commentId", value: commentId), (name: "postId", value: postId)])
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/9/Comment9.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/9/Comment9.swift
@@ -1,0 +1,32 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Comment9: Model {
+  public let commentId: String
+  public let postId: String
+  public var content: String?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(commentId: String,
+      postId: String,
+      content: String? = nil) {
+    self.init(commentId: commentId,
+      postId: postId,
+      content: content,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(commentId: String,
+      postId: String,
+      content: String? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.commentId = commentId
+      self.postId = postId
+      self.content = content
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/9/Post9+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/9/Post9+Schema.swift
@@ -1,0 +1,47 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post9 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case postId
+    case title
+    case comments
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post9 = Post9.keys
+    
+    model.pluralName = "Post9s"
+    
+    model.attributes(
+      .index(fields: ["postId"], name: nil),
+      .primaryKey(fields: [post9.postId])
+    )
+    
+    model.fields(
+      .field(post9.postId, is: .required, ofType: .string),
+      .field(post9.title, is: .optional, ofType: .string),
+      .hasMany(post9.comments, is: .optional, ofType: Comment9.self, associatedWith: Comment9.keys.postId),
+      .field(post9.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post9.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension Post9: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Post9.IdentifierProtocol {
+  public static func identifier(postId: String) -> Self {
+    .make(fields:[(name: "postId", value: postId)])
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/9/Post9.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/9/Post9.swift
@@ -1,0 +1,32 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post9: Model {
+  public let postId: String
+  public var title: String?
+  public var comments: List<Comment9>?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(postId: String,
+      title: String? = nil,
+      comments: List<Comment9>? = []) {
+    self.init(postId: postId,
+      title: title,
+      comments: comments,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(postId: String,
+      title: String? = nil,
+      comments: List<Comment9>? = [],
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.postId = postId
+      self.title = title
+      self.comments = comments
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStorePrimaryKeyBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStorePrimaryKeyBaseTest.swift
@@ -34,7 +34,10 @@ class AWSDataStorePrimaryKeyBaseTest: XCTestCase {
     func setup(withModels models: AmplifyModelRegistration) {
         do {
             loadAmplifyConfig()
-            try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models))
+            try Amplify.add(plugin: AWSDataStorePlugin(
+                modelRegistration: models,
+                configuration: .custom(syncMaxRecords: 100)
+            ))
 
             try Amplify.add(plugin: AWSAPIPlugin(sessionFactory: AmplifyURLSessionFactory()))
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/primarykey_schema.graphql
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/primarykey_schema.graphql
@@ -203,7 +203,19 @@ type Comment8 @model {
   postTitle: String # customized foreign key for parent sort key
 }
 
-# CLI.9. Many To Many
+# CLI.9. CPK sortKey in ID type
+
+type Post9 @model {
+  postId: ID! @primaryKey
+  title: String
+  comments: [Comment9]! @hasMany(indexName: "byPost9", fields: ["postId"])
+}
+
+type Comment9 @model {
+  commentId: ID! @primaryKey(sortKeyFields:["postId"])
+  postId: ID! @index(name: "byPost9")
+  content: String
+}
 
 #type Post9 @model {
 #    customPostId: ID! @primaryKey(sortKeyFields: ["title"])
@@ -239,3 +251,16 @@ type Comment4V2 @model @auth(rules: [{allow: public}]) {
   content: String!
   post: Post4V2 @belongsTo(fields: ["postID"])
 }
+
+# CLI.11
+type Post11 @model {
+  postId: ID! @primaryKey(sortKeyFields: ["sk"])
+  sk: Int!
+}
+
+# CLI.12
+type Post12 @model {
+  postId: ID! @primaryKey(sortKeyFields: ["sk"])
+  sk: Float!
+}
+

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
@@ -39,7 +39,7 @@ class SyncEngineIntegrationTestBase: DataStoreTestBase {
 
     override func tearDown() async throws {
         try await super.tearDown()
-        try await stopDataStore()
+        try await clearDataStore()
         await Amplify.reset()
         try await Task.sleep(seconds: 1)
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
@@ -548,6 +548,17 @@
 		21DFAEA6295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DFAEA5295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift */; };
 		60040D982A18362400D123D6 /* AmplifyURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60040D962A18362400D123D6 /* AmplifyURLSession.swift */; };
 		60040D992A18362400D123D6 /* AmplifyURLSessionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60040D972A18362400D123D6 /* AmplifyURLSessionFactory.swift */; };
+		601E37482A3109FE00E08FCA /* Post11.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601E37462A3109FE00E08FCA /* Post11.swift */; };
+		601E37492A3109FE00E08FCA /* Post11+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601E37472A3109FE00E08FCA /* Post11+Schema.swift */; };
+		601E374C2A310A0500E08FCA /* Post12+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601E374A2A310A0500E08FCA /* Post12+Schema.swift */; };
+		601E374D2A310A0500E08FCA /* Post12.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601E374B2A310A0500E08FCA /* Post12.swift */; };
+		601E374F2A310A4200E08FCA /* AWSDataStoreIntSortKeyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601E374E2A310A4200E08FCA /* AWSDataStoreIntSortKeyTest.swift */; };
+		601E37512A310A5700E08FCA /* AWSDataStoreFloatSortKeyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601E37502A310A5700E08FCA /* AWSDataStoreFloatSortKeyTest.swift */; };
+		60C9C3212A2E948F00ADDB85 /* AWSDataStoreCompositeSortKeyIdentifierTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C9C3202A2E948F00ADDB85 /* AWSDataStoreCompositeSortKeyIdentifierTest.swift */; };
+		60C9C32E2A2FBC1F00ADDB85 /* Post9+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C9C32A2A2FBC1F00ADDB85 /* Post9+Schema.swift */; };
+		60C9C32F2A2FBC1F00ADDB85 /* Post9.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C9C32B2A2FBC1F00ADDB85 /* Post9.swift */; };
+		60C9C3302A2FBC1F00ADDB85 /* Comment9+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C9C32C2A2FBC1F00ADDB85 /* Comment9+Schema.swift */; };
+		60C9C3312A2FBC1F00ADDB85 /* Comment9.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C9C32D2A2FBC1F00ADDB85 /* Comment9.swift */; };
 		681DFE8328E746C10000C36A /* AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8028E746C10000C36A /* AsyncTesting.swift */; };
 		681DFE8428E746C10000C36A /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8128E746C10000C36A /* AsyncExpectation.swift */; };
 		681DFE8528E746C10000C36A /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8228E746C10000C36A /* XCTestCase+AsyncTesting.swift */; };
@@ -1320,6 +1331,17 @@
 		21DFAEA5295F4E9E00B4A883 /* AWSDataStoreLazyLoadPhoneCallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadPhoneCallTests.swift; sourceTree = "<group>"; };
 		60040D962A18362400D123D6 /* AmplifyURLSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmplifyURLSession.swift; sourceTree = "<group>"; };
 		60040D972A18362400D123D6 /* AmplifyURLSessionFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmplifyURLSessionFactory.swift; sourceTree = "<group>"; };
+		601E37462A3109FE00E08FCA /* Post11.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post11.swift; sourceTree = "<group>"; };
+		601E37472A3109FE00E08FCA /* Post11+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post11+Schema.swift"; sourceTree = "<group>"; };
+		601E374A2A310A0500E08FCA /* Post12+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post12+Schema.swift"; sourceTree = "<group>"; };
+		601E374B2A310A0500E08FCA /* Post12.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post12.swift; sourceTree = "<group>"; };
+		601E374E2A310A4200E08FCA /* AWSDataStoreIntSortKeyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreIntSortKeyTest.swift; sourceTree = "<group>"; };
+		601E37502A310A5700E08FCA /* AWSDataStoreFloatSortKeyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreFloatSortKeyTest.swift; sourceTree = "<group>"; };
+		60C9C3202A2E948F00ADDB85 /* AWSDataStoreCompositeSortKeyIdentifierTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreCompositeSortKeyIdentifierTest.swift; sourceTree = "<group>"; };
+		60C9C32A2A2FBC1F00ADDB85 /* Post9+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post9+Schema.swift"; sourceTree = "<group>"; };
+		60C9C32B2A2FBC1F00ADDB85 /* Post9.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post9.swift; sourceTree = "<group>"; };
+		60C9C32C2A2FBC1F00ADDB85 /* Comment9+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Comment9+Schema.swift"; sourceTree = "<group>"; };
+		60C9C32D2A2FBC1F00ADDB85 /* Comment9.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment9.swift; sourceTree = "<group>"; };
 		60CB6B3E2A1454F90051BAD2 /* amplify-swift */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-swift"; path = ../../../..; sourceTree = "<group>"; };
 		681DFE8028E746C10000C36A /* AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncTesting.swift; sourceTree = "<group>"; };
 		681DFE8128E746C10000C36A /* AsyncExpectation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncExpectation.swift; sourceTree = "<group>"; };
@@ -1969,7 +1991,10 @@
 			isa = PBXGroup;
 			children = (
 				211F5095296DD4E00040EB62 /* 7 */,
+				60C9C31F2A2E944800ADDB85 /* 9 */,
 				21BC10C8296DDB2B000E189E /* 10 */,
+				601E37442A3109C900E08FCA /* 11 */,
+				601E37452A3109D000E08FCA /* 12 */,
 				21977D84289C1633005B49D6 /* primarykey_schema.graphql */,
 				21BBFA12289BFE3400B32A39 /* README.md */,
 				21BBFA13289BFE3400B32A39 /* AWSDataStorePrimaryKeyTests.swift */,
@@ -2709,6 +2734,38 @@
 				21DFAE9B295F4E8500B4A883 /* Transcript+Schema.swift */,
 			);
 			path = LL13;
+			sourceTree = "<group>";
+		};
+		601E37442A3109C900E08FCA /* 11 */ = {
+			isa = PBXGroup;
+			children = (
+				601E37462A3109FE00E08FCA /* Post11.swift */,
+				601E37472A3109FE00E08FCA /* Post11+Schema.swift */,
+				601E374E2A310A4200E08FCA /* AWSDataStoreIntSortKeyTest.swift */,
+			);
+			path = 11;
+			sourceTree = "<group>";
+		};
+		601E37452A3109D000E08FCA /* 12 */ = {
+			isa = PBXGroup;
+			children = (
+				601E374B2A310A0500E08FCA /* Post12.swift */,
+				601E374A2A310A0500E08FCA /* Post12+Schema.swift */,
+				601E37502A310A5700E08FCA /* AWSDataStoreFloatSortKeyTest.swift */,
+			);
+			path = 12;
+			sourceTree = "<group>";
+		};
+		60C9C31F2A2E944800ADDB85 /* 9 */ = {
+			isa = PBXGroup;
+			children = (
+				60C9C32D2A2FBC1F00ADDB85 /* Comment9.swift */,
+				60C9C32C2A2FBC1F00ADDB85 /* Comment9+Schema.swift */,
+				60C9C32B2A2FBC1F00ADDB85 /* Post9.swift */,
+				60C9C32A2A2FBC1F00ADDB85 /* Post9+Schema.swift */,
+				60C9C3202A2E948F00ADDB85 /* AWSDataStoreCompositeSortKeyIdentifierTest.swift */,
+			);
+			path = 9;
 			sourceTree = "<group>";
 		};
 		681DFE7F28E746C10000C36A /* AsyncTesting */ = {
@@ -4062,24 +4119,31 @@
 				213DBBC928A5743600B30280 /* Comment4+Schema.swift in Sources */,
 				21BBFC24289C03EB00B32A39 /* AWSDataStorePrimaryKeyBaseTest.swift in Sources */,
 				213DBBD328A5743600B30280 /* Team2.swift in Sources */,
+				60C9C3212A2E948F00ADDB85 /* AWSDataStoreCompositeSortKeyIdentifierTest.swift in Sources */,
 				213DBBB928A5743600B30280 /* ModelCompositeMultiplePk.swift in Sources */,
+				601E374F2A310A4200E08FCA /* AWSDataStoreIntSortKeyTest.swift in Sources */,
+				60C9C32E2A2FBC1F00ADDB85 /* Post9+Schema.swift in Sources */,
 				211F5094296DD4C30040EB62 /* AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift in Sources */,
 				213DBBD128A5743600B30280 /* CommentWithCompositeKey+Schema.swift in Sources */,
 				213DBBAA28A5743600B30280 /* ModelCompositePk+Schema.swift in Sources */,
+				60C9C3312A2FBC1F00ADDB85 /* Comment9.swift in Sources */,
 				213DBBA128A5743600B30280 /* Project2+Schema.swift in Sources */,
 				213DBBAC28A5743600B30280 /* ModelCustomPkDefined+Schema.swift in Sources */,
 				213DBBD428A5743600B30280 /* Team6.swift in Sources */,
 				21BC10D2296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift in Sources */,
 				213DBBA728A5743600B30280 /* Team6+Schema.swift in Sources */,
 				213DBBCF28A5743600B30280 /* Team2+Schema.swift in Sources */,
+				601E374C2A310A0500E08FCA /* Post12+Schema.swift in Sources */,
 				213DBBBE28A5743600B30280 /* ModelExplicitCustomPk+Schema.swift in Sources */,
 				213DBBCC28A5743600B30280 /* PostWithTagsCompositeKey.swift in Sources */,
+				60C9C32F2A2FBC1F00ADDB85 /* Post9.swift in Sources */,
 				213DBBA328A5743600B30280 /* PostWithCompositeKeyUnidirectional+Schema.swift in Sources */,
 				213DBBA528A5743600B30280 /* PostWithCompositeKeyUnidirectional.swift in Sources */,
 				213DBBB328A5743600B30280 /* PostTagsWithCompositeKey.swift in Sources */,
 				213DBBCD28A5743600B30280 /* CommentWithCompositeKeyUnidirectional.swift in Sources */,
 				213DBBD028A5743600B30280 /* PostTagsWithCompositeKey+Schema.swift in Sources */,
 				213DBBB828A5743600B30280 /* TagWithCompositeKey+Schema.swift in Sources */,
+				601E37492A3109FE00E08FCA /* Post11+Schema.swift in Sources */,
 				213DBBBB28A5743600B30280 /* Comment7.swift in Sources */,
 				213DBBB228A5743600B30280 /* ModelCompositePkBelongsTo.swift in Sources */,
 				213DBBA028A5743600B30280 /* PostWithCompositeKeyAndIndex+Schema.swift in Sources */,
@@ -4088,6 +4152,7 @@
 				213DBBAB28A5743600B30280 /* CommentWithCompositeKey.swift in Sources */,
 				213DBB9F28A5743600B30280 /* CommentWithCompositeKeyAndIndex+Schema.swift in Sources */,
 				21977DBF289C171A005B49D6 /* TestConfigHelper.swift in Sources */,
+				601E37512A310A5700E08FCA /* AWSDataStoreFloatSortKeyTest.swift in Sources */,
 				213DBB9C28A5743600B30280 /* ModelImplicitDefaultPk+Schema.swift in Sources */,
 				213DBBC428A5743600B30280 /* Comment8.swift in Sources */,
 				213DBBA628A5743600B30280 /* Project6.swift in Sources */,
@@ -4117,13 +4182,16 @@
 				213DBBCE28A5743600B30280 /* ModelExplicitCustomPk.swift in Sources */,
 				213DBBB728A5743600B30280 /* Post7+Schema.swift in Sources */,
 				213DBBC828A5743600B30280 /* Project2.swift in Sources */,
+				60C9C3302A2FBC1F00ADDB85 /* Comment9+Schema.swift in Sources */,
 				213DBB9D28A5743600B30280 /* ModelImplicitDefaultPk.swift in Sources */,
 				213DBBBA28A5743600B30280 /* Comment8+Schema.swift in Sources */,
 				213DBBC528A5743600B30280 /* TagWithCompositeKey.swift in Sources */,
+				601E374D2A310A0500E08FCA /* Post12.swift in Sources */,
 				213DBBA928A5743600B30280 /* PostWithCompositeKeyAndIndex.swift in Sources */,
 				21BC10CD296DDB4B000E189E /* Comment4V2+Schema.swift in Sources */,
 				213DBBBF28A5743600B30280 /* Post4.swift in Sources */,
 				21BBFC23289C03E900B32A39 /* AWSDataStorePrimaryKeyTests.swift in Sources */,
+				601E37482A3109FE00E08FCA /* Post11.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

Currently, the Composite Primary Key feature assumes that the sortKey in GraphQL must be of type `String`, and it generates queries based on this assumption. However, this is inaccurate and will result in a GraphQL type mismatch error if the sortKey is actually other types, for instance `ID`.

## Description
<!-- Why is this change required? What problem does it solve? -->

- add support for CPK to use inline value for get queries.

## General Checklist
<!-- Check or cross out if not relevant -->

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
