### PR TITLE
ci: ignore deduplicate workflow for unstable release on main branch

### DIFF
--- a/.github/workflows/build_amplify_swift.yml
+++ b/.github/workflows/build_amplify_swift.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref_name != 'main'}}
 
 jobs:
   build-amplify-swift-iOS:

--- a/.github/workflows/fortify_scan.yml
+++ b/.github/workflows/fortify_scan.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref_name != 'main'}}
 
 jobs:
   fortify-scan:

--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref_name != 'main'}}
 
 jobs:
   prepare-for-test:

--- a/.github/workflows/integ_test_api.yml
+++ b/.github/workflows/integ_test_api.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
     id-token: write
-    contents: read 
+    contents: read
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref_name != 'main'}}
 
 jobs:
   unit-tests-without-coverage:


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

- don't cancel the workflows on main branch

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
