### PR TITLE
fix(logging): update flushlog to be blocking end to end

### DIFF
--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
@@ -164,7 +164,22 @@ final class AWSCloudWatchLoggingSessionController {
     }
     
     func flushLogs() async throws {
-        try await session?.logger.flushLogs()
+        guard let logBatches = try await session?.logger.getLogBatches() else { return }
+                
+        for batch in logBatches {
+            try await consumeLogBatch(batch)
+        }
+    }
+    
+    private func consumeLogBatch(_ batch: LogBatch) async throws {
+        do {
+            try await consumer?.consume(batch: batch)
+        } catch {
+            Amplify.Logging.default.error("Error flushing logs with error \(error.localizedDescription)")
+            let payload = HubPayload(eventName: HubPayload.EventName.Logging.flushLogFailure, context: error.localizedDescription)
+            Amplify.Hub.dispatch(to: HubChannel.logging, payload: payload)
+            try batch.complete()
+        }
     }
     
     private func resetCurrentLogs() {

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Persistence/LogActor.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Persistence/LogActor.swift
@@ -57,6 +57,11 @@ actor LogActor {
         }
     }
     
+    func getLogs() throws -> [URL] {
+        let logs = try rotation.getAllLogs()
+        return logs
+    }
+    
     func deleteLogs() throws {
         try rotation.reset()
         try synchronize()

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Persistence/LogActor.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Persistence/LogActor.swift
@@ -50,16 +50,8 @@ actor LogActor {
         try rotation.currentLogFile.synchronize()
     }
     
-    func flushLogs() throws {
-        let logs = try rotation.getAllLogs()
-        for log in logs {
-            rotationSubject.send(log)
-        }
-    }
-    
     func getLogs() throws -> [URL] {
-        let logs = try rotation.getAllLogs()
-        return logs
+        return try rotation.getAllLogs()
     }
     
     func deleteLogs() throws {

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Producer/RotatingLogger.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Producer/RotatingLogger.swift
@@ -43,15 +43,9 @@ final class RotatingLogger {
         try await actor.synchronize()
     }
     
-    func flushLogs() async throws {
-        try await setupSubscription()
-        try await actor.flushLogs()
-    }
-    
     func getLogBatches() async throws -> [RotatingLogBatch] {
         let logs = try await actor.getLogs()
-        let logBatches = logs.map({RotatingLogBatch(url: $0)})
-        return logBatches
+        return logs.map({RotatingLogBatch(url: $0)})
     }
     
     func resetLogs() async throws {

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Producer/RotatingLogger.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Producer/RotatingLogger.swift
@@ -48,6 +48,12 @@ final class RotatingLogger {
         try await actor.flushLogs()
     }
     
+    func getLogBatches() async throws -> [RotatingLogBatch] {
+        let logs = try await actor.getLogs()
+        let logBatches = logs.map({RotatingLogBatch(url: $0)})
+        return logBatches
+    }
+    
     func resetLogs() async throws {
         try await actor.deleteLogs()
     }

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogActorTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogActorTests.swift
@@ -111,7 +111,7 @@ final class LogActorTests: XCTestCase {
     
     
     /// Given: a LogActor
-    /// When: get all logs is excuted
+    /// When: get all logs is called
     /// Then: all logs are returned
     func testLogActorReturnsLogList() async throws {
         var logs = try await systemUnderTest.getLogs()

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogActorTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogActorTests.swift
@@ -110,9 +110,9 @@ final class LogActorTests: XCTestCase {
     }
     
     
-    /// Given: a LogActor
-    /// When: get all logs is called
-    /// Then: all logs are returned
+    /// Given: a LogActor with 1 existing log
+    /// When: get all logs is called after writing and rotating to a new log
+    /// Then: 2 log files are returned
     func testLogActorReturnsLogList() async throws {
         var logs = try await systemUnderTest.getLogs()
         XCTAssertEqual(logs.count, 1)

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogActorTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogActorTests.swift
@@ -109,4 +109,22 @@ final class LogActorTests: XCTestCase {
         XCTAssertTrue(contents.isEmpty)
     }
     
+    
+    /// Given: a LogActor
+    /// When: get all logs is excuted
+    /// Then: all logs are returned
+    func testLogActorReturnsLogList() async throws {
+        var logs = try await systemUnderTest.getLogs()
+        XCTAssertEqual(logs.count, 1)
+        let size = try LogEntry.minimumSizeForLogEntry(level: .error)
+        let numberOfEntries = (fileSizeLimitInBytes/size) + 1
+        let entries = (0..<numberOfEntries).map { LogEntry(category: "", namespace: nil, level: .error, message: "\($0)", created: .init(timeIntervalSince1970: Double($0))) }
+        for entry in entries {
+            try await systemUnderTest.record(entry)
+        }
+        try await systemUnderTest.synchronize()
+        
+        logs = try await systemUnderTest.getLogs()
+        XCTAssertEqual(logs.count, 2)
+    }
 }

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/RotatingLoggerTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/RotatingLoggerTests.swift
@@ -123,9 +123,9 @@ final class RotatingLoggerTests: XCTestCase {
         try assertSingleEntryWith(level: level, message: message)
     }
     
-    /// Given: a rotating logger
-    /// When: get log batch is called
-    /// Then: a list of log batches is returned
+    /// Given: a rotating logger with 1 existing log batch
+    /// When: get log batch is called after writing and rotating to new log file
+    /// Then: a list of log batches with a count of 2 is returned
     func testRotatingLogReturnsLogBatches() async throws {
         var logBatches = try await systemUnderTest.getLogBatches()
         XCTAssertEqual(logBatches.count, 1)

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/RotatingLoggerTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/RotatingLoggerTests.swift
@@ -123,6 +123,22 @@ final class RotatingLoggerTests: XCTestCase {
         try assertSingleEntryWith(level: level, message: message)
     }
     
+    /// Given: a rotating logger
+    /// When: get log batch is called
+    /// Then: a list of log batches is returned
+    func testRotatingLogReturnsLogBatches() async throws {
+        var logBatches = try await systemUnderTest.getLogBatches()
+        XCTAssertEqual(logBatches.count, 1)
+        let size = try LogEntry.minimumSizeForLogEntry(level: .error)
+        let recordsPerFile = (fileSizeLimitInBytes/size)
+        for _ in 0..<recordsPerFile {
+            try await systemUnderTest.record(level: .error, message: "Test message")
+        }
+        try await systemUnderTest.synchronize()
+        logBatches = try await systemUnderTest.getLogBatches()
+        XCTAssertEqual(logBatches.count, 2)
+    }
+    
     private func logWith(level: LogLevel, message: String) async throws {
         switch level {
         case .error:


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
update logging flushlog call to be async and blocking end to end.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
