### PR TITLE
fix(datastore): support CPK sort key with AWS date types

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelIdDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ModelIdDecorator.swift
@@ -103,6 +103,12 @@ fileprivate extension ModelIdDecorator {
             return data
         case let data as Bool:
             return data
+        case let data as Temporal.DateTime:
+            return data.iso8601String
+        case let data as Temporal.Date:
+            return data.iso8601String
+        case let data as Temporal.Time:
+            return data.iso8601String
         default:
             return "\(persistable)"
         }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/13/AWSDataStoreDateTimeSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/13/AWSDataStoreDateTimeSortKeyTest.swift
@@ -1,0 +1,115 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+import Combine
+import XCTest
+import AWSAPIPlugin
+import AWSDataStorePlugin
+
+@testable import Amplify
+@testable import DataStoreHostApp
+
+fileprivate struct TestModels: AmplifyModelRegistration {
+    func registerModels(registry: ModelRegistry.Type) {
+        ModelRegistry.register(modelType: Post13.self)
+    }
+
+    var version: String = "test"
+}
+
+class AWSDataStoreDateTimeSortKeyTest: XCTestCase {
+    let configFile = "testconfiguration/AWSDataStoreCategoryPluginPrimaryKeyIntegrationTests-amplifyconfiguration"
+
+    override func setUp() async throws {
+        continueAfterFailure = true
+        let config = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: configFile)
+        try Amplify.add(plugin: AWSAPIPlugin(
+            sessionFactory: AmplifyURLSessionFactory())
+        )
+        try Amplify.add(plugin: AWSDataStorePlugin(
+            modelRegistration: TestModels(),
+            configuration: .custom(syncMaxRecords: 100)
+        ))
+        Amplify.Logging.logLevel = .verbose
+        try Amplify.configure(config)
+    }
+
+    override func tearDown() async throws {
+        try await Amplify.DataStore.clear()
+        await Amplify.reset()
+        try await Task.sleep(seconds: 1)
+    }
+
+    func waitDataStoreReady() async throws {
+        let ready = expectation(description: "DataStore is ready")
+        var requests: Set<AnyCancellable> = []
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.ready }
+            .sink { _ in
+                ready.fulfill()
+            }
+            .store(in: &requests)
+
+        try await Amplify.DataStore.start()
+        await fulfillment(of: [ready], timeout: 60)
+    }
+
+    func testCreateModel_withSortKeyInAWSDateTimeType_success() async throws {
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+        let post = Post13(postId: UUID().uuidString, sk: Temporal.DateTime.now())
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+    }
+
+    func testQueryCreatedModel_withSortKeyInAWSDateTimeType_success() async throws {
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+        let post = Post13(postId: UUID().uuidString, sk: Temporal.DateTime.now())
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+
+        let queryResult = try await Amplify.API.query(
+            request: .get(
+                Post13.self,
+                byIdentifier: .identifier(postId: post.postId, sk: post.sk)
+            )
+        )
+
+        switch queryResult {
+        case .success(let queriedPost):
+            XCTAssertEqual(post.identifier, queriedPost!.identifier)
+        case .failure(let error):
+            XCTFail("Failed to query comment \(error)")
+        }
+    }
+
+}
+
+

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/13/Post13+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/13/Post13+Schema.swift
@@ -1,0 +1,46 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post13 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case postId
+    case sk
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post13 = Post13.keys
+    
+    model.pluralName = "Post13s"
+    
+    model.attributes(
+      .index(fields: ["postId", "sk"], name: nil),
+      .primaryKey(fields: [post13.postId, post13.sk])
+    )
+    
+    model.fields(
+      .field(post13.postId, is: .required, ofType: .string),
+      .field(post13.sk, is: .required, ofType: .dateTime),
+      .field(post13.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post13.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension Post13: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Post13.IdentifierProtocol {
+  public static func identifier(postId: String,
+      sk: Temporal.DateTime) -> Self {
+    .make(fields:[(name: "postId", value: postId), (name: "sk", value: sk)])
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/13/Post13.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/13/Post13.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post13: Model {
+  public let postId: String
+  public let sk: Temporal.DateTime
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(postId: String,
+      sk: Temporal.DateTime) {
+    self.init(postId: postId,
+      sk: sk,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(postId: String,
+      sk: Temporal.DateTime,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.postId = postId
+      self.sk = sk
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/14/AWSDataStoreDateSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/14/AWSDataStoreDateSortKeyTest.swift
@@ -1,0 +1,115 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+import Combine
+import XCTest
+import AWSAPIPlugin
+import AWSDataStorePlugin
+
+@testable import Amplify
+@testable import DataStoreHostApp
+
+fileprivate struct TestModels: AmplifyModelRegistration {
+    func registerModels(registry: ModelRegistry.Type) {
+        ModelRegistry.register(modelType: Post14.self)
+    }
+
+    var version: String = "test"
+}
+
+class AWSDataStoreDateSortKeyTest: XCTestCase {
+    let configFile = "testconfiguration/AWSDataStoreCategoryPluginPrimaryKeyIntegrationTests-amplifyconfiguration"
+
+    override func setUp() async throws {
+        continueAfterFailure = true
+        let config = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: configFile)
+        try Amplify.add(plugin: AWSAPIPlugin(
+            sessionFactory: AmplifyURLSessionFactory())
+        )
+        try Amplify.add(plugin: AWSDataStorePlugin(
+            modelRegistration: TestModels(),
+            configuration: .custom(syncMaxRecords: 100)
+        ))
+        Amplify.Logging.logLevel = .verbose
+        try Amplify.configure(config)
+    }
+
+    override func tearDown() async throws {
+        try await Amplify.DataStore.clear()
+        await Amplify.reset()
+        try await Task.sleep(seconds: 1)
+    }
+
+    func waitDataStoreReady() async throws {
+        let ready = expectation(description: "DataStore is ready")
+        var requests: Set<AnyCancellable> = []
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.ready }
+            .sink { _ in
+                ready.fulfill()
+            }
+            .store(in: &requests)
+
+        try await Amplify.DataStore.start()
+        await fulfillment(of: [ready], timeout: 60)
+    }
+
+    func testCreateModel_withSortKeyInAWSDateType_success() async throws {
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+        let post = Post14(postId: UUID().uuidString, sk: Temporal.Date.now())
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+    }
+
+    func testQueryCreatedModel_withSortKeyInAWSDateType_success() async throws {
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+        let post = Post14(postId: UUID().uuidString, sk: Temporal.Date.now())
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+
+        let queryResult = try await Amplify.API.query(
+            request: .get(
+                Post14.self,
+                byIdentifier: .identifier(postId: post.postId, sk: post.sk)
+            )
+        )
+
+        switch queryResult {
+        case .success(let queriedPost):
+            XCTAssertEqual(post.identifier, queriedPost!.identifier)
+        case .failure(let error):
+            XCTFail("Failed to query comment \(error)")
+        }
+    }
+
+}
+
+

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/14/Post14+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/14/Post14+Schema.swift
@@ -1,0 +1,46 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post14 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case postId
+    case sk
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post14 = Post14.keys
+    
+    model.pluralName = "Post14s"
+    
+    model.attributes(
+      .index(fields: ["postId", "sk"], name: nil),
+      .primaryKey(fields: [post14.postId, post14.sk])
+    )
+    
+    model.fields(
+      .field(post14.postId, is: .required, ofType: .string),
+      .field(post14.sk, is: .required, ofType: .date),
+      .field(post14.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post14.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension Post14: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Post14.IdentifierProtocol {
+  public static func identifier(postId: String,
+      sk: Temporal.Date) -> Self {
+    .make(fields:[(name: "postId", value: postId), (name: "sk", value: sk)])
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/14/Post14.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/14/Post14.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post14: Model {
+  public let postId: String
+  public let sk: Temporal.Date
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(postId: String,
+      sk: Temporal.Date) {
+    self.init(postId: postId,
+      sk: sk,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(postId: String,
+      sk: Temporal.Date,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.postId = postId
+      self.sk = sk
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/15/AWSDataStoreTimeSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/15/AWSDataStoreTimeSortKeyTest.swift
@@ -1,0 +1,115 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+import Combine
+import XCTest
+import AWSAPIPlugin
+import AWSDataStorePlugin
+
+@testable import Amplify
+@testable import DataStoreHostApp
+
+fileprivate struct TestModels: AmplifyModelRegistration {
+    func registerModels(registry: ModelRegistry.Type) {
+        ModelRegistry.register(modelType: Post15.self)
+    }
+
+    var version: String = "test"
+}
+
+class AWSDataStoreTimeSortKeyTest: XCTestCase {
+    let configFile = "testconfiguration/AWSDataStoreCategoryPluginPrimaryKeyIntegrationTests-amplifyconfiguration"
+
+    override func setUp() async throws {
+        continueAfterFailure = true
+        let config = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: configFile)
+        try Amplify.add(plugin: AWSAPIPlugin(
+            sessionFactory: AmplifyURLSessionFactory())
+        )
+        try Amplify.add(plugin: AWSDataStorePlugin(
+            modelRegistration: TestModels(),
+            configuration: .custom(syncMaxRecords: 100)
+        ))
+        Amplify.Logging.logLevel = .verbose
+        try Amplify.configure(config)
+    }
+
+    override func tearDown() async throws {
+        try await Amplify.DataStore.clear()
+        await Amplify.reset()
+        try await Task.sleep(seconds: 1)
+    }
+
+    func waitDataStoreReady() async throws {
+        let ready = expectation(description: "DataStore is ready")
+        var requests: Set<AnyCancellable> = []
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.ready }
+            .sink { _ in
+                ready.fulfill()
+            }
+            .store(in: &requests)
+
+        try await Amplify.DataStore.start()
+        await fulfillment(of: [ready], timeout: 60)
+    }
+
+    func testCreateModel_withSortKeyInAWSTimeType_success() async throws {
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+        let post = Post15(postId: UUID().uuidString, sk: Temporal.Time.now())
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+    }
+
+    func testQueryCreatedModel_withSortKeyInAWSTimeType_success() async throws {
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+        let post = Post15(postId: UUID().uuidString, sk: Temporal.Time.now())
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+
+        let queryResult = try await Amplify.API.query(
+            request: .get(
+                Post15.self,
+                byIdentifier: .identifier(postId: post.postId, sk: post.sk)
+            )
+        )
+
+        switch queryResult {
+        case .success(let queriedPost):
+            XCTAssertEqual(post.identifier, queriedPost!.identifier)
+        case .failure(let error):
+            XCTFail("Failed to query comment \(error)")
+        }
+    }
+
+}
+
+

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/15/Post15+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/15/Post15+Schema.swift
@@ -1,0 +1,46 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post15 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case postId
+    case sk
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post15 = Post15.keys
+    
+    model.pluralName = "Post15s"
+    
+    model.attributes(
+      .index(fields: ["postId", "sk"], name: nil),
+      .primaryKey(fields: [post15.postId, post15.sk])
+    )
+    
+    model.fields(
+      .field(post15.postId, is: .required, ofType: .string),
+      .field(post15.sk, is: .required, ofType: .time),
+      .field(post15.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post15.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension Post15: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Post15.IdentifierProtocol {
+  public static func identifier(postId: String,
+      sk: Temporal.Time) -> Self {
+    .make(fields:[(name: "postId", value: postId), (name: "sk", value: sk)])
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/15/Post15.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/15/Post15.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post15: Model {
+  public let postId: String
+  public let sk: Temporal.Time
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(postId: String,
+      sk: Temporal.Time) {
+    self.init(postId: postId,
+      sk: sk,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(postId: String,
+      sk: Temporal.Time,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.postId = postId
+      self.sk = sk
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/primarykey_schema.graphql
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/primarykey_schema.graphql
@@ -264,3 +264,20 @@ type Post12 @model {
   sk: Float!
 }
 
+# CLI.13
+type Post13 @model {
+  postId: ID! @primaryKey(sortKeyFields: ["sk"])
+  sk: AWSDateTime!
+}
+
+# CLI.14
+type Post14 @model {
+  postId: ID! @primaryKey(sortKeyFields: ["sk"])
+  sk: AWSDate!
+}
+
+# CLI.15
+type Post15 @model {
+  postId: ID! @primaryKey(sortKeyFields: ["sk"])
+  sk: AWSTime!
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
@@ -559,6 +559,15 @@
 		60C9C32F2A2FBC1F00ADDB85 /* Post9.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C9C32B2A2FBC1F00ADDB85 /* Post9.swift */; };
 		60C9C3302A2FBC1F00ADDB85 /* Comment9+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C9C32C2A2FBC1F00ADDB85 /* Comment9+Schema.swift */; };
 		60C9C3312A2FBC1F00ADDB85 /* Comment9.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C9C32D2A2FBC1F00ADDB85 /* Comment9.swift */; };
+		60E4653F2A33C8440065F99B /* AWSDataStoreDateTimeSortKeyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E4653E2A33C8440065F99B /* AWSDataStoreDateTimeSortKeyTest.swift */; };
+		60E4654F2A33CE830065F99B /* AWSDataStoreDateSortKeyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E4654E2A33CE830065F99B /* AWSDataStoreDateSortKeyTest.swift */; };
+		60E465512A33CF170065F99B /* AWSDataStoreTimeSortKeyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E465502A33CF170065F99B /* AWSDataStoreTimeSortKeyTest.swift */; };
+		60E465542A33D3E70065F99B /* Post13+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E465522A33D3E70065F99B /* Post13+Schema.swift */; };
+		60E465552A33D3E70065F99B /* Post13.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E465532A33D3E70065F99B /* Post13.swift */; };
+		60E465582A33D3FC0065F99B /* Post14.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E465562A33D3FC0065F99B /* Post14.swift */; };
+		60E465592A33D3FC0065F99B /* Post14+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E465572A33D3FC0065F99B /* Post14+Schema.swift */; };
+		60E4655C2A33D4020065F99B /* Post15+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E4655A2A33D4020065F99B /* Post15+Schema.swift */; };
+		60E4655D2A33D4020065F99B /* Post15.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E4655B2A33D4020065F99B /* Post15.swift */; };
 		681DFE8328E746C10000C36A /* AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8028E746C10000C36A /* AsyncTesting.swift */; };
 		681DFE8428E746C10000C36A /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8128E746C10000C36A /* AsyncExpectation.swift */; };
 		681DFE8528E746C10000C36A /* XCTestCase+AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFE8228E746C10000C36A /* XCTestCase+AsyncTesting.swift */; };
@@ -1343,6 +1352,15 @@
 		60C9C32C2A2FBC1F00ADDB85 /* Comment9+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Comment9+Schema.swift"; sourceTree = "<group>"; };
 		60C9C32D2A2FBC1F00ADDB85 /* Comment9.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment9.swift; sourceTree = "<group>"; };
 		60CB6B3E2A1454F90051BAD2 /* amplify-swift */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-swift"; path = ../../../..; sourceTree = "<group>"; };
+		60E4653E2A33C8440065F99B /* AWSDataStoreDateTimeSortKeyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreDateTimeSortKeyTest.swift; sourceTree = "<group>"; };
+		60E4654E2A33CE830065F99B /* AWSDataStoreDateSortKeyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreDateSortKeyTest.swift; sourceTree = "<group>"; };
+		60E465502A33CF170065F99B /* AWSDataStoreTimeSortKeyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreTimeSortKeyTest.swift; sourceTree = "<group>"; };
+		60E465522A33D3E70065F99B /* Post13+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post13+Schema.swift"; sourceTree = "<group>"; };
+		60E465532A33D3E70065F99B /* Post13.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post13.swift; sourceTree = "<group>"; };
+		60E465562A33D3FC0065F99B /* Post14.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post14.swift; sourceTree = "<group>"; };
+		60E465572A33D3FC0065F99B /* Post14+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post14+Schema.swift"; sourceTree = "<group>"; };
+		60E4655A2A33D4020065F99B /* Post15+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post15+Schema.swift"; sourceTree = "<group>"; };
+		60E4655B2A33D4020065F99B /* Post15.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post15.swift; sourceTree = "<group>"; };
 		681DFE8028E746C10000C36A /* AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncTesting.swift; sourceTree = "<group>"; };
 		681DFE8128E746C10000C36A /* AsyncExpectation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncExpectation.swift; sourceTree = "<group>"; };
 		681DFE8228E746C10000C36A /* XCTestCase+AsyncTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AsyncTesting.swift"; sourceTree = "<group>"; };
@@ -1995,6 +2013,9 @@
 				21BC10C8296DDB2B000E189E /* 10 */,
 				601E37442A3109C900E08FCA /* 11 */,
 				601E37452A3109D000E08FCA /* 12 */,
+				60E4653D2A33C80B0065F99B /* 13 */,
+				60E465442A33CD110065F99B /* 14 */,
+				60E465452A33CD150065F99B /* 15 */,
 				21977D84289C1633005B49D6 /* primarykey_schema.graphql */,
 				21BBFA12289BFE3400B32A39 /* README.md */,
 				21BBFA13289BFE3400B32A39 /* AWSDataStorePrimaryKeyTests.swift */,
@@ -2766,6 +2787,36 @@
 				60C9C3202A2E948F00ADDB85 /* AWSDataStoreCompositeSortKeyIdentifierTest.swift */,
 			);
 			path = 9;
+			sourceTree = "<group>";
+		};
+		60E4653D2A33C80B0065F99B /* 13 */ = {
+			isa = PBXGroup;
+			children = (
+				60E465532A33D3E70065F99B /* Post13.swift */,
+				60E465522A33D3E70065F99B /* Post13+Schema.swift */,
+				60E4653E2A33C8440065F99B /* AWSDataStoreDateTimeSortKeyTest.swift */,
+			);
+			path = 13;
+			sourceTree = "<group>";
+		};
+		60E465442A33CD110065F99B /* 14 */ = {
+			isa = PBXGroup;
+			children = (
+				60E465562A33D3FC0065F99B /* Post14.swift */,
+				60E465572A33D3FC0065F99B /* Post14+Schema.swift */,
+				60E4654E2A33CE830065F99B /* AWSDataStoreDateSortKeyTest.swift */,
+			);
+			path = 14;
+			sourceTree = "<group>";
+		};
+		60E465452A33CD150065F99B /* 15 */ = {
+			isa = PBXGroup;
+			children = (
+				60E4655B2A33D4020065F99B /* Post15.swift */,
+				60E4655A2A33D4020065F99B /* Post15+Schema.swift */,
+				60E465502A33CF170065F99B /* AWSDataStoreTimeSortKeyTest.swift */,
+			);
+			path = 15;
 			sourceTree = "<group>";
 		};
 		681DFE7F28E746C10000C36A /* AsyncTesting */ = {
@@ -4125,7 +4176,9 @@
 				60C9C32E2A2FBC1F00ADDB85 /* Post9+Schema.swift in Sources */,
 				211F5094296DD4C30040EB62 /* AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift in Sources */,
 				213DBBD128A5743600B30280 /* CommentWithCompositeKey+Schema.swift in Sources */,
+				60E4655C2A33D4020065F99B /* Post15+Schema.swift in Sources */,
 				213DBBAA28A5743600B30280 /* ModelCompositePk+Schema.swift in Sources */,
+				60E465552A33D3E70065F99B /* Post13.swift in Sources */,
 				60C9C3312A2FBC1F00ADDB85 /* Comment9.swift in Sources */,
 				213DBBA128A5743600B30280 /* Project2+Schema.swift in Sources */,
 				213DBBAC28A5743600B30280 /* ModelCustomPkDefined+Schema.swift in Sources */,
@@ -4153,13 +4206,16 @@
 				213DBB9F28A5743600B30280 /* CommentWithCompositeKeyAndIndex+Schema.swift in Sources */,
 				21977DBF289C171A005B49D6 /* TestConfigHelper.swift in Sources */,
 				601E37512A310A5700E08FCA /* AWSDataStoreFloatSortKeyTest.swift in Sources */,
+				60E465512A33CF170065F99B /* AWSDataStoreTimeSortKeyTest.swift in Sources */,
 				213DBB9C28A5743600B30280 /* ModelImplicitDefaultPk+Schema.swift in Sources */,
 				213DBBC428A5743600B30280 /* Comment8.swift in Sources */,
 				213DBBA628A5743600B30280 /* Project6.swift in Sources */,
+				60E465592A33D3FC0065F99B /* Post14+Schema.swift in Sources */,
 				213DBBC328A5743600B30280 /* PostWithCompositeKey.swift in Sources */,
 				213DBBAF28A5743600B30280 /* PostWithCompositeKey+Schema.swift in Sources */,
 				213DBBC128A5743600B30280 /* ModelCompositePkWithAssociation.swift in Sources */,
 				213DBBC728A5743600B30280 /* Post8+Schema.swift in Sources */,
+				60E4655D2A33D4020065F99B /* Post15.swift in Sources */,
 				213DBBCB28A5743600B30280 /* Post7.swift in Sources */,
 				21BC10CE296DDB4B000E189E /* Comment4V2.swift in Sources */,
 				21BC10CF296DDB4B000E189E /* Post4V2.swift in Sources */,
@@ -4176,7 +4232,9 @@
 				213DBBCA28A5743600B30280 /* ModelCompositePk.swift in Sources */,
 				213DBBB628A5743600B30280 /* CommentWithCompositeKeyUnidirectional+Schema.swift in Sources */,
 				213DBBA228A5743600B30280 /* Post4+Schema.swift in Sources */,
+				60E465542A33D3E70065F99B /* Post13+Schema.swift in Sources */,
 				213DBBC028A5743600B30280 /* Comment7+Schema.swift in Sources */,
+				60E4653F2A33C8440065F99B /* AWSDataStoreDateTimeSortKeyTest.swift in Sources */,
 				21BC10D0296DDB4B000E189E /* Post4V2+Schema.swift in Sources */,
 				213DBBB528A5743600B30280 /* Comment4.swift in Sources */,
 				213DBBCE28A5743600B30280 /* ModelExplicitCustomPk.swift in Sources */,
@@ -4188,10 +4246,12 @@
 				213DBBC528A5743600B30280 /* TagWithCompositeKey.swift in Sources */,
 				601E374D2A310A0500E08FCA /* Post12.swift in Sources */,
 				213DBBA928A5743600B30280 /* PostWithCompositeKeyAndIndex.swift in Sources */,
+				60E465582A33D3FC0065F99B /* Post14.swift in Sources */,
 				21BC10CD296DDB4B000E189E /* Comment4V2+Schema.swift in Sources */,
 				213DBBBF28A5743600B30280 /* Post4.swift in Sources */,
 				21BBFC23289C03E900B32A39 /* AWSDataStorePrimaryKeyTests.swift in Sources */,
 				601E37482A3109FE00E08FCA /* Post11.swift in Sources */,
+				60E4654F2A33CE830065F99B /* AWSDataStoreDateSortKeyTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

- Support CPK sort key with AWS date types
  - AWSDateTime
  - AWSDate
  - AWSTime

## General Checklist
<!-- Check or cross out if not relevant -->

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
