### PR TITLE
chore: Fixing Integration Test for Push Notifications

### DIFF
--- a/.github/workflows/integ_test_push_notifications.yml
+++ b/.github/workflows/integ_test_push_notifications.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   push-notification-integration-test-iOS:
     runs-on: macos-12
+    timeout-minutes: 20
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -47,6 +48,7 @@ jobs:
 
   push-notification-integration-test-tvOS:
     runs-on: macos-13
+    timeout-minutes: 20
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -81,12 +83,13 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp
           scheme: PushNotificationHostApp
-          destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=latest
+          destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=16.4
           sdk: appletvsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
 
   push-notification-integration-test-watchOS:
     runs-on: macos-13
+    timeout-minutes: 20
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -121,6 +124,6 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp
           scheme: PushNotificationWatchTests
-          destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=latest
+          destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=9.4
           sdk: watchsimulator
           xcode_path: '/Applications/Xcode_14.3.app'


### PR DESCRIPTION
## Description
This PR fixes the hanging/failing tvOS and watchOS Push Notifications integration tests.

We were using `OS=latest` and `xcode_path: '/Applications/Xcode_14.3.app'`, which resulted in the tests being run in the beta `tvOS 17.0` and `watchOS 10.0`, as it seems they are installed in the runners now.

By setting them to `16.4` and `9.4`, they now behave properly.

I am also setting a `timeout` for these tests, so that in case they hang again we don't have to wait forever to retry.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
