### PR TITLE
test(datastore): Subscription selectionset for primarykeys only

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSubscriptionTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSubscriptionTests.swift
@@ -161,6 +161,38 @@ class GraphQLSubscriptionTests: XCTestCase {
         XCTAssertNil(document.variables)
     }
 
+    func testOnCreateGraphQLSubscriptionWithPrimaryKeyOnly() {
+
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Comment.schema,
+                                                               operationType: .subscription,
+                                                               primaryKeysOnly: true)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .onCreate))
+        documentBuilder.add(decorator: ConflictResolutionDecorator(graphQLType: .subscription,
+                                                                   primaryKeysOnly: true))
+        let document = documentBuilder.build()
+        let expectedQueryDocument = """
+        subscription OnCreateComment {
+          onCreateComment {
+            id
+            content
+            createdAt
+            post {
+              id
+              __typename
+              _deleted
+            }
+            __typename
+            _version
+            _deleted
+            _lastChangedAt
+          }
+        }
+        """
+        XCTAssertEqual(document.name, "onCreateComment")
+        XCTAssertEqual(document.stringValue, expectedQueryDocument)
+        XCTAssertNil(document.variables)
+    }
+
     /// - Given: a `Model` type
     /// - When:
     ///   - the model has no eager loaded associations


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
Adds test for the logic in this PR - https://github.com/aws-amplify/amplify-swift/pull/3016

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
