### PR TITLE
fix(api): Custom Selection Set with nested has-many missing nextToken

### DIFF
--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL1/GraphQLLazyLoadPostComment4V2Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL1/GraphQLLazyLoadPostComment4V2Tests.swift
@@ -100,6 +100,7 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
                   }
                   __typename
                 }
+                nextToken
               }
             }
             __typename
@@ -161,6 +162,7 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
                   }
                   __typename
                 }
+                nextToken
               }
             }
             __typename

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/CompositePK/GraphQLLazyLoadCompositePKTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/CompositePK/GraphQLLazyLoadCompositePKTests.swift
@@ -40,8 +40,8 @@ final class GraphQLLazyLoadCompositePKTests: GraphQLLazyLoadBaseTest {
             [parent.children, parent.implicitChildren, parent.strangeChildren, parent.childrenSansBelongsTo]
         })
         let expectedDocument = """
-        query GetCompositePKParent($content: String!, $customId: ID!) {
-          getCompositePKParent(content: $content, customId: $customId) {
+        query GetCompositePKParent {
+          getCompositePKParent(content: "content", customId: "\(savedParent.customId)") {
             customId
             content
             createdAt
@@ -60,6 +60,7 @@ final class GraphQLLazyLoadCompositePKTests: GraphQLLazyLoadBaseTest {
                 }
                 __typename
               }
+              nextToken
             }
             implicitChildren {
               items {
@@ -74,6 +75,7 @@ final class GraphQLLazyLoadCompositePKTests: GraphQLLazyLoadBaseTest {
                 }
                 __typename
               }
+              nextToken
             }
             strangeChildren {
               items {
@@ -88,6 +90,7 @@ final class GraphQLLazyLoadCompositePKTests: GraphQLLazyLoadBaseTest {
                 }
                 __typename
               }
+              nextToken
             }
             childrenSansBelongsTo {
               items {
@@ -99,6 +102,7 @@ final class GraphQLLazyLoadCompositePKTests: GraphQLLazyLoadBaseTest {
                 updatedAt
                 __typename
               }
+              nextToken
             }
           }
         }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
@@ -129,6 +129,7 @@ extension SelectionSet {
                 result.append(innerSelectionSetField.stringValue(indentSize: indentSize + 2))
             }
             result.append(doubleIndent + "}")
+            result.append(doubleIndent + "nextToken")
             result.append(indent + "}")
         case .value:
             guard let name = value.name else {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/IncludeAssociationDecoratorTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/IncludeAssociationDecoratorTests.swift
@@ -165,6 +165,7 @@ class IncludeAssociationDecoratorTests: XCTestCase {
                 }
                 __typename
               }
+              nextToken
             }
             """
         let selectionSet = createSelectionSet(for: Post.self, includes: { post in [post.comments] })
@@ -217,6 +218,7 @@ class IncludeAssociationDecoratorTests: XCTestCase {
                 }
                 __typename
               }
+              nextToken
             }
             """
         let selectionSet = createSelectionSet(for: Book.self, includes: { book in
@@ -271,6 +273,7 @@ class IncludeAssociationDecoratorTests: XCTestCase {
                 }
                 __typename
               }
+              nextToken
             }
             """
         let selectionSet = createSelectionSet(for: Author.self, includes: { author in
@@ -310,6 +313,7 @@ class IncludeAssociationDecoratorTests: XCTestCase {
                 }
                 __typename
               }
+              nextToken
             }
             """
         let selectionSet = createSelectionSet(for: Author.self, includes: { author in


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/3093
https://github.com/aws-amplify/amplify-swift/issues/3128

## Description
<!-- Why is this change required? What problem does it solve? -->
This change is required for when custom selection sets including the has-many fields of the model are specified.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
