### PR TITLE
ci: add required identifier fiedl for workflow_call

### DIFF
--- a/.github/workflows/deploy_package.yml
+++ b/.github/workflows/deploy_package.yml
@@ -16,11 +16,15 @@ jobs:
   unit-tests:
     name: Run Plugins Unit Tests
     uses: ./.github/workflows/unit_test.yml
+    with:
+      identifier: 'workflow-call-unit-test'
 
   fortify:
     name: Run Fortify Scan
     uses: ./.github/workflows/fortify_scan.yml
     secrets: inherit
+    with:
+      identifier: 'workflow-call-fortify'
 
   release:
     environment: Release

--- a/.github/workflows/fortify_scan.yml
+++ b/.github/workflows/fortify_scan.yml
@@ -2,6 +2,11 @@ name: Fortify Scan
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      identifier:
+        required: true
+        type: string
+
   push:
     branches-ignore:
       - main

--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -2,6 +2,11 @@ name: Integration Tests
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      identifier:
+        required: true
+        type: string
+
   push:
     branches: [main]
 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,6 +1,11 @@
 name: Unit Tests | All
 on:
   workflow_call:
+    inputs:
+      identifier:
+        required: true
+        type: string
+
   workflow_dispatch:
   push:
     branches-ignore:


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

The same as issue https://github.com/aws-amplify/aws-sdk-ios/pull/4915, currency workflow with group name format `<github.workflow>-<PRNumber or branchName>` will have the same group name when triggered by `workflow_call` event. Adding the input field `identifier` to specify the workflow name.


## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
