### PR TITLE
chore: remove Thread.sleep in storage operation unit tests

### DIFF
--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageDownloadFileOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageDownloadFileOperationTests.swift
@@ -40,7 +40,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
         waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
     }
 
     func testDownloadFileOperationGetIdentityIdError() async throws {
@@ -69,7 +69,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
         
         await waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
     }
 
     func testDownloadFileOperationDownloadLocal() {
@@ -104,7 +104,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDownload(serviceKey: expectedServiceKey, fileURL: url)
     }
 
@@ -140,7 +140,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDownload(serviceKey: expectedServiceKey, fileURL: url)
     }
 
@@ -178,7 +178,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         await waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDownload(serviceKey: expectedServiceKey, fileURL: url)
     }
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageGetDataOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageGetDataOperationTests.swift
@@ -38,7 +38,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
         waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
     }
 
     func testDownloadDataOperationGetIdentityIdError() async throws {
@@ -65,7 +65,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         await waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
     }
 
     func testDownloadDataOperationDownloadData() async throws {
@@ -97,7 +97,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         await waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDownload(serviceKey: expectedServiceKey, fileURL: nil)
     }
 
@@ -130,7 +130,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         await waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDownload(serviceKey: expectedServiceKey, fileURL: nil)
     }
 
@@ -165,7 +165,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         await waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDownload(serviceKey: expectedServiceKey, fileURL: nil)
     }
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageOperationTestBase.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageOperationTestBase.swift
@@ -46,10 +46,4 @@ class AWSS3StorageOperationTestBase: XCTestCase {
     override func tearDown() async throws {
         await Amplify.reset()
     }
-    
-    func waitForOperationToFinish(_ operation: AsynchronousOperation) {
-        while !operation.isFinished {
-            Thread.sleep(forTimeInterval: 0.2)
-        }
-    }
 }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StoragePutDataOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StoragePutDataOperationTests.swift
@@ -41,7 +41,7 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
     }
 
     func testUploadDataOperationGetIdentityIdError() {
@@ -71,7 +71,7 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
     }
 
     func testUploadDataOperationUploadSuccess() {
@@ -113,7 +113,7 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
         XCTAssertEqual(mockStorageService.uploadCalled, 1)
         mockStorageService.verifyUpload(serviceKey: expectedServiceKey,
                                         key: testKey,
@@ -157,7 +157,7 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
         XCTAssertEqual(mockStorageService.uploadCalled, 1)
         mockStorageService.verifyUpload(serviceKey: expectedServiceKey,
                                         key: testKey,
@@ -212,7 +212,7 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
         XCTAssertEqual(mockStorageService.multiPartUploadCalled, 1)
         mockStorageService.verifyMultiPartUpload(serviceKey: expectedServiceKey,
                                                  key: testKey,

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageRemoveOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageRemoveOperationTests.swift
@@ -37,7 +37,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
 
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
         waitForExpectations(timeout: 1)
     }
 
@@ -65,7 +65,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
         await waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
     }
 
     func testRemoveOperationDeleteSuccess() async throws {
@@ -90,7 +90,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         await waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDelete(serviceKey: expectedServiceKey)
     }
 
@@ -116,7 +116,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         await waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDelete(serviceKey: expectedServiceKey)
     }
 
@@ -143,7 +143,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDelete(serviceKey: expectedServiceKey)
     }
 }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests.swift
@@ -41,7 +41,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
     }
 
     func testUploadFileOperationGetIdentityIdError() {
@@ -73,7 +73,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
     }
 
     func testvOperationGetSizeForMissingFileError() {
@@ -102,7 +102,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
     }
 
     func testUploadFileOperationUploadSuccess() {
@@ -147,7 +147,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
         XCTAssertEqual(mockStorageService.uploadCalled, 1)
         mockStorageService.verifyUpload(serviceKey: expectedServiceKey,
                                         key: testKey,
@@ -194,7 +194,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
         XCTAssertEqual(mockStorageService.uploadCalled, 1)
         mockStorageService.verifyUpload(serviceKey: expectedServiceKey,
                                         key: testKey,
@@ -248,7 +248,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
         operation.start()
 
         waitForExpectations(timeout: 1)
-        waitForOperationToFinish(operation)
+        XCTAssertTrue(operation.isFinished)
         XCTAssertEqual(mockStorageService.multiPartUploadCalled, 1)
         mockStorageService.verifyMultiPartUpload(serviceKey: expectedServiceKey,
                                                  key: testKey,


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
#2442 
## Description
* remove Thread.sleep in Storage operation unit tests and revert back to `XCTAssertTrue(operation.isFinished)`
* Ran unit tests at 100 iterations repeated on iOS and macOS without any failures

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
