### PR TITLE
chore: Submitting all coverage reports at the same time

### DIFF
--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -61,6 +61,6 @@ runs:
         cd Build/Build/ProfileData
         cd $(ls -d */|head -n 1)
         pathCoverage=Build/Build/ProfileData/${PWD##*/}/Coverage.profdata
-        cd ../../../../
-        xcrun llvm-cov export -format="lcov" -instr-profile $pathCoverage Build/Build/Products/Debug-${{ inputs.sdk }}/$SCHEME.o > Coverage.lcov
+        cd ${{ github.workspace }}
+        xcrun llvm-cov export -format="lcov" -instr-profile $pathCoverage Build/Build/Products/Debug-${{ inputs.sdk }}/$SCHEME.o > $SCHEME-Coverage.lcov
       shell: bash

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
         with:
           name: ${{ env.SCHEME }}-Coverage-${{ github.sha }}
-          path: ${{ github.workspace }}/${{ env.SCHEME }}_Coverage.lcov
+          path: ${{ github.workspace }}/${{ env.SCHEME }}-Coverage.lcov
           if-no-files-found: error
           retention-days: 1
 

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -11,16 +11,11 @@ on:
         required: false
         type: number
         default: 30
-      submit_coverage_report:
+      generate_coverage_report:
         description: 'Whether to generate and report code coverage'
         required: false
         type: boolean
         default: false
-      coverage_flags:
-        description: 'What flag to include in the coverage report, separated by commas'
-        required: false
-        type: string
-        default: 'tests'
 
 env:
   SCHEME: ${{ inputs.scheme }}
@@ -43,12 +38,16 @@ jobs:
           scheme: ${{ env.SCHEME }}
           destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
-          generate_coverage: ${{ inputs.submit_coverage_report }}
-      - name: Upload Coverage report to Codecov
-        if: ${{ inputs.submit_coverage_report == true }}
-        shell: bash
-        run: |
-          build-support/codecov.sh -F '${{ inputs.coverage_flags }}'
+          generate_coverage: ${{ inputs.generate_coverage_report }}
+      - name: Upload Report File
+        if: ${{ inputs.generate_coverage_report == true }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
+        with:
+          name: ${{ env.SCHEME }}-Coverage-${{ github.sha }}
+          path: ${{ github.workspace }}/${{ env.SCHEME }}_Coverage.lcov
+          if-no-files-found: error
+          retention-days: 1
+
 
   test-macOS:
     name: ${{ inputs.scheme }} macOS Tests

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -53,7 +53,7 @@ jobs:
       generate_coverage_report: true
 
   report-coverage:
-    name: Report Coverage
+    name: ${{ matrix.file.scheme }} Coverage Report
     needs: [unit-tests-with-coverage]
     strategy:
       fail-fast: false

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/run_xcodebuild_test_platforms.yml
     with:
       scheme: ${{ matrix.scheme }}
-      submit_coverage_report: false
+      generate_coverage_report: false
 
   unit-tests-with-coverage:
     name: ${{ matrix.scheme.name }} Unit Tests
@@ -34,21 +34,52 @@ jobs:
       fail-fast: false
       matrix:
         scheme: [
-          { name: Amplify, flags: 'Amplify,unit_tests' },
-          { name: AWSPluginsCore, flags: 'AWSPluginsCore,unit_tests' },
-          { name: AWSAPIPlugin, flags: 'API_plugin_unit_test,unit_tests' },
-          { name: AWSCloudWatchLoggingPlugin, flags: 'Logging_plugin_unit_test,unit_tests' },
-          { name: AWSCognitoAuthPlugin, flags: 'Auth_plugin_unit_test,unit_tests' },
-          { name: AWSDataStorePlugin, flags: 'DataStore_plugin_unit_test,unit_tests' },
-          { name: AWSLocationGeoPlugin, flags: 'Geo_plugin_unit_test,unit_tests' },
-          { name: AWSPredictionsPlugin, flags: 'Predictions_plugin_unit_test,unit_tests' },
-          { name: AWSPinpointAnalyticsPlugin, flags: 'Analytics_plugin_unit_test,unit_tests' },
-          { name: AWSPinpointPushNotificationsPlugin, flags: 'PushNotifications_plugin_unit_test,unit_tests' },
-          { name: AWSS3StoragePlugin, flags: 'Storage_plugin_unit_test,unit_tests' },
-          { name: CoreMLPredictionsPlugin, flags: 'CoreMLPredictions_plugin_unit_test,unit_tests' }
+          Amplify,
+          AWSPluginsCore,
+          AWSAPIPlugin,
+          AWSCloudWatchLoggingPlugin,
+          AWSCognitoAuthPlugin,
+          AWSDataStorePlugin,
+          AWSLocationGeoPlugin,
+          AWSPredictionsPlugin,
+          AWSPinpointAnalyticsPlugin,
+          AWSPinpointPushNotificationsPlugin,
+          AWSS3StoragePlugin,
+          CoreMLPredictionsPlugin
         ]
     uses: ./.github/workflows/run_xcodebuild_test_platforms.yml
     with:
-      scheme: ${{ matrix.scheme.name }}
-      submit_coverage_report: true
-      coverage_flags: ${{ matrix.scheme.flags }}
+      scheme: ${{ matrix.scheme }}
+      generate_coverage_report: true
+
+  report-coverage:
+    needs: [unit-tests-with-coverage]
+    runs-on: macos-13
+    strategy:
+      fail-fast: false
+      matrix:
+        file: [
+          { prefix: Amplify, flags: 'Amplify,unit_tests' },
+          { prefix: AWSPluginsCore, flags: 'AWSPluginsCore,unit_tests' },
+          { prefix: AWSAPIPlugin, flags: 'API_plugin_unit_test,unit_tests' },
+          { prefix: AWSCloudWatchLoggingPlugin, flags: 'Logging_plugin_unit_test,unit_tests' },
+          { prefix: AWSCognitoAuthPlugin, flags: 'Auth_plugin_unit_test,unit_tests' },
+          { prefix: AWSDataStorePlugin, flags: 'DataStore_plugin_unit_test,unit_tests' },
+          { prefix: AWSLocationGeoPlugin, flags: 'Geo_plugin_unit_test,unit_tests' },
+          { prefix: AWSPredictionsPlugin, flags: 'Predictions_plugin_unit_test,unit_tests' },
+          { prefix: AWSPinpointAnalyticsPlugin, flags: 'Analytics_plugin_unit_test,unit_tests' },
+          { prefix: AWSPinpointPushNotificationsPlugin, flags: 'PushNotifications_plugin_unit_test,unit_tests' },
+          { prefix: AWSS3StoragePlugin, flags: 'Storage_plugin_unit_test,unit_tests' },
+          { prefix: CoreMLPredictionsPlugin, flags: 'CoreMLPredictions_plugin_unit_test,unit_tests' }
+        ]
+    steps:
+      - name: Retrieve Coverage file
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a #v3.0.2
+        with:
+          name: ${{ matrix.file.prefix }}-Coverage-${{ github.sha }}
+          path: ${{ github.workspace }}
+
+      - name: Upload report to Codecov
+        shell: bash
+        run: |
+          build-support/codecov.sh -F '${{ matrix.file.flags }}'

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -73,6 +73,10 @@ jobs:
           { prefix: CoreMLPredictionsPlugin, flags: 'CoreMLPredictions_plugin_unit_test,unit_tests' }
         ]
     steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
+        with:
+          persist-credentials: false
+
       - name: Retrieve Coverage file
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a #v3.0.2
         with:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -29,7 +29,7 @@ jobs:
       generate_coverage_report: false
 
   unit-tests-with-coverage:
-    name: ${{ matrix.scheme.name }} Unit Tests
+    name: ${{ matrix.scheme }} Unit Tests
     strategy:
       fail-fast: false
       matrix:
@@ -53,37 +53,26 @@ jobs:
       generate_coverage_report: true
 
   report-coverage:
+    name: Report Coverage
     needs: [unit-tests-with-coverage]
-    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:
         file: [
-          { prefix: Amplify, flags: 'Amplify,unit_tests' },
-          { prefix: AWSPluginsCore, flags: 'AWSPluginsCore,unit_tests' },
-          { prefix: AWSAPIPlugin, flags: 'API_plugin_unit_test,unit_tests' },
-          { prefix: AWSCloudWatchLoggingPlugin, flags: 'Logging_plugin_unit_test,unit_tests' },
-          { prefix: AWSCognitoAuthPlugin, flags: 'Auth_plugin_unit_test,unit_tests' },
-          { prefix: AWSDataStorePlugin, flags: 'DataStore_plugin_unit_test,unit_tests' },
-          { prefix: AWSLocationGeoPlugin, flags: 'Geo_plugin_unit_test,unit_tests' },
-          { prefix: AWSPredictionsPlugin, flags: 'Predictions_plugin_unit_test,unit_tests' },
-          { prefix: AWSPinpointAnalyticsPlugin, flags: 'Analytics_plugin_unit_test,unit_tests' },
-          { prefix: AWSPinpointPushNotificationsPlugin, flags: 'PushNotifications_plugin_unit_test,unit_tests' },
-          { prefix: AWSS3StoragePlugin, flags: 'Storage_plugin_unit_test,unit_tests' },
-          { prefix: CoreMLPredictionsPlugin, flags: 'CoreMLPredictions_plugin_unit_test,unit_tests' }
+          { scheme: Amplify, flags: 'Amplify,unit_tests' },
+          { scheme: AWSPluginsCore, flags: 'AWSPluginsCore,unit_tests' },
+          { scheme: AWSAPIPlugin, flags: 'API_plugin_unit_test,unit_tests' },
+          { scheme: AWSCloudWatchLoggingPlugin, flags: 'Logging_plugin_unit_test,unit_tests' },
+          { scheme: AWSCognitoAuthPlugin, flags: 'Auth_plugin_unit_test,unit_tests' },
+          { scheme: AWSDataStorePlugin, flags: 'DataStore_plugin_unit_test,unit_tests' },
+          { scheme: AWSLocationGeoPlugin, flags: 'Geo_plugin_unit_test,unit_tests' },
+          { scheme: AWSPredictionsPlugin, flags: 'Predictions_plugin_unit_test,unit_tests' },
+          { scheme: AWSPinpointAnalyticsPlugin, flags: 'Analytics_plugin_unit_test,unit_tests' },
+          { scheme: AWSPinpointPushNotificationsPlugin, flags: 'PushNotifications_plugin_unit_test,unit_tests' },
+          { scheme: AWSS3StoragePlugin, flags: 'Storage_plugin_unit_test,unit_tests' },
+          { scheme: CoreMLPredictionsPlugin, flags: 'CoreMLPredictions_plugin_unit_test,unit_tests' }
         ]
-    steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
-        with:
-          persist-credentials: false
-
-      - name: Retrieve Coverage file
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a #v3.0.2
-        with:
-          name: ${{ matrix.file.prefix }}-Coverage-${{ github.sha }}
-          path: ${{ github.workspace }}
-
-      - name: Upload report to Codecov
-        shell: bash
-        run: |
-          build-support/codecov.sh -F '${{ matrix.file.flags }}'
+    uses: ./.github/workflows/upload_coverage_report.yml
+    with:
+      scheme: ${{ matrix.file.scheme }}
+      flags: ${{ matrix.file.flags }}

--- a/.github/workflows/upload_coverage_report.yml
+++ b/.github/workflows/upload_coverage_report.yml
@@ -1,0 +1,36 @@
+name: Uploads the coverage report file to Codecov
+on:
+  workflow_call:
+    inputs:      
+      scheme:
+        description: 'The name of the scheme whose coverage needs to be uploaded.'
+        required: true
+        type: string
+      flags:
+        description: 'What flags to include in the coverage report, separated by commas'
+        required: false
+        type: string
+        default: 'tests'
+
+permissions:
+    contents: read
+
+jobs:
+  upload-coverage:
+    name: ${{ inputs.scheme }} Coverage Report
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
+        with:
+          persist-credentials: false
+
+      - name: Retrieve Coverage report
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a #v3.0.2
+        with:
+          name: ${{ inputs.scheme }}-Coverage-${{ github.sha }}
+          path: ${{ github.workspace }}
+
+      - name: Upload report to Codecov
+        shell: bash
+        run: |
+          build-support/codecov.sh -F '${{ inputs.flags }}'


### PR DESCRIPTION
## Description
While the bash script is more reliable when uploading, Codecov seems to have a pretty tight "timeout" when it comes to considering a workflow "stale", which starts when the first report is received for the same workflow.

To prevent this, instead of having each scheme report their coverage as soon as the tests are done running, I'm instead caching them and bulk reporting all once the unit test succeeded. This also enables us to re-run any failed unit test job without worrying it would take too long.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
