### PR TITLE
chore: Removing integ tests from release workflow

### DIFF
--- a/.github/workflows/deploy_package.yml
+++ b/.github/workflows/deploy_package.yml
@@ -17,11 +17,6 @@ jobs:
     name: Run Plugins Unit Tests
     uses: ./.github/workflows/unit_test.yml
 
-  integration-tests:
-    name: Run Integration Tests
-    uses: ./.github/workflows/integ_test.yml
-    secrets: inherit
-
   fortify:
     name: Run Fortify Scan
     uses: ./.github/workflows/fortify_scan.yml
@@ -30,7 +25,7 @@ jobs:
   release:
     environment: Release
     name: Release new ${{ inputs.type }} version
-    needs: [unit-tests, fortify, integration-tests]
+    needs: [unit-tests, fortify]
     runs-on: macos-latest
     steps: 
       - name: Configure AWS credentials

--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -2,6 +2,8 @@ name: Integration Tests
 on:
   workflow_dispatch:
   workflow_call:
+  push:
+    branches: [main]
 
 permissions:
     id-token: write


### PR DESCRIPTION
## Description
<!-- Why is this change required? What problem does it solve? -->
This PR removes the integration tests workflow from being a dependency of the release workflow and returns to it just being triggered on a push to main (as it was before the migration).

For some reason, one of the tests keeps hanging (not failing), which makes it impossible to continue with the release.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
