### PR TITLE
chore: update datastore tests to use fulfillment rather than expectation

### DIFF
--- a/.github/workflows/integ_test_datastore_auth_cognito.yml
+++ b/.github/workflows/integ_test_datastore_auth_cognito.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginAuthCognitoTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-cognito-test-tvOS:

--- a/.github/workflows/integ_test_datastore_auth_cognito.yml
+++ b/.github/workflows/integ_test_datastore_auth_cognito.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   datastore-integration-auth-cognito-test-iOS:
     timeout-minutes: 30
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/integ_test_datastore_auth_cognito.yml
+++ b/.github/workflows/integ_test_datastore_auth_cognito.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginAuthCognitoTests
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-cognito-test-tvOS:
     timeout-minutes: 30

--- a/.github/workflows/integ_test_datastore_auth_iam.yml
+++ b/.github/workflows/integ_test_datastore_auth_iam.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   datastore-integration-auth-iam-test-iOS:
     timeout-minutes: 30
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/integ_test_datastore_auth_iam.yml
+++ b/.github/workflows/integ_test_datastore_auth_iam.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginAuthIAMTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-iam-test-tvOS:

--- a/.github/workflows/integ_test_datastore_auth_iam.yml
+++ b/.github/workflows/integ_test_datastore_auth_iam.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginAuthIAMTests
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-iam-test-tvOS:
     timeout-minutes: 30

--- a/.github/workflows/integ_test_datastore_multi_auth.yml
+++ b/.github/workflows/integ_test_datastore_multi_auth.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginMultiAuthTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-multi-auth-test-tvOS:

--- a/.github/workflows/integ_test_datastore_multi_auth.yml
+++ b/.github/workflows/integ_test_datastore_multi_auth.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   datastore-integration-multi-auth-test-iOS:
     timeout-minutes: 30
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -33,6 +33,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginMultiAuthTests
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-multi-auth-test-tvOS:
     timeout-minutes: 30

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
@@ -288,8 +288,8 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
         setUp(withModels: TestModelRegistration())
         try await Amplify.DataStore.clear()
         var snapshotCount = 0
-        let initialQueryComplete = asyncExpectation(description: "initial snapshot received")
-        let allSnapshotsReceived = asyncExpectation(description: "query snapshots received")
+        let initialQueryComplete = expectation(description: "initial snapshot received")
+        let allSnapshotsReceived = expectation(description: "query snapshots received")
 
         let subscription = Amplify.DataStore.observeQuery(for: Post.self)
         let sink = Amplify.Publisher.create(subscription).sink { completed in
@@ -302,15 +302,15 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
         } receiveValue: { querySnapshot in
             snapshotCount += 1
             if snapshotCount == 1 {
-                Task { await initialQueryComplete.fulfill() }
+                initialQueryComplete.fulfill()
             }
             if querySnapshot.items.count == 15 {
-                Task { await allSnapshotsReceived.fulfill() }
+                allSnapshotsReceived.fulfill()
             }
         }
-        await waitForExpectations([initialQueryComplete], timeout: 10)
+        await fulfillment(of: [initialQueryComplete], timeout: 10)
         _ = try await setUpLocalStore(numberOfPosts: 15)
-        await waitForExpectations([allSnapshotsReceived], timeout: 10)
+        await fulfillment(of: [allSnapshotsReceived], timeout: 10)
         XCTAssertTrue(snapshotCount >= 2)
         sink.cancel()
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginTests.swift
@@ -79,16 +79,16 @@ class AWSDataStorePluginTests: XCTestCase {
                                         validAuthPluginKey: "MockAuthCategoryPlugin")
         do {
             try plugin.configure(using: nil)
-            let queryCompleted = asyncExpectation(description: "query completed")
+            let queryCompleted = expectation(description: "query completed")
             Task {
                 _ = try await plugin.query(ExampleWithEveryType.self)
-                await queryCompleted.fulfill()
+                queryCompleted.fulfill()
             }
-            await waitForExpectations([queryCompleted], timeout: 1.0)
+            await fulfillment(of: [queryCompleted], timeout: 1.0)
         } catch {
             XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
         }
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [startExpectation], timeout: 1.0)
     }
     
     func testStorageEngineStartsOnPluginStopStart() throws {

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/ListTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/ListTests.swift
@@ -49,7 +49,7 @@ class ListTests: BaseDataStoreTests {
             XCTFail("\(error)")
         }
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [expect], timeout: 1)
     }
 
     // MARK: - Helpers

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/CascadeDeleteOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/CascadeDeleteOperationTests.swift
@@ -87,7 +87,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
         operation.start()
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [completed], timeout: 1)
         guard case .success(let queriedRestaurants) = await queryModelSynchronous(modelType: Restaurant.self,
                                                                                   predicate: predicate) else {
             XCTFail("Failed to query")
@@ -361,7 +361,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
         operation.start()
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [receivedMutationEvent, expectedFailures, expectedSuccess, completed], timeout: 1)
         guard case .success(let queriedRestaurants) = await queryModelSynchronous(modelType: Restaurant.self,
                                                                             predicate: predicate) else {
             XCTFail("Failed to query")
@@ -422,7 +422,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
         operation.start()
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [receivedMutationEvent, expectedFailures, expectedSuccess, completed], timeout: 1)
         guard case .success(let queriedModels) = await queryModelSynchronous(modelType: ModelCompositePk.self,
                                                                             predicate: predicate) else {
             XCTFail("Failed to query")
@@ -729,7 +729,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         }
 
         operation.syncIfNeededAndFinish(result)
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [receivedMutationEvent, expectedFailures, expectedSuccess, completed], timeout: 1)
         XCTAssertEqual(submittedEvents.count, 2)
         // The delete mutations should be synced in reverse order (children to parent)
         XCTAssertEqual(submittedEvents[0].modelName, CommentWithCompositeKey.modelName)
@@ -797,7 +797,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         }
 
         operation.syncIfNeededAndFinish(result)
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [receivedMutationEvent, expectedFailures, expectedSuccess, completed], timeout: 1)
         XCTAssertEqual(submittedEvents.count, 3)
         // The delete mutations should be synced in reverse order (children to parent)
         XCTAssertEqual(submittedEvents[0].modelName, Dish.modelName)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsBase.swift
@@ -47,7 +47,7 @@ class StorageEngineTestsBase: XCTestCase {
             result = sResult
             saveFinished.fulfill()
         }
-        await waitForExpectations(timeout: defaultTimeout)
+        await fulfillment(of: [saveFinished], timeout: defaultTimeout)
         guard let saveResult = result else {
             return .failure(causedBy: "Save operation timed out")
         }
@@ -105,7 +105,7 @@ class StorageEngineTestsBase: XCTestCase {
             queryFinished.fulfill()
         }
 
-        await waitForExpectations(timeout: defaultTimeout)
+        await fulfillment(of: [queryFinished], timeout: defaultTimeout)
         guard let queryResult = result else {
             return .failure(causedBy: "Query operation timed out")
         }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
@@ -96,7 +96,16 @@ class InitialSyncOrchestratorTests: XCTestCase {
             syncCallbackReceived.fulfill()
         }
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(
+            of: [
+                syncCallbackReceived,
+                syncQueriesStartedReceived,
+                syncStartedReceived,
+                finishedReceived,
+                completionFinishedReceived
+            ],
+            timeout: 1
+        )
         XCTAssertEqual(orchestrator.syncOperationQueue.maxConcurrentOperationCount, 1)
         Amplify.Hub.removeListener(hubListener)
         sink.cancel()
@@ -195,7 +204,16 @@ class InitialSyncOrchestratorTests: XCTestCase {
             syncCallbackReceived.fulfill()
         }
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(
+            of: [
+                syncCallbackReceived,
+                syncQueriesStartedReceived,
+                syncStartedReceived,
+                finishedReceived,
+                failureCompletionReceived
+            ],
+            timeout: 1
+        )
         XCTAssertEqual(orchestrator.syncOperationQueue.maxConcurrentOperationCount, 1)
         Amplify.Hub.removeListener(hubListener)
         sink.cancel()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionTests.swift
@@ -99,7 +99,7 @@ class LocalSubscriptionTests: XCTestCase {
     /// - Then:
     ///    - I receive notifications for updates to that model
     func testObserve() async throws {
-        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
+        let receivedMutationEvent = expectation(description: "Received mutation event")
 
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
@@ -122,7 +122,7 @@ class LocalSubscriptionTests: XCTestCase {
                          comments: [])
 
         _ = try await Amplify.DataStore.save(model)
-        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
+        await fulfillment(of: [receivedMutationEvent], timeout: 1.0)
         subscription.cancel()
     }
 
@@ -132,7 +132,7 @@ class LocalSubscriptionTests: XCTestCase {
     /// - Then:
     ///    - I am notified of `create` mutations
     func testCreate() async throws {
-        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
+        let receivedMutationEvent = expectation(description: "Received mutation event")
 
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
@@ -157,7 +157,7 @@ class LocalSubscriptionTests: XCTestCase {
                          comments: [])
 
         _ = try await Amplify.DataStore.save(model)
-        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
+        await fulfillment(of: [receivedMutationEvent], timeout: 1.0)
 
         subscription.cancel()
     }
@@ -185,7 +185,7 @@ class LocalSubscriptionTests: XCTestCase {
         newModel.content = newContent
         newModel.updatedAt = .now()
 
-        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
+        let receivedMutationEvent = expectation(description: "Received mutation event")
 
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
@@ -200,7 +200,7 @@ class LocalSubscriptionTests: XCTestCase {
         
         _ = try await Amplify.DataStore.save(newModel)
 
-        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
+        await fulfillment(of: [receivedMutationEvent], timeout: 1.0)
 
         subscription.cancel()
     }
@@ -211,7 +211,7 @@ class LocalSubscriptionTests: XCTestCase {
     /// - Then:
     ///    - I am notified of `delete` mutations
     func testDelete() async throws {
-        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
+        let receivedMutationEvent = expectation(description: "Received mutation event")
 
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
@@ -232,7 +232,7 @@ class LocalSubscriptionTests: XCTestCase {
 
         _ = try await Amplify.DataStore.save(model)
         _ = try await Amplify.DataStore.delete(model)
-        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
+        await fulfillment(of: [receivedMutationEvent], timeout: 1.0)
 
         subscription.cancel()
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
@@ -73,7 +73,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [mutationEventVerified], timeout: 1)
     }
 
     /// - Given: An existing MutationEvent of type .create
@@ -161,7 +161,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     // MARK: - Existing == .update
@@ -579,7 +579,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     /// - Given: A mutation queue with an in-process .create event
@@ -633,7 +633,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     /// - Given: A mutation queue with an in-process .create event
@@ -671,7 +671,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
@@ -118,13 +118,13 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         try await startAmplifyAndWaitForSync()
 
         // Save initial model
-        let createdNewItem = asyncExpectation(description: "createdNewItem")
+        let createdNewItem = expectation(description: "createdNewItem")
         let postCopy = post
         Task {
             _ = try await Amplify.DataStore.save(postCopy)
-            await createdNewItem.fulfill()
+            createdNewItem.fulfill()
         }
-        await waitForExpectations([createdNewItem])
+        await fulfillment(of: [createdNewItem])
         await fulfillment(of: [apiRespondedWithSuccess], timeout: 1.0, enforceOrder: false)
 
         // Set the responder to reject the mutation. Make sure to push a retry advice before sending
@@ -146,13 +146,13 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         // will be scheduled and probably in "waiting" mode when we send the network unavailable
         // notification below.
         post.content = "Update 1"
-        let savedUpdate1 = asyncExpectation(description: "savedUpdate1")
+        let savedUpdate1 = expectation(description: "savedUpdate1")
         let postCopy1 = post
         Task {
             _ = try await Amplify.DataStore.save(postCopy1)
-            await savedUpdate1.fulfill()
+            savedUpdate1.fulfill()
         }
-        await waitForExpectations([savedUpdate1])
+        await fulfillment(of: [savedUpdate1])
 
         // At this point, the MutationEvent table (the backing store for the outgoing mutation
         // queue) has only a record for the interim update. It is marked as `inProcess: true`,
@@ -178,7 +178,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
 
         // Assert that DataStore has pushed the no-network event. This isn't strictly necessary for
         // correct operation of the queue.
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [networkUnavailable], timeout: 1.0)
 
         // At this point, the MutationEvent table has only a record for update1. It is marked as
         // `inProcess: false`, because the mutation queue has been fully cancelled by the cleanup
@@ -193,13 +193,13 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         // also expect that it will be overwritten by the next mutation, without ever being synced
         // to the service.
         post.content = "Update 2"
-        let savedUpdate2 = asyncExpectation(description: "savedUpdate2")
+        let savedUpdate2 = expectation(description: "savedUpdate2")
         let postCopy2 = post
         Task {
             _ = try await Amplify.DataStore.save(postCopy2)
-            await savedUpdate2.fulfill()
+            savedUpdate2.fulfill()
         }
-        await waitForExpectations([savedUpdate2])
+        await fulfillment(of: [savedUpdate2])
 
         // At this point, the MutationEvent table has only a record for update2. It is marked as
         // `inProcess: false`, because the mutation queue has been fully cancelled.
@@ -210,13 +210,13 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         // even if there were multiple not-in-process mutations, after the reconciliation completes
         // there would only be one record in the MutationEvent table.
         post.content = expectedFinalContent
-        let savedFinalUpdate = asyncExpectation(description: "savedFinalUpdate")
+        let savedFinalUpdate = expectation(description: "savedFinalUpdate")
         let postCopy3 = post
         Task {
             _ = try await Amplify.DataStore.save(postCopy3)
-            await savedFinalUpdate.fulfill()
+            savedFinalUpdate.fulfill()
         }
-        await waitForExpectations([savedFinalUpdate])
+        await fulfillment(of: [savedFinalUpdate])
 
         let syncStarted = expectation(description: "syncStarted")
         setUpSyncStartedListener(
@@ -250,7 +250,15 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         
         apiPlugin.responders = [.mutateRequestListener: acceptSubsequentMutations]
         reachabilitySubject.send(ReachabilityUpdate(isOnline: true))
-        await waitForExpectations(timeout: 5.0)
+        await fulfillment(
+            of: [
+                syncStarted,
+                outboxEmpty,
+                expectedFinalContentReceived,
+                networkAvailableAgain
+            ],
+            timeout: 5.0
+        )
     }
 
     // MARK: - Utilities

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
@@ -104,14 +104,21 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
         }
 
         try Amplify.configure(amplifyConfig)
-        let startSuccess = asyncExpectation(description: "start success")
+        let startSuccess = expectation(description: "start success")
         Task {
             _ = try await Amplify.DataStore.start()
-            await startSuccess.fulfill()
+            startSuccess.fulfill()
         }
-        await waitForExpectations([startSuccess], timeout: 1.0)
+        await fulfillment(of: [startSuccess], timeout: 1.0)
         
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(
+            of: [
+                createSubscriptionStarted,
+                updateSubscriptionStarted,
+                deleteSubscriptionStarted
+            ],
+            timeout: 1.0
+        )
     }
     // TODO: Implement the test below
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
@@ -130,7 +130,20 @@ class RemoteSyncEngineTests: XCTestCase {
 
         remoteSyncEngine.start(api: apiPlugin, auth: nil)
 
-        await waitForExpectations(timeout: defaultAsyncWaitTimeout)
+        await fulfillment(
+            of: [
+                storageAdapterAvailable,
+                subscriptionsPaused,
+                mutationsPaused,
+                stateMutationsCleared,
+                subscriptionsInitialized,
+                subscriptionsEstablishedReceived,
+                cleanedup,
+                failureOnInitialSync,
+                retryAdviceReceivedNetworkError
+            ],
+            timeout: defaultAsyncWaitTimeout
+        )
         remoteSyncEngineSink.cancel()
         Amplify.Hub.removeListener(hubListener)
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -78,7 +78,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        await waitForExpectations(timeout: 2)
+        await fulfillment(of: [expectStarted, expectInitialized], timeout: 2)
 
         // Take action on the sink to prevent compiler warnings about unused variables.
         sink.cancel()
@@ -113,7 +113,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        await waitForExpectations(timeout: 2)
+        await fulfillment(of: [expectStarted, expectInitialized], timeout: 2)
 
         sink.cancel()
     }
@@ -152,7 +152,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        await waitForExpectations(timeout: 2)
+        await fulfillment(of: [expectStarted, expectInitialized], timeout: 2)
 
         sink.cancel()
     }
