### PR TITLE
feat(Auth): Enable tests for watchOS and tvOS

### DIFF
--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
@@ -31,6 +31,11 @@
 		48916F382A412B2800E3E1B1 /* TOTPSetupWhenAuthenticatedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48916F372A412B2800E3E1B1 /* TOTPSetupWhenAuthenticatedTests.swift */; };
 		48916F3A2A412CEE00E3E1B1 /* TOTPHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48916F392A412CEE00E3E1B1 /* TOTPHelper.swift */; };
 		48916F3C2A42333E00E3E1B1 /* MFAPreferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48916F3B2A42333E00E3E1B1 /* MFAPreferenceTests.swift */; };
+		48BCE8922A5456460012C3CD /* TOTPSetupWhenAuthenticatedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48916F372A412B2800E3E1B1 /* TOTPSetupWhenAuthenticatedTests.swift */; };
+		48BCE8932A54564C0012C3CD /* TOTPSetupWhenUnauthenticatedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 483B0D332A42BB1400A1196B /* TOTPSetupWhenUnauthenticatedTests.swift */; };
+		48BCE8942A54564C0012C3CD /* MFASignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48599D492A429893009DE21C /* MFASignInTests.swift */; };
+		48BCE8952A54564C0012C3CD /* MFAPreferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48916F3B2A42333E00E3E1B1 /* MFAPreferenceTests.swift */; };
+		48BCE8962A5456600012C3CD /* TOTPHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48916F392A412CEE00E3E1B1 /* TOTPHelper.swift */; };
 		48E3AB3128E52590004EE395 /* GetCurrentUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48E3AB3028E52590004EE395 /* GetCurrentUserTests.swift */; };
 		681B76952A3CB8DA004B59D9 /* AuthHostAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB53D27B614CE006CCEC7 /* AuthHostAppApp.swift */; };
 		681B76962A3CB8DD004B59D9 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB53F27B614CE006CCEC7 /* ContentView.swift */; };
@@ -750,8 +755,12 @@
 				681B76A72A3CBBAE004B59D9 /* AuthConfirmSignUpTests.swift in Sources */,
 				681B76A82A3CBBAE004B59D9 /* AuthSignOutTests.swift in Sources */,
 				681B76A92A3CBBAE004B59D9 /* AuthFetchDeviceTests.swift in Sources */,
+				48BCE8922A5456460012C3CD /* TOTPSetupWhenAuthenticatedTests.swift in Sources */,
+				48BCE8962A5456600012C3CD /* TOTPHelper.swift in Sources */,
 				681B76AA2A3CBBAE004B59D9 /* AsyncExpectation.swift in Sources */,
+				48BCE8932A54564C0012C3CD /* TOTPSetupWhenUnauthenticatedTests.swift in Sources */,
 				681B76AB2A3CBBAE004B59D9 /* GetCurrentUserTests.swift in Sources */,
+				48BCE8952A54564C0012C3CD /* MFAPreferenceTests.swift in Sources */,
 				681B76AC2A3CBBAE004B59D9 /* AWSAuthBaseTest.swift in Sources */,
 				681B76AD2A3CBBAE004B59D9 /* SignedOutAuthSessionTests.swift in Sources */,
 				681B76AE2A3CBBAE004B59D9 /* AuthSignInHelper.swift in Sources */,
@@ -768,6 +777,7 @@
 				681B76B92A3CBBAE004B59D9 /* SignedInAuthSessionTests.swift in Sources */,
 				681B76BA2A3CBBAE004B59D9 /* AuthSignUpTests.swift in Sources */,
 				681B76BB2A3CBBAE004B59D9 /* AuthConfirmResetPasswordTests.swift in Sources */,
