### PR TITLE
update type names

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/IAMURLRequestInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/IAMURLRequestInterceptor.swift
@@ -42,7 +42,8 @@ struct IAMURLRequestInterceptor: URLRequestInterceptor {
         let httpMethod = (request.httpMethod?.uppercased())
             .flatMap(HttpMethodType.init(rawValue:)) ?? .get
 
-        let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        let queryItems = (URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? [])
+            .map { ClientRuntime.URLQueryItem(name: $0.name, value: $0.value) }
 
         let requestBuilder = SdkHttpRequestBuilder()
             .withHost(host)

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
@@ -21,10 +21,10 @@ class IAMAuthInterceptor: AuthInterceptorAsync {
                                                            RealtimeProviderConstants.amzDate.lowercased(),
                                                            RealtimeProviderConstants.iamSecurityTokenKey.lowercased()]
 
-    let authProvider: CredentialsProvider
+    let authProvider: CredentialsProviding
     let region: AWSRegionType
 
-    init(_ authProvider: CredentialsProvider, region: AWSRegionType) {
+    init(_ authProvider: CredentialsProviding, region: AWSRegionType) {
         self.authProvider = authProvider
         self.region = region
     }
@@ -60,8 +60,14 @@ class IAMAuthInterceptor: AuthInterceptorAsync {
         guard var urlComponents = URLComponents(url: request.url, resolvingAgainstBaseURL: false) else {
             return request
         }
-        let headerQuery = URLQueryItem(name: RealtimeProviderConstants.header, value: base64Auth)
-        let payloadQuery = URLQueryItem(name: RealtimeProviderConstants.payload, value: payloadBase64)
+        let headerQuery = Foundation.URLQueryItem(
+            name: RealtimeProviderConstants.header,
+            value: base64Auth
+        )
+        let payloadQuery = Foundation.URLQueryItem(
+            name: RealtimeProviderConstants.payload,
+            value: payloadBase64
+        )
         urlComponents.queryItems = [headerQuery, payloadQuery]
         guard let signedUrl = urlComponents.url else {
             return request

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -13,7 +13,7 @@ public class AWSAuthService: AWSAuthServiceBehavior {
 
     public init() {}
 
-    public func getCredentialsProvider() -> CredentialsProvider {
+    public func getCredentialsProvider() -> CredentialsProviding {
         return AmplifyAWSCredentialsProvider()
     }
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -11,7 +11,7 @@ import AWSClientRuntime
 
 public protocol AWSAuthServiceBehavior: AnyObject {
 
-    func getCredentialsProvider() -> CredentialsProvider
+    func getCredentialsProvider() -> CredentialsProviding
 
     func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError>
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AmplifyAWSCredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AmplifyAWSCredentialsProvider.swift
@@ -10,7 +10,7 @@ import AWSClientRuntime
 import AwsCommonRuntimeKit
 import Foundation
 
-public class AmplifyAWSCredentialsProvider: AWSClientRuntime.CredentialsProvider {
+public class AmplifyAWSCredentialsProvider: AWSClientRuntime.CredentialsProviding {
 
     public func getCredentials() async throws -> AWSClientRuntime.AWSCredentials {
         let authSession = try await Amplify.Auth.fetchAuthSession()

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AmplifyAWSSignatureV4Signer.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AmplifyAWSSignatureV4Signer.swift
@@ -13,7 +13,7 @@ import AwsCommonRuntimeKit
 
 public protocol AWSSignatureV4Signer {
     func sigV4SignedRequest(requestBuilder: SdkHttpRequestBuilder,
-                            credentialsProvider: AWSClientRuntime.CredentialsProvider,
+                            credentialsProvider: AWSClientRuntime.CredentialsProviding,
                             signingName: Swift.String,
                             signingRegion: Swift.String,
                             date: ClientRuntime.Date) async throws -> SdkHttpRequest?
@@ -24,7 +24,7 @@ public class AmplifyAWSSignatureV4Signer: AWSSignatureV4Signer {
     }
 
     public func sigV4SignedRequest(requestBuilder: SdkHttpRequestBuilder,
-                                   credentialsProvider: AWSClientRuntime.CredentialsProvider,
+                                   credentialsProvider: AWSClientRuntime.CredentialsProviding,
                                    signingName: Swift.String,
                                    signingRegion: Swift.String,
                                    date: ClientRuntime.Date) async throws -> SdkHttpRequest? {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/IAMCredentialProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/IAMCredentialProvider.swift
@@ -10,7 +10,7 @@ import Amplify
 import AWSClientRuntime
 
 public protocol IAMCredentialsProvider {
-    func getCredentialsProvider() -> CredentialsProvider
+    func getCredentialsProvider() -> CredentialsProviding
 }
 
 public struct BasicIAMCredentialsProvider: IAMCredentialsProvider {
@@ -20,7 +20,7 @@ public struct BasicIAMCredentialsProvider: IAMCredentialsProvider {
         self.authService = authService
     }
 
-    public func getCredentialsProvider() -> CredentialsProvider {
+    public func getCredentialsProvider() -> CredentialsProviding {
         return authService.getCredentialsProvider()
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Utils/CustomHttpClientEngine/UserAgentSuffixAppender.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Utils/CustomHttpClientEngine/UserAgentSuffixAppender.swift
@@ -31,7 +31,9 @@ extension UserAgentSuffixAppender: HttpClientEngine {
             name: userAgentHeader,
             value: "\(currentUserAgent) \(suffix)"
         )
-        request.headers = headers
+        // TODO: fix this
+        // Cannot assign to property: 'headers' is a get-only property
+        /* request.headers = headers */
         return try await target.execute(request: request)
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Utils/UserAgentSuffixAppenderTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Utils/UserAgentSuffixAppenderTests.swift
@@ -30,8 +30,9 @@ class UserAgentSuffixAppenderTests: XCTestCase {
     /// When: A request is invoked with an existing User-Agent
     /// Then: The user agent suffix is appended
     func testExecute_withExistingUserAgentHeader_shouldAppendSuffix() async throws {
-        let request = createRequest()
-        request.headers.add(name: userAgentKey, value: "existingUserAgent")
+        let request = createRequest(
+            headers: .init([userAgentKey: "existingUserAgent"])
+        )
 
         _ = try await appender.execute(request: request)
         XCTAssertEqual(httpClientEngine.executeCount, 1)
@@ -69,11 +70,13 @@ class UserAgentSuffixAppenderTests: XCTestCase {
         }
     }
 
-    private func createRequest() -> SdkHttpRequest {
+    private func createReques(headers: Headers? = nil) -> SdkHttpRequest {
         return SdkHttpRequest(
             method: .get,
-            endpoint: .init(host: "customHost"),
-            headers: .init()
+            endpoint: .init(
+                host: "customHost",
+                headers: headers
+            )
         )
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -28,7 +28,7 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
         interactions.append(#function)
     }
 
-    public func getCredentialsProvider() -> CredentialsProvider {
+    public func getCredentialsProvider() -> CredentialsProviding {
         interactions.append(#function)
         let cognitoCredentialsProvider = MyCustomCredentialsProvider()
         return cognitoCredentialsProvider
@@ -61,7 +61,7 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
     }
 }
 
-struct MyCustomCredentialsProvider: CredentialsProvider {
+struct MyCustomCredentialsProvider: CredentialsProviding {
     func getCredentials() async throws -> AWSClientRuntime.AWSCredentials {
         AWSCredentials(
             accessKey: "AKIDEXAMPLE",

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSSignatureV4Signer.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSSignatureV4Signer.swift
@@ -12,7 +12,7 @@ import Foundation
 
 class MockAWSSignatureV4Signer: AWSSignatureV4Signer {
     func sigV4SignedRequest(requestBuilder: SdkHttpRequestBuilder,
-                            credentialsProvider: CredentialsProvider,
+                            credentialsProvider: CredentialsProviding,
                             signingName: String,
                             signingRegion: String,
                             date: Date) throws -> SdkHttpRequest? {

--- a/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/AWSLocationGeoPlugin+Configure.swift
+++ b/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/AWSLocationGeoPlugin+Configure.swift
@@ -31,8 +31,9 @@ extension AWSLocationGeoPlugin {
         let credentialsProvider = authService.getCredentialsProvider()
         let region = configuration.regionName
         let serviceConfiguration = try LocationClient.LocationClientConfiguration(
-            credentialsProvider: credentialsProvider,
-            region: region)
+            region: region,
+            credentialsProvider: credentialsProvider
+        )
 
         let location = LocationClient(config: serviceConfiguration)
         let locationService = AWSLocationAdapter(location: location)

--- a/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Mocks/MockAWSClientConfiguration.swift
+++ b/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Mocks/MockAWSClientConfiguration.swift
@@ -35,7 +35,7 @@ class MockAWSClientConfiguration: LocationClientConfigurationProtocol {
 
     var endpoint: String?
 
-    var credentialsProvider: CredentialsProvider
+    var credentialsProvider: CredentialsProviding
 
     var region: String?
 

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Context/PinpointContext.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Context/PinpointContext.swift
@@ -76,14 +76,14 @@ struct PinpointContextConfiguration {
     /// The Pinpoint region
     let region: String
     /// Used to retrieve the proper AWSCredentials when creating the PinpointCLient
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProviding
     /// Indicates if the App is in Debug or Release build. Defaults to `false`
     /// Setting this flag to true will set the Endpoint Profile to have a channel type of "APNS_SANDBOX".
     let isDebug: Bool
 
     init(appId: String,
          region: String,
-         credentialsProvider: CredentialsProvider,
+         credentialsProvider: CredentialsProviding,
          isDebug: Bool = false) {
         self.appId = appId
         self.region = region

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Extensions/PinpointClient+CredentialsProvider.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Extensions/PinpointClient+CredentialsProvider.swift
@@ -10,11 +10,11 @@ import AWSPluginsCore
 import AWSPinpoint
 
 extension PinpointClient {
-    convenience init(region: String, credentialsProvider: CredentialsProvider) throws {
+    convenience init(region: String, credentialsProvider: CredentialsProviding) throws {
         let configuration = try PinpointClientConfiguration(
+            region: region,
             credentialsProvider: credentialsProvider,
-            frameworkMetadata: AmplifyAWSServiceConfiguration.frameworkMetaData(),
-            region: region
+            frameworkMetadata: AmplifyAWSServiceConfiguration.frameworkMetaData()
         )
         PinpointRequestsRegistry.shared.setCustomHttpEngine(on: configuration)
         self.init(config: configuration)

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Support/Utils/PinpointRequestsRegistry.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Support/Utils/PinpointRequestsRegistry.swift
@@ -69,7 +69,9 @@ private struct CustomPinpointHttpClientEngine: HttpClientEngine {
         let currentUserAgent = headers.value(for: userAgentHeader) ?? ""
         headers.update(name: userAgentHeader,
                        value: "\(currentUserAgent)\(userAgentSuffix)")
-        request.headers = headers
+
+        // FIXME: request.headers is now get only
+        /* request.headers = headers */
 
         await PinpointRequestsRegistry.shared.unregisterSources(for: pinpointApi)
         return try await httpClientEngine.execute(request: request)

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockEndpointClient.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockEndpointClient.swift
@@ -13,7 +13,7 @@ import Foundation
 actor MockEndpointClient: EndpointClientBehaviour {
     let pinpointClient: PinpointClientProtocol = MockPinpointClient()
 
-    class MockCredentialsProvider: CredentialsProvider {
+    class MockCredentialsProvider: CredentialsProviding {
         func getCredentials() async throws -> AWSCredentials {
             return AWSCredentials(accessKey: "", secret: "", expirationTimeout: Date().addingTimeInterval(1000))
         }

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSTranscribeStreamingAdapter.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSTranscribeStreamingAdapter.swift
@@ -22,10 +22,10 @@ class AWSTranscribeStreamingAdapter: AWSTranscribeStreamingBehavior {
         let mediaSampleRateHertz: Int
     }
 
-    let credentialsProvider: CredentialsProvider
+    let credentialsProvider: CredentialsProviding
     let region: String
 
-    init(credentialsProvider: CredentialsProvider, region: String) {
+    init(credentialsProvider: CredentialsProviding, region: String) {
         self.credentialsProvider = credentialsProvider
         self.region = region
     }

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Polly.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Polly.swift
@@ -34,9 +34,18 @@ extension AWSPredictionsService: AWSPollyServiceBehavior {
                 )
             }
 
-            let textToSpeechResult = Predictions.Convert.TextToSpeech.Result(
-                audioData: speech.toBytes().getData()
-            )
+            switch speech {
+            case .data(let data?):
+                let textToSpeechResult = Predictions.Convert.TextToSpeech.Result(
+                    audioData: data
+                )
+                return textToSpeechResult
+            default:
+                // TODO: throw an applicable error here
+                throw PredictionsError.unknown("Missing response", "", nil)
+            }
+
+
             return textToSpeechResult
         } catch let error as SynthesizeSpeechOutputError {
             throw ServiceErrorMapping.synthesizeSpeech.map(error)

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService.swift
@@ -30,36 +30,36 @@ class AWSPredictionsService {
 
     convenience init(
         configuration: PredictionsPluginConfiguration,
-        credentialsProvider: CredentialsProvider,
+        credentialsProvider: CredentialsProviding,
         identifier: String
     ) throws {
         let translateClientConfiguration = try TranslateClient.TranslateClientConfiguration(
-            credentialsProvider: credentialsProvider,
-            region: configuration.convert.region
+            region: configuration.convert.region,
+            credentialsProvider: credentialsProvider
         )
         let awsTranslateClient = TranslateClient(config: translateClientConfiguration)
 
         let pollyClientConfiguration = try PollyClient.PollyClientConfiguration(
-            credentialsProvider: credentialsProvider,
-            region: configuration.convert.region
+            region: configuration.convert.region,
+            credentialsProvider: credentialsProvider
         )
         let awsPollyClient = PollyClient(config: pollyClientConfiguration)
 
         let comprehendClientConfiguration = try ComprehendClient.ComprehendClientConfiguration(
-            credentialsProvider: credentialsProvider,
-            region: configuration.convert.region
+            region: configuration.convert.region,
+            credentialsProvider: credentialsProvider
         )
         let awsComprehendClient = ComprehendClient(config: comprehendClientConfiguration)
 
         let rekognitionClientConfiguration = try RekognitionClient.RekognitionClientConfiguration(
-            credentialsProvider: credentialsProvider,
-            region: configuration.identify.region
+            region: configuration.identify.region,
+            credentialsProvider: credentialsProvider
         )
         let awsRekognitionClient = RekognitionClient(config: rekognitionClientConfiguration)
 
         let textractClientConfiguration = try TextractClient.TextractClientConfiguration(
-            credentialsProvider: credentialsProvider,
-            region: configuration.identify.region
+            region: configuration.identify.region,
+            credentialsProvider: credentialsProvider
         )
         let awsTextractClient = TextractClient(config: textractClientConfiguration)
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
@@ -58,8 +58,8 @@ class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy {
                      logger: Logger = storageLogger) throws {
         let credentialsProvider = authService.getCredentialsProvider()
         let clientConfig = try S3Client.S3ClientConfiguration(
-            credentialsProvider: credentialsProvider,
             region: region,
+            credentialsProvider: credentialsProvider,
             signingRegion: region)
         if var proxy = httpClientEngineProxy {
             proxy.target = clientConfig.httpClientEngine

--- a/AmplifyTestCommon/Mocks/MockCredentialsProvider.swift
+++ b/AmplifyTestCommon/Mocks/MockCredentialsProvider.swift
@@ -8,7 +8,7 @@
 import AWSClientRuntime
 import Foundation
 
-class MockCredentialsProvider: CredentialsProvider {
+class MockCredentialsProvider: CredentialsProviding {
     func getCredentials() async throws -> AWSCredentials {
         return AWSCredentials(
             accessKey: "accessKey",


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
- Updates `CredentialsProvider` to `CredentialsProviding` based on Swift SDK changes.
- Changes some `init` argument ordering based on Swift SDK changes.
- Comments out two places where headers are being set due to the Swift SDK change making the headers property immutable. Tracking this on the base branch PR and will circle back to it in a later PR.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
