### PR TITLE
chore: [v1] Fixing release workflow

### DIFF
--- a/.github/workflows/deploy_package.yml
+++ b/.github/workflows/deploy_package.yml
@@ -21,18 +21,15 @@ jobs:
     name: Run Plugins Unit Tests
     uses: ./.github/workflows/unit_test.yml
 
-  integration-tests:
-    name: Run Integration Tests
-    uses: ./.github/workflows/integ_test.yml
-
   fortify:
     name: Run Fortify Scan
     uses: ./.github/workflows/fortify_scan.yml
+    secrets: inherit
 
   release:
     name: Release new ${{ inputs.type }} version
     environment: Release
-    needs: [unit-tests, fortify, integration-tests]
+    needs: [build-and-test-amplify, unit-tests, fortify]
     runs-on: macos-latest
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -1,6 +1,8 @@
 name: Integration Tests
 on:
   workflow_call:
+  push:
+    branches: [v1]
 
 permissions:
     id-token: write


### PR DESCRIPTION
## Description
This PR makes the following changes to the deploy workflow:
- adds the `secrets: inherit` attribute when calling the fortify workflow, so that it can access the environment's secrets
- removes the integration tests as dependency, to match `main` (since one of the test keeps hanging and blocking the release).

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