+				48BCE8942A54564C0012C3CD /* MFASignInTests.swift in Sources */,
 				681B76BC2A3CBBAE004B59D9 /* AuthDeleteUserTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/xcshareddata/xcschemes/AuthIntegrationTests.xcscheme
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/xcshareddata/xcschemes/AuthIntegrationTests.xcscheme
@@ -12,8 +12,7 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       enableThreadSanitizer = "YES"
-      codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      codeCoverageEnabled = "YES">
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/xcshareddata/xcschemes/AuthIntegrationTests.xcscheme
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/xcshareddata/xcschemes/AuthIntegrationTests.xcscheme
@@ -11,7 +11,18 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      enableThreadSanitizer = "YES">
+      enableThreadSanitizer = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AWSCognitoAuthPlugin"
+            BuildableName = "AWSCognitoAuthPlugin"
+            BlueprintName = "AWSCognitoAuthPlugin"
+            ReferencedContainer = "container:../../../..">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -22,20 +33,6 @@
                BlueprintName = "AuthIntegrationTests"
                ReferencedContainer = "container:AuthHostApp.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "AuthCustomSignInTests/testRuntimeAuthFlowSwitch()">
-               </Test>
-               <Test
-                  Identifier = "AuthCustomSignInTests/testSuccessfulSignInWithCustomAuth()">
-               </Test>
-               <Test
-                  Identifier = "AuthCustomSignInTests/testSuccessfulSignInWithCustomAuthSRP()">
-               </Test>
-               <Test
-                  Identifier = "AuthSRPSignInTests/testNewPasswordRequired()">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/xcshareddata/xcschemes/AuthIntegrationTestsWatch.xcscheme
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/xcshareddata/xcschemes/AuthIntegrationTestsWatch.xcscheme
@@ -11,7 +11,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      enableThreadSanitizer = "YES">
+      enableThreadSanitizer = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/xcshareddata/xcschemes/AuthIntegrationTestsWatch.xcscheme
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/xcshareddata/xcschemes/AuthIntegrationTestsWatch.xcscheme
@@ -23,20 +23,6 @@
                BlueprintName = "AuthIntegrationTestsWatch"
                ReferencedContainer = "container:AuthHostApp.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "AuthCustomSignInTests/testRuntimeAuthFlowSwitch()">
-               </Test>
-               <Test
-                  Identifier = "AuthCustomSignInTests/testSuccessfulSignInWithCustomAuth()">
-               </Test>
-               <Test
-                  Identifier = "AuthCustomSignInTests/testSuccessfulSignInWithCustomAuthSRP()">
-               </Test>
-               <Test
-                  Identifier = "AuthSRPSignInTests/testNewPasswordRequired()">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/xcshareddata/xcschemes/AuthWatchApp.xcscheme
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/xcshareddata/xcschemes/AuthWatchApp.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
-   version = "1.3">
+   LastUpgradeVersion = "1430"
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "485CB53927B614CE006CCEC7"
-               BuildableName = "AuthHostApp.app"
-               BlueprintName = "AuthHostApp"
+               BlueprintIdentifier = "681B767F2A3CB86B004B59D9"
+               BuildableName = "AuthWatchApp.app"
+               BlueprintName = "AuthWatchApp"
                ReferencedContainer = "container:AuthHostApp.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -27,40 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES">
-      <CodeCoverageTargets>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "AWSCognitoAuthPlugin"
-            BuildableName = "AWSCognitoAuthPlugin"
-            BlueprintName = "AWSCognitoAuthPlugin"
-            ReferencedContainer = "container:../../../..">
-         </BuildableReference>
-      </CodeCoverageTargets>
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "485CB59E27B61E04006CCEC7"
-               BuildableName = "AuthIntegrationTests.xctest"
-               BlueprintName = "AuthIntegrationTests"
-               ReferencedContainer = "container:AuthHostApp.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "97914B2629550988002000EA"
-               BuildableName = "AuthStressTests.xctest"
-               BlueprintName = "AuthStressTests"
-               ReferencedContainer = "container:AuthHostApp.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
+      shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -76,9 +43,9 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "485CB53927B614CE006CCEC7"
-            BuildableName = "AuthHostApp.app"
-            BlueprintName = "AuthHostApp"
+            BlueprintIdentifier = "681B767F2A3CB86B004B59D9"
+            BuildableName = "AuthWatchApp.app"
+            BlueprintName = "AuthWatchApp"
             ReferencedContainer = "container:AuthHostApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -93,9 +60,9 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "485CB53927B614CE006CCEC7"
-            BuildableName = "AuthHostApp.app"
-            BlueprintName = "AuthHostApp"
+            BlueprintIdentifier = "681B767F2A3CB86B004B59D9"
+            BuildableName = "AuthWatchApp.app"
+            BlueprintName = "AuthWatchApp"
             ReferencedContainer = "container:AuthHostApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignInTests/AuthCustomSignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignInTests/AuthCustomSignInTests.swift
@@ -53,6 +53,7 @@ class AuthCustomSignInTests: AWSAuthBaseTest {
     ///     }
     ///
     func testSuccessfulSignInWithCustomAuthSRP() async throws {
+        throw XCTSkip("TODO: fix this test. Need custom resource")
 
         let username = "integTest\(UUID().uuidString)"
         let password = "P123@\(UUID().uuidString)"
@@ -114,6 +115,7 @@ class AuthCustomSignInTests: AWSAuthBaseTest {
     ///     }
     ///
     func testRuntimeAuthFlowSwitch() async throws {
+        throw XCTSkip("TODO: fix this test. Need custom resource")
 
         let username = "integTest\(UUID().uuidString)"
         let password = "P123@\(UUID().uuidString)"
@@ -180,6 +182,7 @@ class AuthCustomSignInTests: AWSAuthBaseTest {
     ///        return event;
     ///    };
     func testSuccessfulSignInWithCustomAuth() async throws {
+        throw XCTSkip("TODO: fix this test. Need custom resource")
 
         let username = "integTest\(UUID().uuidString)"
         let password = "P123@\(UUID().uuidString)"

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignInTests/AuthSRPSignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignInTests/AuthSRPSignInTests.swift
@@ -233,7 +233,8 @@ class AuthSRPSignInTests: AWSAuthBaseTest {
     ///         Make sure that you do not enter email and phone number, so that adding a new attribute could also be tested
     ///
     ///   DISABLED TEST, because it needs special setup
-    func testNewPasswordRequired() async {
+    func testNewPasswordRequired() async throws {
+        throw XCTSkip("TODO: fix this test. Need custom resource")
 
         let username = "YOUR USERNAME CREATED IN COGNITO FOR TESTING TEMP PASSWORD FLOW"
         let tempPassword = "YOUR TEMP PASSWORD THAT WAS SET"


### PR DESCRIPTION
## Description
Enabled TOTP tests on watchOS and tvOS.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
