### PR TITLE
fix(datastore): cancel storage engine subscription if exist

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin.swift
@@ -51,6 +51,9 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
             return nil
         }
         set {
+            if let cancellable = iStorageEngineSink as? AnyCancellable {
+                cancellable.cancel()
+            }
             iStorageEngineSink = newValue
         }
     }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

As mentioned in problem report #3021, a potential issue exists during the restart of the datastore plugin where previous subscriptions might not be appropriately terminated. This patch addresses and resolves the issue.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
