### PR TITLE
fix(logging): handle write and flush errors

### DIFF
--- a/Amplify/Categories/Logging/Internal/LoggingCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Logging/Internal/LoggingCategory+CategoryConfigurable.swift
@@ -28,7 +28,7 @@ extension LoggingCategory: CategoryConfigurable {
         try plugin.configure(using: configuration?.plugins[plugin.key])
         self.plugins[plugin.key] = plugin
         
-        if let consolePlugin = try? self.getPlugin(for: AWSUnifiedLoggingPlugin.key) {
+        if plugin.key != AWSUnifiedLoggingPlugin.key, let consolePlugin = try? self.getPlugin(for: AWSUnifiedLoggingPlugin.key) {
             try consolePlugin.configure(using: configuration?.plugins[consolePlugin.key])
         }
         

--- a/Amplify/Categories/Logging/Internal/LoggingCategory+CategoryConfigurable.swift
+++ b/Amplify/Categories/Logging/Internal/LoggingCategory+CategoryConfigurable.swift
@@ -27,6 +27,11 @@ extension LoggingCategory: CategoryConfigurable {
 
         try plugin.configure(using: configuration?.plugins[plugin.key])
         self.plugins[plugin.key] = plugin
+        
+        if let consolePlugin = try? self.getPlugin(for: AWSUnifiedLoggingPlugin.key) {
+            try consolePlugin.configure(using: configuration?.plugins[consolePlugin.key])
+        }
+        
         configurationState = .configured
     }
 

--- a/Amplify/Categories/Logging/LoggingCategory+HubPayloadEventName.swift
+++ b/Amplify/Categories/Logging/LoggingCategory+HubPayloadEventName.swift
@@ -6,7 +6,7 @@
 //
 
 public extension HubPayload.EventName {
-    /// Analytics hub events
+    /// Logging hub events
     struct Logging { }
 }
 

--- a/Amplify/Categories/Logging/LoggingCategory+HubPayloadEventName.swift
+++ b/Amplify/Categories/Logging/LoggingCategory+HubPayloadEventName.swift
@@ -1,0 +1,16 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+public extension HubPayload.EventName {
+    /// Analytics hub events
+    struct Logging { }
+}
+
+public extension HubPayload.EventName.Logging {
+    static let writeLogFailure = "Logging.writeLogFailure"
+    static let flushLogFailure = "Logging.writeLogFailure"
+}

--- a/Amplify/Categories/Logging/LoggingCategory+HubPayloadEventName.swift
+++ b/Amplify/Categories/Logging/LoggingCategory+HubPayloadEventName.swift
@@ -12,5 +12,5 @@ public extension HubPayload.EventName {
 
 public extension HubPayload.EventName.Logging {
     static let writeLogFailure = "Logging.writeLogFailure"
-    static let flushLogFailure = "Logging.writeLogFailure"
+    static let flushLogFailure = "Logging.flushLogFailure"
 }

--- a/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/AWSUnifiedLoggingPlugin.swift
+++ b/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/AWSUnifiedLoggingPlugin.swift
@@ -28,6 +28,7 @@ final public class AWSUnifiedLoggingPlugin: LoggingCategoryPlugin {
 
     let subsystem: String
     var enabled: Bool = true
+    private let lock = NSLock()
     
     /// Initializes the logging system with a default log, and immediately registers a default logger
     public init() {
@@ -104,15 +105,19 @@ extension AWSUnifiedLoggingPlugin {
     
     public func enable() {
         enabled = true
-        for (_, logger) in registeredLogs {
-            logger.enabled = enabled
+        lock.execute {
+            for (_, logger) in registeredLogs {
+                logger.enabled = enabled
+            }
         }
     }
     
     public func disable() {
         enabled = false
-        for (_, logger) in registeredLogs {
-            logger.enabled = enabled
+        lock.execute {
+            for (_, logger) in registeredLogs {
+                logger.enabled = enabled
+            }
         }
     }
     

--- a/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/AWSUnifiedLoggingPlugin.swift
+++ b/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/AWSUnifiedLoggingPlugin.swift
@@ -27,7 +27,8 @@ final public class AWSUnifiedLoggingPlugin: LoggingCategoryPlugin {
     private var registeredLogs = [String: OSLogWrapper]()
 
     let subsystem: String
-
+    var enabled: Bool = true
+    
     /// Initializes the logging system with a default log, and immediately registers a default logger
     public init() {
         self.subsystem = Bundle.main.bundleIdentifier ?? "com.amazonaws.amplify.AWSUnifiedLoggingPlugin"
@@ -72,6 +73,7 @@ final public class AWSUnifiedLoggingPlugin: LoggingCategoryPlugin {
             let osLog = OSLog(subsystem: subsystem, category: category)
             let wrapper = OSLogWrapper(osLog: osLog,
                                        getLogLevel: { Amplify.Logging.logLevel })
+            wrapper.enabled = enabled
             registeredLogs[key] = wrapper
             return wrapper
         }
@@ -101,14 +103,16 @@ extension AWSUnifiedLoggingPlugin {
     }
     
     public func enable() {
+        enabled = true
         for (_, logger) in registeredLogs {
-            logger.enabled = true
+            logger.enabled = enabled
         }
     }
     
     public func disable() {
+        enabled = false
         for (_, logger) in registeredLogs {
-            logger.enabled = false
+            logger.enabled = enabled
         }
     }
     

--- a/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/Internal/ConsoleLoggingConfiguration.swift
+++ b/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/Internal/ConsoleLoggingConfiguration.swift
@@ -55,10 +55,11 @@ extension ConsoleLoggingConfiguration {
     static func decodeConfiguration(from data: Data) throws -> ConsoleLoggingConfiguration? {
         do {
             if let configuration = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-               let configurationJson = configuration["consoleLoggingPlugin"] as? String
+               let configurationJson = configuration["consoleLoggingPlugin"] as? [String: Any]
             {
                 let decoder = JSONDecoder()
-                let consoleLoggingConfiguration = try decoder.decode(ConsoleLoggingConfiguration.self, from: Data(configurationJson.utf8))
+                let data = try JSONSerialization.data(withJSONObject: configurationJson)
+                let consoleLoggingConfiguration = try decoder.decode(ConsoleLoggingConfiguration.self, from: data)
                 return consoleLoggingConfiguration
             }
         } catch {

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
@@ -130,7 +130,10 @@ final class AWSCloudWatchLoggingSessionController {
                 do {
                     try await consumer.consume(batch: batch)
                 } catch {
-                    print(error)
+                    Amplify.Logging.default.error("Error flushing logs with error \(error.localizedDescription)")
+                    let payload = HubPayload(eventName: HubPayload.EventName.Logging.flushLogFailure, context: error.localizedDescription)
+                    Amplify.Hub.dispatch(to: HubChannel.logging, payload: payload)
+                    try batch.complete()
                 }
             }
         }

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Persistence/LogFile.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Persistence/LogFile.swift
@@ -10,12 +10,6 @@ import Foundation
 /// Represents an individual log file on disk used as part of a
 /// LogRotation
 final class LogFile {
-    
-    /// Error types owned by the LogFile class.
-    enum IOError: Error {
-        case spaceExceeded(data: Data, sizeLimitInBytes: UInt64)
-    }
-    
     let fileURL: URL
     let sizeLimitInBytes: UInt64
     
@@ -48,7 +42,11 @@ final class LogFile {
     
     /// Returns the number of bytes available in the underlying file.
     var available: UInt64 {
-        return sizeLimitInBytes - count
+        if sizeLimitInBytes > count {
+            return sizeLimitInBytes - count
+        } else {
+            return 0
+        }
     }
     
     /// Attempts to close the underlying log file.
@@ -68,11 +66,7 @@ final class LogFile {
     
     /// Writes the given **single line of text** represented as a
     /// Data  to the underlying log file.
-    func write(data: Data) throws {
-        if !hasSpace(for: data) {
-            throw IOError.spaceExceeded(data: data, sizeLimitInBytes: sizeLimitInBytes)
-        }
-        
+    func write(data: Data) throws {        
         if #available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *) {
             try self.handle.write(contentsOf: data)
         } else {

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Producer/RotatingLogger.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Producer/RotatingLogger.swift
@@ -67,7 +67,15 @@ final class RotatingLogger {
     private func _record(level: LogLevel, message: @autoclosure () -> String) {
         let payload = message()
         Task {
-            try await self.record(level: level, message:payload)
+            do {
+                try await self.record(level: level, message:payload)
+            } catch {
+                let payload = HubPayload(
+                    eventName: HubPayload.EventName.Logging.writeLogFailure,
+                    context: error.localizedDescription,
+                    data: payload)
+                Amplify.Hub.dispatch(to: HubChannel.logging, payload: payload)
+            }
         }
     }
 }

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingSessionControllerTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingSessionControllerTests.swift
@@ -20,17 +20,17 @@ final class AWSCloudWatchLoggingSessionControllerTests: XCTestCase {
     let mockCloudWatchLogClient = MockCloudWatchLogsClient()
     let mockLoggingNetworkMonitor = MockLoggingNetworkMonitor()
     let category = "amplifytest"
-    
+
     override func tearDown() async throws {
         systemUnderTest = nil
         let file = getLogFile()
         do {
             try FileManager.default.removeItem(atPath: file.path)
         } catch {
-            
+
         }
     }
-    
+
     /// Given: an AWSCloudWatchLoggingSessionController
     /// When: a flush log is called and fails to flush logs
     /// Then: a flushLogFailure Hub Event is sent to the Logging channel
@@ -44,19 +44,30 @@ final class AWSCloudWatchLoggingSessionControllerTests: XCTestCase {
                 break
             }
         }
-        
+
         let bytes = (0..<1024).map { _ in UInt8.random(in: 0..<255) }
         let fileURL = getLogFile()
         FileManager.default.createFile(atPath: fileURL.path,
                                        contents: Data(bytes),
                                        attributes: [FileAttributeKey: Any]())
-        systemUnderTest = AWSCloudWatchLoggingSessionController(credentialsProvider: mockCredentialProvider, authentication: mockAuth, logFilter: mockLoggingFilter, category: category, namespace: nil, logLevel: .error, logGroupName: "logGroupName", region: "us-east-1", localStoreMaxSizeInMB: 1, userIdentifier: nil, networkMonitor: mockLoggingNetworkMonitor)
+        systemUnderTest = AWSCloudWatchLoggingSessionController(
+            credentialsProvider: mockCredentialProvider,
+            authentication: mockAuth,
+            logFilter: mockLoggingFilter,
+            category: category,
+            namespace: nil,
+            logLevel: .error,
+            logGroupName: "logGroupName",
+            region: "us-east-1",
+            localStoreMaxSizeInMB: 1,
+            userIdentifier: nil,
+            networkMonitor: mockLoggingNetworkMonitor)
         systemUnderTest.client = mockCloudWatchLogClient
         systemUnderTest.enable()
         try await systemUnderTest.flushLogs()
         await fulfillment(of: [hubEventExpectation], timeout: 2)
     }
-    
+
     private func getLogFile() -> URL {
         let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
         return documents.appendingPathComponent("amplify")
@@ -71,7 +82,7 @@ class MockLoggingFilter: AWSCloudWatchLoggingFilterBehavior {
     func canLog(withCategory category: String, logLevel: LogLevel, userIdentifier: String?) -> Bool {
         return true
     }
-    
+
     func getDefaultLogLevel(forCategory category: String, userIdentifier: String?) -> LogLevel {
         return .verbose
     }

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingSessionControllerTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingSessionControllerTests.swift
@@ -1,0 +1,84 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AWSCloudWatchLoggingPlugin
+
+import XCTest
+import Amplify
+import Network
+@testable import AmplifyTestCommon
+
+final class AWSCloudWatchLoggingSessionControllerTests: XCTestCase {
+    var systemUnderTest: AWSCloudWatchLoggingSessionController!
+    let mockCredentialProvider = MockCredentialsProvider()
+    let mockAuth = MockAuthCategoryPlugin()
+    let mockLoggingFilter = MockLoggingFilter()
+    let mockCloudWatchLogClient = MockCloudWatchLogsClient()
+    let mockLoggingNetworkMonitor = MockLoggingNetworkMonitor()
+    let category = "amplifytest"
+    
+    override func tearDown() async throws {
+        systemUnderTest = nil
+        let file = getLogFile()
+        do {
+            try FileManager.default.removeItem(atPath: file.path)
+        } catch {
+            
+        }
+    }
+    
+    /// Given: an AWSCloudWatchLoggingSessionController
+    /// When: a flush log is called and fails to flush logs
+    /// Then: a flushLogFailure Hub Event is sent to the Logging channel
+    func testConsumeFailureSendsHubEvent() async throws {
+        let hubEventExpectation = expectation(description: "Should receive the hub event")
+        _ = Amplify.Hub.listen(to: .logging) { payload in
+            switch payload.eventName {
+            case HubPayload.EventName.Logging.flushLogFailure:
+                hubEventExpectation.fulfill()
+            default:
+                break
+            }
+        }
+        
+        let bytes = (0..<1024).map { _ in UInt8.random(in: 0..<255) }
+        let fileURL = getLogFile()
+        FileManager.default.createFile(atPath: fileURL.path,
+                                       contents: Data(bytes),
+                                       attributes: [FileAttributeKey: Any]())
+        systemUnderTest = AWSCloudWatchLoggingSessionController(credentialsProvider: mockCredentialProvider, authentication: mockAuth, logFilter: mockLoggingFilter, category: category, namespace: nil, logLevel: .error, logGroupName: "logGroupName", region: "us-east-1", localStoreMaxSizeInMB: 1, userIdentifier: nil, networkMonitor: mockLoggingNetworkMonitor)
+        systemUnderTest.client = mockCloudWatchLogClient
+        systemUnderTest.enable()
+        try await systemUnderTest.flushLogs()
+        await fulfillment(of: [hubEventExpectation], timeout: 2)
+    }
+    
+    private func getLogFile() -> URL {
+        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        return documents.appendingPathComponent("amplify")
+                                 .appendingPathComponent("logging")
+                                 .appendingPathComponent("guest")
+                                 .appendingPathComponent(category)
+                                 .appendingPathComponent("amplify.0.log")
+    }
+}
+
+class MockLoggingFilter: AWSCloudWatchLoggingFilterBehavior {
+    func canLog(withCategory category: String, logLevel: LogLevel, userIdentifier: String?) -> Bool {
+        return true
+    }
+    
+    func getDefaultLogLevel(forCategory category: String, userIdentifier: String?) -> LogLevel {
+        return .verbose
+    }
+}
+
+class MockLoggingNetworkMonitor: LoggingNetworkMonitor {
+    var isOnline: Bool = true
+    func startMonitoring(using queue: DispatchQueue) {}
+    func stopMonitoring() {}
+}

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogFileTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogFileTests.swift
@@ -58,13 +58,13 @@ final class LogFileTests: XCTestCase {
     
     /// Given: a data is written
     /// When: there is not enough space to write
-    /// Then: the log file throws errror
-    func testLogFileWriteBeyondSpaceLimitThrowsError() throws {
-        let bytes = (0..<sizeLimitInBytes).map { _ in UInt8.random(in: 0..<255) }
+    /// Then: the log writes data
+    func testLogFileWritesBeyondSpaceLimit() throws {
+        let bytes = (0..<sizeLimitInBytes*2).map { _ in UInt8.random(in: 0..<255) }
         let data = Data(bytes)
         
         let availableBeforeWrite = systemUnderTest.hasSpace(for: data)
-        XCTAssertTrue(availableBeforeWrite)
+        XCTAssertFalse(availableBeforeWrite)
         
         try systemUnderTest.write(data: data)
 
@@ -75,17 +75,5 @@ final class LogFileTests: XCTestCase {
         
         let contents = FileManager.default.contents(atPath: fileURL.path)
         XCTAssertEqual(contents, data)
-        
-        do {
-            try systemUnderTest.write(data: data)
-            XCTFail("Expecting failure")
-        } catch {
-            XCTAssertNotNil(error)
-        }
-        
-        // Not partial writes allowed
-        let contentsAfterFailure = FileManager.default.contents(atPath: fileURL.path)
-        XCTAssertEqual(contentsAfterFailure, data)
     }
-    
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
Fix the following logger issue:
* fix issue with disabling the console logger via json configuration file
* add Logging Hub events to handle cases where logging fails to write or flush log events
* remove check that prevents persisting of log messages larger than the log file size and allow logs to persist.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
