### PR TITLE
test: timeouts, parallelization, and 4xx assertion

### DIFF
--- a/.github/workflows/integ_test_storage.yml
+++ b/.github/workflows/integ_test_storage.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   storage-integration-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/integ_test_storage.yml
+++ b/.github/workflows/integ_test_storage.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Storage/Tests/StorageHostApp/
           scheme: AWSS3StoragePluginIntegrationTests
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   storage-integration-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_storage.yml
+++ b/.github/workflows/integ_test_storage.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Storage/Tests/StorageHostApp/
           scheme: AWSS3StoragePluginIntegrationTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   storage-integration-test-tvOS:

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLMutateCombineTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLMutateCombineTests.swift
@@ -118,7 +118,7 @@ class GraphQLMutateCombineTests: OperationTestBase {
             }
         })
 
-        waitForExpectations(timeout: 0.1)
+        waitForExpectations(timeout: 1.0)
         sink.cancel()
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLMutateCombineTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLMutateCombineTests.swift
@@ -118,7 +118,7 @@ class GraphQLMutateCombineTests: OperationTestBase {
             }
         })
 
-        waitForExpectations(timeout: 0.05)
+        waitForExpectations(timeout: 0.1)
         sink.cancel()
     }
 }

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/PredictionsHostApp.xcodeproj/xcshareddata/xcschemes/AWSPredictionsPluginIntegrationTests.xcscheme
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/PredictionsHostApp.xcodeproj/xcshareddata/xcschemes/AWSPredictionsPluginIntegrationTests.xcscheme
@@ -13,8 +13,7 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "903555F729141355004B83C2"

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/PredictionsHostApp.xcodeproj/xcshareddata/xcschemes/PredictionsWatchApp.xcscheme
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/PredictionsHostApp.xcodeproj/xcshareddata/xcschemes/PredictionsWatchApp.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6875F8EF2A3CCC84001C9AAF"
+               BuildableName = "PredictionsWatchApp.app"
+               BlueprintName = "PredictionsWatchApp"
+               ReferencedContainer = "container:PredictionsHostApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6875F8EF2A3CCC84001C9AAF"
+            BuildableName = "PredictionsWatchApp.app"
+            BlueprintName = "PredictionsWatchApp"
+            ReferencedContainer = "container:PredictionsHostApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6875F8EF2A3CCC84001C9AAF"
+            BuildableName = "PredictionsWatchApp.app"
+            BlueprintName = "PredictionsWatchApp"
+            ReferencedContainer = "container:PredictionsHostApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginOptionsUsabilityTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginOptionsUsabilityTests.swift
@@ -89,10 +89,10 @@ class AWSS3StoragePluginOptionsUsabilityTests: AWSS3StoragePluginTestBase {
                 return
             }
 
-            XCTAssertEqual(response.statusCode, 403)
+            XCTAssertTrue(400..<500.contains(response.statusCode))
         }
         task2.resume()
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [urlExpired], timeout: TestCommonConstants.networkTimeout)
         
         // Remove the key
         await remove(key: key)

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginOptionsUsabilityTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginOptionsUsabilityTests.swift
@@ -89,7 +89,7 @@ class AWSS3StoragePluginOptionsUsabilityTests: AWSS3StoragePluginTestBase {
                 return
             }
 
-            XCTAssertTrue(400..<500.contains(response.statusCode))
+            XCTAssertTrue((400..<500).contains(response.statusCode))
         }
         task2.resume()
         await fulfillment(of: [urlExpired], timeout: TestCommonConstants.networkTimeout)


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
Makes a few necessary changes to tests.
- Disables test parallelization in Predictions integration tests.
- Increases timeout for `GraphQLMutateCombineTests.testMutateFails` due to watchOS timeouts.
- Asserts on 4xx for expired presigned URL instead of 403.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
