### PR TITLE
chore: Fixing typo in codecov flags. 

### DIFF
--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -30,6 +30,7 @@ permissions:
 
 jobs:
   test-iOS:
+    name: ${{ inputs.scheme }} iOS Tests
     runs-on: macos-13
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
@@ -47,9 +48,10 @@ jobs:
         if: ${{ inputs.submit_coverage_report == true }}
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         with:
-          flags: $${{ inputs.coverage_flags }}
+          flags: ${{ inputs.coverage_flags }}
 
   test-macOS:
+    name: ${{ inputs.scheme }} macOS Tests
     runs-on: macos-13
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
@@ -65,6 +67,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   test-tvOS:
+    name: ${{ inputs.scheme }} tvOS Tests
     runs-on: macos-13
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
@@ -80,6 +83,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   test-watchOS:
+    name: ${{ inputs.scheme }} watchOS Tests
     runs-on: macos-13
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:


### PR DESCRIPTION
## Description
Fixing typo in codecov flags, which had an extra `$` and caused the report to not be uploaded. 

Also adding names to tests job in order to differentiate them when they run as part of the release workflows.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
