### PR TITLE
test(datastore): add integ test cases for other aws scalar types as CPK sort key

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/11/AWSDataStoreIntSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/11/AWSDataStoreIntSortKeyTest.swift
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+/** Model Schema
+type Post11 @model {
+  postId: ID! @primaryKey(sortKeyFields: ["sk"])
+  sk: Int!
+}
+*/
 
 import Foundation
 import Combine

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/12/AWSDataStoreFloatSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/12/AWSDataStoreFloatSortKeyTest.swift
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+/** Model Schema
+type Post12 @model {
+  postId: ID! @primaryKey(sortKeyFields: ["sk"])
+  sk: Float!
+}
+*/
 
 import Foundation
 import Combine

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/13/AWSDataStoreDateTimeSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/13/AWSDataStoreDateTimeSortKeyTest.swift
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+/** Model Schema
+type Post13 @model {
+  postId: ID! @primaryKey(sortKeyFields: ["sk"])
+  sk: AWSDateTime!
+}
+*/
 
 import Foundation
 import Combine

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/14/AWSDataStoreDateSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/14/AWSDataStoreDateSortKeyTest.swift
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+/** Model Schema
+type Post14 @model {
+  postId: ID! @primaryKey(sortKeyFields: ["sk"])
+  sk: AWSDate!
+}
+*/
 
 import Foundation
 import Combine

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/15/AWSDataStoreTimeSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/15/AWSDataStoreTimeSortKeyTest.swift
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+/** Model Schema
+type Post15 @model {
+  postId: ID! @primaryKey(sortKeyFields: ["sk"])
+  sk: AWSTime!
+}
+*/
 
 import Foundation
 import Combine

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/16/AWSDataStoreAWSURLSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/16/AWSDataStoreAWSURLSortKeyTest.swift
@@ -1,0 +1,79 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+import Combine
+import XCTest
+@testable import Amplify
+
+fileprivate struct TestModels: AmplifyModelRegistration {
+    func registerModels(registry: ModelRegistry.Type) {
+        ModelRegistry.register(modelType: Post16.self)
+    }
+
+    public let version: String = "test"
+}
+
+
+class AWSDataStoreAWSURLSortKeyTest: AWSDataStoreSortKeyBaseTest {
+    func testCreateModel_withSortKeyInAWSURLType_success() async throws {
+        try await setUp(models: TestModels())
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+
+        let url = URL(string: "https://google.com")
+        let post = Post16(postId: UUID().uuidString, sk: url!.absoluteString)
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+    }
+
+    func testQueryCreatedModel_withSortKeyInAWSURLType_success() async throws {
+        try await setUp(models: TestModels())
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+
+        let url = URL(string: "https://google.com")
+        let post = Post16(postId: UUID().uuidString, sk: url!.absoluteString)
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+
+        let queryResult = try await Amplify.API.query(
+            request: .get(
+                Post16.self,
+                byIdentifier: .identifier(postId: post.postId, sk: post.sk)
+            )
+        )
+
+        switch queryResult {
+        case .success(let queriedPost):
+            XCTAssertEqual(post.identifier, queriedPost!.identifier)
+        case .failure(let error):
+            XCTFail("Failed to query comment \(error)")
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/16/AWSDataStoreAWSURLSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/16/AWSDataStoreAWSURLSortKeyTest.swift
@@ -5,6 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+/** Model Schema
+type Post16 @model {
+    postId: ID! @primaryKey(sortKeyFields: ["sk"])
+    sk: AWSURL!
+}
+*/
+
 
 import Foundation
 import Combine

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/16/Post16+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/16/Post16+Schema.swift
@@ -1,0 +1,46 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post16 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case postId
+    case sk
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post16 = Post16.keys
+    
+    model.pluralName = "Post16s"
+    
+    model.attributes(
+      .index(fields: ["postId", "sk"], name: nil),
+      .primaryKey(fields: [post16.postId, post16.sk])
+    )
+    
+    model.fields(
+      .field(post16.postId, is: .required, ofType: .string),
+      .field(post16.sk, is: .required, ofType: .string),
+      .field(post16.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post16.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension Post16: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Post16.IdentifierProtocol {
+  public static func identifier(postId: String,
+      sk: String) -> Self {
+    .make(fields:[(name: "postId", value: postId), (name: "sk", value: sk)])
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/16/Post16.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/16/Post16.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post16: Model {
+  public let postId: String
+  public let sk: String
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(postId: String,
+      sk: String) {
+    self.init(postId: postId,
+      sk: sk,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(postId: String,
+      sk: String,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.postId = postId
+      self.sk = sk
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/17/AWSDataStoreAWSEmailSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/17/AWSDataStoreAWSEmailSortKeyTest.swift
@@ -5,6 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+/** Model Schema
+type Post17 @model {
+    postId: ID! @primaryKey(sortKeyFields: ["sk"])
+    sk: AWSEmail!
+}
+*/
+
 
 import Foundation
 import Combine

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/17/AWSDataStoreAWSEmailSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/17/AWSDataStoreAWSEmailSortKeyTest.swift
@@ -1,0 +1,77 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+import Combine
+import XCTest
+@testable import Amplify
+
+fileprivate struct TestModels: AmplifyModelRegistration {
+    func registerModels(registry: ModelRegistry.Type) {
+        ModelRegistry.register(modelType: Post17.self)
+    }
+
+    public let version: String = "test"
+}
+
+
+class AWSDataStoreAWSEmailSortKeyTest: AWSDataStoreSortKeyBaseTest {
+    func testCreateModel_withSortKeyInAWSEmailType_success() async throws {
+        try await setUp(models: TestModels())
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+
+        let post = Post17(postId: UUID().uuidString, sk: "test@example.com")
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+    }
+
+    func testQueryCreatedModel_withSortKeyInAWSEmailType_success() async throws {
+        try await setUp(models: TestModels())
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+
+        let post = Post17(postId: UUID().uuidString, sk: "test@example.com")
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+
+        let queryResult = try await Amplify.API.query(
+            request: .get(
+                Post17.self,
+                byIdentifier: .identifier(postId: post.postId, sk: post.sk)
+            )
+        )
+
+        switch queryResult {
+        case .success(let queriedPost):
+            XCTAssertEqual(post.identifier, queriedPost!.identifier)
+        case .failure(let error):
+            XCTFail("Failed to query comment \(error)")
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/17/Post17+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/17/Post17+Schema.swift
@@ -1,0 +1,46 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post17 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case postId
+    case sk
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post17 = Post17.keys
+    
+    model.pluralName = "Post17s"
+    
+    model.attributes(
+      .index(fields: ["postId", "sk"], name: nil),
+      .primaryKey(fields: [post17.postId, post17.sk])
+    )
+    
+    model.fields(
+      .field(post17.postId, is: .required, ofType: .string),
+      .field(post17.sk, is: .required, ofType: .string),
+      .field(post17.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post17.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension Post17: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Post17.IdentifierProtocol {
+  public static func identifier(postId: String,
+      sk: String) -> Self {
+    .make(fields:[(name: "postId", value: postId), (name: "sk", value: sk)])
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/17/Post17.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/17/Post17.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post17: Model {
+  public let postId: String
+  public let sk: String
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(postId: String,
+      sk: String) {
+    self.init(postId: postId,
+      sk: sk,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(postId: String,
+      sk: String,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.postId = postId
+      self.sk = sk
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/18/AWSDataStoreAWSPhoneSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/18/AWSDataStoreAWSPhoneSortKeyTest.swift
@@ -5,6 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+/** Model Schema
+type Post18 @model {
+    postId: ID! @primaryKey(sortKeyFields: ["sk"])
+    sk: AWSPhone!
+}
+*/
+
 
 import Foundation
 import Combine

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/18/AWSDataStoreAWSPhoneSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/18/AWSDataStoreAWSPhoneSortKeyTest.swift
@@ -1,0 +1,77 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+import Combine
+import XCTest
+@testable import Amplify
+
+fileprivate struct TestModels: AmplifyModelRegistration {
+    func registerModels(registry: ModelRegistry.Type) {
+        ModelRegistry.register(modelType: Post18.self)
+    }
+
+    public let version: String = "test"
+}
+
+
+class AWSDataStoreAWSPhoneSortKeyTest: AWSDataStoreSortKeyBaseTest {
+    func testCreateModel_withSortKeyInAWSPhoneType_success() async throws {
+        try await setUp(models: TestModels())
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+
+        let post = Post18(postId: UUID().uuidString, sk: "+12133734253")
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+    }
+
+    func testQueryCreatedModel_withSortKeyInAWSPhoneType_success() async throws {
+        try await setUp(models: TestModels())
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+
+        let post = Post18(postId: UUID().uuidString, sk: "+12133734253")
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+
+        let queryResult = try await Amplify.API.query(
+            request: .get(
+                Post18.self,
+                byIdentifier: .identifier(postId: post.postId, sk: post.sk)
+            )
+        )
+
+        switch queryResult {
+        case .success(let queriedPost):
+            XCTAssertEqual(post.identifier, queriedPost!.identifier)
+        case .failure(let error):
+            XCTFail("Failed to query comment \(error)")
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/18/Post18+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/18/Post18+Schema.swift
@@ -1,0 +1,46 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post18 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case postId
+    case sk
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post18 = Post18.keys
+    
+    model.pluralName = "Post18s"
+    
+    model.attributes(
+      .index(fields: ["postId", "sk"], name: nil),
+      .primaryKey(fields: [post18.postId, post18.sk])
+    )
+    
+    model.fields(
+      .field(post18.postId, is: .required, ofType: .string),
+      .field(post18.sk, is: .required, ofType: .string),
+      .field(post18.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post18.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension Post18: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Post18.IdentifierProtocol {
+  public static func identifier(postId: String,
+      sk: String) -> Self {
+    .make(fields:[(name: "postId", value: postId), (name: "sk", value: sk)])
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/18/Post18.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/18/Post18.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post18: Model {
+  public let postId: String
+  public let sk: String
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(postId: String,
+      sk: String) {
+    self.init(postId: postId,
+      sk: sk,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(postId: String,
+      sk: String,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.postId = postId
+      self.sk = sk
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/19/AWSDataStoreAWSIPAddressSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/19/AWSDataStoreAWSIPAddressSortKeyTest.swift
@@ -5,6 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+/** Model Schema
+type Post19 @model {
+    postId: ID! @primaryKey(sortKeyFields: ["sk"])
+    sk: AWSIPAddress!
+}
+*/
+
 
 import Foundation
 import Combine

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/19/AWSDataStoreAWSIPAddressSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/19/AWSDataStoreAWSIPAddressSortKeyTest.swift
@@ -1,0 +1,97 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+import Combine
+import XCTest
+@testable import Amplify
+
+fileprivate struct TestModels: AmplifyModelRegistration {
+    func registerModels(registry: ModelRegistry.Type) {
+        ModelRegistry.register(modelType: Post19.self)
+    }
+
+    public let version: String = "test"
+}
+
+
+class AWSDataStoreAWSIPAddressSortKeyTest: AWSDataStoreSortKeyBaseTest {
+    func testCreateModel_withSortKeyInIPV4Type_success() async throws {
+        try await setUp(models: TestModels())
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+
+        let post = Post19(postId: UUID().uuidString, sk: "1.1.1.1/16")
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+    }
+
+    func testCreateModel_withSortKeyInIPV6Type_success() async throws {
+        try await setUp(models: TestModels())
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+
+        let post = Post19(postId: UUID().uuidString, sk: "1a2b:3c4b::1234:4567")
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+    }
+
+    func testQueryCreatedModel_withSortKeyInAWSIPAddressType_success() async throws {
+        try await setUp(models: TestModels())
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+
+        let post = Post19(postId: UUID().uuidString, sk: "1.1.1.1/16")
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+
+        let queryResult = try await Amplify.API.query(
+            request: .get(
+                Post19.self,
+                byIdentifier: .identifier(postId: post.postId, sk: post.sk)
+            )
+        )
+
+        switch queryResult {
+        case .success(let queriedPost):
+            XCTAssertEqual(post.identifier, queriedPost!.identifier)
+        case .failure(let error):
+            XCTFail("Failed to query comment \(error)")
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/19/Post19+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/19/Post19+Schema.swift
@@ -1,0 +1,46 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post19 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case postId
+    case sk
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post19 = Post19.keys
+    
+    model.pluralName = "Post19s"
+    
+    model.attributes(
+      .index(fields: ["postId", "sk"], name: nil),
+      .primaryKey(fields: [post19.postId, post19.sk])
+    )
+    
+    model.fields(
+      .field(post19.postId, is: .required, ofType: .string),
+      .field(post19.sk, is: .required, ofType: .string),
+      .field(post19.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post19.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension Post19: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Post19.IdentifierProtocol {
+  public static func identifier(postId: String,
+      sk: String) -> Self {
+    .make(fields:[(name: "postId", value: postId), (name: "sk", value: sk)])
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/19/Post19.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/19/Post19.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post19: Model {
+  public let postId: String
+  public let sk: String
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(postId: String,
+      sk: String) {
+    self.init(postId: postId,
+      sk: sk,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(postId: String,
+      sk: String,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.postId = postId
+      self.sk = sk
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/20/AWSDataStoreAWSTimestampSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/20/AWSDataStoreAWSTimestampSortKeyTest.swift
@@ -5,6 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+/** Model Schema
+type Post20 @model {
+    postId: ID! @primaryKey(sortKeyFields: ["sk"])
+    sk: AWSTimestamp!
+}
+*/
+
 
 import Foundation
 import Combine

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/20/AWSDataStoreAWSTimestampSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/20/AWSDataStoreAWSTimestampSortKeyTest.swift
@@ -1,0 +1,77 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+import Combine
+import XCTest
+@testable import Amplify
+
+fileprivate struct TestModels: AmplifyModelRegistration {
+    func registerModels(registry: ModelRegistry.Type) {
+        ModelRegistry.register(modelType: Post20.self)
+    }
+
+    public let version: String = "test"
+}
+
+
+class AWSDataStoreAWSTimestampSortKeyTest: AWSDataStoreSortKeyBaseTest {
+    func testCreateModel_withSortKeyInAWSTimestampType_success() async throws {
+        try await setUp(models: TestModels())
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+
+        let post = Post20(postId: UUID().uuidString, sk: Int(Date().timeIntervalSince1970))
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+    }
+
+    func testQueryCreatedModel_withSortKeyInAWSTimestampType_success() async throws {
+        try await setUp(models: TestModels())
+        try await waitDataStoreReady()
+        var requests: Set<AnyCancellable> = []
+
+        let post = Post20(postId: UUID().uuidString, sk: Int(Date().timeIntervalSince1970))
+        let postCreated = expectation(description: "Post is created")
+        postCreated.assertForOverFulfill = false
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.syncReceived }
+            .compactMap { $0.data as? MutationEvent }
+            .filter { $0.modelId == post.identifier }
+            .sink { _ in
+                postCreated.fulfill()
+            }.store(in: &requests)
+
+        try await Amplify.DataStore.save(post)
+        await fulfillment(of: [postCreated], timeout: 5)
+
+        let queryResult = try await Amplify.API.query(
+            request: .get(
+                Post20.self,
+                byIdentifier: .identifier(postId: post.postId, sk: post.sk)
+            )
+        )
+
+        switch queryResult {
+        case .success(let queriedPost):
+            XCTAssertEqual(post.identifier, queriedPost!.identifier)
+        case .failure(let error):
+            XCTFail("Failed to query comment \(error)")
+        }
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/20/Post20+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/20/Post20+Schema.swift
@@ -1,0 +1,46 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension Post20 {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case postId
+    case sk
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let post20 = Post20.keys
+    
+    model.pluralName = "Post20s"
+    
+    model.attributes(
+      .index(fields: ["postId", "sk"], name: nil),
+      .primaryKey(fields: [post20.postId, post20.sk])
+    )
+    
+    model.fields(
+      .field(post20.postId, is: .required, ofType: .string),
+      .field(post20.sk, is: .required, ofType: .int),
+      .field(post20.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(post20.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension Post20: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Custom
+  public typealias IdentifierProtocol = ModelIdentifier<Self, ModelIdentifierFormat.Custom>
+}
+
+extension Post20.IdentifierProtocol {
+  public static func identifier(postId: String,
+      sk: Int) -> Self {
+    .make(fields:[(name: "postId", value: postId), (name: "sk", value: sk)])
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/20/Post20.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/20/Post20.swift
@@ -1,0 +1,27 @@
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct Post20: Model {
+  public let postId: String
+  public let sk: Int
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(postId: String,
+      sk: Int) {
+    self.init(postId: postId,
+      sk: sk,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(postId: String,
+      sk: Int,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.postId = postId
+      self.sk = sk
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStoreSortKeyBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStoreSortKeyBaseTest.swift
@@ -1,0 +1,60 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+import Combine
+import XCTest
+
+import AWSAPIPlugin
+import AWSDataStorePlugin
+
+@testable import Amplify
+@testable import DataStoreHostApp
+
+class AWSDataStoreSortKeyBaseTest: XCTestCase {
+    static let defaultConfigFile = "AWSDataStoreCategoryPluginPrimaryKeyIntegrationTests-amplifyconfiguration"
+    override func setUp() async throws {
+        continueAfterFailure = false
+    }
+
+    override func tearDown() async throws {
+        try await Amplify.DataStore.clear()
+        await Amplify.reset()
+        try await Task.sleep(seconds: 1)
+    }
+
+    func setUp(
+        models: AmplifyModelRegistration,
+        configFile: String = AWSDataStoreSortKeyBaseTest.defaultConfigFile
+    ) async throws {
+        let config = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: "testconfiguration/\(configFile)")
+        try Amplify.add(plugin: AWSAPIPlugin(sessionFactory: AmplifyURLSessionFactory()))
+        try Amplify.add(plugin: AWSDataStorePlugin(
+            modelRegistration: models,
+            configuration: .custom(syncMaxRecords: 100)
+        ))
+
+        Amplify.Logging.logLevel = .verbose
+        try Amplify.configure(config)
+    }
+
+    func waitDataStoreReady() async throws {
+        let ready = expectation(description: "DataStore is ready")
+        var requests: Set<AnyCancellable> = []
+        Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.ready }
+            .sink { _ in
+                ready.fulfill()
+            }
+            .store(in: &requests)
+
+        try await Amplify.DataStore.start()
+        await fulfillment(of: [ready], timeout: 60)
+    }
+
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/primarykey_schema.graphql
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/primarykey_schema.graphql
@@ -281,3 +281,33 @@ type Post15 @model {
   postId: ID! @primaryKey(sortKeyFields: ["sk"])
   sk: AWSTime!
 }
+
+# CLI.16
+type Post16 @model {
+    postId: ID! @primaryKey(sortKeyFields: ["sk"])
+    sk: AWSURL!
+}
+
+# CLI.17
+type Post17 @model {
+    postId: ID! @primaryKey(sortKeyFields: ["sk"])
+    sk: AWSEmail!
+}
+
+# CLI.18
+type Post18 @model {
+    postId: ID! @primaryKey(sortKeyFields: ["sk"])
+    sk: AWSPhone!
+}
+
+# CLI.19
+type Post19 @model {
+    postId: ID! @primaryKey(sortKeyFields: ["sk"])
+    sk: AWSIPAddress!
+}
+
+# CLI.20
+type Post20 @model {
+    postId: ID! @primaryKey(sortKeyFields: ["sk"])
+    sk: AWSTimestamp!
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
@@ -554,6 +554,22 @@
 		601E374D2A310A0500E08FCA /* Post12.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601E374B2A310A0500E08FCA /* Post12.swift */; };
 		601E374F2A310A4200E08FCA /* AWSDataStoreIntSortKeyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601E374E2A310A4200E08FCA /* AWSDataStoreIntSortKeyTest.swift */; };
 		601E37512A310A5700E08FCA /* AWSDataStoreFloatSortKeyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601E37502A310A5700E08FCA /* AWSDataStoreFloatSortKeyTest.swift */; };
+		602E8BF62A37D13700A3EA1E /* AWSDataStoreAWSPhoneSortKeyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602E8BED2A37D13600A3EA1E /* AWSDataStoreAWSPhoneSortKeyTest.swift */; };
+		602E8BF72A37D13700A3EA1E /* AWSDataStoreAWSURLSortKeyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602E8BEF2A37D13700A3EA1E /* AWSDataStoreAWSURLSortKeyTest.swift */; };
+		602E8BF82A37D13700A3EA1E /* AWSDataStoreAWSTimestampSortKeyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602E8BF12A37D13700A3EA1E /* AWSDataStoreAWSTimestampSortKeyTest.swift */; };
+		602E8BF92A37D13700A3EA1E /* AWSDataStoreAWSIPAddressSortKeyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602E8BF32A37D13700A3EA1E /* AWSDataStoreAWSIPAddressSortKeyTest.swift */; };
+		602E8BFA2A37D13700A3EA1E /* AWSDataStoreAWSEmailSortKeyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602E8BF52A37D13700A3EA1E /* AWSDataStoreAWSEmailSortKeyTest.swift */; };
+		602E8BFC2A37D14900A3EA1E /* AWSDataStoreSortKeyBaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602E8BFB2A37D14900A3EA1E /* AWSDataStoreSortKeyBaseTest.swift */; };
+		6080BE5F2A37D48A0086EBDF /* Post16.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6080BE5D2A37D48A0086EBDF /* Post16.swift */; };
+		6080BE602A37D48A0086EBDF /* Post16+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6080BE5E2A37D48A0086EBDF /* Post16+Schema.swift */; };
+		6080BE632A37D4940086EBDF /* Post17+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6080BE612A37D4940086EBDF /* Post17+Schema.swift */; };
+		6080BE642A37D4940086EBDF /* Post17.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6080BE622A37D4940086EBDF /* Post17.swift */; };
+		6080BE672A37D49F0086EBDF /* Post18+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6080BE652A37D49F0086EBDF /* Post18+Schema.swift */; };
+		6080BE682A37D49F0086EBDF /* Post18.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6080BE662A37D49F0086EBDF /* Post18.swift */; };
+		6080BE6B2A37D4A70086EBDF /* Post19.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6080BE692A37D4A70086EBDF /* Post19.swift */; };
+		6080BE6C2A37D4A70086EBDF /* Post19+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6080BE6A2A37D4A70086EBDF /* Post19+Schema.swift */; };
+		6080BE6F2A37D4B00086EBDF /* Post20+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6080BE6D2A37D4B00086EBDF /* Post20+Schema.swift */; };
+		6080BE702A37D4B00086EBDF /* Post20.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6080BE6E2A37D4B00086EBDF /* Post20.swift */; };
 		60C9C3212A2E948F00ADDB85 /* AWSDataStoreCompositeSortKeyIdentifierTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C9C3202A2E948F00ADDB85 /* AWSDataStoreCompositeSortKeyIdentifierTest.swift */; };
 		60C9C32E2A2FBC1F00ADDB85 /* Post9+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C9C32A2A2FBC1F00ADDB85 /* Post9+Schema.swift */; };
 		60C9C32F2A2FBC1F00ADDB85 /* Post9.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C9C32B2A2FBC1F00ADDB85 /* Post9.swift */; };
@@ -1346,6 +1362,22 @@
 		601E374B2A310A0500E08FCA /* Post12.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post12.swift; sourceTree = "<group>"; };
 		601E374E2A310A4200E08FCA /* AWSDataStoreIntSortKeyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreIntSortKeyTest.swift; sourceTree = "<group>"; };
 		601E37502A310A5700E08FCA /* AWSDataStoreFloatSortKeyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreFloatSortKeyTest.swift; sourceTree = "<group>"; };
+		602E8BED2A37D13600A3EA1E /* AWSDataStoreAWSPhoneSortKeyTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSDataStoreAWSPhoneSortKeyTest.swift; sourceTree = "<group>"; };
+		602E8BEF2A37D13700A3EA1E /* AWSDataStoreAWSURLSortKeyTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSDataStoreAWSURLSortKeyTest.swift; sourceTree = "<group>"; };
+		602E8BF12A37D13700A3EA1E /* AWSDataStoreAWSTimestampSortKeyTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSDataStoreAWSTimestampSortKeyTest.swift; sourceTree = "<group>"; };
+		602E8BF32A37D13700A3EA1E /* AWSDataStoreAWSIPAddressSortKeyTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSDataStoreAWSIPAddressSortKeyTest.swift; sourceTree = "<group>"; };
+		602E8BF52A37D13700A3EA1E /* AWSDataStoreAWSEmailSortKeyTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSDataStoreAWSEmailSortKeyTest.swift; sourceTree = "<group>"; };
+		602E8BFB2A37D14900A3EA1E /* AWSDataStoreSortKeyBaseTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSDataStoreSortKeyBaseTest.swift; sourceTree = "<group>"; };
+		6080BE5D2A37D48A0086EBDF /* Post16.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post16.swift; sourceTree = "<group>"; };
+		6080BE5E2A37D48A0086EBDF /* Post16+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post16+Schema.swift"; sourceTree = "<group>"; };
+		6080BE612A37D4940086EBDF /* Post17+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post17+Schema.swift"; sourceTree = "<group>"; };
+		6080BE622A37D4940086EBDF /* Post17.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post17.swift; sourceTree = "<group>"; };
+		6080BE652A37D49F0086EBDF /* Post18+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post18+Schema.swift"; sourceTree = "<group>"; };
+		6080BE662A37D49F0086EBDF /* Post18.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post18.swift; sourceTree = "<group>"; };
+		6080BE692A37D4A70086EBDF /* Post19.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post19.swift; sourceTree = "<group>"; };
+		6080BE6A2A37D4A70086EBDF /* Post19+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post19+Schema.swift"; sourceTree = "<group>"; };
+		6080BE6D2A37D4B00086EBDF /* Post20+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post20+Schema.swift"; sourceTree = "<group>"; };
+		6080BE6E2A37D4B00086EBDF /* Post20.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post20.swift; sourceTree = "<group>"; };
 		60C9C3202A2E948F00ADDB85 /* AWSDataStoreCompositeSortKeyIdentifierTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreCompositeSortKeyIdentifierTest.swift; sourceTree = "<group>"; };
 		60C9C32A2A2FBC1F00ADDB85 /* Post9+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post9+Schema.swift"; sourceTree = "<group>"; };
 		60C9C32B2A2FBC1F00ADDB85 /* Post9.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post9.swift; sourceTree = "<group>"; };
@@ -2016,10 +2048,16 @@
 				60E4653D2A33C80B0065F99B /* 13 */,
 				60E465442A33CD110065F99B /* 14 */,
 				60E465452A33CD150065F99B /* 15 */,
+				602E8BEE2A37D13700A3EA1E /* 16 */,
+				602E8BF42A37D13700A3EA1E /* 17 */,
+				602E8BEC2A37D13600A3EA1E /* 18 */,
+				602E8BF22A37D13700A3EA1E /* 19 */,
+				602E8BF02A37D13700A3EA1E /* 20 */,
 				21977D84289C1633005B49D6 /* primarykey_schema.graphql */,
 				21BBFA12289BFE3400B32A39 /* README.md */,
 				21BBFA13289BFE3400B32A39 /* AWSDataStorePrimaryKeyTests.swift */,
 				21BBFA14289BFE3400B32A39 /* AWSDataStorePrimaryKeyBaseTest.swift */,
+				602E8BFB2A37D14900A3EA1E /* AWSDataStoreSortKeyBaseTest.swift */,
 			);
 			path = PrimaryKey;
 			sourceTree = "<group>";
@@ -2776,6 +2814,61 @@
 			);
 			path = 12;
 			sourceTree = "<group>";
+		};
+		602E8BEC2A37D13600A3EA1E /* 18 */ = {
+			isa = PBXGroup;
+			children = (
+				6080BE662A37D49F0086EBDF /* Post18.swift */,
+				6080BE652A37D49F0086EBDF /* Post18+Schema.swift */,
+				602E8BED2A37D13600A3EA1E /* AWSDataStoreAWSPhoneSortKeyTest.swift */,
+			);
+			name = 18;
+			path = AWSDataStorePluginCPKTests/PrimaryKey/18;
+			sourceTree = SOURCE_ROOT;
+		};
+		602E8BEE2A37D13700A3EA1E /* 16 */ = {
+			isa = PBXGroup;
+			children = (
+				6080BE5D2A37D48A0086EBDF /* Post16.swift */,
+				6080BE5E2A37D48A0086EBDF /* Post16+Schema.swift */,
+				602E8BEF2A37D13700A3EA1E /* AWSDataStoreAWSURLSortKeyTest.swift */,
+			);
+			name = 16;
+			path = AWSDataStorePluginCPKTests/PrimaryKey/16;
+			sourceTree = SOURCE_ROOT;
+		};
+		602E8BF02A37D13700A3EA1E /* 20 */ = {
+			isa = PBXGroup;
+			children = (
+				6080BE6E2A37D4B00086EBDF /* Post20.swift */,
+				6080BE6D2A37D4B00086EBDF /* Post20+Schema.swift */,
+				602E8BF12A37D13700A3EA1E /* AWSDataStoreAWSTimestampSortKeyTest.swift */,
+			);
+			name = 20;
+			path = AWSDataStorePluginCPKTests/PrimaryKey/20;
+			sourceTree = SOURCE_ROOT;
+		};
+		602E8BF22A37D13700A3EA1E /* 19 */ = {
+			isa = PBXGroup;
+			children = (
+				6080BE692A37D4A70086EBDF /* Post19.swift */,
+				6080BE6A2A37D4A70086EBDF /* Post19+Schema.swift */,
+				602E8BF32A37D13700A3EA1E /* AWSDataStoreAWSIPAddressSortKeyTest.swift */,
+			);
+			name = 19;
+			path = AWSDataStorePluginCPKTests/PrimaryKey/19;
+			sourceTree = SOURCE_ROOT;
+		};
+		602E8BF42A37D13700A3EA1E /* 17 */ = {
+			isa = PBXGroup;
+			children = (
+				6080BE622A37D4940086EBDF /* Post17.swift */,
+				6080BE612A37D4940086EBDF /* Post17+Schema.swift */,
+				602E8BF52A37D13700A3EA1E /* AWSDataStoreAWSEmailSortKeyTest.swift */,
+			);
+			name = 17;
+			path = AWSDataStorePluginCPKTests/PrimaryKey/17;
+			sourceTree = SOURCE_ROOT;
 		};
 		60C9C31F2A2E944800ADDB85 /* 9 */ = {
 			isa = PBXGroup;
@@ -4164,10 +4257,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6080BE6B2A37D4A70086EBDF /* Post19.swift in Sources */,
 				213DBBA828A5743600B30280 /* Post8.swift in Sources */,
 				213DBBB128A5743600B30280 /* Project6+Schema.swift in Sources */,
 				213DBBAE28A5743600B30280 /* PostWithTagsCompositeKey+Schema.swift in Sources */,
 				213DBBC928A5743600B30280 /* Comment4+Schema.swift in Sources */,
+				6080BE5F2A37D48A0086EBDF /* Post16.swift in Sources */,
 				21BBFC24289C03EB00B32A39 /* AWSDataStorePrimaryKeyBaseTest.swift in Sources */,
 				213DBBD328A5743600B30280 /* Team2.swift in Sources */,
 				60C9C3212A2E948F00ADDB85 /* AWSDataStoreCompositeSortKeyIdentifierTest.swift in Sources */,
@@ -4177,28 +4272,35 @@
 				211F5094296DD4C30040EB62 /* AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift in Sources */,
 				213DBBD128A5743600B30280 /* CommentWithCompositeKey+Schema.swift in Sources */,
 				60E4655C2A33D4020065F99B /* Post15+Schema.swift in Sources */,
+				602E8BF92A37D13700A3EA1E /* AWSDataStoreAWSIPAddressSortKeyTest.swift in Sources */,
 				213DBBAA28A5743600B30280 /* ModelCompositePk+Schema.swift in Sources */,
 				60E465552A33D3E70065F99B /* Post13.swift in Sources */,
+				602E8BFC2A37D14900A3EA1E /* AWSDataStoreSortKeyBaseTest.swift in Sources */,
 				60C9C3312A2FBC1F00ADDB85 /* Comment9.swift in Sources */,
 				213DBBA128A5743600B30280 /* Project2+Schema.swift in Sources */,
 				213DBBAC28A5743600B30280 /* ModelCustomPkDefined+Schema.swift in Sources */,
 				213DBBD428A5743600B30280 /* Team6.swift in Sources */,
 				21BC10D2296DDB63000E189E /* AWSDataStorePrimaryKeyPostComment4V2Test.swift in Sources */,
+				6080BE6C2A37D4A70086EBDF /* Post19+Schema.swift in Sources */,
 				213DBBA728A5743600B30280 /* Team6+Schema.swift in Sources */,
+				602E8BFA2A37D13700A3EA1E /* AWSDataStoreAWSEmailSortKeyTest.swift in Sources */,
 				213DBBCF28A5743600B30280 /* Team2+Schema.swift in Sources */,
 				601E374C2A310A0500E08FCA /* Post12+Schema.swift in Sources */,
+				6080BE632A37D4940086EBDF /* Post17+Schema.swift in Sources */,
 				213DBBBE28A5743600B30280 /* ModelExplicitCustomPk+Schema.swift in Sources */,
 				213DBBCC28A5743600B30280 /* PostWithTagsCompositeKey.swift in Sources */,
 				60C9C32F2A2FBC1F00ADDB85 /* Post9.swift in Sources */,
 				213DBBA328A5743600B30280 /* PostWithCompositeKeyUnidirectional+Schema.swift in Sources */,
 				213DBBA528A5743600B30280 /* PostWithCompositeKeyUnidirectional.swift in Sources */,
 				213DBBB328A5743600B30280 /* PostTagsWithCompositeKey.swift in Sources */,
+				6080BE682A37D49F0086EBDF /* Post18.swift in Sources */,
 				213DBBCD28A5743600B30280 /* CommentWithCompositeKeyUnidirectional.swift in Sources */,
 				213DBBD028A5743600B30280 /* PostTagsWithCompositeKey+Schema.swift in Sources */,
 				213DBBB828A5743600B30280 /* TagWithCompositeKey+Schema.swift in Sources */,
 				601E37492A3109FE00E08FCA /* Post11+Schema.swift in Sources */,
 				213DBBBB28A5743600B30280 /* Comment7.swift in Sources */,
 				213DBBB228A5743600B30280 /* ModelCompositePkBelongsTo.swift in Sources */,
+				602E8BF82A37D13700A3EA1E /* AWSDataStoreAWSTimestampSortKeyTest.swift in Sources */,
 				213DBBA028A5743600B30280 /* PostWithCompositeKeyAndIndex+Schema.swift in Sources */,
 				213DBB9E28A5743600B30280 /* ModelExplicitDefaultPk+Schema.swift in Sources */,
 				213DBBD228A5743600B30280 /* ModelCompositePkBelongsTo+Schema.swift in Sources */,
@@ -4225,6 +4327,7 @@
 				213DBBBC28A5743600B30280 /* ModelCustomPKDefined.swift in Sources */,
 				213DBBB428A5743600B30280 /* ModelCompositeIntPk+Schema.swift in Sources */,
 				213DBBC628A5743600B30280 /* ModelCompositeIntPk.swift in Sources */,
+				6080BE6F2A37D4B00086EBDF /* Post20+Schema.swift in Sources */,
 				213DBBD528A5743600B30280 /* CommentWithCompositeKeyAndIndex.swift in Sources */,
 				213DBBB028A5743600B30280 /* ModelExplicitDefaultPk.swift in Sources */,
 				213DBBAD28A5743600B30280 /* ModelCompositeMultiplePk+Schema.swift in Sources */,
@@ -4241,17 +4344,23 @@
 				213DBBB728A5743600B30280 /* Post7+Schema.swift in Sources */,
 				213DBBC828A5743600B30280 /* Project2.swift in Sources */,
 				60C9C3302A2FBC1F00ADDB85 /* Comment9+Schema.swift in Sources */,
+				6080BE702A37D4B00086EBDF /* Post20.swift in Sources */,
 				213DBB9D28A5743600B30280 /* ModelImplicitDefaultPk.swift in Sources */,
 				213DBBBA28A5743600B30280 /* Comment8+Schema.swift in Sources */,
 				213DBBC528A5743600B30280 /* TagWithCompositeKey.swift in Sources */,
 				601E374D2A310A0500E08FCA /* Post12.swift in Sources */,
 				213DBBA928A5743600B30280 /* PostWithCompositeKeyAndIndex.swift in Sources */,
+				6080BE602A37D48A0086EBDF /* Post16+Schema.swift in Sources */,
+				6080BE642A37D4940086EBDF /* Post17.swift in Sources */,
 				60E465582A33D3FC0065F99B /* Post14.swift in Sources */,
 				21BC10CD296DDB4B000E189E /* Comment4V2+Schema.swift in Sources */,
 				213DBBBF28A5743600B30280 /* Post4.swift in Sources */,
 				21BBFC23289C03E900B32A39 /* AWSDataStorePrimaryKeyTests.swift in Sources */,
 				601E37482A3109FE00E08FCA /* Post11.swift in Sources */,
 				60E4654F2A33CE830065F99B /* AWSDataStoreDateSortKeyTest.swift in Sources */,
+				602E8BF62A37D13700A3EA1E /* AWSDataStoreAWSPhoneSortKeyTest.swift in Sources */,
+				6080BE672A37D49F0086EBDF /* Post18+Schema.swift in Sources */,
+				602E8BF72A37D13700A3EA1E /* AWSDataStoreAWSURLSortKeyTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
- add integration test cases for other AWS scalar types
  - AWSPhone
  - AWSURL
  - AWSEmail
  - AWSIPAddress
  - AWSTimestamp
  
## General Checklist
<!-- Check or cross out if not relevant -->

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
