### PR TITLE
chore: Fixing wrong parsing in release workflow

### DIFF
--- a/.github/workflows/deploy_package.yml
+++ b/.github/workflows/deploy_package.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           PAT=$(aws secretsmanager get-secret-value \
           --secret-id "$DEPLOY_SECRET_ARN" \
-          | jq ".SecretString | fromjson | .Credential")
+          | jq -r ".SecretString | fromjson | .Credential")
           echo "token=$PAT" >> $GITHUB_OUTPUT
 
       - name: Checkout repo


### PR DESCRIPTION
## Description
Unquoting the retrieved token on the release workflow, as it caused the checkout to fail.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
