### PR TITLE
NOTICKET: add keychain account

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -140,7 +140,11 @@ extension AWSCognitoAuthPlugin {
     }
 
     private func makeCredentialStore() -> AmplifyAuthCredentialStoreBehavior {
-        AWSCognitoAuthCredentialStore(authConfiguration: authConfiguration)
+        AWSCognitoAuthCredentialStore(
+            authConfiguration: authConfiguration,
+            accessGroup: keychainAccessGroup,
+            account: keychainAccount
+        )
     }
 
     private func makeLegacyKeychainStore(service: String) -> KeychainStoreBehavior {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
@@ -28,6 +28,9 @@ public final class AWSCognitoAuthPlugin: AWSCognitoAuthPluginBehavior {
 
     var analyticsHandler: UserPoolAnalyticsBehavior!
 
+    var keychainAccessGroup: String?
+    var keychainAccount: String?
+
     var taskQueue: TaskQueue<Any>!
 
     var httpClientEngineProxy: HttpClientEngineProxy?
@@ -41,6 +44,8 @@ public final class AWSCognitoAuthPlugin: AWSCognitoAuthPluginBehavior {
     }
 
     /// Instantiates an instance of the AWSCognitoAuthPlugin.
-    public init() {
+    public init(keychainAccessGroup: String? = nil, keychainAccount: String? = nil) {
+        self.keychainAccessGroup = keychainAccessGroup
+        self.keychainAccount = keychainAccount
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AWSCognitoAuthCredentialStore.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AWSCognitoAuthCredentialStore.swift
@@ -30,9 +30,13 @@ struct AWSCognitoAuthCredentialStore {
     private let keychain: KeychainStoreBehavior
     private let userDefaults = UserDefaults.standard
 
-    init(authConfiguration: AuthConfiguration, accessGroup: String? = nil) {
+    init(
+        authConfiguration: AuthConfiguration,
+        accessGroup: String? = nil,
+        account: String? = nil
+    ) {
         self.authConfiguration = authConfiguration
-        self.keychain = KeychainStore(service: service, accessGroup: accessGroup)
+        self.keychain = KeychainStore(service: service, accessGroup: accessGroup, account: account)
 
         if !userDefaults.bool(forKey: isKeychainConfiguredKey) {
             try? clearAllCredentials()

--- a/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStore.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStore.swift
@@ -71,9 +71,10 @@ public struct KeychainStore: KeychainStoreBehavior {
         self.init(service: service, accessGroup: nil)
     }
 
-    public init(service: String, accessGroup: String? = nil) {
+    public init(service: String, accessGroup: String? = nil, account: String? = nil) {
         var attributes = KeychainStoreAttributes(service: service)
         attributes.accessGroup = accessGroup
+        attributes.account = account
         self.init(attributes: attributes)
     }
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStoreAttributes.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStoreAttributes.swift
@@ -12,7 +12,8 @@ struct KeychainStoreAttributes {
     var itemClass: String = KeychainStore.Constants.ClassGenericPassword
     var service: String
     var accessGroup: String?
-    
+    var account: String?
+
 }
 
 extension KeychainStoreAttributes {
@@ -24,6 +25,9 @@ extension KeychainStoreAttributes {
         ]
         if let accessGroup = accessGroup {
             query[KeychainStore.Constants.AttributeAccessGroup] = accessGroup
+        }
+        if let account {
+            query[KeychainStore.Constants.AttributeAccount] = account
         }
         return query
     }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Keychain/KeychainStoreAttributesTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Keychain/KeychainStoreAttributesTests.swift
@@ -65,6 +65,47 @@ class KeychainStoreAttributesTests: XCTestCase {
         XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.UseDataProtectionKeyChain] as? Bool, true)
     }
 
+    /// Given: an instance of `KeychainStoreAttributes`
+    /// When: `keychainStoreAttribute.defaultGetQuery()` is invoked with a required service param and access group
+    /// Then: Validate if the attributes contain the correct get query params
+    ///     - AttributeService
+    ///     - Class
+    ///     - Account
+    func testDefaultGetQueryWithAccount() {
+        keychainStoreAttribute = KeychainStoreAttributes(service: "someService")
+        keychainStoreAttribute.account = "account"
+
+        let defaultGetAttributes = keychainStoreAttribute.defaultGetQuery()
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.AttributeService] as? String, "someService")
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.Class] as? String, KeychainStore.Constants.ClassGenericPassword)
+        XCTAssertNil(defaultGetAttributes[KeychainStore.Constants.AttributeAccessGroup] as? String)
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.AttributeAccount] as? String, "account")
+        XCTAssertNil(defaultGetAttributes[KeychainStore.Constants.AttributeAccessible] as? String)
+        XCTAssertNil(defaultGetAttributes[KeychainStore.Constants.UseDataProtectionKeyChain] as? String)
+    }
+
+    /// Given: an instance of `KeychainStoreAttributes`
+    /// When: `keychainStoreAttribute.defaultSetQuery()` is invoked with a required service param and access group
+    /// Then: Validate if the attributes contain the correct get query params
+    ///     - AttributeService
+    ///     - Class
+    ///     - AttributeAccount
+    ///     - AttributeAccessible
+    ///     - UseDataProtectionKeyChain
+    func testDefaultSetQueryWithAccount() {
+        keychainStoreAttribute = KeychainStoreAttributes(service: "someService")
+        keychainStoreAttribute.account = "account"
+
+        let defaultGetAttributes = keychainStoreAttribute.defaultSetQuery()
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.AttributeService] as? String, "someService")
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.Class] as? String, KeychainStore.Constants.ClassGenericPassword)
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.AttributeAccount] as? String, "account")
+        XCTAssertNil(defaultGetAttributes[KeychainStore.Constants.AttributeAccessGroup] as? String)
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.AttributeAccessible] as? String, KeychainStore.Constants.AttributeAccessibleAfterFirstUnlockThisDeviceOnly)
+        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.UseDataProtectionKeyChain] as? Bool, true)
+    }
+
+
     override func tearDown() {
         keychainStoreAttribute = nil
     }


### PR DESCRIPTION
Currently we can only have 1 account bc keyChain doesn't support it.
So implement that.

This breaks 'legacyMigration', but we don't care about it.