### PR TITLE
test(datastore): fix lazy load integration test helper method

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKChildSansTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKChildSansTests.swift
@@ -28,23 +28,23 @@ extension AWSDataStoreLazyLoadCompositePKTests {
         await setup(withModels: CompositePKModels())
         
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         let child = initChildSansBelongsTo(with: savedParent)
-        try await saveAndWaitForSync(child)
+        try await createAndWaitForSync(child)
     }
     
     func testUpdateChildSansBelongsTo() async throws {
         await setup(withModels: CompositePKModels())
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         let child = initChildSansBelongsTo(with: parent)
-        var savedChild = try await saveAndWaitForSync(child)
+        var savedChild = try await createAndWaitForSync(child)
         XCTAssertEqual(savedChild.compositePKParentChildrenSansBelongsToCustomId, savedParent.customId)
         XCTAssertEqual(savedChild.compositePKParentChildrenSansBelongsToContent, savedParent.content)
         
         // update the child to a new parent
         let newParent = initParent()
-        let savedNewParent = try await saveAndWaitForSync(newParent)
+        let savedNewParent = try await createAndWaitForSync(newParent)
         savedChild.compositePKParentChildrenSansBelongsToCustomId = savedNewParent.customId
         savedChild.compositePKParentChildrenSansBelongsToContent = savedNewParent.content
         let updatedChild = try await updateAndWaitForSync(savedChild)
@@ -55,9 +55,9 @@ extension AWSDataStoreLazyLoadCompositePKTests {
     func testDeleteChildSansBelongsTo() async throws {
         await setup(withModels: CompositePKModels())
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         let child = initChildSansBelongsTo(with: parent)
-        let savedChild = try await saveAndWaitForSync(child)
+        let savedChild = try await createAndWaitForSync(child)
         
         try await deleteAndWaitForSync(savedChild)
         try await assertModelDoesNotExist(savedChild)
@@ -69,9 +69,9 @@ extension AWSDataStoreLazyLoadCompositePKTests {
     func testGetChildSansBelongsTo() async throws {
         await setup(withModels: CompositePKModels())
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         let child = initChildSansBelongsTo(with: parent)
-        let savedChild = try await saveAndWaitForSync(child)
+        let savedChild = try await createAndWaitForSync(child)
         
         // query parent and load the children
         let queriedParent = try await query(for: savedParent)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKChildTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKChildTests.swift
@@ -24,23 +24,23 @@ extension AWSDataStoreLazyLoadCompositePKTests {
         await setup(withModels: CompositePKModels())
         
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         let child = initChild(with: savedParent)
-        try await saveAndWaitForSync(child)
+        try await createAndWaitForSync(child)
     }
     
     func testUpdateCompositePKChild() async throws {
         await setup(withModels: CompositePKModels())
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         let child = initChild(with: parent)
-        var savedChild = try await saveAndWaitForSync(child)
+        var savedChild = try await createAndWaitForSync(child)
         let loadedParent = try await savedChild.parent
         XCTAssertEqual(loadedParent?.identifier, savedParent.identifier)
         
         // update the child to a new parent
         let newParent = initParent()
-        let savedNewParent = try await saveAndWaitForSync(newParent)
+        let savedNewParent = try await createAndWaitForSync(newParent)
         savedChild.setParent(savedNewParent)
         let updatedChild = try await updateAndWaitForSync(savedChild)
         let loadedNewParent = try await updatedChild.parent
@@ -50,10 +50,10 @@ extension AWSDataStoreLazyLoadCompositePKTests {
     func testUpdateFromNoParentCompositePKChild() async throws {
         await setup(withModels: CompositePKModels())
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         
         let childWithoutParent = initChild()
-        var savedChild = try await saveAndWaitForSync(childWithoutParent)
+        var savedChild = try await createAndWaitForSync(childWithoutParent)
         let nilParent = try await savedChild.parent
         XCTAssertNil(nilParent)
         
@@ -67,9 +67,9 @@ extension AWSDataStoreLazyLoadCompositePKTests {
     func testDeleteCompositePKChild() async throws {
         await setup(withModels: CompositePKModels())
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         let child = initChild(with: parent)
-        let savedChild = try await saveAndWaitForSync(child)
+        let savedChild = try await createAndWaitForSync(child)
         
         try await deleteAndWaitForSync(savedParent)
         try await assertModelDoesNotExist(savedParent)
@@ -80,9 +80,9 @@ extension AWSDataStoreLazyLoadCompositePKTests {
         await setup(withModels: CompositePKModels())
         
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         let child = initChild(with: parent)
-        let savedCompositePKChild = try await saveAndWaitForSync(child)
+        let savedCompositePKChild = try await createAndWaitForSync(child)
         
         // query parent and load the children
         let queriedParent = try await query(for: savedParent)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKImplicitTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKImplicitTests.swift
@@ -24,23 +24,23 @@ extension AWSDataStoreLazyLoadCompositePKTests {
         await setup(withModels: CompositePKModels())
         
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         let child = initImplicitChild(with: savedParent)
-        try await saveAndWaitForSync(child)
+        try await createAndWaitForSync(child)
     }
     
     func testUpdateImplicitChild() async throws {
         await setup(withModels: CompositePKModels())
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         let child = initImplicitChild(with: parent)
-        var savedChild = try await saveAndWaitForSync(child)
+        var savedChild = try await createAndWaitForSync(child)
         let loadedParent = try await savedChild.parent
         XCTAssertEqual(loadedParent.identifier, savedParent.identifier)
         
         // update the child to a new parent
         let newParent = initParent()
-        let savedNewParent = try await saveAndWaitForSync(newParent)
+        let savedNewParent = try await createAndWaitForSync(newParent)
         savedChild.setParent(savedNewParent)
         let updatedChild = try await updateAndWaitForSync(savedChild)
         let loadedNewParent = try await updatedChild.parent
@@ -51,9 +51,9 @@ extension AWSDataStoreLazyLoadCompositePKTests {
     func testDeleteImplicitChild() async throws {
         await setup(withModels: CompositePKModels())
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         let child = initImplicitChild(with: parent)
-        let savedChild = try await saveAndWaitForSync(child)
+        let savedChild = try await createAndWaitForSync(child)
         
         try await deleteAndWaitForSync(savedChild)
         try await assertModelDoesNotExist(savedChild)
@@ -64,9 +64,9 @@ extension AWSDataStoreLazyLoadCompositePKTests {
     func testGetImplicitChild() async throws {
         await setup(withModels: CompositePKModels())
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         let child = initImplicitChild(with: parent)
-        let savedChild = try await saveAndWaitForSync(child)
+        let savedChild = try await createAndWaitForSync(child)
         
         // query parent and load the children
         let queriedParent = try await query(for: savedParent)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKStrangeExplicitTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKStrangeExplicitTests.swift
@@ -24,23 +24,23 @@ extension AWSDataStoreLazyLoadCompositePKTests {
         await setup(withModels: CompositePKModels())
         
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         let child = initStrangeExplicitChild(with: savedParent)
-        try await saveAndWaitForSync(child)
+        try await createAndWaitForSync(child)
     }
     
     func testUpdateStrangeExplicitChild() async throws {
         await setup(withModels: CompositePKModels())
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         let child = initStrangeExplicitChild(with: parent)
-        var savedChild = try await saveAndWaitForSync(child)
+        var savedChild = try await createAndWaitForSync(child)
         let loadedParent = try await savedChild.parent
         XCTAssertEqual(loadedParent.identifier, savedParent.identifier)
         
         // update the child to a new parent
         let newParent = initParent()
-        let savedNewParent = try await saveAndWaitForSync(newParent)
+        let savedNewParent = try await createAndWaitForSync(newParent)
         savedChild.setParent(savedNewParent)
         let updatedChild = try await updateAndWaitForSync(savedChild)
         let loadedNewParent = try await updatedChild.parent
@@ -51,9 +51,9 @@ extension AWSDataStoreLazyLoadCompositePKTests {
     func testDeleteStrangeExplicitChild() async throws {
         await setup(withModels: CompositePKModels())
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         let child = initStrangeExplicitChild(with: parent)
-        let savedChild = try await saveAndWaitForSync(child)
+        let savedChild = try await createAndWaitForSync(child)
         
         try await deleteAndWaitForSync(savedChild)
         try await assertModelDoesNotExist(savedChild)
@@ -64,9 +64,9 @@ extension AWSDataStoreLazyLoadCompositePKTests {
     func testGetStrangeExplicitChild() async throws {
         await setup(withModels: CompositePKModels())
         let parent = initParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         let child = initStrangeExplicitChild(with: parent)
-        let savedChild = try await saveAndWaitForSync(child)
+        let savedChild = try await createAndWaitForSync(child)
         
         // query parent and load the children
         let queriedParent = try await query(for: savedParent)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/CompositePK/AWSDataStoreLazyLoadCompositePKTests.swift
@@ -22,7 +22,7 @@ class AWSDataStoreLazyLoadCompositePKTests: AWSDataStoreLazyLoadBaseTest {
     func testSaveCompositePKParent() async throws {
         await setup(withModels: CompositePKModels())
         let parent = initParent()
-        try await saveAndWaitForSync(parent)
+        try await createAndWaitForSync(parent)
     }
 }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/HasOneParentChild/AWSDataStoreLazyLoadHasOneTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/HasOneParentChild/AWSDataStoreLazyLoadHasOneTests.swift
@@ -34,7 +34,7 @@ class AWSDataStoreLazyLoadHasOneTests: AWSDataStoreLazyLoadBaseTest {
     func testSaveHasOneParent_withoutChild_success() async throws {
         await setup(withModels: HasOneModels())
         let parent = HasOneParent()
-        try await saveAndWaitForSync(parent)
+        try await createAndWaitForSync(parent)
     }
 
     /*
@@ -47,7 +47,7 @@ class AWSDataStoreLazyLoadHasOneTests: AWSDataStoreLazyLoadBaseTest {
     func testSaveHasOneChild_success() async throws {
         await setup(withModels: HasOneModels())
         let child = HasOneChild()
-        try await saveAndWaitForSync(child)
+        try await createAndWaitForSync(child)
     }
 
     /*
@@ -60,10 +60,10 @@ class AWSDataStoreLazyLoadHasOneTests: AWSDataStoreLazyLoadBaseTest {
     func testSaveHasOneParent_withChild_success() async throws {
         await setup(withModels: HasOneModels())
         let child = HasOneChild()
-        try await saveAndWaitForSync(child)
+        try await createAndWaitForSync(child)
         // populating `hasOneParentChildId` is required to sync successfully
         let parent = HasOneParent(child: child, hasOneParentChildId: child.id)
-        try await saveAndWaitForSync(parent)
+        try await createAndWaitForSync(parent)
         
         // Query from API
         let response = try await Amplify.API.query(request: .get(HasOneParent.self, byId: parent.id))
@@ -113,9 +113,9 @@ class AWSDataStoreLazyLoadHasOneTests: AWSDataStoreLazyLoadBaseTest {
     func testUpdateHasOneParent_withNewChild_success() async throws {
         await setup(withModels: HasOneModels())
         let child = HasOneChild()
-        let savedChild = try await saveAndWaitForSync(child)
+        let savedChild = try await createAndWaitForSync(child)
         let parent = HasOneParent(child: savedChild, hasOneParentChildId: savedChild.id)
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
 
         var queriedParent = try await query(for: savedParent)
         XCTAssertEqual(queriedParent.hasOneParentChildId, savedChild.id)
@@ -127,7 +127,7 @@ class AWSDataStoreLazyLoadHasOneTests: AWSDataStoreLazyLoadBaseTest {
                             ]))
 
         let newChild = HasOneChild()
-        let savedNewChild = try await saveAndWaitForSync(newChild)
+        let savedNewChild = try await createAndWaitForSync(newChild)
 
         // Update parent to new child
         queriedParent.setChild(savedNewChild)
@@ -191,7 +191,7 @@ class AWSDataStoreLazyLoadHasOneTests: AWSDataStoreLazyLoadBaseTest {
     func testDeleteHasOneChild_success() async throws {
         await setup(withModels: HasOneModels())
         let child = HasOneChild()
-        let savedChild = try await saveAndWaitForSync(child)
+        let savedChild = try await createAndWaitForSync(child)
         try await assertModelExists(savedChild)
 
         try await deleteAndWaitForSync(savedChild)
@@ -209,7 +209,7 @@ class AWSDataStoreLazyLoadHasOneTests: AWSDataStoreLazyLoadBaseTest {
     func testDeleteHasOneParent_withoutChild_success() async throws {
         await setup(withModels: HasOneModels())
         let parent = HasOneParent()
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
         try await assertModelExists(savedParent)
 
         try await deleteAndWaitForSync(savedParent)
@@ -227,9 +227,9 @@ class AWSDataStoreLazyLoadHasOneTests: AWSDataStoreLazyLoadBaseTest {
     func testDeleteHasOneParent_withChild_success() async throws {
         await setup(withModels: HasOneModels())
         let child = HasOneChild()
-        let savedChild = try await saveAndWaitForSync(child)
+        let savedChild = try await createAndWaitForSync(child)
         let parent = HasOneParent(child: savedChild, hasOneParentChildId: savedChild.id)
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
 
         let queriedParent = try await query(for: savedParent)
         XCTAssertEqual(queriedParent.hasOneParentChildId, savedChild.id)
@@ -250,9 +250,9 @@ class AWSDataStoreLazyLoadHasOneTests: AWSDataStoreLazyLoadBaseTest {
     func testDeleteHasOneChild_withParent_success() async throws {
         await setup(withModels: HasOneModels())
         let child = HasOneChild()
-        let savedChild = try await saveAndWaitForSync(child)
+        let savedChild = try await createAndWaitForSync(child)
         let parent = HasOneParent(child: savedChild, hasOneParentChildId: savedChild.id)
-        let savedParent = try await saveAndWaitForSync(parent)
+        let savedParent = try await createAndWaitForSync(parent)
 
         let queriedParent = try await query(for: savedParent)
         XCTAssertEqual(queriedParent.hasOneParentChildId, savedChild.id)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL13/AWSDataStoreLazyLoadPhoneCallTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL13/AWSDataStoreLazyLoadPhoneCallTests.swift
@@ -30,7 +30,7 @@ class AWSDataStoreLazyLoadPhoneCallTests: AWSDataStoreLazyLoadBaseTest {
     func testSavePerson() async throws {
         await setup(withModels: PhoneCallModels())
         let person = Person(name: "name")
-        try await saveAndWaitForSync(person)
+        try await createAndWaitForSync(person)
     }
     
     /// Saving a PhoneCall, requires a caller and a callee, should be successful.
@@ -45,12 +45,12 @@ class AWSDataStoreLazyLoadPhoneCallTests: AWSDataStoreLazyLoadBaseTest {
     func testSavePhoneCall() async throws {
         await setup(withModels: PhoneCallModels())
         let caller = Person(name: "caller")
-        let savedCaller = try await saveAndWaitForSync(caller)
+        let savedCaller = try await createAndWaitForSync(caller)
         let callee = Person(name: "callee")
-        let savedCallee = try await saveAndWaitForSync(callee)
+        let savedCallee = try await createAndWaitForSync(callee)
 
         let phoneCall = PhoneCall(caller: savedCaller, callee: savedCallee)
-        let savedPhoneCall = try await saveAndWaitForSync(phoneCall)
+        let savedPhoneCall = try await createAndWaitForSync(phoneCall)
         let queriedPhoneCall = try await query(for: savedPhoneCall)
         assertLazyReference(queriedPhoneCall._caller,
                             state: .notLoaded(identifiers: [.init(name: "id", value: caller.id)]))
@@ -84,9 +84,9 @@ class AWSDataStoreLazyLoadPhoneCallTests: AWSDataStoreLazyLoadBaseTest {
     func testSavePhoneCallAndTranscriptBiDirectional() async throws {
         await setup(withModels: PhoneCallModels())
         let caller = Person(name: "caller")
-        let savedCaller = try await saveAndWaitForSync(caller)
+        let savedCaller = try await createAndWaitForSync(caller)
         let callee = Person(name: "callee")
-        let savedCallee = try await saveAndWaitForSync(callee)
+        let savedCallee = try await createAndWaitForSync(callee)
         var phoneCall = PhoneCall(caller: savedCaller, callee: savedCallee)
         let transcript = Transcript(text: "text", phoneCall: phoneCall)
         
@@ -95,9 +95,9 @@ class AWSDataStoreLazyLoadPhoneCallTests: AWSDataStoreLazyLoadBaseTest {
         // phoneCall.setTranscript(transcript)
         phoneCall.phoneCallTranscriptId = transcript.id
         
-        let savedPhoneCall = try await saveAndWaitForSync(phoneCall)
+        let savedPhoneCall = try await createAndWaitForSync(phoneCall)
         XCTAssertEqual(savedPhoneCall.phoneCallTranscriptId, transcript.id)
-        let savedTranscript = try await saveAndWaitForSync(transcript)
+        let savedTranscript = try await createAndWaitForSync(transcript)
         assertLazyReference(savedTranscript._phoneCall,
                             state: .notLoaded(identifiers: [
                                 .init(name: PhoneCall.keys.id.stringValue, value: savedPhoneCall.id)
@@ -130,14 +130,14 @@ class AWSDataStoreLazyLoadPhoneCallTests: AWSDataStoreLazyLoadBaseTest {
     func testUpdatePhoneCallToTranscript() async throws {
         await setup(withModels: PhoneCallModels())
         let caller = Person(name: "caller")
-        let savedCaller = try await saveAndWaitForSync(caller)
+        let savedCaller = try await createAndWaitForSync(caller)
         let callee = Person(name: "callee")
-        let savedCallee = try await saveAndWaitForSync(callee)
+        let savedCallee = try await createAndWaitForSync(callee)
         let phoneCall = PhoneCall(caller: savedCaller, callee: savedCallee)
-        let savedPhoneCall = try await saveAndWaitForSync(phoneCall)
+        let savedPhoneCall = try await createAndWaitForSync(phoneCall)
         XCTAssertNil(savedPhoneCall.phoneCallTranscriptId)
         let transcript = Transcript(text: "text", phoneCall: phoneCall)
-        let savedTranscript = try await saveAndWaitForSync(transcript)
+        let savedTranscript = try await createAndWaitForSync(transcript)
         
         
         var queriedPhoneCall = try await query(for: savedPhoneCall)
@@ -149,7 +149,7 @@ class AWSDataStoreLazyLoadPhoneCallTests: AWSDataStoreLazyLoadBaseTest {
     func testDeletePerson() async throws {
         await setup(withModels: PhoneCallModels())
         let person = Person(name: "name")
-        let savedPerson = try await saveAndWaitForSync(person)
+        let savedPerson = try await createAndWaitForSync(person)
         
         try await deleteAndWaitForSync(savedPerson)
         try await assertModelDoesNotExist(savedPerson)
@@ -166,11 +166,11 @@ class AWSDataStoreLazyLoadPhoneCallTests: AWSDataStoreLazyLoadBaseTest {
     func testDeletePhoneCall() async throws {
         await setup(withModels: PhoneCallModels())
         let caller = Person(name: "caller")
-        let savedCaller = try await saveAndWaitForSync(caller)
+        let savedCaller = try await createAndWaitForSync(caller)
         let callee = Person(name: "callee")
-        let savedCallee = try await saveAndWaitForSync(callee)
+        let savedCallee = try await createAndWaitForSync(callee)
         let phoneCall = PhoneCall(caller: savedCaller, callee: savedCallee)
-        let savedPhoneCall = try await saveAndWaitForSync(phoneCall)
+        let savedPhoneCall = try await createAndWaitForSync(phoneCall)
         
         try await deleteAndWaitForSync(savedPhoneCall)
         try await assertModelExists(caller)
@@ -189,11 +189,11 @@ class AWSDataStoreLazyLoadPhoneCallTests: AWSDataStoreLazyLoadBaseTest {
     func testDeletePersonWithPhoneCall() async throws {
         await setup(withModels: PhoneCallModels())
         let caller = Person(name: "caller")
-        let savedCaller = try await saveAndWaitForSync(caller)
+        let savedCaller = try await createAndWaitForSync(caller)
         let callee = Person(name: "callee")
-        let savedCallee = try await saveAndWaitForSync(callee)
+        let savedCallee = try await createAndWaitForSync(callee)
         let phoneCall = PhoneCall(caller: savedCaller, callee: savedCallee)
-        let savedPhoneCall = try await saveAndWaitForSync(phoneCall)
+        let savedPhoneCall = try await createAndWaitForSync(phoneCall)
      
         try await deleteAndWaitForSync(savedCaller)
         try await assertModelDoesNotExist(savedCaller)
@@ -213,15 +213,15 @@ class AWSDataStoreLazyLoadPhoneCallTests: AWSDataStoreLazyLoadBaseTest {
     func testDeleteTranscript() async throws {
         await setup(withModels: PhoneCallModels())
         let caller = Person(name: "caller")
-        let savedCaller = try await saveAndWaitForSync(caller)
+        let savedCaller = try await createAndWaitForSync(caller)
         let callee = Person(name: "callee")
-        let savedCallee = try await saveAndWaitForSync(callee)
+        let savedCallee = try await createAndWaitForSync(callee)
         var phoneCall = PhoneCall(caller: savedCaller, callee: savedCallee)
         let transcript = Transcript(text: "text", phoneCall: phoneCall)
         phoneCall.phoneCallTranscriptId = transcript.id
         
-        let savedPhoneCall = try await saveAndWaitForSync(phoneCall)
-        let savedTranscript = try await saveAndWaitForSync(transcript)
+        let savedPhoneCall = try await createAndWaitForSync(phoneCall)
+        let savedTranscript = try await createAndWaitForSync(transcript)
         
         try await deleteAndWaitForSync(transcript)
         try await assertModelDoesNotExist(transcript)
@@ -239,15 +239,15 @@ class AWSDataStoreLazyLoadPhoneCallTests: AWSDataStoreLazyLoadBaseTest {
     func testDeletePhoneCallWithTranscript() async throws {
         await setup(withModels: PhoneCallModels())
         let caller = Person(name: "caller")
-        let savedCaller = try await saveAndWaitForSync(caller)
+        let savedCaller = try await createAndWaitForSync(caller)
         let callee = Person(name: "callee")
-        let savedCallee = try await saveAndWaitForSync(callee)
+        let savedCallee = try await createAndWaitForSync(callee)
         var phoneCall = PhoneCall(caller: savedCaller, callee: savedCallee)
         let transcript = Transcript(text: "text", phoneCall: phoneCall)
         phoneCall.phoneCallTranscriptId = transcript.id
         
-        let savedPhoneCall = try await saveAndWaitForSync(phoneCall)
-        let savedTranscript = try await saveAndWaitForSync(transcript)
+        let savedPhoneCall = try await createAndWaitForSync(phoneCall)
+        let savedTranscript = try await createAndWaitForSync(transcript)
         
         try await deleteAndWaitForSync(savedPhoneCall)
         try await assertModelDoesNotExist(savedPhoneCall)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/AWSDataStoreLazyLoadUserPostCommentTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL14/AWSDataStoreLazyLoadUserPostCommentTests.swift
@@ -21,34 +21,34 @@ final class AWSDataStoreLazyLoadUserPostCommentTests: AWSDataStoreLazyLoadBaseTe
     func testSaveUser() async throws {
         await setup(withModels: UserPostCommentModels())
         let user = User(username: "name")
-        try await saveAndWaitForSync(user)
+        try await createAndWaitForSync(user)
     }
     
     func testSaveUserSettings() async throws {
         await setup(withModels: UserPostCommentModels())
         let user = User(username: "name")
-        let savedUser = try await saveAndWaitForSync(user)
+        let savedUser = try await createAndWaitForSync(user)
         
         let userSettings = UserSettings(language: "en-us", user: savedUser)
-        try await saveAndWaitForSync(userSettings)
+        try await createAndWaitForSync(userSettings)
     }
     
     func testSavePost() async throws {
         await setup(withModels: UserPostCommentModels())
         let user = User(username: "name")
-        let savedUser = try await saveAndWaitForSync(user)
+        let savedUser = try await createAndWaitForSync(user)
         let post = Post(title: "title", rating: 1, status: .active, author: savedUser)
-        try await saveAndWaitForSync(post)
+        try await createAndWaitForSync(post)
     }
     
     func testSaveComment() async throws {
         await setup(withModels: UserPostCommentModels())
         let user = User(username: "name")
-        let savedUser = try await saveAndWaitForSync(user)
+        let savedUser = try await createAndWaitForSync(user)
         let post = Post(title: "title", rating: 1, status: .active, author: savedUser)
-        let savedPost = try await saveAndWaitForSync(post)
+        let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(content: "content", post: savedPost, author: savedUser)
-        try await saveAndWaitForSync(comment)
+        try await createAndWaitForSync(comment)
     }
     
     /// LazyLoad from queried models
@@ -62,13 +62,13 @@ final class AWSDataStoreLazyLoadUserPostCommentTests: AWSDataStoreLazyLoadBaseTe
     func testLazyLoad() async throws {
         await setup(withModels: UserPostCommentModels())
         let user = User(username: "name")
-        let savedUser = try await saveAndWaitForSync(user)
+        let savedUser = try await createAndWaitForSync(user)
         let userSettings = UserSettings(language: "en-us", user: savedUser)
-        try await saveAndWaitForSync(userSettings)
+        try await createAndWaitForSync(userSettings)
         let post = Post(title: "title", rating: 1, status: .active, author: savedUser)
-        let savedPost = try await saveAndWaitForSync(post)
+        let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(content: "content", post: savedPost, author: savedUser)
-        try await saveAndWaitForSync(comment)
+        try await createAndWaitForSync(comment)
         
         // Traverse from User
         let queriedUser = try await query(for: user)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL2/AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL2/AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift
@@ -23,15 +23,15 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         await setup(withModels: BlogPostComment8V2Models())
         
         let blog = Blog(name: "name")
-        let savedBlog = try await saveAndWaitForSync(blog)
+        let savedBlog = try await createAndWaitForSync(blog)
     }
     
     func testSavePost() async throws {
         await setup(withModels: BlogPostComment8V2Models())
         let blog = Blog(name: "name")
         let post = Post(name: "name", randomId: "randomId", blog: blog)
-        let savedBlog = try await saveAndWaitForSync(blog)
-        let savedPost = try await saveAndWaitForSync(post)
+        let savedBlog = try await createAndWaitForSync(blog)
+        let savedPost = try await createAndWaitForSync(post)
         
     }
     
@@ -40,8 +40,8 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
 
         let post = Post(name: "name", randomId: "randomId")
         let comment = Comment(content: "content", post: post)
-        let savedPost = try await saveAndWaitForSync(post)
-        let savedComment = try await saveAndWaitForSync(comment)
+        let savedPost = try await createAndWaitForSync(post)
+        let savedComment = try await createAndWaitForSync(comment)
     }
     
     func testLazyLoad() async throws {
@@ -50,9 +50,9 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         let blog = Blog(name: "name")
         let post = Post(name: "name", randomId: "randomId", blog: blog)
         let comment = Comment(content: "content", post: post)
-        let savedBlog = try await saveAndWaitForSync(blog)
-        let savedPost = try await saveAndWaitForSync(post)
-        let savedComment = try await saveAndWaitForSync(comment)
+        let savedBlog = try await createAndWaitForSync(blog)
+        let savedPost = try await createAndWaitForSync(post)
+        let savedComment = try await createAndWaitForSync(comment)
     }
     
     func assertComment(_ comment: Comment,
@@ -107,14 +107,14 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
     func testSaveWithoutPost() async throws {
         await setup(withModels: BlogPostComment8V2Models())
         let comment = Comment(content: "content")
-        let savedComment = try await saveAndWaitForSync(comment)
+        let savedComment = try await createAndWaitForSync(comment)
         var queriedComment = try await query(for: savedComment)
         assertLazyReference(queriedComment._post,
                         state: .notLoaded(identifiers: nil))
         let post = Post(name: "name", randomId: "randomId")
-        let savedPost = try await saveAndWaitForSync(post)
+        let savedPost = try await createAndWaitForSync(post)
         queriedComment.setPost(savedPost)
-        let saveCommentWithPost = try await saveAndWaitForSync(queriedComment, assertVersion: 2)
+        let saveCommentWithPost = try await updateAndWaitForSync(queriedComment)
         let queriedComment2 = try await query(for: saveCommentWithPost)
         try await assertComment(queriedComment2, canLazyLoad: post)
     }
@@ -123,12 +123,12 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         await setup(withModels: BlogPostComment8V2Models())
         let post = Post(name: "name", randomId: "randomId")
         let comment = Comment(content: "content", post: post)
-        let savedPost = try await saveAndWaitForSync(post)
-        let savedComment = try await saveAndWaitForSync(comment)
+        let savedPost = try await createAndWaitForSync(post)
+        let savedComment = try await createAndWaitForSync(comment)
         let queriedComment = try await query(for: savedComment)
         assertLazyReference(queriedComment._post,
                         state: .notLoaded(identifiers: [.init(name: "id", value: post.identifier)]))
-        let savedQueriedComment = try await saveAndWaitForSync(queriedComment, assertVersion: 2)
+        let savedQueriedComment = try await updateAndWaitForSync(queriedComment)
         let queriedComment2 = try await query(for: savedQueriedComment)
         try await assertComment(queriedComment2, canLazyLoad: savedPost)
     }
@@ -138,16 +138,16 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         
         let post = Post(name: "name", randomId: "randomId")
         let comment = Comment(content: "content", post: post)
-        _ = try await saveAndWaitForSync(post)
-        let savedComment = try await saveAndWaitForSync(comment)
+        _ = try await createAndWaitForSync(post)
+        let savedComment = try await createAndWaitForSync(comment)
         var queriedComment = try await query(for: savedComment)
         assertLazyReference(queriedComment._post,
                         state: .notLoaded(identifiers: [.init(name: "id", value: post.identifier)]))
         
         let newPost = Post(name: "name")
-        _ = try await saveAndWaitForSync(newPost)
+        _ = try await createAndWaitForSync(newPost)
         queriedComment.setPost(newPost)
-        let saveCommentWithNewPost = try await saveAndWaitForSync(queriedComment, assertVersion: 2)
+        let saveCommentWithNewPost = try await updateAndWaitForSync(queriedComment)
         let queriedComment2 = try await query(for: saveCommentWithNewPost)
         try await assertComment(queriedComment2, canLazyLoad: newPost)
     }
@@ -157,14 +157,14 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         
         let post = Post(name: "name", randomId: "randomId")
         let comment = Comment(content: "content", post: post)
-        _ = try await saveAndWaitForSync(post)
-        let savedComment = try await saveAndWaitForSync(comment)
+        _ = try await createAndWaitForSync(post)
+        let savedComment = try await createAndWaitForSync(comment)
         var queriedComment = try await query(for: savedComment)
         assertLazyReference(queriedComment._post,
                         state: .notLoaded(identifiers: [.init(name: "id", value: post.identifier)]))
         
         queriedComment.setPost(nil)
-        let saveCommentRemovePost = try await saveAndWaitForSync(queriedComment, assertVersion: 2)
+        let saveCommentRemovePost = try await updateAndWaitForSync(queriedComment)
         let queriedCommentNoPost = try await query(for: saveCommentRemovePost)
         assertLazyReference(queriedCommentNoPost._post,
                         state: .notLoaded(identifiers: nil))
@@ -175,8 +175,8 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         
         let post = Post(name: "name", randomId: "randomId")
         let comment = Comment(content: "content", post: post)
-        let savedPost = try await saveAndWaitForSync(post)
-        let savedComment = try await saveAndWaitForSync(comment)
+        let savedPost = try await createAndWaitForSync(post)
+        let savedComment = try await createAndWaitForSync(comment)
         try await deleteAndWaitForSync(savedPost)
         try await assertModelDoesNotExist(savedComment)
         try await assertModelDoesNotExist(savedPost)
@@ -196,7 +196,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
                    let receivedPost = try? mutationEvent.decodeModel(as: Post.self),
                    receivedPost.id == post.id {
                         
-                    try await saveAndWaitForSync(comment)
+                    try await createAndWaitForSync(comment)
                     
                     guard let comments = receivedPost.comments else {
                         XCTFail("Lazy List does not exist")
@@ -229,7 +229,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         await setup(withModels: BlogPostComment8V2Models())
         try await startAndWaitForReady()
         let post = Post(name: "name", randomId: "randomId")
-        let savedPost = try await saveAndWaitForSync(post)
+        let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(content: "content", post: post)
         let mutationEventReceived = asyncExpectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Comment.self)
@@ -266,7 +266,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedPost = querySnapshot.items.first {
-                    try await saveAndWaitForSync(comment)
+                    try await createAndWaitForSync(comment)
                     guard let comments = receivedPost.comments else {
                         XCTFail("Lazy List does not exist")
                         return
@@ -299,7 +299,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         try await startAndWaitForReady()
         
         let post = Post(name: "name", randomId: "randomId")
-        let savedPost = try await saveAndWaitForSync(post)
+        let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(content: "content", post: post)
         let snapshotReceived = asyncExpectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Comment.self, where: Comment.keys.id == comment.id)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL4/AWSDataStoreLazyLoadPostTagTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL4/AWSDataStoreLazyLoadPostTagTests.swift
@@ -24,9 +24,9 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         let post = Post(postId: UUID().uuidString, title: "title")
         let tag = Tag(name: "name")
         let postTag = PostTag(postWithTagsCompositeKey: post, tagWithCompositeKey: tag)
-        let savedPost = try await saveAndWaitForSync(post)
-        let savedTag = try await saveAndWaitForSync(tag)
-        let savedPostTag = try await saveAndWaitForSync(postTag)
+        let savedPost = try await createAndWaitForSync(post)
+        let savedTag = try await createAndWaitForSync(tag)
+        let savedPostTag = try await createAndWaitForSync(postTag)
         
         try await assertPost(savedPost, canLazyLoad: savedPostTag)
         try await assertTag(savedTag, canLazyLoad: savedPostTag)
@@ -102,16 +102,16 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         let post = Post(postId: UUID().uuidString, title: "title")
         let tag = Tag(name: "name")
         let postTag = PostTag(postWithTagsCompositeKey: post, tagWithCompositeKey: tag)
-        let savedPost = try await saveAndWaitForSync(post)
-        let savedTag = try await saveAndWaitForSync(tag)
-        let savedPostTag = try await saveAndWaitForSync(postTag)
+        let savedPost = try await createAndWaitForSync(post)
+        let savedTag = try await createAndWaitForSync(tag)
+        let savedPostTag = try await createAndWaitForSync(postTag)
         
         // update the post tag with a new post
         var queriedPostTag = try await query(for: savedPostTag)
         let newPost = Post(postId: UUID().uuidString, title: "title")
-        _ = try await saveAndWaitForSync(newPost)
+        _ = try await createAndWaitForSync(newPost)
         queriedPostTag.setPostWithTagsCompositeKey(newPost)
-        let savedPostTagWithNewPost = try await saveAndWaitForSync(queriedPostTag, assertVersion: 2)
+        let savedPostTagWithNewPost = try await updateAndWaitForSync(queriedPostTag)
         assertLazyReference(
             savedPostTagWithNewPost._postWithTagsCompositeKey,
             state: .notLoaded(identifiers: [
@@ -125,9 +125,9 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         // update the post tag with a new tag
         var queriedPostTagWithNewPost = try await query(for: savedPostTagWithNewPost)
         let newTag = Tag(name: "name")
-        _ = try await saveAndWaitForSync(newTag)
+        _ = try await createAndWaitForSync(newTag)
         queriedPostTagWithNewPost.setTagWithCompositeKey(newTag)
-        let savedPostTagWithNewTag = try await saveAndWaitForSync(queriedPostTagWithNewPost, assertVersion: 3)
+        let savedPostTagWithNewTag = try await updateAndWaitForSync(queriedPostTagWithNewPost, assertVersion: 3)
         assertLazyReference(
             savedPostTagWithNewTag._tagWithCompositeKey,
             state: .notLoaded(identifiers: [
@@ -166,9 +166,9 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         let post = Post(postId: UUID().uuidString, title: "title")
         let tag = Tag(name: "name")
         let postTag = PostTag(postWithTagsCompositeKey: post, tagWithCompositeKey: tag)
-        let savedPost = try await saveAndWaitForSync(post)
-        let savedTag = try await saveAndWaitForSync(tag)
-        let savedPostTag = try await saveAndWaitForSync(postTag)
+        let savedPost = try await createAndWaitForSync(post)
+        let savedTag = try await createAndWaitForSync(tag)
+        let savedPostTag = try await createAndWaitForSync(postTag)
         
         try await deleteAndWaitForSync(savedPost)
         
@@ -182,9 +182,9 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         let post = Post(postId: UUID().uuidString, title: "title")
         let tag = Tag(name: "name")
         let postTag = PostTag(postWithTagsCompositeKey: post, tagWithCompositeKey: tag)
-        let savedPost = try await saveAndWaitForSync(post)
-        let savedTag = try await saveAndWaitForSync(tag)
-        let savedPostTag = try await saveAndWaitForSync(postTag)
+        let savedPost = try await createAndWaitForSync(post)
+        let savedTag = try await createAndWaitForSync(tag)
+        let savedPostTag = try await createAndWaitForSync(postTag)
         
         try await deleteAndWaitForSync(savedTag)
         
@@ -198,9 +198,9 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         let post = Post(postId: UUID().uuidString, title: "title")
         let tag = Tag(name: "name")
         let postTag = PostTag(postWithTagsCompositeKey: post, tagWithCompositeKey: tag)
-        let savedPost = try await saveAndWaitForSync(post)
-        let savedTag = try await saveAndWaitForSync(tag)
-        let savedPostTag = try await saveAndWaitForSync(postTag)
+        let savedPost = try await createAndWaitForSync(post)
+        let savedTag = try await createAndWaitForSync(tag)
+        let savedPostTag = try await createAndWaitForSync(postTag)
         
         try await deleteAndWaitForSync(savedPostTag)
         
@@ -292,8 +292,8 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         try await startAndWaitForReady()
         let post = Post(postId: UUID().uuidString, title: "title")
         let tag = Tag(name: "name")
-        let savedPost = try await saveAndWaitForSync(post)
-        let savedTag = try await saveAndWaitForSync(tag)
+        let savedPost = try await createAndWaitForSync(post)
+        let savedTag = try await createAndWaitForSync(tag)
         
         let postTag = PostTag(postWithTagsCompositeKey: post, tagWithCompositeKey: tag)
         
@@ -399,8 +399,8 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         try await startAndWaitForReady()
         let post = Post(postId: UUID().uuidString, title: "title")
         let tag = Tag(name: "name")
-        try await saveAndWaitForSync(post)
-        try await saveAndWaitForSync(tag)
+        try await createAndWaitForSync(post)
+        try await createAndWaitForSync(tag)
         
         let postTag = PostTag(postWithTagsCompositeKey: post, tagWithCompositeKey: tag)
         

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL5/AWSDataStoreLazyLoadProjectTeam1Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL5/AWSDataStoreLazyLoadProjectTeam1Tests.swift
@@ -23,7 +23,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
     func testSaveTeam() async throws {
         await setup(withModels: ProjectTeam1Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         try await assertModelExists(savedTeam)
     }
     
@@ -31,7 +31,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam1Models())
         let project = Project(projectId: UUID().uuidString,
                               name: "name")
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         try await assertModelExists(savedProject)
         assertProjectDoesNotContainTeam(savedProject)
     }
@@ -39,7 +39,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
     func testSaveProjectWithTeam() async throws {
         await setup(withModels: ProjectTeam1Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         
         // Project initializer variation #1 (pass both team reference and fields in)
         let project = Project(projectId: UUID().uuidString,
@@ -47,7 +47,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
                               team: team,
                               project1TeamTeamId: team.teamId,
                               project1TeamName: team.name)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         let queriedProject = try await query(for: savedProject)
         assertProject(queriedProject, hasTeam: savedTeam)
         
@@ -55,7 +55,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
         let project2 = Project(projectId: UUID().uuidString,
                                name: "name",
                                team: team)
-        let savedProject2 = try await saveAndWaitForSync(project2)
+        let savedProject2 = try await createAndWaitForSync(project2)
         let queriedProject2 = try await query(for: savedProject2)
         assertProjectDoesNotContainTeam(queriedProject2)
         
@@ -64,7 +64,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
                                name: "name",
                                project1TeamTeamId: team.teamId,
                                project1TeamName: team.name)
-        let savedProject3 = try await saveAndWaitForSync(project3)
+        let savedProject3 = try await createAndWaitForSync(project3)
         let queriedProject3 = try await query(for: savedProject3)
         assertProject(queriedProject3, hasTeam: savedTeam)
     }
@@ -73,9 +73,9 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam1Models())
         
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let projectWithTeam = initializeProjectWithTeam(savedTeam)
-        let savedProjectWithTeam = try await saveAndWaitForSync(projectWithTeam)
+        let savedProjectWithTeam = try await createAndWaitForSync(projectWithTeam)
         let queriedProjectWithTeam = try await query(for: savedProjectWithTeam)
         assertProject(queriedProjectWithTeam, hasTeam: savedTeam)
         
@@ -86,7 +86,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
 
         // Update the team with the project.
         queriedTeam.setProject(queriedProjectWithTeam)
-        let savedTeamWithProject = try await saveAndWaitForSync(queriedTeam, assertVersion: 2)
+        let savedTeamWithProject = try await updateAndWaitForSync(queriedTeam)
         
         assertLazyReference(
             savedTeamWithProject._project,
@@ -121,65 +121,65 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
     func testSaveProjectWithTeamThenUpdate() async throws {
         await setup(withModels: ProjectTeam1Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         assertProject(savedProject, hasTeam: savedTeam)
         let queriedProject = try await query(for: savedProject)
         assertProject(queriedProject, hasTeam: savedTeam)
-        let updatedProject = try await saveAndWaitForSync(project, assertVersion: 2)
+        let updatedProject = try await updateAndWaitForSync(project)
         assertProject(updatedProject, hasTeam: savedTeam)
     }
     
     func testSaveProjectWithoutTeamUpdateProjectWithTeam() async throws {
         await setup(withModels: ProjectTeam1Models())
         let project = Project(projectId: UUID().uuidString, name: "name")
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         assertProjectDoesNotContainTeam(savedProject)
         
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         var queriedProject = try await query(for: savedProject)
         queriedProject.project1TeamTeamId = team.teamId
         queriedProject.project1TeamName = team.name
-        let savedProjectWithNewTeam = try await saveAndWaitForSync(queriedProject, assertVersion: 2)
+        let savedProjectWithNewTeam = try await updateAndWaitForSync(queriedProject)
         assertProject(savedProjectWithNewTeam, hasTeam: savedTeam)
     }
     
     func testSaveTeamSaveProjectWithTeamUpdateProjectToNoTeam() async throws {
         await setup(withModels: ProjectTeam1Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         var queriedProject = try await query(for: savedProject)
         assertProject(queriedProject, hasTeam: savedTeam)
         queriedProject.project1TeamTeamId = nil
         queriedProject.project1TeamName = nil
-        let savedProjectWithNoTeam = try await saveAndWaitForSync(queriedProject, assertVersion: 2)
+        let savedProjectWithNoTeam = try await updateAndWaitForSync(queriedProject)
         assertProjectDoesNotContainTeam(savedProjectWithNoTeam)
     }
     
     func testSaveProjectWithTeamUpdateProjectToNewTeam() async throws {
         await setup(withModels: ProjectTeam1Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         let newTeam = Team(teamId: UUID().uuidString, name: "name")
-        let savedNewTeam = try await saveAndWaitForSync(newTeam)
+        let savedNewTeam = try await createAndWaitForSync(newTeam)
         var queriedProject = try await query(for: savedProject)
         assertProject(queriedProject, hasTeam: savedTeam)
         queriedProject.project1TeamTeamId = newTeam.teamId
         queriedProject.project1TeamName = newTeam.name
-        let savedProjectWithNewTeam = try await saveAndWaitForSync(queriedProject, assertVersion: 2)
+        let savedProjectWithNewTeam = try await updateAndWaitForSync(queriedProject)
         assertProject(queriedProject, hasTeam: savedNewTeam)
     }
     
     func testDeleteTeam() async throws {
         await setup(withModels: ProjectTeam1Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         try await assertModelExists(savedTeam)
         try await deleteAndWaitForSync(savedTeam)
         try await assertModelDoesNotExist(savedTeam)
@@ -188,7 +188,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
     func testDeleteProject() async throws {
         await setup(withModels: ProjectTeam1Models())
         let project = Project(projectId: UUID().uuidString, name: "name")
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         try await assertModelExists(savedProject)
         try await deleteAndWaitForSync(savedProject)
         try await assertModelDoesNotExist(savedProject)
@@ -197,9 +197,9 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
     func testDeleteProjectWithTeam() async throws {
         await setup(withModels: ProjectTeam1Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         
         try await assertModelExists(savedProject)
         try await assertModelExists(savedTeam)
@@ -217,7 +217,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam1Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
         let mutationEventReceived = asyncExpectation(description: "Received mutation event")
@@ -278,7 +278,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam1Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
         let snapshotReceived = asyncExpectation(description: "Received query snapshot")

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL6/AWSDataStoreLazyLoadProjectTeam2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL6/AWSDataStoreLazyLoadProjectTeam2Tests.swift
@@ -23,7 +23,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
     func testSaveTeam() async throws {
         await setup(withModels: ProjectTeam2Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         try await assertModelExists(savedTeam)
     }
     
@@ -31,7 +31,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam2Models())
         let project = Project(projectId: UUID().uuidString,
                               name: "name")
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         try await assertModelExists(savedProject)
         assertProjectDoesNotContainTeam(savedProject)
     }
@@ -39,7 +39,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
     func testSaveProjectWithTeam() async throws {
         await setup(withModels: ProjectTeam2Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         
         // Project initializer variation #1 (pass both team reference and fields in)
         let project = Project(projectId: UUID().uuidString,
@@ -47,7 +47,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
                               team: team,
                               project2TeamTeamId: team.teamId,
                               project2TeamName: team.name)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         let queriedProject = try await query(for: savedProject)
         assertProject(queriedProject, hasTeam: savedTeam)
         
@@ -55,7 +55,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
         let project2 = Project(projectId: UUID().uuidString,
                                name: "name",
                                team: team)
-        let savedProject2 = try await saveAndWaitForSync(project2)
+        let savedProject2 = try await createAndWaitForSync(project2)
         let queriedProject2 = try await query(for: savedProject2)
         assertProjectDoesNotContainTeam(queriedProject2)
         
@@ -64,7 +64,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
                                name: "name",
                                project2TeamTeamId: team.teamId,
                                project2TeamName: team.name)
-        let savedProject3 = try await saveAndWaitForSync(project3)
+        let savedProject3 = try await createAndWaitForSync(project3)
         let queriedProject3 = try await query(for: savedProject3)
         assertProject(queriedProject3, hasTeam: savedTeam)
     }
@@ -85,59 +85,59 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
     func testSaveProjectWithTeamThenUpdate() async throws {
         await setup(withModels: ProjectTeam2Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
     
         let project = initializeProjectWithTeam(team)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         assertProject(savedProject, hasTeam: savedTeam)
         let queriedProject = try await query(for: savedProject)
         assertProject(queriedProject, hasTeam: savedTeam)
-        let updatedProject = try await saveAndWaitForSync(project, assertVersion: 2)
+        let updatedProject = try await updateAndWaitForSync(project)
         assertProject(updatedProject, hasTeam: savedTeam)
     }
     
     func testSaveProjectWithoutTeamUpdateProjectWithTeam() async throws {
         await setup(withModels: ProjectTeam2Models())
         let project = Project(projectId: UUID().uuidString, name: "name")
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         assertProjectDoesNotContainTeam(savedProject)
         
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         var queriedProject = try await query(for: savedProject)
         queriedProject.project2TeamTeamId = team.teamId
         queriedProject.project2TeamName = team.name
-        let savedProjectWithNewTeam = try await saveAndWaitForSync(queriedProject, assertVersion: 2)
+        let savedProjectWithNewTeam = try await updateAndWaitForSync(queriedProject)
         assertProject(savedProjectWithNewTeam, hasTeam: savedTeam)
     }
     
     func testSaveTeamSaveProjectWithTeamUpdateProjectToNoTeam() async throws {
         await setup(withModels: ProjectTeam2Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         var queriedProject = try await query(for: savedProject)
         assertProject(queriedProject, hasTeam: savedTeam)
         queriedProject.project2TeamTeamId = nil
         queriedProject.project2TeamName = nil
-        let savedProjectWithNoTeam = try await saveAndWaitForSync(queriedProject, assertVersion: 2)
+        let savedProjectWithNoTeam = try await updateAndWaitForSync(queriedProject)
         assertProjectDoesNotContainTeam(savedProjectWithNoTeam)
     }
     
     func testSaveProjectWithTeamUpdateProjectToNewTeam() async throws {
         await setup(withModels: ProjectTeam2Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         let newTeam = Team(teamId: UUID().uuidString, name: "name")
-        let savedNewTeam = try await saveAndWaitForSync(newTeam)
+        let savedNewTeam = try await createAndWaitForSync(newTeam)
         var queriedProject = try await query(for: savedProject)
         assertProject(queriedProject, hasTeam: savedTeam)
         queriedProject.project2TeamTeamId = newTeam.teamId
         queriedProject.project2TeamName = newTeam.name
-        try await saveAndWaitForSync(queriedProject, assertVersion: 2)
+        try await updateAndWaitForSync(queriedProject)
 
         let queriedProjectV2 = try await query(for: savedProject)
         assertProject(queriedProjectV2, hasTeam: savedNewTeam)
@@ -146,7 +146,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
     func testDeleteTeam() async throws {
         await setup(withModels: ProjectTeam2Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         try await assertModelExists(savedTeam)
         try await deleteAndWaitForSync(savedTeam)
         try await assertModelDoesNotExist(savedTeam)
@@ -155,7 +155,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
     func testDeleteProject() async throws {
         await setup(withModels: ProjectTeam2Models())
         let project = Project(projectId: UUID().uuidString, name: "name")
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         try await assertModelExists(savedProject)
         try await deleteAndWaitForSync(savedProject)
         try await assertModelDoesNotExist(savedProject)
@@ -164,9 +164,9 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
     func testDeleteProjectWithTeam() async throws {
         await setup(withModels: ProjectTeam2Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         
         try await assertModelExists(savedProject)
         try await assertModelExists(savedTeam)
@@ -184,7 +184,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam2Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
         let mutationEventReceived = asyncExpectation(description: "Received mutation event")
@@ -245,7 +245,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam2Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
         let snapshotReceived = asyncExpectation(description: "Received query snapshot")

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL7/AWSDataStoreLazyLoadPostComment4Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL7/AWSDataStoreLazyLoadPostComment4Tests.swift
@@ -17,7 +17,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
     func testSavePost() async throws {
         await setup(withModels: PostComment4Models())
         let post = Post(postId: UUID().uuidString, title: "title")
-        let savedPost = try await saveAndWaitForSync(post)
+        let savedPost = try await createAndWaitForSync(post)
     }
     
     func testSaveComment() async throws {
@@ -28,8 +28,8 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               post4CommentsPostId: post.postId,
                               post4CommentsTitle: post.title)
-        let savedPost = try await saveAndWaitForSync(post)
-        let savedComment = try await saveAndWaitForSync(comment)
+        let savedPost = try await createAndWaitForSync(post)
+        let savedComment = try await createAndWaitForSync(comment)
     }
     
     func testLazyLoad() async throws {
@@ -39,8 +39,8 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               post4CommentsPostId: post.postId,
                               post4CommentsTitle: post.title)
-        let savedPost = try await saveAndWaitForSync(post)
-        let savedComment = try await saveAndWaitForSync(comment)
+        let savedPost = try await createAndWaitForSync(post)
+        let savedComment = try await createAndWaitForSync(comment)
         assertComment(savedComment, contains: savedPost)
         try await assertPost(savedPost, canLazyLoad: savedComment)
         
@@ -83,14 +83,14 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
     func testSaveWithoutPost() async throws {
         await setup(withModels: PostComment4Models())
         let comment = Comment(commentId: UUID().uuidString, content: "content")
-        let savedComment = try await saveAndWaitForSync(comment)
+        let savedComment = try await createAndWaitForSync(comment)
         var queriedComment = try await query(for: savedComment)
         assertCommentDoesNotContainPost(queriedComment)
         let post = Post(postId: UUID().uuidString, title: "title")
-        let savedPost = try await saveAndWaitForSync(post)
+        let savedPost = try await createAndWaitForSync(post)
         queriedComment.post4CommentsPostId = savedPost.postId
         queriedComment.post4CommentsTitle = savedPost.title
-        let saveCommentWithPost = try await saveAndWaitForSync(queriedComment, assertVersion: 2)
+        let saveCommentWithPost = try await updateAndWaitForSync(queriedComment)
         let queriedComment2 = try await query(for: saveCommentWithPost)
         assertComment(queriedComment2, contains: post)
     }
@@ -102,11 +102,11 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               post4CommentsPostId: post.postId,
                               post4CommentsTitle: post.title)
-        let savedPost = try await saveAndWaitForSync(post)
-        let savedComment = try await saveAndWaitForSync(comment)
+        let savedPost = try await createAndWaitForSync(post)
+        let savedComment = try await createAndWaitForSync(comment)
         let queriedComment = try await query(for: savedComment)
         assertComment(queriedComment, contains: post)
-        let savedQueriedComment = try await saveAndWaitForSync(queriedComment, assertVersion: 2)
+        let savedQueriedComment = try await updateAndWaitForSync(queriedComment)
         let queriedComment2 = try await query(for: savedQueriedComment)
         assertComment(queriedComment2, contains: savedPost)
     }
@@ -119,15 +119,15 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               post4CommentsPostId: post.postId,
                               post4CommentsTitle: post.title)
-        _ = try await saveAndWaitForSync(post)
-        let savedComment = try await saveAndWaitForSync(comment)
+        _ = try await createAndWaitForSync(post)
+        let savedComment = try await createAndWaitForSync(comment)
         var queriedComment = try await query(for: savedComment)
         assertComment(queriedComment, contains: post)
         let newPost = Post(postId: UUID().uuidString, title: "title")
-        _ = try await saveAndWaitForSync(newPost)
+        _ = try await createAndWaitForSync(newPost)
         queriedComment.post4CommentsPostId = newPost.postId
         queriedComment.post4CommentsTitle = newPost.title
-        let saveCommentWithNewPost = try await saveAndWaitForSync(queriedComment, assertVersion: 2)
+        let saveCommentWithNewPost = try await updateAndWaitForSync(queriedComment)
         let queriedComment2 = try await query(for: saveCommentWithNewPost)
         assertComment(queriedComment2, contains: newPost)
     }
@@ -140,15 +140,15 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               post4CommentsPostId: post.postId,
                               post4CommentsTitle: post.title)
-        _ = try await saveAndWaitForSync(post)
-        let savedComment = try await saveAndWaitForSync(comment)
+        _ = try await createAndWaitForSync(post)
+        let savedComment = try await createAndWaitForSync(comment)
         var queriedComment = try await query(for: savedComment)
         assertComment(queriedComment, contains: post)
         
         queriedComment.post4CommentsPostId = nil
         queriedComment.post4CommentsTitle = nil
         
-        let saveCommentRemovePost = try await saveAndWaitForSync(queriedComment, assertVersion: 2)
+        let saveCommentRemovePost = try await updateAndWaitForSync(queriedComment)
         let queriedCommentNoPost = try await query(for: saveCommentRemovePost)
         assertCommentDoesNotContainPost(queriedCommentNoPost)
     }
@@ -161,8 +161,8 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               post4CommentsPostId: post.postId,
                               post4CommentsTitle: post.title)
-        let savedPost = try await saveAndWaitForSync(post)
-        let savedComment = try await saveAndWaitForSync(comment)
+        let savedPost = try await createAndWaitForSync(post)
+        let savedComment = try await createAndWaitForSync(comment)
         try await deleteAndWaitForSync(savedPost)
         
         // The expected behavior when deleting a post should be that the
@@ -188,7 +188,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                    version == 1,
                    let receivedPost = try? mutationEvent.decodeModel(as: Post.self),
                    receivedPost.postId == post.postId {
-                    let savedComment = try await saveAndWaitForSync(comment)
+                    let savedComment = try await createAndWaitForSync(comment)
                     try await assertPost(receivedPost, canLazyLoad: savedComment)
                     await mutationEventReceived.fulfill()
                 }
@@ -210,7 +210,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
         await setup(withModels: PostComment4Models())
         try await startAndWaitForReady()
         let post = Post(postId: UUID().uuidString, title: "title")
-        let savedPost = try await saveAndWaitForSync(post)
+        let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(commentId: UUID().uuidString,
                               content: "content",
                               post4CommentsPostId: post.postId,
@@ -253,7 +253,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedPost = querySnapshot.items.first {
-                    let savedComment = try await saveAndWaitForSync(comment)
+                    let savedComment = try await createAndWaitForSync(comment)
                     try await assertPost(receivedPost, canLazyLoad: savedComment)
                     await snapshotReceived.fulfill()
                 }
@@ -276,7 +276,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
         try await startAndWaitForReady()
         
         let post = Post(postId: UUID().uuidString, title: "title")
-        let savedPost = try await saveAndWaitForSync(post)
+        let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(commentId: UUID().uuidString,
                               content: "content",
                               post4CommentsPostId: post.postId,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL8/AWSDataStoreLazyLoadProjectTeam5Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL8/AWSDataStoreLazyLoadProjectTeam5Tests.swift
@@ -23,7 +23,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
     func testSaveTeam() async throws {
         await setup(withModels: ProjectTeam5Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         try await assertModelExists(savedTeam)
     }
     
@@ -31,7 +31,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam5Models())
         let project = Project(projectId: UUID().uuidString,
                               name: "name")
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         try await assertModelExists(savedProject)
         assertProjectDoesNotContainTeam(savedProject)
     }
@@ -39,7 +39,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
     func testSaveProjectWithTeam() async throws {
         await setup(withModels: ProjectTeam5Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         
         // Project initializer variation #1 (pass both team reference and fields in)
         let project = Project(projectId: UUID().uuidString,
@@ -47,7 +47,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
                               team: team,
                               teamId: team.teamId,
                               teamName: team.name)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         let queriedProject = try await query(for: savedProject)
         assertProject(queriedProject, hasTeam: savedTeam)
         
@@ -55,7 +55,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
         let project2 = Project(projectId: UUID().uuidString,
                                name: "name",
                                team: team)
-        let savedProject2 = try await saveAndWaitForSync(project2)
+        let savedProject2 = try await createAndWaitForSync(project2)
         let queriedProject2 = try await query(for: savedProject2)
         assertProjectDoesNotContainTeam(queriedProject2)
         
@@ -64,7 +64,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
                                name: "name",
                                teamId: team.teamId,
                                teamName: team.name)
-        let savedProject3 = try await saveAndWaitForSync(project3)
+        let savedProject3 = try await createAndWaitForSync(project3)
         let queriedProject3 = try await query(for: savedProject3)
         assertProject(queriedProject3, hasTeam: savedTeam)
     }
@@ -85,66 +85,66 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
     func testSaveProjectWithTeamThenUpdate() async throws {
         await setup(withModels: ProjectTeam5Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
     
         let project = initializeProjectWithTeam(team)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         assertProject(savedProject, hasTeam: savedTeam)
         let queriedProject = try await query(for: savedProject)
         assertProject(queriedProject, hasTeam: savedTeam)
-        let updatedProject = try await saveAndWaitForSync(project, assertVersion: 2)
+        let updatedProject = try await updateAndWaitForSync(project)
         assertProject(updatedProject, hasTeam: savedTeam)
     }
     
     func testSaveProjectWithoutTeamUpdateProjectWithTeam() async throws {
         await setup(withModels: ProjectTeam5Models())
         let project = Project(projectId: UUID().uuidString, name: "name")
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         assertProjectDoesNotContainTeam(savedProject)
         
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         var queriedProject = try await query(for: savedProject)
         queriedProject.teamId = team.teamId
         queriedProject.teamName = team.name
-        let savedProjectWithNewTeam = try await saveAndWaitForSync(queriedProject, assertVersion: 2)
+        let savedProjectWithNewTeam = try await updateAndWaitForSync(queriedProject)
         assertProject(savedProjectWithNewTeam, hasTeam: savedTeam)
     }
     
     func testSaveTeamSaveProjectWithTeamUpdateProjectToNoTeam() async throws {
         await setup(withModels: ProjectTeam5Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         var queriedProject = try await query(for: savedProject)
         assertProject(queriedProject, hasTeam: savedTeam)
         queriedProject.teamId = nil
         queriedProject.teamName = nil
-        let savedProjectWithNoTeam = try await saveAndWaitForSync(queriedProject, assertVersion: 2)
+        let savedProjectWithNoTeam = try await updateAndWaitForSync(queriedProject)
         assertProjectDoesNotContainTeam(savedProjectWithNoTeam)
     }
     
     func testSaveProjectWithTeamUpdateProjectToNewTeam() async throws {
         await setup(withModels: ProjectTeam5Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         let newTeam = Team(teamId: UUID().uuidString, name: "name")
-        let savedNewTeam = try await saveAndWaitForSync(newTeam)
+        let savedNewTeam = try await createAndWaitForSync(newTeam)
         var queriedProject = try await query(for: savedProject)
         assertProject(queriedProject, hasTeam: savedTeam)
         queriedProject.teamId = newTeam.teamId
         queriedProject.teamName = newTeam.name
-        let savedProjectWithNewTeam = try await saveAndWaitForSync(queriedProject, assertVersion: 2)
+        let savedProjectWithNewTeam = try await updateAndWaitForSync(queriedProject)
         assertProject(queriedProject, hasTeam: savedNewTeam)
     }
     
     func testDeleteTeam() async throws {
         await setup(withModels: ProjectTeam5Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         try await assertModelExists(savedTeam)
         try await deleteAndWaitForSync(savedTeam)
         try await assertModelDoesNotExist(savedTeam)
@@ -153,7 +153,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
     func testDeleteProject() async throws {
         await setup(withModels: ProjectTeam5Models())
         let project = Project(projectId: UUID().uuidString, name: "name")
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         try await assertModelExists(savedProject)
         try await deleteAndWaitForSync(savedProject)
         try await assertModelDoesNotExist(savedProject)
@@ -162,13 +162,13 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
     func testDeleteProjectWithTeam() async throws {
         await setup(withModels: ProjectTeam5Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = Project(projectId: UUID().uuidString,
                               name: "name",
                               team: team,
                               teamId: team.teamId,
                               teamName: team.name)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         
         try await assertModelExists(savedProject)
         try await assertModelExists(savedTeam)
@@ -186,7 +186,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam5Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
         let mutationEventReceived = asyncExpectation(description: "Received mutation event")
@@ -247,7 +247,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam5Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
         let snapshotReceived = asyncExpectation(description: "Received query snapshot")

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL9/AWSDataStoreLazyLoadProjectTeam6Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL9/AWSDataStoreLazyLoadProjectTeam6Tests.swift
@@ -23,7 +23,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
     func testSaveTeam() async throws {
         await setup(withModels: ProjectTeam6Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         try await assertModelExists(savedTeam)
     }
     
@@ -31,7 +31,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam6Models())
         let project = Project(projectId: UUID().uuidString,
                               name: "name")
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         try await assertModelExists(savedProject)
         assertProjectDoesNotContainTeam(savedProject)
     }
@@ -39,7 +39,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
     func testSaveProjectWithTeam() async throws {
         await setup(withModels: ProjectTeam6Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         
         // Project initializer variation #1 (pass both team reference and fields in)
         let project = Project(projectId: UUID().uuidString,
@@ -47,7 +47,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
                               team: team,
                               teamId: team.teamId,
                               teamName: team.name)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         let queriedProject = try await query(for: savedProject)
         assertProject(queriedProject, hasTeam: savedTeam)
         
@@ -55,7 +55,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
         let project2 = Project(projectId: UUID().uuidString,
                                name: "name",
                                team: team)
-        let savedProject2 = try await saveAndWaitForSync(project2)
+        let savedProject2 = try await createAndWaitForSync(project2)
         let queriedProject2 = try await query(for: savedProject2)
         assertProjectDoesNotContainTeam(queriedProject2)
         
@@ -64,7 +64,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
                                name: "name",
                                teamId: team.teamId,
                                teamName: team.name)
-        let savedProject3 = try await saveAndWaitForSync(project3)
+        let savedProject3 = try await createAndWaitForSync(project3)
         let queriedProject3 = try await query(for: savedProject3)
         assertProject(queriedProject3, hasTeam: savedTeam)
     }
@@ -85,66 +85,66 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
     func testSaveProjectWithTeamThenUpdate() async throws {
         await setup(withModels: ProjectTeam6Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
     
         let project = initializeProjectWithTeam(team)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         assertProject(savedProject, hasTeam: savedTeam)
         let queriedProject = try await query(for: savedProject)
         assertProject(queriedProject, hasTeam: savedTeam)
-        let updatedProject = try await saveAndWaitForSync(project, assertVersion: 2)
+        let updatedProject = try await updateAndWaitForSync(project)
         assertProject(updatedProject, hasTeam: savedTeam)
     }
     
     func testSaveProjectWithoutTeamUpdateProjectWithTeam() async throws {
         await setup(withModels: ProjectTeam6Models())
         let project = Project(projectId: UUID().uuidString, name: "name")
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         assertProjectDoesNotContainTeam(savedProject)
         
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         var queriedProject = try await query(for: savedProject)
         queriedProject.teamId = team.teamId
         queriedProject.teamName = team.name
-        let savedProjectWithNewTeam = try await saveAndWaitForSync(queriedProject, assertVersion: 2)
+        let savedProjectWithNewTeam = try await updateAndWaitForSync(queriedProject)
         assertProject(savedProjectWithNewTeam, hasTeam: savedTeam)
     }
     
     func testSaveTeamSaveProjectWithTeamUpdateProjectToNoTeam() async throws {
         await setup(withModels: ProjectTeam6Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         var queriedProject = try await query(for: savedProject)
         assertProject(queriedProject, hasTeam: savedTeam)
         queriedProject.teamId = nil
         queriedProject.teamName = nil
-        let savedProjectWithNoTeam = try await saveAndWaitForSync(queriedProject, assertVersion: 2)
+        let savedProjectWithNoTeam = try await updateAndWaitForSync(queriedProject)
         assertProjectDoesNotContainTeam(savedProjectWithNoTeam)
     }
     
     func testSaveProjectWithTeamUpdateProjectToNewTeam() async throws {
         await setup(withModels: ProjectTeam6Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         let newTeam = Team(teamId: UUID().uuidString, name: "name")
-        let savedNewTeam = try await saveAndWaitForSync(newTeam)
+        let savedNewTeam = try await createAndWaitForSync(newTeam)
         var queriedProject = try await query(for: savedProject)
         assertProject(queriedProject, hasTeam: savedTeam)
         queriedProject.teamId = newTeam.teamId
         queriedProject.teamName = newTeam.name
-        let savedProjectWithNewTeam = try await saveAndWaitForSync(queriedProject, assertVersion: 2)
+        let savedProjectWithNewTeam = try await updateAndWaitForSync(queriedProject)
         assertProject(queriedProject, hasTeam: savedNewTeam)
     }
     
     func testDeleteTeam() async throws {
         await setup(withModels: ProjectTeam6Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         try await assertModelExists(savedTeam)
         try await deleteAndWaitForSync(savedTeam)
         try await assertModelDoesNotExist(savedTeam)
@@ -153,7 +153,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
     func testDeleteProject() async throws {
         await setup(withModels: ProjectTeam6Models())
         let project = Project(projectId: UUID().uuidString, name: "name")
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         try await assertModelExists(savedProject)
         try await deleteAndWaitForSync(savedProject)
         try await assertModelDoesNotExist(savedProject)
@@ -162,9 +162,9 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
     func testDeleteProjectWithTeam() async throws {
         await setup(withModels: ProjectTeam6Models())
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
-        let savedProject = try await saveAndWaitForSync(project)
+        let savedProject = try await createAndWaitForSync(project)
         
         try await assertModelExists(savedProject)
         try await assertModelExists(savedTeam)
@@ -182,7 +182,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam6Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
         let mutationEventReceived = asyncExpectation(description: "Received mutation event")
@@ -243,7 +243,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam6Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let savedTeam = try await saveAndWaitForSync(team)
+        let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
         let snapshotReceived = asyncExpectation(description: "Received query snapshot")


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
- change test helper method to use both `mutationType` and `version` to filter incoming mutationEvent from remote server

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