@@ -187,7 +187,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        await waitForExpectations(timeout: 2)
+        await fulfillment(of: [expectStarted, expectInitialized], timeout: 2)
 
         sink.cancel()
     }
@@ -228,7 +228,7 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        await waitForExpectations(timeout: 2)
+        await fulfillment(of: [expectStarted, expectInitialized], timeout: 2)
 
         sink.cancel()
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
@@ -38,7 +38,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
                                                      version: 2)
         let localMetadataSaved = expectation(description: "Local metadata saved")
         storageAdapter.save(localSyncMetadata) { _ in localMetadataSaved.fulfill() }
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [localMetadataSaved], timeout: 1.0)
 
         var valueListenerFromRequest: MutationSyncInProcessListener?
         let expectationListener = expectation(description: "listener")
@@ -57,7 +57,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
             mockRemoteSyncEngineFor_testUpdateAfterDelete()
             try await startAmplifyAndWaitForSync()
         }
-        await waitForExpectations(timeout: 2.0)
+        await fulfillment(of: [expectationListener], timeout: 2.0)
 
         guard let valueListener = valueListenerFromRequest else {
                 XCTFail("Incoming responder didn't set up listener")
@@ -149,7 +149,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
             mockRemoteSyncEngineFor_testDeleteWithNoLocalModel()
             try await startAmplifyAndWaitForSync()
         }
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [expectationListener], timeout: 1)
 
         guard let valueListener = valueListenerFromRequest else {
             XCTFail("Incoming responder didn't set up listener")
@@ -176,7 +176,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
         let remoteMutationSync = MutationSync(model: anyModel, syncMetadata: remoteSyncMetadata)
         valueListener(.data(.success(remoteMutationSync)))
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [syncReceivedNotification], timeout: 1)
 
         let finalLocalMetadata = try storageAdapter.queryMutationSyncMetadata(for: model.id,
                                                                                  modelName: MockSynced.modelName)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -51,7 +51,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
             subscriptionEventsSubject.send(.mutationEvent(mutationSync))
         }
 
-        wait(for: [eventsNotSaved], timeout: 5.0)
+        await fulfillment(of: [eventsNotSaved], timeout: 5.0)
     }
 
     /// - Given: An AWSModelReconciliationQueue that has been buffering events
@@ -120,7 +120,17 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         queue.start()
 
-        await waitForExpectations(timeout: 5.0)
+        await fulfillment(
+            of: [
+                event1Saved,
+                event2Saved,
+                event3Saved,
+                eventsSentViaPublisher1,
+                eventsSentViaPublisher2,
+                eventsSentViaPublisher3
+            ],
+            timeout: 5.0
+        )
         queueSink.cancel()
     }
 
@@ -190,7 +200,15 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         queue.start()
 
-        await waitForExpectations(timeout: 5.0)
+        await fulfillment(
+            of: [
+                event1Saved,
+                event3Saved,
+                eventsSentViaPublisher1,
+                eventsSentViaPublisher3
+            ],
+            timeout: 5.0
+        )
         queueSink.cancel()
     }
 
@@ -283,7 +301,15 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         queue.start()
 
-        await waitForExpectations(timeout: 5.0)
+        await fulfillment(
+            of: [
+                allEventsProcessed,
+                eventsSentViaPublisher1,
+                eventsSentViaPublisher2,
+                eventsSentViaPublisher3
+            ],
+            timeout: 5.0
+        )
         queueSink.cancel()
     }
 
@@ -351,7 +377,15 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         queue.start()
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(
+            of: [
+                event1ShouldBeProcessed,
+                event2ShouldBeProcessed,
+                eventsSentViaPublisher1,
+                eventsSentViaPublisher2
+            ],
+            timeout: 1.0
+        )
 
         let event1ShouldNotBeProcessed = expectation(description: "Event 1 should not be processed")
         event1ShouldNotBeProcessed.isInverted = true
@@ -393,7 +427,15 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
         let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
         subscriptionEventsSubject.send(.mutationEvent(mutationSync))
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(
+            of: [
+                event1ShouldNotBeProcessed,
+                event2ShouldNotBeProcessed,
+                event3ShouldBeProcessed,
+                eventsSentViaPublisher3
+            ],
+            timeout: 1.0
+        )
         queueSink.cancel()
     }
 
@@ -437,7 +479,7 @@ extension ModelReconciliationQueueBehaviorTests {
         })
 
         subscriptionEventsSubject.send(completion: completion)
-        wait(for: [eventSentViaPublisher], timeout: 1.0)
+        await fulfillment(of: [eventSentViaPublisher], timeout: 1.0)
         queueSink.cancel()
     }
 
@@ -465,7 +507,7 @@ extension ModelReconciliationQueueBehaviorTests {
         })
 
         subscriptionEventsSubject.send(completion: completion)
-        wait(for: [eventSentViaPublisher], timeout: 1.0)
+        await fulfillment(of: [eventSentViaPublisher], timeout: 1.0)
         queueSink.cancel()
     }
 
@@ -493,7 +535,7 @@ extension ModelReconciliationQueueBehaviorTests {
         })
 
         subscriptionEventsSubject.send(completion: completion)
-        wait(for: [eventSentViaPublisher], timeout: 1.0)
+        await fulfillment(of: [eventSentViaPublisher], timeout: 1.0)
         queueSink.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/LocalStoreIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/LocalStoreIntegrationTestBase.swift
@@ -30,13 +30,13 @@ class LocalStoreIntegrationTestBase: XCTestCase {
     }
 
     override func tearDown() async throws {
-        let clearComplete = asyncExpectation(description: "clear completed")
+        let clearComplete = expectation(description: "clear completed")
         
         Task {
             try await Amplify.DataStore.clear()
             await clearComplete.fulfill()
         }
-        await waitForExpectations([clearComplete], timeout: 5)
+        await fulfillment(of: [clearComplete], timeout: 5)
         await Amplify.reset()
     }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreAuthBaseTest.swift
@@ -79,7 +79,6 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
         try await clearDataStore()
         try await signOut()
         await Amplify.reset()
-        try await Task.sleep(seconds: 1)
     }
 
     // MARK: - Test Helpers

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreAuthBaseTest.swift
@@ -85,18 +85,18 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
     // MARK: - Test Helpers
     func makeExpectations() -> AuthTestExpectations {
         AuthTestExpectations(
-            subscriptionsEstablished: asyncExpectation(description: "Subscriptions established"),
-            modelsSynced: asyncExpectation(description: "Models synced"),
+            subscriptionsEstablished: expectation(description: "Subscriptions established"),
+            modelsSynced: expectation(description: "Models synced"),
 
-            query: asyncExpectation(description: "Query success"),
+            query: expectation(description: "Query success"),
 
-            mutationSave: asyncExpectation(description: "Mutation save success"),
-            mutationSaveProcessed: asyncExpectation(description: "Mutation save processed"),
+            mutationSave: expectation(description: "Mutation save success"),
+            mutationSaveProcessed: expectation(description: "Mutation save processed"),
 
-            mutationDelete: asyncExpectation(description: "Mutation delete success"),
-            mutationDeleteProcessed: asyncExpectation(description: "Mutation delete processed"),
+            mutationDelete: expectation(description: "Mutation delete success"),
+            mutationDeleteProcessed: expectation(description: "Mutation delete processed"),
 
-            ready: asyncExpectation(description: "Ready")
+            ready: expectation(description: "Ready")
         )
     }
 
@@ -297,7 +297,7 @@ extension AWSDataStoreAuthBaseTest {
                 onFailure(error as! DataStoreError)
             }
         }
-        await waitForExpectations([expectations.query], timeout: 60)
+        await fulfillment(of: [expectations.query], timeout: 60)
     }
     
     /// Asserts that DataStore is in a ready state and subscriptions are established
