### PR TITLE
fix: update dep versions for xcodeproj and xcodegen

### DIFF
--- a/AmplifyTools/AmplifyXcode/Package.resolved
+++ b/AmplifyTools/AmplifyXcode/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/tadija/AEXML",
         "state": {
           "branch": null,
-          "revision": "e4d517844dd03dac557e35d77a8e9ab438de91a6",
-          "version": "4.4.0"
+          "revision": "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
+          "version": "4.6.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit",
         "state": {
           "branch": null,
-          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
-          "version": "1.0.0"
+          "revision": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+          "version": "1.0.1"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
-          "version": "0.9.2"
+          "revision": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+          "version": "0.10.1"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI.git",
         "state": {
           "branch": null,
-          "revision": "2816678bcc37f4833d32abeddbdf5e757fa891d8",
-          "version": "6.0.2"
+          "revision": "2e949055d9797c1a6bddcda0e58dada16cc8e970",
+          "version": "6.0.3"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/yonaskolb/XcodeGen",
         "state": {
           "branch": null,
-          "revision": "bb4a3fa2dd720594e47f33cd48cce84fcf9f7066",
-          "version": "2.18.0"
+          "revision": "ee60884b132078035d30f9892eb8e3e91ba2382c",
+          "version": "2.35.0"
         }
       },
       {
@@ -96,17 +96,8 @@
         "repositoryURL": "https://github.com/tuist/xcodeproj",
         "state": {
           "branch": null,
-          "revision": "545bfa746b6eb4ea0ad8d3a12c6590445392bb50",
-          "version": "7.13.0"
-        }
-      },
-      {
-        "package": "XcodeProjCExt",
-        "repositoryURL": "https://github.com/tuist/XcodeProjCExt",
-        "state": {
-          "branch": null,
-          "revision": "21a510c225ff2bc83d5920a21d902af4b1e7e218",
-          "version": "0.1.0"
+          "revision": "5fdac93cb4a7fd4bad5ac2da34e5bc878263043f",
+          "version": "8.10.0"
         }
       },
       {
@@ -114,8 +105,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
-          "version": "2.0.0"
+          "revision": "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
+          "version": "5.0.6"
         }
       }
     ]

--- a/AmplifyTools/AmplifyXcode/Package.swift
+++ b/AmplifyTools/AmplifyXcode/Package.swift
@@ -13,8 +13,8 @@ let package = Package(
         .executable(name: "amplify-xcode", targets: ["AmplifyXcode"])
     ],
     dependencies: [
-        .package(name: "XcodeProj", url: "https://github.com/tuist/xcodeproj", .upToNextMajor(from: "7.13.0")),
-        .package(url: "https://github.com/yonaskolb/XcodeGen", from: "2.18.0"),
+        .package(name: "XcodeProj", url: "https://github.com/tuist/xcodeproj", .upToNextMinor(from: "8.10.0")),
+        .package(url: "https://github.com/yonaskolb/XcodeGen", from: "2.35.0"),
         .package(url: "https://github.com/kylef/PathKit", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0")
     ],


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
- https://github.com/aws-amplify/amplify-cli/issues/12998

## Description
<!-- Why is this change required? What problem does it solve? -->
Updates dependency versioning rules for XcodeProj to [include support for `com.apple.product-type.extensionkit-extension` extension product types](https://github.com/tuist/XcodeProj/blob/main/Sources/XcodeProj/Objects/Targets/PBXProductType.swift#L15) added in [8.8.0](https://github.com/tuist/XcodeProj/releases/tag/8.8.0).

After this is merged to `main`, we'll cut a PR to https://github.com/aws-amplify/amplify-cli with a prebuilt binary to include in their next available release.

---
For anyone tracking this, I recommend waiting until the new version lands in Amplify CLI. However, if you need an immediate workaround:
```bash
AMP_XCODE_DIR=~/.amplify/lib/aws-amplify-amplify-frontend-ios/resources

# make a backup of the existing Amplify Xcode program.
# If this workaround causes problems, you can always go back to the previous build
# by renaming `amplify-xcode-backup` back to `amplify-xcode`.
mv $AMP_XCODE_PATH/amplify-xcode $AMP_XCODE_PATH/amplify-xcode-backup

# checkout fix branch
git clone https://github.com/aws-amplify/amplify-swift --branch amplify-tools-update-xcodeproj

# build new Amplify Xcode
cd amplify-swift/AmplifyTools/AmplifyXcode
swift build -c release --disable-sandbox

# copy program over to directory where Amplify CLI expects it
cp .build/release/amplify-xcode $AMP_XCODE_DIR/amplify-xcode
```


## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
