### PR TITLE
feat(auth): Add definitions for supporting OIDC plugin

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthSessionBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthSessionBehavior.swift
@@ -1,0 +1,17 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Amplify
+
+public protocol AWSAuthSessionBehavior<OIDCCredentials> : AuthSession {
+    associatedtype OIDCCredentials
+    var awsCredentialsResult: Result<AWSTemporaryCredentials, AuthError> { get }
+    var identityIdResult: Result<String, AuthError> { get  }
+    var userSubResult: Result<String, AuthError> { get }
+    var oidcTokensResult: Result<OIDCCredentials, AuthError> { get }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthSessionBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthSessionBehavior.swift
@@ -8,10 +8,10 @@
 import Foundation
 import Amplify
 
-public protocol AWSAuthSessionBehavior<OIDCCredentials> : AuthSession {
-    associatedtype OIDCCredentials
+public protocol AWSAuthSessionBehavior<TokensType> : AuthSession {
+    associatedtype TokensType
     var awsCredentialsResult: Result<AWSTemporaryCredentials, AuthError> { get }
     var identityIdResult: Result<String, AuthError> { get  }
     var userSubResult: Result<String, AuthError> { get }
-    var oidcTokensResult: Result<OIDCCredentials, AuthError> { get }
+    var tokensResult: Result<TokensType, AuthError> { get }
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
None

## Description
<!-- Why is this change required? What problem does it solve? -->
This PR adds definition for Auth Session behavior which needs to be implemented by OIDC plugin developers for satisfying `fetchAuthSession` Auth category API.

## General Checklist
<!-- Check or cross out if not relevant -->

~~- [ ] Added new tests to cover change, if needed~~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~~
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