@@ -333,7 +333,7 @@ extension AWSDataStoreAuthBaseTest {
         
         try await Amplify.DataStore.start()
         
-        await waitForExpectations([expectations.subscriptionsEstablished,
+        await fulfillment(of: [expectations.subscriptionsEstablished,
                                    expectations.modelsSynced,
                                    expectations.ready],
                                   timeout: 60)
@@ -380,7 +380,7 @@ extension AWSDataStoreAuthBaseTest {
                 onFailure(error)
             }
         }
-        await waitForExpectations([expectations.mutationSave,
+        await fulfillment(of: [expectations.mutationSave,
                                    expectations.mutationSaveProcessed], timeout: 60)
         Task {
             do {
@@ -391,7 +391,7 @@ extension AWSDataStoreAuthBaseTest {
                 onFailure(error)
             }
         }
-        await waitForExpectations([expectations.mutationDelete,
+        await fulfillment(of: [expectations.mutationDelete,
                                    expectations.mutationDeleteProcessed], timeout: 60)
     }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreAuthBaseTest.swift
@@ -292,7 +292,7 @@ extension AWSDataStoreAuthBaseTest {
             do {
                 let posts = try await Amplify.DataStore.query(modelType)
                 XCTAssertNotNil(posts)
-                await expectations.query.fulfill()
+                expectations.query.fulfill()
             } catch {
                 onFailure(error as! DataStoreError)
             }
@@ -315,18 +315,18 @@ extension AWSDataStoreAuthBaseTest {
             .sink { event in
                 // subscription fulfilled
                 if event.eventName == dataStoreEvents.subscriptionsEstablished {
-                    Task { await expectations.subscriptionsEstablished.fulfill() }
+                    expectations.subscriptionsEstablished.fulfill()
                 }
                 // modelsSynced fulfilled
                 if event.eventName == dataStoreEvents.modelSynced {
                     modelSyncedCount += 1
                     if modelSyncedCount == expectedModelSynced {
-                        Task { await expectations.modelsSynced.fulfill() }
+                        expectations.modelsSynced.fulfill()
                     }
                 }
                 
                 if event.eventName == dataStoreEvents.ready {
-                    Task { await expectations.ready.fulfill() }
+                    expectations.ready.fulfill()
                 }
             }
             .store(in: &requests)
@@ -361,12 +361,12 @@ extension AWSDataStoreAuthBaseTest {
                 }
 
                 if mutationEvent.mutationType == GraphQLMutationType.create.rawValue {
-                    Task { await expectations.mutationSaveProcessed.fulfill() }
+                    expectations.mutationSaveProcessed.fulfill()
                     return
                 }
 
                 if mutationEvent.mutationType == GraphQLMutationType.delete.rawValue {
-                    Task { await expectations.mutationDeleteProcessed.fulfill() }
+                    expectations.mutationDeleteProcessed.fulfill()
                     return
                 }
             }
@@ -375,7 +375,7 @@ extension AWSDataStoreAuthBaseTest {
             do {
                 let posts = try await Amplify.DataStore.save(model)
                 XCTAssertNotNil(posts)
-                Task { await expectations.mutationSave.fulfill() }
+                expectations.mutationSave.fulfill()
             } catch let error as DataStoreError {
                 onFailure(error)
             }
@@ -386,7 +386,7 @@ extension AWSDataStoreAuthBaseTest {
             do {
                 let deletedposts: () = try await Amplify.DataStore.delete(model)
                 XCTAssertNotNil(deletedposts)
-                Task { await expectations.mutationDelete.fulfill() }
+                expectations.mutationDelete.fulfill()
             } catch let error as DataStoreError {
                 onFailure(error)
             }
@@ -408,15 +408,15 @@ extension AWSDataStoreAuthBaseTest {
 // MARK: - Expectations
 extension AWSDataStoreAuthBaseTest {
     struct AuthTestExpectations {
-        var subscriptionsEstablished: AsyncExpectation
-        var modelsSynced: AsyncExpectation
-        var query: AsyncExpectation
-        var mutationSave: AsyncExpectation
-        var mutationSaveProcessed: AsyncExpectation
-        var mutationDelete: AsyncExpectation
-        var mutationDeleteProcessed: AsyncExpectation
-        var ready: AsyncExpectation
-        var expectations: [AsyncExpectation] {
+        var subscriptionsEstablished: XCTestExpectation
+        var modelsSynced: XCTestExpectation
+        var query: XCTestExpectation
+        var mutationSave: XCTestExpectation
+        var mutationSaveProcessed: XCTestExpectation
+        var mutationDelete: XCTestExpectation
+        var mutationDeleteProcessed: XCTestExpectation
+        var ready: XCTestExpectation
+        var expectations: [XCTestExpectation] {
             return [subscriptionsEstablished,
                     modelsSynced,
                     query,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthIntegrationTests+Support.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthIntegrationTests+Support.swift
@@ -14,7 +14,7 @@ import DataStoreHostApp
 
 extension AWSDataStoreCategoryPluginAuthIntegrationTests {
     func saveModel<T: Model>(_ model: T) async throws {
-        let localSaveInvoked = asyncExpectation(description: "local model was saved")
+        let localSaveInvoked = expectation(description: "local model was saved")
         Task {
             do {
                 let savedposts = try await Amplify.DataStore.save(model)
@@ -25,6 +25,6 @@ extension AWSDataStoreCategoryPluginAuthIntegrationTests {
                 throw error
             }
         }
-        await waitForExpectations([localSaveInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [localSaveInvoked], timeout: TestCommonConstants.networkTimeout)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthIntegrationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthIntegrationTests.swift
@@ -40,7 +40,7 @@ class AWSDataStoreCategoryPluginAuthIntegrationTests: AWSDataStoreAuthBaseTest {
             return
         }
 
-        let syncReceivedInvoked = asyncExpectation(description: "Received SyncReceived event")
+        let syncReceivedInvoked = expectation(description: "Received SyncReceived event")
         var remoteTodoOptional: TodoExplicitOwnerField?
         let syncReceivedListener = Amplify.Hub.listen(to: .dataStore, eventName: syncReceived) { payload in
             guard let mutationEvent = payload.data as? MutationEvent,
@@ -60,7 +60,7 @@ class AWSDataStoreCategoryPluginAuthIntegrationTests: AWSDataStoreAuthBaseTest {
 
         try await signIn(user: user1)
 
-        await waitForExpectations([syncReceivedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [syncReceivedInvoked], timeout: TestCommonConstants.networkTimeout)
         Amplify.Hub.removeListener(syncReceivedListener)
         guard let remoteTodo = remoteTodoOptional else {
             XCTFail("Should have received a SyncReceived event with the remote note reconciled to local store")

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthIntegrationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthIntegrationTests.swift
@@ -50,7 +50,7 @@ class AWSDataStoreCategoryPluginAuthIntegrationTests: AWSDataStoreAuthBaseTest {
             }
             if todo.id == savedLocalTodo.id {
                 remoteTodoOptional = todo
-                Task { await syncReceivedInvoked.fulfill() }
+                syncReceivedInvoked.fulfill()
             }
         }
         guard try await HubListenerTestUtilities.waitForListener(with: syncReceivedListener, timeout: 5.0) else {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthIAMTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthIAMTests/AWSDataStoreAuthBaseTest.swift
@@ -87,18 +87,18 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
     // MARK: - Test Helpers
     func makeExpectations() -> AuthTestExpectations {
         AuthTestExpectations(
-            subscriptionsEstablished: AsyncExpectation(description: "Subscriptions established"),
-            modelsSynced: AsyncExpectation(description: "Models synced"),
+            subscriptionsEstablished: expectation(description: "Subscriptions established"),
+            modelsSynced: expectation(description: "Models synced"),
 
-            query: AsyncExpectation(description: "Query success"),
+            query: expectation(description: "Query success"),
 
-            mutationSave: AsyncExpectation(description: "Mutation save success"),
-            mutationSaveProcessed: AsyncExpectation(description: "Mutation save processed"),
+            mutationSave: expectation(description: "Mutation save success"),
+            mutationSaveProcessed: expectation(description: "Mutation save processed"),
 
-            mutationDelete: AsyncExpectation(description: "Mutation delete success"),
-            mutationDeleteProcessed: AsyncExpectation(description: "Mutation delete processed"),
+            mutationDelete: expectation(description: "Mutation delete success"),
+            mutationDeleteProcessed: expectation(description: "Mutation delete processed"),
 
-            ready: AsyncExpectation(description: "Ready")
+            ready: expectation(description: "Ready")
         )
     }
 
@@ -206,7 +206,7 @@ extension AWSDataStoreAuthBaseTest {
             XCTFail("Invalid user", file: file, line: line)
             return
         }
-        let signInInvoked = AsyncExpectation(description: "sign in completed")
+        let signInInvoked = expectation(description: "sign in completed")
         do {
             _ = try await Amplify.Auth.signIn(username: user.username,
                                                        password: user.password,
@@ -220,7 +220,7 @@ extension AWSDataStoreAuthBaseTest {
                 await signInInvoked.fulfill() // won't count as pass
             }
         }
-        await waitForExpectations([signInInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [signInInvoked], timeout: TestCommonConstants.networkTimeout)
         
         let signedIn = await isSignedIn()
         XCTAssert(signedIn, file: file, line: line)
@@ -229,20 +229,20 @@ extension AWSDataStoreAuthBaseTest {
     /// Signout current signed-in user
     func signOut(file: StaticString = #file,
                  line: UInt = #line) async {
-        let signoutInvoked = AsyncExpectation(description: "sign out completed")
+        let signoutInvoked = expectation(description: "sign out completed")
         Task {
             _ = await Amplify.Auth.signOut()
             await signoutInvoked.fulfill()
         }
         
-        await waitForExpectations([signoutInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [signoutInvoked], timeout: TestCommonConstants.networkTimeout)
         
         let signedIn = await isSignedIn()
         XCTAssert(!signedIn, file: file, line: line)
     }
 
     func isSignedIn() async -> Bool {
-        let checkIsSignedInCompleted = AsyncExpectation(description: "retrieve auth session completed")
+        let checkIsSignedInCompleted = expectation(description: "retrieve auth session completed")
         var resultOptional: Bool?
         do {
             let authSession = try await Amplify.Auth.fetchAuthSession()
@@ -254,7 +254,7 @@ extension AWSDataStoreAuthBaseTest {
             fatalError("Failed to get auth session \(error)")
         }
         
-        await waitForExpectations([checkIsSignedInCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [checkIsSignedInCompleted], timeout: TestCommonConstants.networkTimeout)
         guard let result = resultOptional else {
             XCTFail("Could not get isSignedIn for user")
             return false
@@ -264,7 +264,7 @@ extension AWSDataStoreAuthBaseTest {
     }
 
     func getUserSub() async -> String {
-        let retrieveUserSubCompleted = AsyncExpectation(description: "retrieve userSub completed")
+        let retrieveUserSubCompleted = expectation(description: "retrieve userSub completed")
         var resultOptional: String?
         do {
             let authSession = try await Amplify.Auth.fetchAuthSession()
@@ -285,7 +285,7 @@ extension AWSDataStoreAuthBaseTest {
             XCTFail("Failed to get auth session \(error)")
         }
 
-        await waitForExpectations([retrieveUserSubCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [retrieveUserSubCompleted], timeout: TestCommonConstants.networkTimeout)
         guard let result = resultOptional else {
             XCTFail("Could not get userSub for user")
             return ""
@@ -295,7 +295,7 @@ extension AWSDataStoreAuthBaseTest {
     }
 
     func getIdentityId() async -> String {
-        let retrieveIdentityCompleted = AsyncExpectation(description: "retrieve identity completed")
+        let retrieveIdentityCompleted = expectation(description: "retrieve identity completed")
         var resultOptional: String?
         do {
             let authSession = try await Amplify.Auth.fetchAuthSession()
@@ -315,7 +315,7 @@ extension AWSDataStoreAuthBaseTest {
         } catch(let error) {
             XCTFail("Failed to get auth session \(error)")
         }
-        await waitForExpectations([retrieveIdentityCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [retrieveIdentityCompleted], timeout: TestCommonConstants.networkTimeout)
         guard let result = resultOptional else {
             XCTFail("Could not get identityId for user")
             return ""
@@ -329,7 +329,7 @@ extension AWSDataStoreAuthBaseTest {
                               file: StaticString = #file,
                               line: UInt = #line) async -> M? {
         var queriedModel: M?
-        let queriedInvoked = AsyncExpectation(description: "Model queried")
+        let queriedInvoked = expectation(description: "Model queried")
 
         do {
             let model = try await Amplify.DataStore.query(M.self, byId: id)
@@ -341,7 +341,7 @@ extension AWSDataStoreAuthBaseTest {
             XCTFail("Failed to query model \(error)", file: file, line: line)
         }
         
-        await waitForExpectations([queriedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [queriedInvoked], timeout: TestCommonConstants.networkTimeout)
         return queriedModel
     }
 }
@@ -369,7 +369,7 @@ extension AWSDataStoreAuthBaseTest {
                 await expectations.query.fulfill()
             }
         }.store(in: &requests)
-        await waitForExpectations([expectations.query],
+        await fulfillment(of: [expectations.query],
              timeout: 60)
     }
 
@@ -413,7 +413,7 @@ extension AWSDataStoreAuthBaseTest {
         } catch(let error) {
             XCTFail("Failure due to error: \(error)")
         }
-        await waitForExpectations([expectations.subscriptionsEstablished,
+        await fulfillment(of: [expectations.subscriptionsEstablished,
                                    expectations.modelsSynced,
                                    expectations.ready],
                              timeout: 60)
@@ -467,7 +467,7 @@ extension AWSDataStoreAuthBaseTest {
             }
         }.store(in: &requests)
 
-        await waitForExpectations([expectations.mutationSave, expectations.mutationSaveProcessed], timeout: 60)
+        await fulfillment(of: [expectations.mutationSave, expectations.mutationSaveProcessed], timeout: 60)
 
         Amplify.Publisher.create {
             try await Amplify.DataStore.delete(model)
@@ -483,7 +483,7 @@ extension AWSDataStoreAuthBaseTest {
             }
         }.store(in: &requests)
 
-        await waitForExpectations([expectations.mutationDelete, expectations.mutationDeleteProcessed], timeout: 60)
+        await fulfillment(of: [expectations.mutationDelete, expectations.mutationDeleteProcessed], timeout: 60)
     }
 
     func assertUsedAuthTypes(_ authTypes: [AWSAuthorizationType],

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthIAMTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthIAMTests/AWSDataStoreAuthBaseTest.swift
@@ -211,14 +211,10 @@ extension AWSDataStoreAuthBaseTest {
             _ = try await Amplify.Auth.signIn(username: user.username,
                                                        password: user.password,
                                                        options: nil)
-            Task {
-                await signInInvoked.fulfill()
-            }
+            signInInvoked.fulfill()
         } catch(let error) {
             XCTFail("Signin failure \(error)", file: file, line: line)
-            Task {
-                await signInInvoked.fulfill() // won't count as pass
-            }
+            signInInvoked.fulfill() // won't count as pass
         }
         await fulfillment(of: [signInInvoked], timeout: TestCommonConstants.networkTimeout)
         
@@ -232,7 +228,7 @@ extension AWSDataStoreAuthBaseTest {
         let signoutInvoked = expectation(description: "sign out completed")
         Task {
             _ = await Amplify.Auth.signOut()
-            await signoutInvoked.fulfill()
+            signoutInvoked.fulfill()
         }
         
         await fulfillment(of: [signoutInvoked], timeout: TestCommonConstants.networkTimeout)
@@ -247,9 +243,7 @@ extension AWSDataStoreAuthBaseTest {
         do {
             let authSession = try await Amplify.Auth.fetchAuthSession()
             resultOptional = authSession.isSignedIn
-            Task {
-                await checkIsSignedInCompleted.fulfill()
-            }
+            checkIsSignedInCompleted.fulfill()
         } catch(let error) {
             fatalError("Failed to get auth session \(error)")
         }
@@ -275,9 +269,7 @@ extension AWSDataStoreAuthBaseTest {
             switch cognitoAuthSession.getUserSub() {
             case .success(let userSub):
                 resultOptional = userSub
-                Task {
-                    await retrieveUserSubCompleted.fulfill()
-                }
+                retrieveUserSubCompleted.fulfill()
             case .failure(let error):
                 XCTFail("Failed to get auth session \(error)")
             }
@@ -306,9 +298,7 @@ extension AWSDataStoreAuthBaseTest {
             switch cognitoAuthSession.getIdentityId() {
             case .success(let identityId):
                 resultOptional = identityId
-                Task {
-                    await retrieveIdentityCompleted.fulfill()
-                }
+                retrieveIdentityCompleted.fulfill()
             case .failure(let error):
                 XCTFail("Failed to get auth session \(error)")
             }
@@ -334,9 +324,7 @@ extension AWSDataStoreAuthBaseTest {
         do {
             let model = try await Amplify.DataStore.query(M.self, byId: id)
             queriedModel = model
-            Task {
-                await queriedInvoked.fulfill()
-            }
+            queriedInvoked.fulfill()
         } catch(let error) {
             XCTFail("Failed to query model \(error)", file: file, line: line)
         }
@@ -365,9 +353,7 @@ extension AWSDataStoreAuthBaseTest {
         }
         receiveValue: { posts in
             XCTAssertNotNil(posts)
-            Task {
-                await expectations.query.fulfill()
-            }
+            expectations.query.fulfill()
         }.store(in: &requests)
         await fulfillment(of: [expectations.query],
              timeout: 60)
@@ -385,25 +371,19 @@ extension AWSDataStoreAuthBaseTest {
             .sink { event in
                 // subscription fulfilled
                 if event.eventName == dataStoreEvents.subscriptionsEstablished {
-                    Task {
-                        await expectations.subscriptionsEstablished.fulfill()
-                    }
+                    expectations.subscriptionsEstablished.fulfill()
                 }
 
                 // modelsSynced fulfilled
                 if event.eventName == dataStoreEvents.modelSynced {
                     modelSyncedCount += 1
                     if modelSyncedCount == expectedModelSynced {
-                        Task {
-                            await expectations.modelsSynced.fulfill()
-                        }
+                        expectations.modelsSynced.fulfill()
                     }
                 }
 
                 if event.eventName == dataStoreEvents.ready {
-                    Task {
-                        await expectations.ready.fulfill()
-                    }
+                    expectations.ready.fulfill()
                 }
             }
             .store(in: &requests)
@@ -438,16 +418,12 @@ extension AWSDataStoreAuthBaseTest {
                 }
 
                 if mutationEvent.mutationType == GraphQLMutationType.create.rawValue {
-                    Task {
-                        await expectations.mutationSaveProcessed.fulfill()
-                    }
+                    expectations.mutationSaveProcessed.fulfill()
                     return
                 }
 
                 if mutationEvent.mutationType == GraphQLMutationType.delete.rawValue {
-                    Task {
-                        await expectations.mutationDeleteProcessed.fulfill()
-                    }
+                    expectations.mutationDeleteProcessed.fulfill()
                     return
                 }
             }
@@ -462,9 +438,7 @@ extension AWSDataStoreAuthBaseTest {
         }
         receiveValue: { posts in
             XCTAssertNotNil(posts)
-            Task {
-                await expectations.mutationSave.fulfill()
-            }
+            expectations.mutationSave.fulfill()
         }.store(in: &requests)
 
         await fulfillment(of: [expectations.mutationSave, expectations.mutationSaveProcessed], timeout: 60)
@@ -478,9 +452,7 @@ extension AWSDataStoreAuthBaseTest {
         }
         receiveValue: { posts in
             XCTAssertNotNil(posts)
-            Task {
-                await expectations.mutationDelete.fulfill()
-            }
+            expectations.mutationDelete.fulfill()
         }.store(in: &requests)
 
         await fulfillment(of: [expectations.mutationDelete, expectations.mutationDeleteProcessed], timeout: 60)
@@ -499,15 +471,15 @@ extension AWSDataStoreAuthBaseTest {
 // MARK: - Expectations
 extension AWSDataStoreAuthBaseTest {
     struct AuthTestExpectations {
-        var subscriptionsEstablished: AsyncExpectation
-        var modelsSynced: AsyncExpectation
-        var query: AsyncExpectation
-        var mutationSave: AsyncExpectation
-        var mutationSaveProcessed: AsyncExpectation
-        var mutationDelete: AsyncExpectation
-        var mutationDeleteProcessed: AsyncExpectation
-        var ready: AsyncExpectation
-        var expectations: [AsyncExpectation] {
+        var subscriptionsEstablished: XCTestExpectation
+        var modelsSynced: XCTestExpectation
+        var query: XCTestExpectation
+        var mutationSave: XCTestExpectation
+        var mutationSaveProcessed: XCTestExpectation
+        var mutationDelete: XCTestExpectation
+        var mutationDeleteProcessed: XCTestExpectation
+        var ready: XCTestExpectation
+        var expectations: [XCTestExpectation] {
             return [subscriptionsEstablished,
                     modelsSynced,
                     query,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/11/AWSDataStoreIntSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/11/AWSDataStoreIntSortKeyTest.swift
@@ -51,7 +51,6 @@ class AWSDataStoreIntSortKeyTest: XCTestCase {
     override func tearDown() async throws {
         try await Amplify.DataStore.clear()
         await Amplify.reset()
-        try await Task.sleep(seconds: 1)
     }
 
     func waitDataStoreReady() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/12/AWSDataStoreFloatSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/12/AWSDataStoreFloatSortKeyTest.swift
@@ -51,7 +51,6 @@ class AWSDataStoreFloatSortKeyTest: XCTestCase {
     override func tearDown() async throws {
         try await Amplify.DataStore.clear()
         await Amplify.reset()
-        try await Task.sleep(seconds: 1)
     }
 
     func waitDataStoreReady() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/13/AWSDataStoreDateTimeSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/13/AWSDataStoreDateTimeSortKeyTest.swift
@@ -51,7 +51,6 @@ class AWSDataStoreDateTimeSortKeyTest: XCTestCase {
     override func tearDown() async throws {
         try await Amplify.DataStore.clear()
         await Amplify.reset()
-        try await Task.sleep(seconds: 1)
     }
 
     func waitDataStoreReady() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/14/AWSDataStoreDateSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/14/AWSDataStoreDateSortKeyTest.swift
@@ -51,7 +51,6 @@ class AWSDataStoreDateSortKeyTest: XCTestCase {
     override func tearDown() async throws {
         try await Amplify.DataStore.clear()
         await Amplify.reset()
-        try await Task.sleep(seconds: 1)
     }
 
     func waitDataStoreReady() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/15/AWSDataStoreTimeSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/15/AWSDataStoreTimeSortKeyTest.swift
@@ -51,7 +51,6 @@ class AWSDataStoreTimeSortKeyTest: XCTestCase {
     override func tearDown() async throws {
         try await Amplify.DataStore.clear()
         await Amplify.reset()
-        try await Task.sleep(seconds: 1)
     }
 
     func waitDataStoreReady() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/9/AWSDataStoreCompositeSortKeyIdentifierTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/9/AWSDataStoreCompositeSortKeyIdentifierTest.swift
@@ -45,7 +45,6 @@ class AWSDataStoreCompositeSortKeyIdentifierTest: XCTestCase {
     override func tearDown() async throws {
         try await Amplify.DataStore.clear()
         await Amplify.reset()
-        try await Task.sleep(seconds: 1)
     }
 
     func waitDataStoreReady() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStorePrimaryKeyBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStorePrimaryKeyBaseTest.swift
@@ -122,7 +122,7 @@ extension AWSDataStorePrimaryKeyBaseTest {
 
         try await Amplify.DataStore.start()
 
-        await waitForExpectations(timeout: 60)
+        await fulfillment(of: [ready, subscriptionsEstablished, modelsSynced], timeout: 60)
     }
 
     /// Assert that a save and a delete mutation complete successfully.
@@ -152,7 +152,7 @@ extension AWSDataStorePrimaryKeyBaseTest {
 
         let savedModels = try await Amplify.DataStore.save(model)
         XCTAssertNotNil(savedModels)
-        await waitForExpectations(timeout: 60)
+        await fulfillment(of: [mutationSaveProcessed], timeout: 60)
         
         let mutationDeleteProcessed = expectation(description: "mutation delete processed")
         Amplify
@@ -173,7 +173,7 @@ extension AWSDataStorePrimaryKeyBaseTest {
             .store(in: &requests)
         
         try await Amplify.DataStore.delete(model)
-        await waitForExpectations(timeout: 60)
+        await fulfillment(of: [mutationDeleteProcessed], timeout: 60)
     }
 
     /// Assert that a save and a delete mutation complete successfully.
@@ -211,7 +211,7 @@ extension AWSDataStorePrimaryKeyBaseTest {
         // save child
         _ = try await Amplify.DataStore.save(child)
 
-        await waitForExpectations(timeout: 60)
+        await fulfillment(of: [mutationSaveProcessed], timeout: 60)
         
         guard shouldDeleteParent else {
             return
@@ -242,6 +242,6 @@ extension AWSDataStorePrimaryKeyBaseTest {
         
         // delete parent
         try await Amplify.DataStore.delete(parent)
-        await waitForExpectations(timeout: 60)
+        await fulfillment(of: [mutationDeleteProcessed], timeout: 60)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStoreSortKeyBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStoreSortKeyBaseTest.swift
@@ -27,7 +27,6 @@ class AWSDataStoreSortKeyBaseTest: XCTestCase {
     override func tearDown() async throws {
         try await Amplify.DataStore.clear()
         await Amplify.reset()
-        try await Task.sleep(seconds: 1)
     }
 
     func setUp(

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/AWSDataStorePluginConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/AWSDataStorePluginConfigurationTests.swift
@@ -13,7 +13,6 @@ class AWSDataStorePluginConfigurationTests: XCTestCase {
 
     override func tearDown() async throws {
         await Amplify.reset()
-        try await Task.sleep(seconds: 1)
     }
 
     // Note this test requires the ability to write a new database in the Documents directcory, so it must be embedded

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario2Tests.swift
@@ -88,7 +88,7 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
         let anotherTeam = Team2(name: "name1")
         var project = Project2(teamID: team.id, team: team)
         let expectedUpdatedProject = Project2(id: project.id, name: project.name, teamID: anotherTeam.id)
-        let syncUpdatedProjectReceived = asyncExpectation(description: "received updated project from sync path")
+        let syncUpdatedProjectReceived = expectation(description: "received updated project from sync path")
         let hubListener = Amplify.Hub.listen(to: .dataStore,
                                              eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
             guard let mutationEvent = payload.data as? MutationEvent else {
@@ -121,7 +121,7 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
             XCTAssertEqual(queriedProject, project)
             XCTAssertEqual(queriedProject.teamID, anotherTeam.id)
         }
-        await waitForExpectations([syncUpdatedProjectReceived], timeout: networkTimeout)
+        await fulfillment(of: [syncUpdatedProjectReceived], timeout: networkTimeout)
     }
 
     func testDeleteAndGetProjectReturnsNilWithSync() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario4Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario4Tests.swift
@@ -92,10 +92,7 @@ class DataStoreConnectionScenario4Tests: SyncEngineIntegrationTestBase {
         let comment = try await saveComment(content: "content", post: post)
         try await Amplify.DataStore.delete(comment)
         let queriedComment = try await Amplify.DataStore.query(Comment4.self, byId: comment.id)
-        guard queriedComment == nil else {
-            XCTFail("Should be nil after deletion")
-            return
-        }
+        XCTAssertNil(queriedComment, "Should be nil after deletion")
     }
 
     func testListCommentsByPostID() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreConfigurationTests.swift
@@ -17,7 +17,6 @@ class DataStoreConfigurationTests: XCTestCase {
     override func tearDown() async throws {
         try await Amplify.DataStore.clear()
         await Amplify.reset()
-        try await Task.sleep(seconds: 1)
     }
 
     func testConfigureWithSameSchemaDoesNotDeleteDatabase() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreConsecutiveUpdatesTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreConsecutiveUpdatesTests.swift
@@ -83,7 +83,7 @@ class DataStoreConsecutiveUpdatesTests: SyncEngineIntegrationTestBase {
         let queryResult = try await queryPost(byId: updatedPost.id)
         XCTAssertEqual(queryResult, updatedPost)
 
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [updateSyncReceived], timeout: networkTimeout)
 
         // query the updated post in eventual consistent state
         let queryResultAfterSync = try await queryPost(byId: updatedPost.id)
@@ -202,8 +202,8 @@ class DataStoreConsecutiveUpdatesTests: SyncEngineIntegrationTestBase {
         updatedPost.title = "MyUpdatedPost"
         updatedPost.content = "This is my updated post."
 
-        let saveSyncReceived = asyncExpectation(description: "Received create mutation event on subscription for Post")
-        let deleteSyncReceived = asyncExpectation(description: "Received delete mutation event on subscription for Post")
+        let saveSyncReceived = expectation(description: "Received create mutation event on subscription for Post")
+        let deleteSyncReceived = expectation(description: "Received delete mutation event on subscription for Post")
 
         let hubListener = Amplify.Hub.listen(
             to: .dataStore,
@@ -237,7 +237,7 @@ class DataStoreConsecutiveUpdatesTests: SyncEngineIntegrationTestBase {
 
         // save the post, update and delete immediately
         _ = try await Amplify.DataStore.save(newPost)
-        await waitForExpectations([saveSyncReceived], timeout: networkTimeout)
+        await fulfillment(of: [saveSyncReceived], timeout: networkTimeout)
 
         _ = try await Amplify.DataStore.save(updatedPost)
         try await Amplify.DataStore.delete(updatedPost)
@@ -246,7 +246,7 @@ class DataStoreConsecutiveUpdatesTests: SyncEngineIntegrationTestBase {
         let queryResult = try await queryPost(byId: newPost.id)
         XCTAssertNil(queryResult)
 
-        await waitForExpectations([deleteSyncReceived], timeout: networkTimeout)
+        await fulfillment(of: [deleteSyncReceived], timeout: networkTimeout)
 
         // query the deleted post
         let queryResultAfterSync = try await queryPost(byId: updatedPost.id)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreCustomPrimaryKeyTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreCustomPrimaryKeyTests.swift
@@ -69,7 +69,7 @@ class DataStoreCustomPrimaryKeyTests: SyncEngineIntegrationTestBase {
 
         // create customer order
         _ = try await Amplify.DataStore.save(customerOrder)
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [createReceived], timeout: networkTimeout)
 
         // update customer order
         let updateReceived = expectation(description: "Update notification received")
@@ -102,7 +102,7 @@ class DataStoreCustomPrimaryKeyTests: SyncEngineIntegrationTestBase {
             return
         }
         _ = try await Amplify.DataStore.save(updatedCustomerOrder)
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [updateReceived], timeout: networkTimeout)
         
         // query the updated order
         let queriedOrder = try await Amplify.DataStore.query(CustomerOrder.self, byId: updatedCustomerOrder.id)
@@ -144,7 +144,7 @@ class DataStoreCustomPrimaryKeyTests: SyncEngineIntegrationTestBase {
         }
 
         _ = try await Amplify.DataStore.delete(CustomerOrder.self, withIdentifier: updatedCustomerOrder.id)
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: networkTimeout)
         
         // query the customer order after deletion
         let queriedOrder2 = try await Amplify.DataStore.query(CustomerOrder.self, byId: updatedCustomerOrder.id)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -686,7 +686,7 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
 
         _ = try await Amplify.DataStore.save(newPost)
         
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [createReceived], timeout: networkTimeout)
     }
 }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -572,7 +572,6 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
             }
         try await Amplify.DataStore.save(newPost)
         await fulfillment(of: [initExpectation], timeout: 10)
-        try await Task.sleep(seconds: 1)
 
         for post in posts {
             Task {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreHubEventsTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreHubEventsTests.swift
@@ -41,7 +41,6 @@ class DataStoreHubEventTests: HubEventsIntegrationTestBase {
         try configureAmplify(withModels: TestModelRegistration())
         try await Amplify.DataStore.clear()
         await Amplify.reset()
-        try await Task.sleep(seconds: 1)
 
         let networkStatusReceived = expectation(description: "networkStatus received")
         var networkStatusActive = false

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
@@ -41,8 +41,8 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         await setUp(withModels: TestModelRegistration())
         try startAmplify()
         try await clearDataStore()
-        let snapshotWithIsSynced = asyncExpectation(description: "query snapshot with isSynced true")
-        let querySnapshotsCancelled = asyncExpectation(description: "query snapshots cancelled")
+        let snapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
+        let querySnapshotsCancelled = expectation(description: "query snapshots cancelled")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Post.self)
         let task = Task {
             var snapshots = [DataStoreQuerySnapshot<Post>]()
@@ -60,12 +60,12 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
             XCTAssertFalse(snapshots[0].isSynced)
             await querySnapshotsCancelled.fulfill()
         }
-        let receivedPost = asyncExpectation(description: "received Post")
+        let receivedPost = expectation(description: "received Post")
         try await savePostAndWaitForSync(Post(title: "title", content: "content", createdAt: .now()),
                                          postSyncedExpctation: receivedPost)
-        await waitForExpectations([snapshotWithIsSynced, receivedPost], timeout: 100)
+        await fulfillment(of: [snapshotWithIsSynced, receivedPost], timeout: 100)
         task.cancel()
-        await waitForExpectations([querySnapshotsCancelled], timeout: 10)
+        await fulfillment(of: [querySnapshotsCancelled], timeout: 10)
     }
 
     /// ObserveQuery API will eventually return query snapshot with `isSynced` true
@@ -82,7 +82,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         try startAmplify()
         try await clearDataStore()
         var snapshots = [DataStoreQuerySnapshot<Post>]()
-        let snapshotWithIsSynced = asyncExpectation(description: "query snapshot with isSynced true")
+        let snapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self)).sink { completed in
             switch completed {
             case .finished:
@@ -96,10 +96,10 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
                 Task { await snapshotWithIsSynced.fulfill() }
             }
         }.store(in: &cancellables)
-        let receivedPost = asyncExpectation(description: "received Post")
+        let receivedPost = expectation(description: "received Post")
         try await savePostAndWaitForSync(Post(title: "title", content: "content", createdAt: .now()),
                                          postSyncedExpctation: receivedPost)
-        await waitForExpectations([snapshotWithIsSynced, receivedPost], timeout: 100)
+        await fulfillment(of: [snapshotWithIsSynced, receivedPost], timeout: 100)
         
         XCTAssertTrue(snapshots.count >= 2)
         XCTAssertFalse(snapshots[0].isSynced)
@@ -121,8 +121,8 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         try await clearDataStore()
         var snapshots = [DataStoreQuerySnapshot<Post>]()
         var isObserveQueryReadyForTest = false
-        let observeQueryReadyForTest = asyncExpectation(description: "received query snapshot with .isSynced true")
-        let snapshotWithPost = asyncExpectation(description: "received first snapshot")
+        let observeQueryReadyForTest = expectation(description: "received query snapshot with .isSynced true")
+        let snapshotWithPost = expectation(description: "received first snapshot")
         let post = Post(title: "title", content: "content", createdAt: .now())
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self)).sink { completed in
             switch completed {
@@ -141,10 +141,10 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
                 Task { await snapshotWithPost.fulfill() }
             }
         }.store(in: &cancellables)
-        await waitForExpectations([observeQueryReadyForTest], timeout: 100)
+        await fulfillment(of: [observeQueryReadyForTest], timeout: 100)
         
         _ = try await Amplify.DataStore.save(post)
-        await waitForExpectations([snapshotWithPost], timeout: 100)
+        await fulfillment(of: [snapshotWithPost], timeout: 100)
     }
 
     /// Apply a query predicate "title begins with 'xyz'"
@@ -182,9 +182,9 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         try await clearDataStore()
 
         var snapshots = [DataStoreQuerySnapshot<Post>]()
-        let snapshotWithIsSynced = asyncExpectation(description: "query snapshot with isSynced true")
+        let snapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
         var snapshotWithIsSyncedFulfilled = false
-        let receivedPostFromObserveQuery = asyncExpectation(description: "received Post")
+        let receivedPostFromObserveQuery = expectation(description: "received Post")
         let post4 = Post(title: "\(randomTitle) 4", content: "content", createdAt: .now())
         let predicate = Post.keys.title.beginsWith(randomTitle)
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self, where: predicate)).sink { completed in
@@ -209,10 +209,10 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
             
         }.store(in: &cancellables)
 
-        await waitForExpectations([snapshotWithIsSynced], timeout: 100)
+        await fulfillment(of: [snapshotWithIsSynced], timeout: 100)
 
         try await savePostAndWaitForSync(post4)
-        await waitForExpectations([receivedPostFromObserveQuery], timeout: 100)
+        await fulfillment(of: [receivedPostFromObserveQuery], timeout: 100)
         
         XCTAssertTrue(snapshots.count >= 2)
     }
@@ -232,7 +232,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         try await clearDataStore()
         let post1 = Post(title: "title", content: "content", createdAt: .now())
         let post2 = Post(title: "title", content: "content", createdAt: .now().add(value: 1, to: .second))
-        let snapshotWithSavedPost = asyncExpectation(description: "query snapshot with saved post")
+        let snapshotWithSavedPost = expectation(description: "query snapshot with saved post")
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self, sort: .ascending(Post.keys.createdAt)))
         .sink { completed in
             switch completed {
@@ -256,7 +256,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
 
         try await savePostAndWaitForSync(post1)
         try await savePostAndWaitForSync(post2)
-        await waitForExpectations([snapshotWithSavedPost], timeout: 100)
+        await fulfillment(of: [snapshotWithSavedPost], timeout: 100)
     }
 
     /// ObserveQuery with DataStore delta sync. Ensure datastore has synced the models and stopped.
@@ -276,7 +276,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         let numberOfPosts = try await queryNumberOfPosts()
         XCTAssertTrue(numberOfPosts > 0)
         try await stopDataStore()
-        let snapshotWithIsSynced = asyncExpectation(description: "query snapshot with isSynced true")
+        let snapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
         var snapshots = [DataStoreQuerySnapshot<Post>]()
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self)).sink { completed in
             switch completed {
@@ -291,10 +291,10 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
                 Task { await snapshotWithIsSynced.fulfill() }
             }
         }.store(in: &cancellables)
-        let receivedPost = asyncExpectation(description: "received Post")
+        let receivedPost = expectation(description: "received Post")
         try await savePostAndWaitForSync(Post(title: "title", content: "content", createdAt: .now()),
                                          postSyncedExpctation: receivedPost)
-        await waitForExpectations([snapshotWithIsSynced, receivedPost], timeout: 30)
+        await fulfillment(of: [snapshotWithIsSynced, receivedPost], timeout: 30)
         XCTAssertTrue(snapshots.count >= 2)
         XCTAssertFalse(snapshots[0].isSynced)
         XCTAssertTrue(snapshots.last!.isSynced)
@@ -317,7 +317,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         try await startAmplifyAndWaitForReady()
         try await clearDataStore()
 
-        let snapshotWithIsSynced = asyncExpectation(description: "query snapshot with isSynced true")
+        let snapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
         var snapshots = [DataStoreQuerySnapshot<Post>]()
 
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self)).sink { completed in
@@ -335,11 +335,11 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         }.store(in: &cancellables)
 
         let newPost = Post(title: "title", content: "content", createdAt: .now())
-        let receivedPost = asyncExpectation(description: "received Post")
+        let receivedPost = expectation(description: "received Post")
         try await savePostAndWaitForSync(newPost,
                                          postSyncedExpctation: receivedPost)
 
-        await waitForExpectations([snapshotWithIsSynced, receivedPost], timeout: 30)
+        await fulfillment(of: [snapshotWithIsSynced, receivedPost], timeout: 30)
         XCTAssertTrue(snapshots.count >= 2)
         XCTAssertFalse(snapshots[0].isSynced)
         XCTAssertEqual(1, snapshots.filter({ $0.isSynced }).count)
@@ -368,14 +368,14 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         let testId = UUID().uuidString
         var snapshotCount = 0
         let predicate = Post.keys.title.beginsWith("xyz") && Post.keys.content == testId
-        let snapshotExpectation1 = asyncExpectation(description: "received snapshot 1")
-        let snapshotExpectation23 = asyncExpectation(description: "received snapshot 2 / 3",
+        let snapshotExpectation1 = expectation(description: "received snapshot 1")
+        let snapshotExpectation23 = expectation(description: "received snapshot 2 / 3",
                                                      expectedFulfillmentCount: 2)
-        let snapshotExpectation4 = asyncExpectation(description: "received snapshot 4")
-        let snapshotExpectation56 = asyncExpectation(description: "received snapshot 5 / 6",
+        let snapshotExpectation4 = expectation(description: "received snapshot 4")
+        let snapshotExpectation56 = expectation(description: "received snapshot 5 / 6",
                                                      expectedFulfillmentCount: 2)
-        let snapshotExpectation7 = asyncExpectation(description: "received snapshot 7")
-        let snapshotExpectation8 = asyncExpectation(description: "received snapshot 8")
+        let snapshotExpectation7 = expectation(description: "received snapshot 7")
+        let snapshotExpectation8 = expectation(description: "received snapshot 8")
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self, where: predicate)).sink { completed in
             switch completed {
             case .finished:
@@ -421,42 +421,42 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
                 Task { await snapshotExpectation8.fulfill() }
             }
         }.store(in: &cancellables)
-        await waitForExpectations([snapshotExpectation1], timeout: 10)
+        await fulfillment(of: [snapshotExpectation1], timeout: 10)
         
         // (1) Add model that matches predicate - should be received on the snapshot
         let postMatchPredicate = Post(title: "xyz 1", content: testId, createdAt: .now())
         
         try await savePostAndWaitForSync(postMatchPredicate)
-        await waitForExpectations([snapshotExpectation23], timeout: 10)
+        await fulfillment(of: [snapshotExpectation23], timeout: 10)
         
         // (2) Add model that does not match predicate - should not be received on the snapshot
         // (3) Update model that used to match the predicate to no longer match - should be removed from snapshot
         let postDoesNotMatch = Post(title: "doesNotMatch", content: testId, createdAt: .now())
-        let postDoesNotMatchExpectation = asyncExpectation(description: "received postDoesNotMatchExpectation")
+        let postDoesNotMatchExpectation = expectation(description: "received postDoesNotMatchExpectation")
         try await savePostAndWaitForSync(postDoesNotMatch, postSyncedExpctation: postDoesNotMatchExpectation)
         var postMatchPredicateNoLongerMatches = postMatchPredicate
         postMatchPredicateNoLongerMatches.title = "doesNotMatch"
         try await savePostAndWaitForSync(postMatchPredicateNoLongerMatches)
-        await waitForExpectations([snapshotExpectation4], timeout: 10)
+        await fulfillment(of: [snapshotExpectation4], timeout: 10)
         
         // (4) Update model that does not match predicate to match - should be added to snapshot
         var postDoesNotMatchNowMatches = postDoesNotMatch
         postDoesNotMatchNowMatches.title = "xyz 2"
         try await savePostAndWaitForSync(postDoesNotMatchNowMatches)
-        await waitForExpectations([snapshotExpectation56], timeout: 10)
+        await fulfillment(of: [snapshotExpectation56], timeout: 10)
         
         // (5) Delete the model that matches the predicate - should be removed
         try await deletePostAndWaitForSync(postDoesNotMatchNowMatches)
-        await waitForExpectations([snapshotExpectation7], timeout: 10)
+        await fulfillment(of: [snapshotExpectation7], timeout: 10)
         
         // (6) Delete the model that does not match predicate - should have no snapshot emitted
-        let postMatchPredicateNoLongerMatchesExpectation = asyncExpectation(description: " received")
+        let postMatchPredicateNoLongerMatchesExpectation = expectation(description: " received")
         try await deletePostAndWaitForSync(postMatchPredicateNoLongerMatches,
                                            postSyncedExpctation: postMatchPredicateNoLongerMatchesExpectation)
 
         // Save "xyz 3" to force a snapshot to be emitted
         try await savePostAndWaitForSync(Post(title: "xyz 3", content: testId, createdAt: .now()))
-        await waitForExpectations([snapshotExpectation8], timeout: 10)
+        await fulfillment(of: [snapshotExpectation8], timeout: 10)
     }
 
     /// ObserveQuery is set up with a sort order.
@@ -575,7 +575,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     func testObserveQueryShouldResetOnDataStoreStop() async throws {
         await setUp(withModels: TestModelRegistration())
         try await startAmplifyAndWaitForReady()
-        let firstSnapshotWithIsSynced = asyncExpectation(description: "query snapshot with isSynced true")
+        let firstSnapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
         var onComplete: ((Subscribers.Completion<Error>) -> Void) = { _ in }
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self))
             .sink { onComplete($0) } receiveValue: { querySnapshot in
@@ -583,9 +583,9 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
                     Task { await firstSnapshotWithIsSynced.fulfill() }
                 }
             }.store(in: &cancellables)
-        await waitForExpectations([firstSnapshotWithIsSynced], timeout: 10)
+        await fulfillment(of: [firstSnapshotWithIsSynced], timeout: 10)
         
-        let observeQueryReceivedCompleted = asyncExpectation(description: "observeQuery received completed",
+        let observeQueryReceivedCompleted = expectation(description: "observeQuery received completed",
                                                              isInverted: true)
         onComplete = { completed in
             switch completed {
@@ -596,7 +596,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
             }
         }
         try await Amplify.DataStore.stop()
-        await waitForExpectations([observeQueryReceivedCompleted], timeout: 10)
+        await fulfillment(of: [observeQueryReceivedCompleted], timeout: 10)
     }
 
     /// Ensure clearing datastore will not complete the observeQuery subscribers.
@@ -610,7 +610,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     func testObserveQueryShouldResetOnDataStoreClear() async throws {
         await setUp(withModels: TestModelRegistration())
         try await startAmplifyAndWaitForReady()
-        let firstSnapshotWithIsSynced = asyncExpectation(description: "query snapshot with isSynced true")
+        let firstSnapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
         var onComplete: ((Subscribers.Completion<Error>) -> Void) = { _ in }
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self))
             .sink { onComplete($0) } receiveValue: { querySnapshot in
@@ -618,9 +618,9 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
                     Task { await firstSnapshotWithIsSynced.fulfill() }
                 }
             }.store(in: &cancellables)
-        await waitForExpectations([firstSnapshotWithIsSynced], timeout: 100)
+        await fulfillment(of: [firstSnapshotWithIsSynced], timeout: 100)
         
-        let observeQueryReceivedCompleted = asyncExpectation(description: "observeQuery received completed",
+        let observeQueryReceivedCompleted = expectation(description: "observeQuery received completed",
                                                              isInverted: true)
         onComplete = { completed in
             switch completed {
@@ -631,15 +631,15 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
             }
         }
         try await Amplify.DataStore.clear()
-        await waitForExpectations([observeQueryReceivedCompleted], timeout: 10)
+        await fulfillment(of: [observeQueryReceivedCompleted], timeout: 10)
     }
 
     func testObserveQueryShouldStartOnDataStoreStart() async throws {
         try await setUp(withModels: TestModelRegistration())
         try await startAmplifyAndWaitForReady()
-        let firstSnapshot = asyncExpectation(description: "first query snapshot")
-        let secondSnapshot = asyncExpectation(description: "second query snapshot")
-        let observeQueryReceivedCompleted = asyncExpectation(description: "observeQuery received completed", isInverted: true)
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
+        let observeQueryReceivedCompleted = expectation(description: "observeQuery received completed", isInverted: true)
         var querySnapshots = [DataStoreQuerySnapshot<Post>]()
         let sink = Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self)).sink { completed in
             switch completed {
@@ -656,11 +656,11 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
                 Task { await secondSnapshot.fulfill() }
             }
         }
-        await waitForExpectations([firstSnapshot], timeout: 100)
+        await fulfillment(of: [firstSnapshot], timeout: 100)
         try await Amplify.DataStore.stop()
-        await waitForExpectations([observeQueryReceivedCompleted], timeout: 10)
+        await fulfillment(of: [observeQueryReceivedCompleted], timeout: 10)
         try await Amplify.DataStore.start()
-        await waitForExpectations([secondSnapshot], timeout: 10)
+        await fulfillment(of: [secondSnapshot], timeout: 10)
         sink.cancel()
     }
 
@@ -668,7 +668,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     func savePostAndWaitForSync(_ post: Post, postSyncedExpctation: AsyncExpectation? = nil) async throws {
         // Wait for a fulfillment count of 2 (first event due to the locally source mutation saved to the local store
         // and the second event due to the subscription event received from the remote store)
-        let receivedPost = postSyncedExpctation ?? asyncExpectation(description: "received Post",
+        let receivedPost = postSyncedExpctation ?? expectation(description: "received Post",
                                                                     expectedFulfillmentCount: 2)
         Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
@@ -685,14 +685,14 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         
         _ = try await Amplify.DataStore.save(post)
         if postSyncedExpctation == nil {
-            await waitForExpectations([receivedPost], timeout: 100)
+            await fulfillment(of: [receivedPost], timeout: 100)
         }
     }
 
     func deletePostAndWaitForSync(_ post: Post, postSyncedExpctation: AsyncExpectation? = nil) async throws {
         // Wait for a fulfillment count of 2 (first event due to the locally source mutation deleted from the local
         // store and the second event due to the subscription event received from the remote store)
-        let deletedPost = postSyncedExpctation ?? asyncExpectation(description: "deleted Post",
+        let deletedPost = postSyncedExpctation ?? expectation(description: "deleted Post",
                                                                    expectedFulfillmentCount: 2)
         Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
@@ -709,7 +709,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         
         _ = try await Amplify.DataStore.delete(post)
         if postSyncedExpctation == nil {
-            await waitForExpectations([deletedPost], timeout: 100)
+            await fulfillment(of: [deletedPost], timeout: 100)
         }
     }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
@@ -43,7 +43,6 @@ class HubEventsIntegrationTestBase: XCTestCase {
     override func tearDown() async throws {
         try await Amplify.DataStore.clear()
         await Amplify.reset()
-        try await Task.sleep(seconds: 1)
     }
 
     func configureAmplify(withModels models: AmplifyModelRegistration) throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
@@ -44,7 +44,6 @@ class SyncEngineIntegrationTestBase: DataStoreTestBase {
         try await super.tearDown()
         try await clearDataStore()
         await Amplify.reset()
-        try await Task.sleep(seconds: 1)
     }
 
     func setUp(

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/AWSDataStoreLazyLoadPostComment4V2.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/AWSDataStoreLazyLoadPostComment4V2.swift
@@ -18,7 +18,7 @@ class AWSDataStoreLazyLoadPostComment4V2: AWSDataStoreLazyLoadBaseTest {
         let post = Post4V2(title: "title")
         let comment = Comment4V2(content: "content", post: post)
         
-        let commentSynced = asyncExpectation(description: "DataStore start success")
+        let commentSynced = expectation(description: "DataStore start success")
         let mutationEvents = Amplify.DataStore.observe(Comment4V2.self)
         Task {
             do {
@@ -35,7 +35,7 @@ class AWSDataStoreLazyLoadPostComment4V2: AWSDataStoreLazyLoadBaseTest {
         try await Amplify.DataStore.save(post)
         try await Amplify.DataStore.save(comment)
         
-        await waitForExpectations([commentSynced], timeout: 10)
+        await fulfillment(of: [commentSynced], timeout: 10)
     }
 }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL1/AWSDataStoreLazyLoadPostComment4V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL1/AWSDataStoreLazyLoadPostComment4V2Tests.swift
@@ -232,7 +232,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
         try await startAndWaitForReady()
         let post = Post(title: "title")
         let comment = Comment(content: "content", post: post)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -266,7 +266,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -276,7 +276,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
         let post = Post(title: "title")
         let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(content: "content", post: post)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Comment.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -297,7 +297,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -306,7 +306,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
         try await startAndWaitForReady()
         let post = Post(title: "title")
         let comment = Comment(content: "content", post: post)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Post.self, where: Post.keys.id == post.id)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -335,7 +335,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -346,7 +346,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
         let post = Post(title: "title")
         let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(content: "content", post: post)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Comment.self, where: Comment.keys.id == comment.id)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -364,7 +364,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL10/AWSDataStoreLazyLoadPostComment7Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL10/AWSDataStoreLazyLoadPostComment7Tests.swift
@@ -195,7 +195,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
         try await startAndWaitForReady()
         let post = Post(postId: UUID().uuidString, title: "title")
         let comment = Comment(commentId: UUID().uuidString, content: "content", post: post)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -228,7 +228,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -238,7 +238,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
         let post = Post(postId: UUID().uuidString, title: "title")
         let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(commentId: UUID().uuidString, content: "content", post: post)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Comment.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -259,7 +259,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -268,7 +268,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
         try await startAndWaitForReady()
         let post = Post(postId: UUID().uuidString, title: "title")
         let comment = Comment(commentId: UUID().uuidString, content: "content", post: post)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Post.self, where: Post.keys.postId == post.postId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -297,7 +297,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -308,7 +308,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
         let post = Post(postId: UUID().uuidString, title: "title")
         let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(commentId: UUID().uuidString, content: "content", post: post)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Comment.self, where: Comment.keys.commentId == comment.commentId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -326,7 +326,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL11/AWSDataStoreLazyLoadPostComment8Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL11/AWSDataStoreLazyLoadPostComment8Tests.swift
@@ -177,7 +177,7 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               postId: post.postId,
                               postTitle: post.title)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -199,7 +199,7 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -212,7 +212,7 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               postId: post.postId,
                               postTitle: post.title)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Comment.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -233,7 +233,7 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -245,7 +245,7 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               postId: post.postId,
                               postTitle: post.title)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Post.self, where: Post.keys.postId == post.postId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -264,7 +264,7 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -278,7 +278,7 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               postId: post.postId,
                               postTitle: post.title)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Comment.self, where: Comment.keys.commentId == comment.commentId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -296,7 +296,7 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/DefaultPK/AWSDataStoreLazyLoadDefaultPKTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/DefaultPK/AWSDataStoreLazyLoadDefaultPKTests.swift
@@ -230,7 +230,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
         try await startAndWaitForReady()
         let parent = Parent()
         let child = Child(parent: parent)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Parent.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -264,7 +264,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -274,7 +274,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
         let parent = Parent()
         let savedParent = try await createAndWaitForSync(parent)
         let child = Child(parent: parent)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Child.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -295,7 +295,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -304,7 +304,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
         try await startAndWaitForReady()
         let parent = Parent()
         let child = Child(parent: parent)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Parent.self, where: Parent.keys.id == parent.id)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -333,7 +333,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -344,7 +344,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
         let parent = Parent()
         let savedParent = try await createAndWaitForSync(parent)
         let child = Child(parent: parent)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Child.self, where: Child.keys.id == child.id)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -362,7 +362,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/HasOneParentChild/AWSDataStoreLazyLoadHasOneTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/HasOneParentChild/AWSDataStoreLazyLoadHasOneTests.swift
@@ -154,7 +154,7 @@ class AWSDataStoreLazyLoadHasOneTests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: HasOneModels())
         try await startAndWaitForReady()
         let child = HasOneChild()
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(HasOneChild.self)
 
         Task {
@@ -176,7 +176,7 @@ class AWSDataStoreLazyLoadHasOneTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
 
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL2/AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL2/AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift
@@ -187,7 +187,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         try await startAndWaitForReady()
         let post = Post(name: "name", randomId: "randomId")
         let comment = Comment(content: "content", post: post)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -221,7 +221,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -231,7 +231,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         let post = Post(name: "name", randomId: "randomId")
         let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(content: "content", post: post)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Comment.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -252,7 +252,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -261,7 +261,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         try await startAndWaitForReady()
         let post = Post(name: "name", randomId: "randomId")
         let comment = Comment(content: "content", post: post)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Post.self, where: Post.keys.id == post.id)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -290,7 +290,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -301,7 +301,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         let post = Post(name: "name", randomId: "randomId")
         let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(content: "content", post: post)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Comment.self, where: Comment.keys.id == comment.id)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -319,7 +319,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL3/AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL3/AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests.swift
@@ -180,7 +180,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
         try await startAndWaitForReady()
         let post = Post(title: "title")
         let comment = Comment(content: "content", post: post)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -213,7 +213,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -223,7 +223,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
         let post = Post(title: "title")
         let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(content: "content", post: post)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Comment.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -244,7 +244,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -253,7 +253,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
         try await startAndWaitForReady()
         let post = Post(title: "title")
         let comment = Comment(content: "content", post: post)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Post.self, where: Post.keys.id == post.id)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -282,7 +282,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -293,7 +293,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
         let post = Post(title: "title")
         let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(content: "content", post: post)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Comment.self, where: Comment.keys.id == comment.id)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -311,7 +311,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL4/AWSDataStoreLazyLoadPostTagTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL4/AWSDataStoreLazyLoadPostTagTests.swift
@@ -213,7 +213,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: PostTagModels())
         try await startAndWaitForReady()
         let post = Post(postId: UUID().uuidString, title: "title")
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -244,7 +244,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -253,7 +253,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         try await startAndWaitForReady()
         let tag = Tag(name: "name")
         
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Tag.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -283,7 +283,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -297,7 +297,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         
         let postTag = PostTag(postWithTagsCompositeKey: post, tagWithCompositeKey: tag)
         
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(PostTag.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -319,7 +319,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -327,7 +327,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: PostTagModels())
         try await startAndWaitForReady()
         let post = Post(postId: UUID().uuidString, title: "title")
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Post.self, where: Post.keys.postId == post.postId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -354,7 +354,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -363,7 +363,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         try await startAndWaitForReady()
         let tag = Tag(name: "name")
         
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Tag.self, where: Tag.keys.id == tag.id)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -390,7 +390,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -404,7 +404,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         
         let postTag = PostTag(postWithTagsCompositeKey: post, tagWithCompositeKey: tag)
         
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: PostTag.self, where: PostTag.keys.id == postTag.id)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -422,7 +422,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL5/AWSDataStoreLazyLoadProjectTeam1Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL5/AWSDataStoreLazyLoadProjectTeam1Tests.swift
@@ -220,7 +220,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
         let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Project.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -241,7 +241,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -249,7 +249,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam1Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Team.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -270,7 +270,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -281,7 +281,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
         let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Project.self, where: Project.keys.projectId == project.projectId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -299,7 +299,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -307,7 +307,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam1Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Team.self, where: Team.keys.teamId == team.teamId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -325,7 +325,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL6/AWSDataStoreLazyLoadProjectTeam2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL6/AWSDataStoreLazyLoadProjectTeam2Tests.swift
@@ -187,7 +187,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
         let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Project.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -208,7 +208,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -216,7 +216,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam2Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Team.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -237,7 +237,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -248,7 +248,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
         let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Project.self, where: Project.keys.projectId == project.projectId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -266,7 +266,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -274,7 +274,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam2Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Team.self, where: Team.keys.teamId == team.teamId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -292,7 +292,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL6/AWSDataStoreLazyLoadProjectTeam2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL6/AWSDataStoreLazyLoadProjectTeam2Tests.swift
@@ -196,7 +196,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
                    let receivedProject = try? mutationEvent.decodeModel(as: Project.self),
                    receivedProject.projectId == project.projectId {
                     assertProject(receivedProject, hasTeam: savedTeam)
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -225,7 +225,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
                    let receivedTeam = try? mutationEvent.decodeModel(as: Team.self),
                    receivedTeam.teamId == team.teamId {
                         
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -254,7 +254,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
             for try await querySnapshot in querySnapshots {
                 if let receivedProject = querySnapshot.items.first {
                     assertProject(receivedProject, hasTeam: savedTeam)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -280,7 +280,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
             for try await querySnapshot in querySnapshots {
                 if let receivedTeam = querySnapshot.items.first {
                     XCTAssertEqual(receivedTeam.teamId, team.teamId)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL7/AWSDataStoreLazyLoadPostComment4Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL7/AWSDataStoreLazyLoadPostComment4Tests.swift
@@ -180,7 +180,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               post4CommentsPostId: post.postId,
                               post4CommentsTitle: post.title)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -202,7 +202,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -215,7 +215,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               post4CommentsPostId: post.postId,
                               post4CommentsTitle: post.title)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Comment.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -236,7 +236,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -248,7 +248,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               post4CommentsPostId: post.postId,
                               post4CommentsTitle: post.title)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Post.self, where: Post.keys.postId == post.postId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -267,7 +267,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -281,7 +281,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               post4CommentsPostId: post.postId,
                               post4CommentsTitle: post.title)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Comment.self, where: Comment.keys.commentId == comment.commentId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -299,7 +299,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL8/AWSDataStoreLazyLoadProjectTeam5Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL8/AWSDataStoreLazyLoadProjectTeam5Tests.swift
@@ -189,7 +189,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
         let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Project.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -210,7 +210,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -218,7 +218,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam5Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Team.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -239,7 +239,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -250,7 +250,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
         let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Project.self, where: Project.keys.projectId == project.projectId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -268,7 +268,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -276,7 +276,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam5Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Team.self, where: Team.keys.teamId == team.teamId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -294,7 +294,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL9/AWSDataStoreLazyLoadProjectTeam6Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL9/AWSDataStoreLazyLoadProjectTeam6Tests.swift
@@ -185,7 +185,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
         let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Project.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -206,7 +206,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -214,7 +214,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam6Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Team.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -235,7 +235,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -246,7 +246,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
         let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Project.self, where: Project.keys.projectId == project.projectId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -264,7 +264,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -272,7 +272,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam6Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Team.self, where: Team.keys.teamId == team.teamId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -290,7 +290,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/AWSDataStoreLazyLoadBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/AWSDataStoreLazyLoadBaseTest.swift
@@ -33,7 +33,6 @@ class AWSDataStoreLazyLoadBaseTest: XCTestCase {
             try await clearDataStore()
         }
         await Amplify.reset()
-        try await Task.sleep(seconds: 1)
     }
     
     func setupConfig() {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreAuthBaseTest.swift
@@ -89,15 +89,11 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
         AuthTestExpectations(
             subscriptionsEstablished: expectation(description: "Subscriptions established"),
             modelsSynced: expectation(description: "Models synced"),
-
             query: expectation(description: "Query success"),
-
             mutationSave: expectation(description: "Mutation save success"),
             mutationSaveProcessed: expectation(description: "Mutation save processed"),
-
             mutationDelete: expectation(description: "Mutation delete success"),
             mutationDeleteProcessed: expectation(description: "Mutation delete processed"),
-
             ready: expectation(description: "Ready")
         )
     }
@@ -211,14 +207,10 @@ extension AWSDataStoreAuthBaseTest {
             _ = try await Amplify.Auth.signIn(username: user.username,
                                                        password: user.password,
                                                        options: nil)
-            Task {
-                await signInInvoked.fulfill()
-            }
+            signInInvoked.fulfill()
         } catch(let error) {
             XCTFail("Signin failure \(error)", file: file, line: line)
-            Task {
-                await signInInvoked.fulfill() // won't count as pass
-            }
+            signInInvoked.fulfill() // won't count as pass
         }
         await fulfillment(of: [signInInvoked], timeout: TestCommonConstants.networkTimeout)
         
@@ -232,7 +224,7 @@ extension AWSDataStoreAuthBaseTest {
         let signoutInvoked = expectation(description: "sign out completed")
         Task {
             _ = await Amplify.Auth.signOut()
-            await signoutInvoked.fulfill()
+            signoutInvoked.fulfill()
         }
         
         await fulfillment(of: [signoutInvoked], timeout: TestCommonConstants.networkTimeout)
@@ -248,9 +240,7 @@ extension AWSDataStoreAuthBaseTest {
         do {
             let authSession = try await Amplify.Auth.fetchAuthSession()
             resultOptional = authSession.isSignedIn
-            Task {
-                await checkIsSignedInCompleted.fulfill()
-            }
+            checkIsSignedInCompleted.fulfill()
         } catch(let error) {
             fatalError("Failed to get auth session \(error)")
         }
@@ -276,9 +266,7 @@ extension AWSDataStoreAuthBaseTest {
             switch cognitoAuthSession.getUserSub() {
             case .success(let userSub):
                 resultOptional = userSub
-                Task {
-                    await retrieveUserSubCompleted.fulfill()
-                }
+                retrieveUserSubCompleted.fulfill()
             case .failure(let error):
                 XCTFail("Failed to get auth session \(error)")
             }
@@ -307,9 +295,7 @@ extension AWSDataStoreAuthBaseTest {
             switch cognitoAuthSession.getIdentityId() {
             case .success(let identityId):
                 resultOptional = identityId
-                Task {
-                    await retrieveIdentityCompleted.fulfill()
-                }
+                retrieveIdentityCompleted.fulfill()
             case .failure(let error):
                 XCTFail("Failed to get auth session \(error)")
             }
@@ -335,9 +321,7 @@ extension AWSDataStoreAuthBaseTest {
         do {
             let model = try await Amplify.DataStore.query(M.self, byId: id)
             queriedModel = model
-            Task {
-                await queriedInvoked.fulfill()
-            }
+            queriedInvoked.fulfill()
         } catch(let error) {
             XCTFail("Failed to query model \(error)", file: file, line: line)
         }
@@ -366,9 +350,7 @@ extension AWSDataStoreAuthBaseTest {
         }
         receiveValue: { posts in
             XCTAssertNotNil(posts)
-            Task {
-                await expectations.query.fulfill()
-            }
+            expectations.query.fulfill()
         }.store(in: &requests)
         await fulfillment(of: [expectations.query],
              timeout: 60)
@@ -386,25 +368,19 @@ extension AWSDataStoreAuthBaseTest {
             .sink { event in
                 // subscription fulfilled
                 if event.eventName == dataStoreEvents.subscriptionsEstablished {
-                    Task {
-                        await expectations.subscriptionsEstablished.fulfill()
-                    }
+                    expectations.subscriptionsEstablished.fulfill()
                 }
 
                 // modelsSynced fulfilled
                 if event.eventName == dataStoreEvents.modelSynced {
                     modelSyncedCount += 1
                     if modelSyncedCount == expectedModelSynced {
-                        Task {
-                            await expectations.modelsSynced.fulfill()
-                        }
+                        expectations.modelsSynced.fulfill()
                     }
                 }
 
                 if event.eventName == dataStoreEvents.ready {
-                    Task {
-                        await expectations.ready.fulfill()
-                    }
+                    expectations.ready.fulfill()
                 }
             }
             .store(in: &requests)
@@ -439,16 +415,12 @@ extension AWSDataStoreAuthBaseTest {
                 }
 
                 if mutationEvent.mutationType == GraphQLMutationType.create.rawValue {
-                    Task {
-                        await expectations.mutationSaveProcessed.fulfill()
-                    }
+                    expectations.mutationSaveProcessed.fulfill()
                     return
                 }
 
                 if mutationEvent.mutationType == GraphQLMutationType.delete.rawValue {
-                    Task {
-                        await expectations.mutationDeleteProcessed.fulfill()
-                    }
+                    expectations.mutationDeleteProcessed.fulfill()
                     return
                 }
             }
@@ -463,9 +435,7 @@ extension AWSDataStoreAuthBaseTest {
         }
         receiveValue: { posts in
             XCTAssertNotNil(posts)
-            Task {
-                await expectations.mutationSave.fulfill()
-            }
+            expectations.mutationSave.fulfill()
         }.store(in: &requests)
 
         await fulfillment(of: [expectations.mutationSave, expectations.mutationSaveProcessed], timeout: 60)
@@ -479,9 +449,7 @@ extension AWSDataStoreAuthBaseTest {
         }
         receiveValue: { posts in
             XCTAssertNotNil(posts)
-            Task {
-                await expectations.mutationDelete.fulfill()
-            }
+            expectations.mutationDelete.fulfill()
         }.store(in: &requests)
 
         await fulfillment(of: [expectations.mutationDelete, expectations.mutationDeleteProcessed], timeout: 60)
@@ -500,15 +468,15 @@ extension AWSDataStoreAuthBaseTest {
 // MARK: - Expectations
 extension AWSDataStoreAuthBaseTest {
     struct AuthTestExpectations {
-        var subscriptionsEstablished: AsyncExpectation
-        var modelsSynced: AsyncExpectation
-        var query: AsyncExpectation
-        var mutationSave: AsyncExpectation
-        var mutationSaveProcessed: AsyncExpectation
-        var mutationDelete: AsyncExpectation
-        var mutationDeleteProcessed: AsyncExpectation
-        var ready: AsyncExpectation
-        var expectations: [AsyncExpectation] {
+        var subscriptionsEstablished: XCTestExpectation
+        var modelsSynced: XCTestExpectation
+        var query: XCTestExpectation
+        var mutationSave: XCTestExpectation
+        var mutationSaveProcessed: XCTestExpectation
+        var mutationDelete: XCTestExpectation
+        var mutationDeleteProcessed: XCTestExpectation
+        var ready: XCTestExpectation
+        var expectations: [XCTestExpectation] {
             return [subscriptionsEstablished,
                     modelsSynced,
                     query,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreAuthBaseTest.swift
@@ -87,18 +87,18 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
     // MARK: - Test Helpers
     func makeExpectations() -> AuthTestExpectations {
         AuthTestExpectations(
-            subscriptionsEstablished: AsyncExpectation(description: "Subscriptions established"),
-            modelsSynced: AsyncExpectation(description: "Models synced"),
+            subscriptionsEstablished: expectation(description: "Subscriptions established"),
+            modelsSynced: expectation(description: "Models synced"),
 
-            query: AsyncExpectation(description: "Query success"),
+            query: expectation(description: "Query success"),
 
-            mutationSave: AsyncExpectation(description: "Mutation save success"),
-            mutationSaveProcessed: AsyncExpectation(description: "Mutation save processed"),
+            mutationSave: expectation(description: "Mutation save success"),
+            mutationSaveProcessed: expectation(description: "Mutation save processed"),
 
-            mutationDelete: AsyncExpectation(description: "Mutation delete success"),
-            mutationDeleteProcessed: AsyncExpectation(description: "Mutation delete processed"),
+            mutationDelete: expectation(description: "Mutation delete success"),
+            mutationDeleteProcessed: expectation(description: "Mutation delete processed"),
 
-            ready: AsyncExpectation(description: "Ready")
+            ready: expectation(description: "Ready")
         )
     }
 
@@ -206,7 +206,7 @@ extension AWSDataStoreAuthBaseTest {
             XCTFail("Invalid user", file: file, line: line)
             return
         }
-        let signInInvoked = AsyncExpectation(description: "sign in completed")
+        let signInInvoked = expectation(description: "sign in completed")
         do {
             _ = try await Amplify.Auth.signIn(username: user.username,
                                                        password: user.password,
@@ -220,7 +220,7 @@ extension AWSDataStoreAuthBaseTest {
                 await signInInvoked.fulfill() // won't count as pass
             }
         }
-        await waitForExpectations([signInInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [signInInvoked], timeout: TestCommonConstants.networkTimeout)
         
         let signedIn = await isSignedIn()
         XCTAssert(signedIn, file: file, line: line)
@@ -229,13 +229,13 @@ extension AWSDataStoreAuthBaseTest {
     /// Signout current signed-in user
     func signOut(file: StaticString = #file,
                  line: UInt = #line) async {
-        let signoutInvoked = AsyncExpectation(description: "sign out completed")
+        let signoutInvoked = expectation(description: "sign out completed")
         Task {
             _ = await Amplify.Auth.signOut()
             await signoutInvoked.fulfill()
         }
         
-        await waitForExpectations([signoutInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [signoutInvoked], timeout: TestCommonConstants.networkTimeout)
         
         let signedIn = await isSignedIn()
         XCTAssert(!signedIn, file: file, line: line)
@@ -243,7 +243,7 @@ extension AWSDataStoreAuthBaseTest {
 
 
     func isSignedIn() async -> Bool {
-        let checkIsSignedInCompleted = AsyncExpectation(description: "retrieve auth session completed")
+        let checkIsSignedInCompleted = expectation(description: "retrieve auth session completed")
         var resultOptional: Bool?
         do {
             let authSession = try await Amplify.Auth.fetchAuthSession()
@@ -255,7 +255,7 @@ extension AWSDataStoreAuthBaseTest {
             fatalError("Failed to get auth session \(error)")
         }
         
-        await waitForExpectations([checkIsSignedInCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [checkIsSignedInCompleted], timeout: TestCommonConstants.networkTimeout)
         guard let result = resultOptional else {
             XCTFail("Could not get isSignedIn for user")
             return false
@@ -265,7 +265,7 @@ extension AWSDataStoreAuthBaseTest {
     }
 
     func getUserSub() async -> String {
-        let retrieveUserSubCompleted = AsyncExpectation(description: "retrieve userSub completed")
+        let retrieveUserSubCompleted = expectation(description: "retrieve userSub completed")
         var resultOptional: String?
         do {
             let authSession = try await Amplify.Auth.fetchAuthSession()
@@ -286,7 +286,7 @@ extension AWSDataStoreAuthBaseTest {
             XCTFail("Failed to get auth session \(error)")
         }
 
-        await waitForExpectations([retrieveUserSubCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [retrieveUserSubCompleted], timeout: TestCommonConstants.networkTimeout)
         guard let result = resultOptional else {
             XCTFail("Could not get userSub for user")
             return ""
@@ -296,7 +296,7 @@ extension AWSDataStoreAuthBaseTest {
     }
 
     func getIdentityId() async -> String {
-        let retrieveIdentityCompleted = AsyncExpectation(description: "retrieve identity completed")
+        let retrieveIdentityCompleted = expectation(description: "retrieve identity completed")
         var resultOptional: String?
         do {
             let authSession = try await Amplify.Auth.fetchAuthSession()
@@ -316,7 +316,7 @@ extension AWSDataStoreAuthBaseTest {
         } catch(let error) {
             XCTFail("Failed to get auth session \(error)")
         }
-        await waitForExpectations([retrieveIdentityCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [retrieveIdentityCompleted], timeout: TestCommonConstants.networkTimeout)
         guard let result = resultOptional else {
             XCTFail("Could not get identityId for user")
             return ""
@@ -330,7 +330,7 @@ extension AWSDataStoreAuthBaseTest {
                               file: StaticString = #file,
                               line: UInt = #line) async -> M? {
         var queriedModel: M?
-        let queriedInvoked = AsyncExpectation(description: "Model queried")
+        let queriedInvoked = expectation(description: "Model queried")
 
         do {
             let model = try await Amplify.DataStore.query(M.self, byId: id)
@@ -342,7 +342,7 @@ extension AWSDataStoreAuthBaseTest {
             XCTFail("Failed to query model \(error)", file: file, line: line)
         }
         
-        await waitForExpectations([queriedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [queriedInvoked], timeout: TestCommonConstants.networkTimeout)
         return queriedModel
     }
 }
@@ -370,7 +370,7 @@ extension AWSDataStoreAuthBaseTest {
                 await expectations.query.fulfill()
             }
         }.store(in: &requests)
-        await waitForExpectations([expectations.query],
+        await fulfillment(of: [expectations.query],
              timeout: 60)
     }
 
@@ -414,7 +414,7 @@ extension AWSDataStoreAuthBaseTest {
         } catch(let error) {
             XCTFail("Failure due to error: \(error)")
         }
-        await waitForExpectations([expectations.subscriptionsEstablished,
+        await fulfillment(of: [expectations.subscriptionsEstablished,
                                    expectations.modelsSynced,
                                    expectations.ready],
                              timeout: 60)
@@ -468,7 +468,7 @@ extension AWSDataStoreAuthBaseTest {
             }
         }.store(in: &requests)
 
-        await waitForExpectations([expectations.mutationSave, expectations.mutationSaveProcessed], timeout: 60)
+        await fulfillment(of: [expectations.mutationSave, expectations.mutationSaveProcessed], timeout: 60)
 
         Amplify.Publisher.create {
             try await Amplify.DataStore.delete(model)
@@ -484,7 +484,7 @@ extension AWSDataStoreAuthBaseTest {
             }
         }.store(in: &requests)
 
-        await waitForExpectations([expectations.mutationDelete, expectations.mutationDeleteProcessed], timeout: 60)
+        await fulfillment(of: [expectations.mutationDelete, expectations.mutationDeleteProcessed], timeout: 60)
     }
     
     func assertUsedAuthTypes(_ authTypes: [AWSAuthorizationType],

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthCombinationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthCombinationTests.swift
@@ -30,18 +30,18 @@ class AWSDataStoreMultiAuthCombinationTests: AWSDataStoreAuthBaseTest {
         Task {
             do {
                 try await Amplify.DataStore.start()
-                await startExpectation.fulfill()
+                startExpectation.fulfill()
             } catch(let error) {
                 XCTFail("DataStore start failure \(error)")
             }
         }
 
         // we're only interested in "ready-state" expectations
-        await expectations.query.fulfill()
-        await expectations.mutationSave.fulfill()
-        await expectations.mutationSaveProcessed.fulfill()
-        await expectations.mutationDelete.fulfill()
-        await expectations.mutationDeleteProcessed.fulfill()
+        expectations.query.fulfill()
+        expectations.mutationSave.fulfill()
+        expectations.mutationSaveProcessed.fulfill()
+        expectations.mutationDelete.fulfill()
+        expectations.mutationDeleteProcessed.fulfill()
 
         await fulfillment(of: [
                 startExpectation,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthCombinationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthCombinationTests.swift
@@ -22,7 +22,7 @@ class AWSDataStoreMultiAuthCombinationTests: AWSDataStoreAuthBaseTest {
         await signIn(user: user1)
 
         let expectations = makeExpectations()
-        let startExpectation = asyncExpectation(description: "DataStore start success")
+        let startExpectation = expectation(description: "DataStore start success")
 
         await assertDataStoreReady(expectations)
 
@@ -43,7 +43,7 @@ class AWSDataStoreMultiAuthCombinationTests: AWSDataStoreAuthBaseTest {
         await expectations.mutationDelete.fulfill()
         await expectations.mutationDeleteProcessed.fulfill()
 
-        await waitForExpectations([
+        await fulfillment(of: [
                 startExpectation,
                 expectations.query,
                 expectations.mutationSave,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthSingleRuleTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthSingleRuleTests.swift
@@ -101,7 +101,7 @@ class AWSDataStoreMultiAuthSingleRuleTests: AWSDataStoreAuthBaseTest {
 
         assertUsedAuthTypes([.amazonCognitoUserPools])
 
-        await waitForExpectations([
+        await fulfillment(of: [
                 expectations.query,
                 expectations.mutationSave,
                 expectations.mutationSaveProcessed,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthSingleRuleTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthSingleRuleTests.swift
@@ -88,25 +88,29 @@ class AWSDataStoreMultiAuthSingleRuleTests: AWSDataStoreAuthBaseTest {
         let expectations = makeExpectations()
 
         // we're only interested in "ready-state" expectations
-        await expectations.query.fulfill()
-        await expectations.mutationSave.fulfill()
-        await expectations.mutationSaveProcessed.fulfill()
-        await expectations.mutationDelete.fulfill()
-        await expectations.mutationDeleteProcessed.fulfill()
+        expectations.query.fulfill()
+        expectations.mutationSave.fulfill()
+        expectations.mutationSaveProcessed.fulfill()
+        expectations.mutationDelete.fulfill()
+        expectations.mutationDeleteProcessed.fulfill()
 
         // GroupUPPost won't sync for user2 but DataStore should reach a
         // "ready" state
-        await expectations.modelsSynced.fulfill()
+        expectations.modelsSynced.fulfill()
         await assertDataStoreReady(expectations, expectedModelSynced: 0)
 
         assertUsedAuthTypes([.amazonCognitoUserPools])
 
-        await fulfillment(of: [
+        await fulfillment(
+            of: [
                 expectations.query,
                 expectations.mutationSave,
                 expectations.mutationSaveProcessed,
                 expectations.mutationDelete,
-                expectations.mutationDeleteProcessed], timeout: TestCommonConstants.networkTimeout)
+                expectations.mutationDeleteProcessed
+            ],
+            timeout: TestCommonConstants.networkTimeout
+        )
     }
 
     func testGroupOIDC() throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TestSupport/SyncEngineIntegrationV2TestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TestSupport/SyncEngineIntegrationV2TestBase.swift
@@ -38,7 +38,6 @@ class SyncEngineIntegrationV2TestBase: DataStoreTestBase {
     override func tearDown() async throws {
         try await Amplify.DataStore.clear()
         await Amplify.reset()
-        try await Task.sleep(seconds: 1)
     }
 
     // swiftlint:enable force_try

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionOptionalAssociations.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionOptionalAssociations.swift
@@ -226,7 +226,7 @@ class DataStoreConnectionOptionalAssociations: SyncEngineIntegrationV2TestBase {
             XCTFail("Failed to query comment without post")
             return
         }
-        
+
         XCTAssertNil(queriedCommentWithoutPost.post)
         
         queriedPost.blog = nil

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/xcshareddata/xcschemes/AWSDataStorePluginIntegrationTests.xcscheme
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/xcshareddata/xcschemes/AWSDataStorePluginIntegrationTests.xcscheme
@@ -54,6 +54,12 @@
                   Identifier = "DataStoreObserveQueryTests/testObserveQuery_withClearedDataStore_fullySyncedWithMaxRecords()">
                </Test>
                <Test
+                  Identifier = "DataStoreObserveQueryTests/testPredicateWithCreateUpdateDelete()">
+               </Test>
+               <Test
+                  Identifier = "DataStoreObserveQueryTests/testSortWithCreateUpdateDelete()">
+               </Test>
+               <Test
                   Identifier = "DataStoreTestBase">
                </Test>
                <Test

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/xcshareddata/xcschemes/AWSDataStorePluginIntegrationTests.xcscheme
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/xcshareddata/xcschemes/AWSDataStorePluginIntegrationTests.xcscheme
@@ -48,6 +48,12 @@
                   Identifier = "DataStoreLocalStoreTests">
                </Test>
                <Test
+                  Identifier = "DataStoreObserveQueryTests/testInitialSyncWithPredicate()">
+               </Test>
+               <Test
+                  Identifier = "DataStoreObserveQueryTests/testObserveQuery_withClearedDataStore_fullySyncedWithMaxRecords()">
+               </Test>
+               <Test
                   Identifier = "DataStoreTestBase">
                </Test>
                <Test

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/xcshareddata/xcschemes/AWSDataStorePluginIntegrationTestsWatch.xcscheme
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/xcshareddata/xcschemes/AWSDataStorePluginIntegrationTestsWatch.xcscheme
@@ -33,6 +33,18 @@
                   Identifier = "DataStoreLocalStoreTests">
                </Test>
                <Test
+                  Identifier = "DataStoreObserveQueryTests/testInitialSyncWithPredicate()">
+               </Test>
+               <Test
+                  Identifier = "DataStoreObserveQueryTests/testObserveQueryInitialSync()">
+               </Test>
+               <Test
+                  Identifier = "DataStoreObserveQueryTests/testPredicateWithCreateUpdateDelete()">
+               </Test>
+               <Test
+                  Identifier = "DataStoreObserveQueryTests/testSortWithCreateUpdateDelete()">
+               </Test>
+               <Test
                   Identifier = "DataStoreTestBase">
                </Test>
                <Test

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/xcshareddata/xcschemes/DataStoreHostApp.xcscheme
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/xcshareddata/xcschemes/DataStoreHostApp.xcscheme
@@ -109,6 +109,14 @@
                BlueprintName = "AWSDataStorePluginMultiAuthTests"
                ReferencedContainer = "container:DataStoreHostApp.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "AWSDataStoreMultiAuthSingleRuleTests/testGroupOIDC()">
+               </Test>
+               <Test
+                  Identifier = "AWSDataStoreMultiAuthSingleRuleTests/testOwnerOIDC()">
+               </Test>
+            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO">

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/xcshareddata/xcschemes/DataStoreHostApp.xcscheme
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/xcshareddata/xcschemes/DataStoreHostApp.xcscheme
@@ -29,7 +29,7 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO"
+            skipped = "YES"
             parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
@@ -40,13 +40,72 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "21801C7928F9A22900FFA37E"
                BuildableName = "AWSDataStorePluginLazyLoadTests.xctest"
                BlueprintName = "AWSDataStorePluginLazyLoadTests"
+               ReferencedContainer = "container:DataStoreHostApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "213DBBD928A5770000B30280"
+               BuildableName = "AWSDataStorePluginAuthCognitoTests.xctest"
+               BlueprintName = "AWSDataStorePluginAuthCognitoTests"
+               ReferencedContainer = "container:DataStoreHostApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "213DBBE628A5771400B30280"
+               BuildableName = "AWSDataStorePluginAuthIAMTests.xctest"
+               BlueprintName = "AWSDataStorePluginAuthIAMTests"
+               ReferencedContainer = "container:DataStoreHostApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "21BBFB71289C00AC00B32A39"
+               BuildableName = "AWSDataStorePluginCPKTests.xctest"
+               BlueprintName = "AWSDataStorePluginCPKTests"
+               ReferencedContainer = "container:DataStoreHostApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "21BBFB40289BFF6A00B32A39"
+               BuildableName = "AWSDataStorePluginIntegrationTests.xctest"
+               BlueprintName = "AWSDataStorePluginIntegrationTests"
+               ReferencedContainer = "container:DataStoreHostApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "213DBBF328A5772500B30280"
+               BuildableName = "AWSDataStorePluginMultiAuthTests.xctest"
+               BlueprintName = "AWSDataStorePluginMultiAuthTests"
+               ReferencedContainer = "container:DataStoreHostApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "21BBFB64289C007700B32A39"
+               BuildableName = "AWSDataStorePluginV2Tests.xctest"
+               BlueprintName = "AWSDataStorePluginV2Tests"
                ReferencedContainer = "container:DataStoreHostApp.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/xcshareddata/xcschemes/DataStoreHostApp.xcscheme
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/xcshareddata/xcschemes/DataStoreHostApp.xcscheme
@@ -88,6 +88,17 @@
                BlueprintName = "AWSDataStorePluginIntegrationTests"
                ReferencedContainer = "container:DataStoreHostApp.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "DataStoreObserveQueryTests/testInitialSyncWithPredicate()">
+               </Test>
+               <Test
+                  Identifier = "DataStoreObserveQueryTests/testPredicateWithCreateUpdateDelete()">
+               </Test>
+               <Test
+                  Identifier = "DataStoreObserveQueryTests/testSortWithCreateUpdateDelete()">
+               </Test>
+            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO">

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressBaseTest.swift
@@ -74,6 +74,6 @@ class DataStoreStressBaseTest: XCTestCase {
 
         try await Amplify.DataStore.start()
 
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [eventReceived], timeout: networkTimeout)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressTests.swift
@@ -48,7 +48,7 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
             posts.append(post)
         }
         
-        let postsSyncedToCloud = asyncExpectation(description: "All posts saved and synced to cloud",
+        let postsSyncedToCloud = expectation(description: "All posts saved and synced to cloud",
                                                   expectedFulfillmentCount: concurrencyLimit)
 
         let postsCopy = posts
@@ -78,7 +78,7 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
             }
         }
         
-        await waitForExpectations([postsSyncedToCloud], timeout: networkTimeout)
+        await fulfillment(of: [postsSyncedToCloud], timeout: networkTimeout)
     }
     
     /// Perform concurrent saves and observe the data successfuly synced from cloud
@@ -96,7 +96,7 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
 
         let posts = await saveAndSyncPosts(concurrencyLimit: concurrencyLimit)
         
-        let localQueryForPosts = asyncExpectation(description: "Query for the post is successful",
+        let localQueryForPosts = expectation(description: "Query for the post is successful",
                                                 expectedFulfillmentCount: concurrencyLimit)
         
         DispatchQueue.concurrentPerform(iterations: concurrencyLimit) { index in
@@ -110,7 +110,7 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
             }
         }
         
-        await waitForExpectations([localQueryForPosts], timeout: networkTimeout)
+        await fulfillment(of: [localQueryForPosts], timeout: networkTimeout)
     }
     
     /// Perform concurrent saves and observe the data successfuly synced from cloud
@@ -128,7 +128,7 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
 
         let posts = await saveAndSyncPosts(concurrencyLimit: concurrencyLimit)
         
-        let localQueryForPosts = asyncExpectation(description: "Query for the post is successful",
+        let localQueryForPosts = expectation(description: "Query for the post is successful",
                                                   expectedFulfillmentCount: concurrencyLimit)
         
         DispatchQueue.concurrentPerform(iterations: concurrencyLimit) { index in
@@ -144,7 +144,7 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
             }
         }
         
-        await waitForExpectations([localQueryForPosts], timeout: networkTimeout)
+        await fulfillment(of: [localQueryForPosts], timeout: networkTimeout)
     }
     
     /// Perform concurrent saves and observe the data successfuly synced from cloud. Then delete the items afterwards
@@ -164,10 +164,10 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
         
         let posts = await saveAndSyncPosts(concurrencyLimit: concurrencyLimit)
         
-        let postsDeletedLocally = asyncExpectation(description: "All posts deleted locally",
+        let postsDeletedLocally = expectation(description: "All posts deleted locally",
                                                    expectedFulfillmentCount: concurrencyLimit)
         
-        let postsDeletedFromCloud = asyncExpectation(description: "All posts deleted and synced to cloud",
+        let postsDeletedFromCloud = expectation(description: "All posts deleted and synced to cloud",
                                                      expectedFulfillmentCount: concurrencyLimit)
         
         let mutationEvents = Amplify.DataStore.observe(Post.self)
@@ -197,7 +197,7 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
             }
         }
         
-        await waitForExpectations([postsDeletedLocally, postsDeletedFromCloud], timeout: networkTimeout)
+        await fulfillment(of: [postsDeletedLocally, postsDeletedFromCloud], timeout: networkTimeout)
     }
     
     
@@ -213,7 +213,7 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
             posts.append(post)
         }
         
-        let postsSyncedToCloud = asyncExpectation(description: "All posts saved and synced to cloud",
+        let postsSyncedToCloud = expectation(description: "All posts saved and synced to cloud",
                                                   expectedFulfillmentCount: concurrencyLimit)
         
         let postsCopy = posts
@@ -242,7 +242,7 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
                 _ = try await Amplify.DataStore.save(capturedPosts[index])
             }
         }
-        await waitForExpectations([postsSyncedToCloud], timeout: networkTimeout)
+        await fulfillment(of: [postsSyncedToCloud], timeout: networkTimeout)
         
         return capturedPosts
     }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
