### PR TITLE
chore: update xcode version for canary test

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -16,13 +16,13 @@ jobs:
       matrix:
         include:
           - os: macos-12
-            xcode-version: 14.2
+            xcode-version: 14.3.1
             device: iPhone 14 Pro
-            version: 16.2
+            version: 16.4
           - os: macos-12
-            xcode-version: 13.4.1
+            xcode-version: 14.1
             device: iPhone 13 Pro
-            version: 15.5
+            version: 16.1
     name: Canary Test - Xcode ${{ matrix.xcode-version }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -50,7 +50,7 @@ jobs:
           sudo xcode-select -s "/Applications/Xcode_${{ matrix.xcode-version }}.app"
           xcodebuild -version
 
-      - name: Run Tests - ${{ matrix.device }} with iOS${{ matrix.version }}
+      - name: Run Tests - ${{ matrix.device }} with iOS ${{ matrix.version }}
         working-directory: ${{ github.workspace }}/canaries/example
         run: bundle exec fastlane scan --device "${{ matrix.device }}" --deployment_target_version "${{ matrix.version }}"
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
Updates min. and max. Xcode versions for running canary test workflow.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
