### PR TITLE
feat(Auth): Adding TOTP states, events, data models and resolvers

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/InitiateAuthDeviceSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/InitiateAuthDeviceSRP.swift
@@ -86,6 +86,8 @@ struct InitiateAuthDeviceSRP: Action {
         _ response: SignInResponseBehavior,
         with stateData: SRPStateData) -> StateMachineEvent {
 
+
+            //HS: TODO: Combine this logic with responedToAuthChallenge
             if let challengeName = response.challengeName {
                 switch challengeName {
                 case .devicePasswordVerifier:

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/ConfirmSignInEventData.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/ConfirmSignInEventData.swift
@@ -12,6 +12,7 @@ struct ConfirmSignInEventData {
     let answer: String
     let attributes: [String: String]
     let metadata: [String: String]?
+    let friendlyDeviceName: String?
 
 }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/RespondToAuthChallenge.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/RespondToAuthChallenge.swift
@@ -39,6 +39,32 @@ extension RespondToAuthChallenge {
                                        attributeKey: nil)
     }
 
+    var getAllowedMFATypesForSelection: Set<MFAType> {
+        return getMFATypes(forKey: "MFAS_CAN_CHOOSE")
+    }
+
+    var getAllowedMFATypesForSetup: Set<MFAType> {
+        return getMFATypes(forKey: "MFAS_CAN_SETUP")
+    }
+
+    /// Helper method to extract MFA types from parameters
+    private func getMFATypes(forKey key: String) -> Set<MFAType> {
+        var mfaTypes = Set<MFAType>()
+        guard let mfaTypeParametersData = parameters?[key]?.data(using: .utf8),
+              let mfaTypesArray = try? JSONDecoder().decode(
+                [String].self, from: mfaTypeParametersData) else {
+            return mfaTypes
+        }
+
+        for mfaTypeValue in mfaTypesArray {
+            if let mfaType = MFAType(rawValue: String(mfaTypeValue)) {
+                mfaTypes.insert(mfaType)
+            }
+        }
+
+        return mfaTypes
+    }
+
     var debugDictionary: [String: Any] {
         return ["challenge": challenge,
                 "username": username.masked()]
@@ -46,11 +72,12 @@ extension RespondToAuthChallenge {
 
     func getChallengeKey() throws -> String {
         switch challenge {
-        case .customChallenge: return "ANSWER"
+        case .customChallenge, .selectMfaType: return "ANSWER"
         case .smsMfa: return "SMS_MFA_CODE"
+        case .softwareTokenMfa: return "SOFTWARE_TOKEN_MFA_CODE"
         case .newPasswordRequired: return "NEW_PASSWORD"
         default:
-            let message = "UnSupported challenge response \(challenge)"
+            let message = "Unsupported challenge type for response key generation \(challenge)"
             let error = SignInError.unknown(message: message)
             throw error
         }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/SignInTOTPSetupData.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/SignInTOTPSetupData.swift
@@ -1,0 +1,30 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+
+struct SignInTOTPSetupData {
+
+    let secretCode: String
+    let session: String
+    let username: String
+
+}
+
+extension SignInTOTPSetupData: CustomDebugDictionaryConvertible {
+    var debugDictionary: [String: Any] {
+        [
+            "sharedSecret": secretCode.redacted(),
+            "session": session.masked(),
+            "username": username.masked()
+        ]
+    }
+}
+
+extension SignInTOTPSetupData: Codable { }
+
+extension SignInTOTPSetupData: Equatable { }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SetUpTOTPEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SetUpTOTPEvent.swift
@@ -1,0 +1,71 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// Session value created by the service
+typealias UserSession = String
+
+struct SetUpTOTPEvent: StateMachineEvent {
+
+    enum EventType {
+
+        case setUpTOTP(SignInResponseBehavior)
+
+        case waitForAnswer(SignInTOTPSetupData)
+
+        case verifyChallengeAnswer(ConfirmSignInEventData)
+
+        case respondToAuthChallenge(UserSession)
+
+        case verified
+
+        case throwError(SignInError)
+
+    }
+
+    let id: String
+    let eventType: EventType
+    let time: Date?
+
+    var type: String {
+        switch eventType {
+        case .setUpTOTP: return "SetUpTOTPEvent.setUpTOTP"
+        case .verified: return "SetUpTOTPEvent.verified"
+        case .verifyChallengeAnswer: return "SetUpTOTPEvent.verifyChallengeAnswer"
+        case .waitForAnswer: return "SetUpTOTPEvent.waitForAnswer"
+        case .respondToAuthChallenge: return "SetUpTOTPEvent.respondToAuthChallenge"
+        case .throwError: return "SetUpTOTPEvent.throwError"
+        }
+    }
+
+    init(id: String = UUID().uuidString,
+         eventType: EventType,
+         time: Date? = nil) {
+        self.id = id
+        self.eventType = eventType
+        self.time = time
+    }
+}
+
+extension SetUpTOTPEvent.EventType: Equatable {
+    static func == (lhs: SetUpTOTPEvent.EventType, rhs: SetUpTOTPEvent.EventType) -> Bool {
+        switch (lhs, rhs) {
+        case (.setUpTOTP, .setUpTOTP),
+            (.verified, .verified),
+            (.verifyChallengeAnswer, .verifyChallengeAnswer),
+            (.waitForAnswer, .waitForAnswer),
+            (.respondToAuthChallenge, .respondToAuthChallenge),
+            (.throwError, .throwError):
+            return true
+        default:
+            return false
+        }
+    }
+
+
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInEvent.swift
@@ -38,6 +38,8 @@ struct SignInEvent: StateMachineEvent {
 
         case respondDevicePasswordVerifier(SRPStateData, SignInResponseBehavior)
 
+        case initiateTOTPSetup(Username, SignInResponseBehavior)
+
         case throwPasswordVerifierError(SignInError)
 
         case finalizeSignIn(SignedInData)
@@ -76,6 +78,7 @@ struct SignInEvent: StateMachineEvent {
         case .receivedChallenge: return "SignInEvent.receivedChallenge"
         case .verifySMSChallenge: return "SignInEvent.verifySMSChallenge"
         case .retryRespondPasswordVerifier: return "SignInEvent.retryRespondPasswordVerifier"
+        case .initiateTOTPSetup: return "SignInEvent.initiateTOTPSetup"
         }
     }
 
@@ -109,7 +112,8 @@ extension SignInEvent.EventType: Equatable {
             (.throwAuthError, .throwAuthError),
             (.receivedChallenge, .receivedChallenge),
             (.verifySMSChallenge, .verifySMSChallenge),
-            (.retryRespondPasswordVerifier, .retryRespondPasswordVerifier):
+            (.retryRespondPasswordVerifier, .retryRespondPasswordVerifier),
+            (.initiateTOTPSetup, .initiateTOTPSetup):
             return true
         default: return false
         }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/DebugInfo/SignInState+Debug.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/DebugInfo/SignInState+Debug.swift
@@ -40,6 +40,10 @@ extension SignInState {
             additionalMetadataDictionary = ["DeviceSRPState": deviceSRPState.debugDictionary]
         case .signedIn(let data):
             additionalMetadataDictionary = ["SignedInData": data.debugDictionary]
+        case .resolvingTOTPSetup(let signInTOTPSetupState, let signInEventData):
+            additionalMetadataDictionary = [
+                "SignInTOTPSetupState": signInTOTPSetupState.debugDictionary,
+                "SignInEventData" : signInEventData.debugDictionary]
         case .error:
             additionalMetadataDictionary = [:]
         }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/DebugInfo/SignInTOTPSetupState+Debug.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/DebugInfo/SignInTOTPSetupState+Debug.swift
@@ -1,0 +1,28 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension SignInTOTPSetupState {
+
+    var debugDictionary: [String: Any] {
+        var additionalMetadataDictionary: [String: Any] = [:]
+        switch self {
+        case .waitingForAnswer(let signInTOTPSetupData):
+            additionalMetadataDictionary = signInTOTPSetupData.debugDictionary
+        case .verifying(let signInSetupData, let confirmSignInEventData):
+            additionalMetadataDictionary = confirmSignInEventData.debugDictionary
+            additionalMetadataDictionary = additionalMetadataDictionary.merging(
+                signInSetupData.debugDictionary,
+                uniquingKeysWith: {$1})
+        case .error(let error):
+            additionalMetadataDictionary["error"] = error
+        default: additionalMetadataDictionary = [:]
+        }
+        return [type: additionalMetadataDictionary]
+    }
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/SignInState.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/SignInState.swift
@@ -14,6 +14,7 @@ enum SignInState: State {
     case signingInWithCustom(CustomSignInState, SignInEventData)
     case signingInViaMigrateAuth(MigrateSignInState, SignInEventData)
     case resolvingChallenge(SignInChallengeState, AuthChallengeType, SignInMethod)
+    case resolvingTOTPSetup(SignInTOTPSetupState, SignInEventData)
     case signingInWithHostedUI(HostedUISignInState)
     case confirmingDevice
     case resolvingDeviceSrpa(DeviceSRPState)
@@ -32,6 +33,7 @@ extension SignInState {
         case .signingInWithCustom: return "SignInState.signingInWithCustom"
         case .signingInViaMigrateAuth: return "SignInState.signingInViaMigrateAuth"
         case .resolvingChallenge: return "SignInState.resolvingChallenge"
+        case .resolvingTOTPSetup: return "SignInState.resolvingTOTPSetup"
         case .confirmingDevice: return "SignInState.confirmingDevice"
         case .resolvingDeviceSrpa: return "SignInState.resolvingDeviceSrpa"
         case .signedIn: return "SignInState.signedIn"

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/SignInTOTPSetupState.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/States/SignInTOTPSetupState.swift
@@ -1,0 +1,57 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+enum SignInTOTPSetupState: State {
+
+    case notStarted
+
+    case setUpTOTP
+
+    case waitingForAnswer(SignInTOTPSetupData)
+
+    case verifying(SignInTOTPSetupData, ConfirmSignInEventData)
+
+    case respondingToAuthChallenge
+
+    case success
+
+    case error(SignInTOTPSetupData?, SignInError)
+}
+
+extension SignInTOTPSetupState {
+
+    var type: String {
+        switch self {
+        case .notStarted: return "SignInTOTPSetupState.notStarted"
+        case .setUpTOTP: return "SignInTOTPSetupState.setUpTOTP"
+        case .waitingForAnswer: return "SignInTOTPSetupState.waitingForAnswer"
+        case .verifying: return "SignInTOTPSetupState.verifying"
+        case .respondingToAuthChallenge: return "SignInTOTPSetupState.respondingToAuthChallenge"
+        case .success: return "SignInTOTPSetupState.success"
+        case .error: return "SignInTOTPSetupState.error"
+        }
+    }
+}
+
+extension SignInTOTPSetupState: Equatable {
+    static func == (lhs: SignInTOTPSetupState, rhs: SignInTOTPSetupState) -> Bool {
+        switch (lhs, rhs) {
+        case (.notStarted, .notStarted),
+            (.setUpTOTP, .setUpTOTP),
+            (.waitingForAnswer, .waitingForAnswer),
+            (.verifying, .verifying),
+            (.respondingToAuthChallenge, .respondingToAuthChallenge),
+            (.success, .success),
+            (.error, .error):
+            return true
+        default: return false
+        }
+    }
+
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/ErrorMapping/SignInError+Helper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/ErrorMapping/SignInError+Helper.swift
@@ -25,6 +25,12 @@ extension SignInError {
                case .userNotConfirmedException = internalError {
                 return true
             }
+
+            if let internalError: VerifySoftwareTokenOutputError = serviceError.internalAWSServiceError(),
+               case .userNotConfirmedException = internalError {
+                return true
+            }
+
         default: break
         }
         return false
@@ -39,6 +45,11 @@ extension SignInError {
             }
 
             if let internalError: RespondToAuthChallengeOutputError = serviceError.internalAWSServiceError(),
+               case .passwordResetRequiredException = internalError {
+                return true
+            }
+
+            if let internalError: VerifySoftwareTokenOutputError = serviceError.internalAWSServiceError(),
                case .passwordResetRequiredException = internalError {
                 return true
             }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SignIn/SignInState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/SignIn/SignInState+Resolver.swift
@@ -98,6 +98,14 @@ extension SignInState {
                                  actions: [action])
                 }
 
+                if let signInEvent = event as? SignInEvent,
+                   case .initiateTOTPSetup(_, let challengeResponse) = signInEvent.eventType {
+                    let action = InitializeTOTPSetup(
+                        authResponse: challengeResponse)
+                    return .init(newState: .resolvingTOTPSetup(.notStarted, signInEventData),
+                                 actions: [action])
+                }
+
                 let resolution = SRPSignInState.Resolver().resolve(oldState: srpSignInState,
                                                                    byApplying: event)
                 let signingInWithSRP = SignInState.signingInWithSRP(resolution.newState,
@@ -250,6 +258,53 @@ extension SignInState {
                 let signingInWithSRP = SignInState.signingInWithSRPCustom(resolution.newState,
                                                                           signInEventData)
                 return .init(newState: signingInWithSRP, actions: resolution.actions)
+
+
+            case .resolvingTOTPSetup(let setUpTOTPState, let signInEventData):
+
+                if case .finalizeSignIn(let signedInData) = event.isSignInEvent {
+                    return .init(newState: .signedIn(signedInData),
+                                 actions: [SignInComplete(signedInData: signedInData)])
+                }
+
+                if let signInEvent = event as? SignInEvent,
+                   case .receivedChallenge(let challenge) = signInEvent.eventType {
+                    let action = InitializeResolveChallenge(challenge: challenge,
+                                                            signInMethod: signInEventData.signInMethod)
+                    let subState = SignInChallengeState.notStarted
+                    return .init(newState: .resolvingChallenge(
+                        subState,
+                        challenge.challenge.authChallengeType,
+                        signInEventData.signInMethod
+                    ), actions: [action])
+                }
+
+                if let signInEvent = event as? SignInEvent,
+                   case .confirmDevice(let signedInData) = signInEvent.eventType {
+                    let action = ConfirmDevice(signedInData: signedInData)
+                    return .init(newState: .confirmingDevice,
+                                 actions: [action])
+                }
+
+                if let signInEvent = event as? SignInEvent,
+                   case .initiateDeviceSRP(let username, let challengeResponse) = signInEvent.eventType {
+                    let action = StartDeviceSRPFlow(
+                        username: username,
+                        authResponse: challengeResponse)
+                    return .init(newState: .resolvingDeviceSrpa(.notStarted),
+                                 actions: [action])
+                }
+
+                let resolution = SignInTOTPSetupState.Resolver(
+                    signInEventData: signInEventData).resolve(
+                        oldState: setUpTOTPState,
+                        byApplying: event)
+                let settingUpTOTPState = SignInState.resolvingTOTPSetup(
+                    resolution.newState,
+                    signInEventData)
+                return .init(newState: settingUpTOTPState, actions: resolution.actions)
+
+
             case .resolvingDeviceSrpa(let deviceSrpState):
                 let signInMethod = SignInMethod.apiBased(.userSRP)
                 if let signInEvent = event as? SignInEvent,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/TOTPSetup/SignInTOTPSetupState+Resolver.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/Resolvers/TOTPSetup/SignInTOTPSetupState+Resolver.swift
@@ -1,0 +1,145 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension SignInTOTPSetupState {
+    struct Resolver: StateMachineResolver {
+        typealias StateType = SignInTOTPSetupState
+        let defaultState = SignInTOTPSetupState.notStarted
+
+        let signInEventData: SignInEventData
+
+        func resolve(
+            oldState: SignInTOTPSetupState,
+            byApplying event: StateMachineEvent
+        ) -> StateResolution<SignInTOTPSetupState> {
+
+            guard let setupTOTPEvent = event as? SetUpTOTPEvent else {
+                return .from(oldState)
+            }
+
+            switch oldState {
+            case .notStarted:
+                return resolveNotStarted(byApplying: setupTOTPEvent)
+            case .setUpTOTP:
+                return resolveSetUpTOTPState(byApplying: setupTOTPEvent)
+            case .waitingForAnswer(let signInTOTPSetupData):
+                return resolveWaitForAnswer(
+                    byApplying: setupTOTPEvent,
+                    with: signInTOTPSetupData)
+            case .verifying(let signInTOTPSetupData, _):
+                return resolveVerifyingState(
+                    byApplying: setupTOTPEvent, with: signInTOTPSetupData)
+            case .error(let signInTOTPSetupData, _):
+                return resolveErrorState(byApplying: setupTOTPEvent,
+                                         with: signInTOTPSetupData)
+            default:
+                return .from(.notStarted)
+            }
+        }
+
+        private func resolveNotStarted(
+            byApplying signInEvent: SetUpTOTPEvent) -> StateResolution<SignInTOTPSetupState> {
+                switch signInEvent.eventType {
+                case .setUpTOTP(let authResponse):
+                    let action = SetUpTOTP(
+                        authResponse: authResponse,
+                        signInEventData: signInEventData)
+                    return StateResolution(
+                        newState: SignInTOTPSetupState.setUpTOTP,
+                        actions: [action]
+                    )
+                case .throwError(let error):
+                    return .init(newState: .error(nil, error))
+                default:
+                    return .from(.notStarted)
+                }
+            }
+
+        private func resolveSetUpTOTPState(
+            byApplying signInEvent: SetUpTOTPEvent) -> StateResolution<SignInTOTPSetupState> {
+                switch signInEvent.eventType {
+                case .waitForAnswer(let totpSetupResponse):
+                    return StateResolution(
+                        newState: SignInTOTPSetupState.waitingForAnswer(totpSetupResponse),
+                        actions: []
+                    )
+                case .throwError(let error):
+                    return .init(newState: .error(nil, error))
+                default:
+                    return .from(.notStarted)
+                }
+            }
+
+        private func resolveWaitForAnswer(
+            byApplying signInEvent: SetUpTOTPEvent,
+            with signInTOTPSetupData: SignInTOTPSetupData) -> StateResolution<SignInTOTPSetupState> {
+                switch signInEvent.eventType {
+                case .verifyChallengeAnswer(let confirmSignInEventData):
+                    let action = VerifyTOTPSetup(
+                        session: signInTOTPSetupData.session,
+                        totpCode: confirmSignInEventData.answer,
+                        friendlyDeviceName: confirmSignInEventData.friendlyDeviceName)
+                    return StateResolution(
+                        newState: SignInTOTPSetupState.verifying(
+                            signInTOTPSetupData,
+                            confirmSignInEventData),
+                        actions: [action]
+                    )
+                case .throwError(let error):
+                    return .init(newState: .error(signInTOTPSetupData, error))
+                default:
+                    return .from(.notStarted)
+                }
+            }
+
+        private func resolveVerifyingState(
+            byApplying signInEvent: SetUpTOTPEvent,
+            with signInTOTPSetupData: SignInTOTPSetupData) -> StateResolution<SignInTOTPSetupState> {
+                switch signInEvent.eventType {
+                case .respondToAuthChallenge(let session):
+                    let action = CompleteTOTPSetup(
+                        userSession: session,
+                        signInEventData: signInEventData)
+                    return StateResolution(
+                        newState: SignInTOTPSetupState.respondingToAuthChallenge,
+                        actions: [action]
+                    )
+                case .throwError(let error):
+                    return .init(newState: .error(signInTOTPSetupData, error))
+                default:
+                    return .from(.notStarted)
+                }
+            }
+
+        private func resolveErrorState(
+            byApplying signInEvent: SetUpTOTPEvent,
+            with signInTOTPSetupData: SignInTOTPSetupData?) -> StateResolution<SignInTOTPSetupState> {
+
+                switch signInEvent.eventType {
+                case .verifyChallengeAnswer(let confirmSignInEventData):
+                    guard let signInTOTPSetupData = signInTOTPSetupData else {
+                        return .from(.notStarted)
+                    }
+                    let action = VerifyTOTPSetup(
+                        session: signInTOTPSetupData.session,
+                        totpCode: confirmSignInEventData.answer,
+                        friendlyDeviceName: confirmSignInEventData.friendlyDeviceName)
+                    return StateResolution(
+                        newState: SignInTOTPSetupState.verifying(
+                            signInTOTPSetupData,
+                            confirmSignInEventData),
+                        actions: [action]
+                    )
+                default:
+                    return .from(.notStarted)
+                }
+            }
+
+    }
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/UserPoolSignInHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/UserPoolSignInHelper.swift
@@ -72,10 +72,7 @@ struct UserPoolSignInHelper: DefaultLogger {
         case .selectMFAType:
             return .init(nextStep: .continueSignInWithMFASelection(challenge.getAllowedMFATypesForSelection))
         case .setUpMFA:
-            throw AuthError.invalidState(
-                "Invalid state flow. setUpMFA is handled internally in `SignInState.resolvingTOTPSetup` state.",
-                AmplifyErrorMessages.shouldNotHappenReportBugToAWSWithoutLineInfo(),
-                nil)
+            throw AuthError.unknown("Invalid state flow. setUpMFA is handled internally in `SignInState.resolvingTOTPSetup` state.")
         case .unknown(let cognitoChallengeType):
             throw AuthError.unknown("Challenge not supported\(cognitoChallengeType)", nil)
         }


### PR DESCRIPTION
## Description
### TOTP PR Number # 6

Depends on: 
* #3040 
* #3041 
* #3042
* #3043 
* #3044 

Changes
* Add new states, event for TOTP
* Add the implementation of resolvers
* Add all the data models related to the new states and events

_NOTE: The unit and integration tests will fail until all changes make it to the feature branch_
(The PR is directed towards a feature branch)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
