### PR TITLE
fix(Auth): Refactor the expires in logic of the authentication result

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/RefreshAuthorizationSession/UserPool/RefreshHostedUITokens.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/RefreshAuthorizationSession/UserPool/RefreshHostedUITokens.swift
@@ -97,13 +97,12 @@ struct RefreshHostedUITokens: Action {
             throw FetchSessionError.service(error)
 
         } else if let idToken = json["id_token"] as? String,
-                  let accessToken = json["access_token"] as? String,
-                  let expiresIn = json["expires_in"] as? Int {
+                  let accessToken = json["access_token"] as? String {
             let userPoolTokens = AWSCognitoUserPoolTokens(
                 idToken: idToken,
                 accessToken: accessToken,
                 refreshToken: existingSignedIndata.cognitoUserPoolTokens.refreshToken,
-                expiresIn: expiresIn)
+                expiresIn: json["expires_in"] as? Int)
             return SignedInData(
                 signedInDate: existingSignedIndata.signedInDate,
                 signInMethod: existingSignedIndata.signInMethod,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/HostedUI/FetchHostedUISignInToken.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/HostedUI/FetchHostedUISignInToken.swift
@@ -81,13 +81,12 @@ struct FetchHostedUISignInToken: Action {
 
         } else if let idToken = json["id_token"] as? String,
                   let accessToken = json["access_token"] as? String,
-                  let refreshToken = json["refresh_token"] as? String,
-                  let expiresIn = json["expires_in"] as? Int {
+                  let refreshToken = json["refresh_token"] as? String {
             let userPoolTokens = AWSCognitoUserPoolTokens(
                 idToken: idToken,
                 accessToken: accessToken,
                 refreshToken: refreshToken,
-                expiresIn: expiresIn)
+                expiresIn: json["expires_in"] as? Int)
             let signedInData = SignedInData(
                 signedInDate: Date(),
                 signInMethod: .hostedUI(result.options),

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSCognitoUserPoolTokens.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSCognitoUserPoolTokens.swift
@@ -41,10 +41,10 @@ public struct AWSCognitoUserPoolTokens: AuthCognitoTokens {
         self.expiration = expiration
     }
 
-    public init(idToken: String,
-                accessToken: String,
-                refreshToken: String,
-                expiresIn: Int? = nil) {
+    init(idToken: String,
+         accessToken: String,
+         refreshToken: String,
+         expiresIn: Int? = nil) {
 
         self.idToken = idToken
         self.accessToken = accessToken
@@ -71,7 +71,7 @@ public struct AWSCognitoUserPoolTokens: AuthCognitoTokens {
             self.expiration = Date().addingTimeInterval(TimeInterval((expirationDoubleValue ?? 0)))
         }
     }
-
+    
 }
 
 extension AWSCognitoUserPoolTokens: Equatable { }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockData/AWSCognitoUserPoolTokens+Mock.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockData/AWSCognitoUserPoolTokens+Mock.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import AWSCognitoAuthPlugin
+@testable import AWSCognitoAuthPlugin
 
 extension AWSCognitoUserPoolTokens {
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockData/AWSCognitoUserPoolTokens+Mock.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockData/AWSCognitoUserPoolTokens+Mock.swift
@@ -40,4 +40,17 @@ extension AWSCognitoUserPoolTokens {
             refreshToken: "refreshToken",
             expiresIn: 121)
     }
+
+    static var testDataWithoutExp: AWSCognitoUserPoolTokens {
+        let tokenDataWithoutExp = [
+            "sub": "1234567890",
+            "username": "John Doe",
+            "iat": "1516239022"
+        ]
+        return AWSCognitoUserPoolTokens(
+            idToken: CognitoAuthTestHelper.buildToken(for: tokenDataWithoutExp),
+            accessToken: CognitoAuthTestHelper.buildToken(for: tokenDataWithoutExp),
+            refreshToken: "refreshToken",
+            expiresIn: nil)
+    }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
@@ -107,6 +107,42 @@ class AWSAuthHostedUISignInTests: XCTestCase {
     }
 
     @MainActor
+    func testSuccessfulSignIn_missingExpiresIn_testTokenMissingExp() async throws {
+        mockTokenResult = ["id_token": AWSCognitoUserPoolTokens.testDataWithoutExp.idToken,
+                           "access_token": AWSCognitoUserPoolTokens.testData.accessToken,
+                           "refresh_token": AWSCognitoUserPoolTokens.testData.refreshToken] as [String: Any]
+        mockJson = try! JSONSerialization.data(withJSONObject: mockTokenResult)
+        MockURLProtocol.requestHandler = { _ in
+            return (HTTPURLResponse(), self.mockJson)
+        }
+
+        mockHostedUIResult = .success([
+            .init(name: "state", value: mockState),
+            .init(name: "code", value: mockProof)
+        ])
+        let result = try await plugin.signInWithWebUI(presentationAnchor: ASPresentationAnchor(), options: nil)
+        XCTAssertTrue(result.isSignedIn)
+    }
+
+    @MainActor
+    func testSuccessfulSignIn_missingExpiresIn_testBothTokenMissingExp() async throws {
+        mockTokenResult = ["id_token": AWSCognitoUserPoolTokens.testDataWithoutExp.idToken,
+                           "access_token": AWSCognitoUserPoolTokens.testDataWithoutExp.accessToken,
+                           "refresh_token": AWSCognitoUserPoolTokens.testData.refreshToken] as [String: Any]
+        mockJson = try! JSONSerialization.data(withJSONObject: mockTokenResult)
+        MockURLProtocol.requestHandler = { _ in
+            return (HTTPURLResponse(), self.mockJson)
+        }
+
+        mockHostedUIResult = .success([
+            .init(name: "state", value: mockState),
+            .init(name: "code", value: mockProof)
+        ])
+        let result = try await plugin.signInWithWebUI(presentationAnchor: ASPresentationAnchor(), options: nil)
+        XCTAssertTrue(result.isSignedIn)
+    }
+
+    @MainActor
     func testUserCancelSignIn() async {
         mockHostedUIResult = .failure(.cancelled)
         let expectation  = expectation(description: "SignIn operation should complete")

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
@@ -89,6 +89,24 @@ class AWSAuthHostedUISignInTests: XCTestCase {
     }
 
     @MainActor
+    func testSuccessfulSignIn_missingExpiresIn() async throws {
+        mockTokenResult = ["id_token": AWSCognitoUserPoolTokens.testData.idToken,
+                           "access_token": AWSCognitoUserPoolTokens.testData.accessToken,
+                           "refresh_token": AWSCognitoUserPoolTokens.testData.refreshToken] as [String: Any]
+        mockJson = try! JSONSerialization.data(withJSONObject: mockTokenResult)
+        MockURLProtocol.requestHandler = { _ in
+            return (HTTPURLResponse(), self.mockJson)
+        }
+
+        mockHostedUIResult = .success([
+            .init(name: "state", value: mockState),
+            .init(name: "code", value: mockProof)
+        ])
+        let result = try await plugin.signInWithWebUI(presentationAnchor: ASPresentationAnchor(), options: nil)
+        XCTAssertTrue(result.isSignedIn)
+    }
+
+    @MainActor
     func testUserCancelSignIn() async {
         mockHostedUIResult = .failure(.cancelled)
         let expectation  = expectation(description: "SignIn operation should complete")


### PR DESCRIPTION
## Issue \#
#3107 

## Description
Using the min expiration time of the idToken and accessToken to detemine Authentication result expiry in the abscence of expiry details from the service. 

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
