### PR TITLE
fix(logging): delete logs when user identifier changes

### DIFF
--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
@@ -140,7 +140,7 @@ final class AWSCloudWatchLoggingSessionController {
     }
     
     private func userIdentifierDidChange() {
-        flushCurrentLogs()
+        resetCurrentLogs()
         updateSession()
         updateConsumer()
         connectProducerAndConsumer()
@@ -167,10 +167,10 @@ final class AWSCloudWatchLoggingSessionController {
         try await session?.logger.flushLogs()
     }
     
-    private func flushCurrentLogs() {
+    private func resetCurrentLogs() {
         Task {
             do {
-                try await flushLogs()
+                try await session?.logger.resetLogs()
             } catch {
                 Amplify.Logging.error("Error resetting logs with \(error)")
             }

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
@@ -140,6 +140,7 @@ final class AWSCloudWatchLoggingSessionController {
     }
     
     private func userIdentifierDidChange() {
+        flushCurrentLogs()
         updateSession()
         updateConsumer()
         connectProducerAndConsumer()
@@ -164,6 +165,16 @@ final class AWSCloudWatchLoggingSessionController {
     
     func flushLogs() async throws {
         try await session?.logger.flushLogs()
+    }
+    
+    private func flushCurrentLogs() {
+        Task {
+            do {
+                try await flushLogs()
+            } catch {
+                Amplify.Logging.error("Error resetting logs with \(error)")
+            }
+        }
     }
 }
 

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Persistence/LogActor.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Persistence/LogActor.swift
@@ -56,4 +56,9 @@ actor LogActor {
             rotationSubject.send(log)
         }
     }
+    
+    func deleteLogs() throws {
+        try rotation.reset()
+        try rotation.currentLogFile.synchronize()
+    }
 }

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Persistence/LogActor.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Persistence/LogActor.swift
@@ -59,6 +59,6 @@ actor LogActor {
     
     func deleteLogs() throws {
         try rotation.reset()
-        try rotation.currentLogFile.synchronize()
+        try synchronize()
     }
 }

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Producer/RotatingLogger.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Producer/RotatingLogger.swift
@@ -48,6 +48,10 @@ final class RotatingLogger {
         try await actor.flushLogs()
     }
     
+    func resetLogs() async throws {
+        try await actor.deleteLogs()
+    }
+    
     func record(level: LogLevel, message: @autoclosure () -> String) async throws {
         try await setupSubscription()
         let entry = LogEntry(category: self.category, namespace: self.namespace, level: level, message: message())

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingSessionControllerTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingSessionControllerTests.swift
@@ -20,9 +20,13 @@ final class AWSCloudWatchLoggingSessionControllerTests: XCTestCase {
     let mockCloudWatchLogClient = MockCloudWatchLogsClient()
     let mockLoggingNetworkMonitor = MockLoggingNetworkMonitor()
     let category = "amplifytest"
+    var unsubscribeToken: UnsubscribeToken?
 
     override func tearDown() async throws {
         systemUnderTest = nil
+        if let token = unsubscribeToken {
+            Amplify.Hub.removeListener(token)
+        }
         let file = getLogFile()
         do {
             try FileManager.default.removeItem(atPath: file.path)
@@ -36,7 +40,7 @@ final class AWSCloudWatchLoggingSessionControllerTests: XCTestCase {
     /// Then: a flushLogFailure Hub Event is sent to the Logging channel
     func testConsumeFailureSendsHubEvent() async throws {
         let hubEventExpectation = expectation(description: "Should receive the hub event")
-        _ = Amplify.Hub.listen(to: .logging) { payload in
+        unsubscribeToken = Amplify.Hub.listen(to: .logging) { payload in
             switch payload.eventName {
             case HubPayload.EventName.Logging.flushLogFailure:
                 hubEventExpectation.fulfill()
@@ -66,6 +70,43 @@ final class AWSCloudWatchLoggingSessionControllerTests: XCTestCase {
         systemUnderTest.enable()
         try await systemUnderTest.flushLogs()
         await fulfillment(of: [hubEventExpectation], timeout: 2)
+    }
+    
+    /// Given: an AWSCloudWatchLoggingSessionController
+    /// When: the user identifier is changed
+    /// Then: a flush log is called and fails with a flushLogFailure hub event
+    func testResetLogsWhenIdentifierChanges() async throws {
+        let hubEventExpectation = expectation(description: "should receive flush failure event")
+        unsubscribeToken = Amplify.Hub.listen(to: .logging) { payload in
+            switch payload.eventName {
+            case HubPayload.EventName.Logging.flushLogFailure:
+                hubEventExpectation.fulfill()
+            default:
+                break
+            }
+        }
+
+        let bytes = (0..<1024).map { _ in UInt8.random(in: 0..<255) }
+        let fileURL = getLogFile()
+        FileManager.default.createFile(atPath: fileURL.path,
+                                       contents: Data(bytes),
+                                       attributes: [FileAttributeKey: Any]())
+        systemUnderTest = AWSCloudWatchLoggingSessionController(
+            credentialsProvider: mockCredentialProvider,
+            authentication: mockAuth,
+            logFilter: mockLoggingFilter,
+            category: category,
+            namespace: nil,
+            logLevel: .error,
+            logGroupName: "logGroupName",
+            region: "us-east-1",
+            localStoreMaxSizeInMB: 1,
+            userIdentifier: nil,
+            networkMonitor: mockLoggingNetworkMonitor)
+        systemUnderTest.client = mockCloudWatchLogClient
+        systemUnderTest.enable()
+        systemUnderTest.setCurrentUser(identifier: "123")
+        await fulfillment(of: [hubEventExpectation], timeout: 5)
     }
 
     private func getLogFile() -> URL {

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingSessionControllerTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingSessionControllerTests.swift
@@ -71,43 +71,6 @@ final class AWSCloudWatchLoggingSessionControllerTests: XCTestCase {
         try await systemUnderTest.flushLogs()
         await fulfillment(of: [hubEventExpectation], timeout: 2)
     }
-    
-    /// Given: an AWSCloudWatchLoggingSessionController
-    /// When: the user identifier is changed
-    /// Then: a flush log is called and fails with a flushLogFailure hub event
-    func testResetLogsWhenIdentifierChanges() async throws {
-        let hubEventExpectation = expectation(description: "should receive flush failure event")
-        unsubscribeToken = Amplify.Hub.listen(to: .logging) { payload in
-            switch payload.eventName {
-            case HubPayload.EventName.Logging.flushLogFailure:
-                hubEventExpectation.fulfill()
-            default:
-                break
-            }
-        }
-
-        let bytes = (0..<1024).map { _ in UInt8.random(in: 0..<255) }
-        let fileURL = getLogFile()
-        FileManager.default.createFile(atPath: fileURL.path,
-                                       contents: Data(bytes),
-                                       attributes: [FileAttributeKey: Any]())
-        systemUnderTest = AWSCloudWatchLoggingSessionController(
-            credentialsProvider: mockCredentialProvider,
-            authentication: mockAuth,
-            logFilter: mockLoggingFilter,
-            category: category,
-            namespace: nil,
-            logLevel: .error,
-            logGroupName: "logGroupName",
-            region: "us-east-1",
-            localStoreMaxSizeInMB: 1,
-            userIdentifier: nil,
-            networkMonitor: mockLoggingNetworkMonitor)
-        systemUnderTest.client = mockCloudWatchLogClient
-        systemUnderTest.enable()
-        systemUnderTest.setCurrentUser(identifier: "123")
-        await fulfillment(of: [hubEventExpectation], timeout: 5)
-    }
 
     private func getLogFile() -> URL {
         let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogActorTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogActorTests.swift
@@ -90,4 +90,23 @@ final class LogActorTests: XCTestCase {
         }
         XCTAssertEqual(decoded.sorted(), entries.sorted())
     }
+    
+    /// Given: a Log file
+    /// When: LogActor deletes the log
+    /// Then: the log file is emptied
+    func testLogActorDeletesEntry() async throws {
+        let entry = LogEntry(category: "LogActorTests", namespace: nil, level: .error, message: UUID().uuidString, created: .init(timeIntervalSince1970: 0))
+        try await systemUnderTest.record(entry)
+        try await systemUnderTest.synchronize()
+        
+        let files = try FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+        let fileURL = try XCTUnwrap(files.first)
+        var contents = try XCTUnwrap(FileManager.default.contents(atPath: fileURL.path))
+        XCTAssertNotNil(contents)
+        
+        try await systemUnderTest.deleteLogs()
+        contents = try XCTUnwrap(FileManager.default.contents(atPath: fileURL.path))
+        XCTAssertTrue(contents.isEmpty)
+    }
+    
 }

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogRotationTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogRotationTests.swift
@@ -163,4 +163,30 @@ final class LogRotationTests: XCTestCase {
             }
         }
     }
+    
+    /// Given: a log rotation
+    /// When: reset is executed
+    /// Then: log rotation is reset to 0
+    func testLogRotationResets() throws {
+        let originalContents = try FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+        XCTAssertEqual(originalContents.map { $0.lastPathComponent }, [
+            "amplify.0.log"
+        ])
+
+        systemUnderTest = try LogRotation(directory: directory,
+                                          fileSizeLimitInBytes: fileSizeLimitInBytes)
+        XCTAssertEqual(systemUnderTest.currentLogFile.fileURL.lastPathComponent, "amplify.1.log")
+        try systemUnderTest.rotate()
+        
+        var rotatedContents = try FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+        XCTAssertEqual(rotatedContents.map { $0.lastPathComponent }, [
+            "amplify.2.log",
+            "amplify.1.log",
+            "amplify.0.log",
+        ])
+    
+        
+        try systemUnderTest.reset()
+        XCTAssertEqual(systemUnderTest.currentLogFile.fileURL.lastPathComponent, "amplify.0.log")
+    }
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
Update logger so that existing logs are deleted the user identifier changes due to sign in or sign out

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
