### PR TITLE
feat(Auth): Removed deviceNotFound TODO which is not applicable for TOTP

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/InitiateAuthDeviceSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/InitiateAuthDeviceSRP.swift
@@ -85,23 +85,12 @@ struct InitiateAuthDeviceSRP: Action {
     func parseResponse(
         _ response: SignInResponseBehavior,
         with stateData: SRPStateData) -> StateMachineEvent {
-
-
-            //HS: TODO: Combine this logic with responedToAuthChallenge
-            if let challengeName = response.challengeName {
-                switch challengeName {
-                case .devicePasswordVerifier:
-                    return SignInEvent(eventType: .respondDevicePasswordVerifier(stateData, response))
-                default:
-                    let message = "Unsupported challenge response during DeviceSRPAuth \(challengeName)"
-                    let error = SignInError.unknown(message: message)
-                    return SignInEvent(eventType: .throwAuthError(error))
-                }
-            } else {
-                let message = "Response did not contain challenge info"
-                let error = SignInError.invalidServiceResponse(message: message)
+            guard case .devicePasswordVerifier = response.challengeName else {
+                let message = "Unsupported challenge response during DeviceSRPAuth \(response.challengeName ?? .sdkUnknown("Response did not contain challenge info"))"
+                let error = SignInError.unknown(message: message)
                 return SignInEvent(eventType: .throwAuthError(error))
             }
+            return SignInEvent(eventType: .respondDevicePasswordVerifier(stateData, response))
         }
 
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SoftwareTokenSetup/CompleteTOTPSetup.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SoftwareTokenSetup/CompleteTOTPSetup.swift
@@ -81,16 +81,7 @@ struct CompleteTOTPSetup: Action {
             logVerbose("\(#fileID) Sending event \(responseEvent)",
                        environment: environment)
             await dispatcher.send(responseEvent)
-            // TODO: HS:
-            //        } catch let error where deviceNotFound(error: error, deviceMetadata: deviceMetadata) {
-            //            logVerbose("\(#fileID) Received device not found \(error)", environment: environment)
-            //            // Remove the saved device details and retry verify challenge
-            //            await DeviceMetadataHelper.removeDeviceMetaData(for: username, with: environment)
-            //            let event = SignInChallengeEvent(
-            //                eventType: .retryVerifyChallengeAnswer(confirmSignEventData)
-            //            )
-            //            logVerbose("\(#fileID) Sending event \(event)", environment: environment)
-            //            await dispatcher.send(event)
+
         } catch let error as SignInError {
             logError(error.authError.errorDescription, environment: environment)
             let errorEvent = SignInEvent(eventType: .throwAuthError(error))
@@ -106,21 +97,6 @@ struct CompleteTOTPSetup: Action {
             await dispatcher.send(errorEvent)
         }
     }
-
-// TODO: HS: Figure out if this is needed
-//    func deviceNotFound(error: Error, deviceMetadata: DeviceMetadata) -> Bool {
-//
-//        // If deviceMetadata was not send, the error returned is not from device not found.
-//        if case .noData = deviceMetadata {
-//            return false
-//        }
-//
-//        if let serviceError: RespondToAuthChallengeOutputError = error.internalAWSServiceError(),
-//           case .resourceNotFoundException = serviceError {
-//            return true
-//        }
-//        return false
-//    }
 
 }
 


### PR DESCRIPTION
## Description
Removed the TODO's pending for TOTP. 
 * Validated that deviceNotFound use case is not valid when setting up TOTP during sign in.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
