### PR TITLE
chore: Caching dependencies when building and testing

### DIFF
--- a/.github/composite_actions/run_xcodebuild/action.yml
+++ b/.github/composite_actions/run_xcodebuild/action.yml
@@ -19,6 +19,10 @@ inputs:
     required: false
     type: string
     default: 'iphonesimulator'
+  disable_package_resolution:
+    required: false
+    type: boolean
+    default: false
   other_flags:
     required: false
     type: string
@@ -39,6 +43,11 @@ runs:
         if [ ! -z "$XCODE_PATH" ]; then
           sudo xcode-select -s $XCODE_PATH
         fi
+
+        otherFlags="${{ inputs.other_flags }}"
+        if [ "${{ inputs.disable_package_resolution }}" == "true" ]; then
+          otherFlags+=" -disableAutomaticPackageResolution"
+        fi
         xcodebuild -version
-        xcodebuild build -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
+        xcodebuild build -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' $otherFlags | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
       shell: bash

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -39,6 +39,10 @@ inputs:
     required: false
     type: string
     default: ''
+  disable_package_resolution:
+    required: false
+    type: boolean
+    default: false
   test_without_building:
     required: false
     type: boolean
@@ -66,7 +70,7 @@ runs:
         clonedSourcePackagesPath=""
         if [ ! -z "$CLONED_SOURCE_PACKAGES_PATH" ]; then
           echo "Using custom cloned source packages path"
-          clonedSourcePackagesPath+="-clonedSourcePackagesDirPath $CLONED_SOURCE_PACKAGES_PATH"
+          clonedSourcePackagesPath+="-clonedSourcePackagesDirPath $CLONED_SOURCE_PACKAGES_PATH -disableAutomaticPackageResolution"
         fi
 
         derivedDataPath=""
@@ -86,6 +90,11 @@ runs:
           if [ -z "$derivedDataPath" ]; then
             derivedDataPath+="-derivedDataPath Build/"
           fi
+        fi
+
+        if [ "${{ inputs.disable_package_resolution }}" == "true" ]; then
+          echo "Disabling Automatic Package Resolution"
+          clonedSourcePackagesPath+=" -disableAutomaticPackageResolution"
         fi
 
         retryFlags=""

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -77,7 +77,7 @@ runs:
 
         xcode-select -p
         xcodebuild -version
-        xcodebuild test -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $clonedSourcePackagesPath $coverageFlags $retryFlags | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
+        xcodebuild test -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $clonedSourcePackagesPath $coverageFlags $retryFlags | xcpretty --simple --color --report html && exit ${PIPESTATUS[0]}
       shell: bash
 
     - name: Generate Coverage report

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -19,15 +19,7 @@ inputs:
     required: false
     type: string
     default: 'iphonesimulator'
-  other_flags:
-    required: false
-    type: string
-    default: ''
   generate_coverage:
-    required: false
-    type: boolean
-    default: false
-  retry_on_failure:
     required: false
     type: boolean
     default: false
@@ -47,6 +39,10 @@ inputs:
     required: false
     type: boolean
     default: false
+  other_flags:
+    required: false
+    type: string
+    default: ''
 
 runs:
   using: "composite"
@@ -97,12 +93,6 @@ runs:
           clonedSourcePackagesPath+=" -disableAutomaticPackageResolution"
         fi
 
-        retryFlags=""
-        if [ "${{ inputs.retry_on_failure }}" == "true" ]; then
-          echo "Retries are enabled"
-          retryFlags+="-retry-tests-on-failure"
-        fi
-
         action=""
         if [ "${{ inputs.test_without_building }}" == "true" ]; then
           echo "Testing without building..."
@@ -113,7 +103,7 @@ runs:
 
         xcode-select -p
         xcodebuild -version
-        xcodebuild $action -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $clonedSourcePackagesPath $derivedDataPath $coverageFlags $retryFlags | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
+        xcodebuild $action -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $clonedSourcePackagesPath $derivedDataPath $coverageFlags | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
       shell: bash
 
     - name: Generate Coverage report

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -80,7 +80,7 @@ runs:
           echo "Code Coverage is enabled!"
           coverageFlags+="-enableCodeCoverage YES"
           if [ -z "$clonedSourcePackagesPath" ]; then
-            clonedSourcePackagesPath+="-clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/$SCHEME"
+            clonedSourcePackagesPath+="-clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/Amplify"
           fi
 
           if [ -z "$derivedDataPath" ]; then

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -27,10 +27,18 @@ inputs:
     required: false
     type: boolean
     default: false
-  retry-on-failure:
+  retry_on_failure:
     required: false
     type: boolean
     default: false
+  cloned_source_packages_path:
+    required: false
+    type: string
+    default: ''
+  derived_data_path:
+    required: false
+    type: string
+    default: ''
 
 runs:
   using: "composite"
@@ -40,6 +48,8 @@ runs:
         SCHEME: ${{ inputs.scheme }}
         PROJECT_PATH: ${{ inputs.project_path }}
         XCODE_PATH: ${{ inputs.xcode_path }}
+        CLONED_SOURCE_PACKAGES_PATH: ${{ inputs.cloned_source_packages_path }}
+        DERIVED_DATA_PATH: ${{ inputs.derived_data_path }}
       run: |
         if [ ! -z "$PROJECT_PATH" ]; then
           cd $PROJECT_PATH
@@ -48,10 +58,11 @@ runs:
           echo "Using Xcode $XCODE_PATH"
           sudo xcode-select -s $XCODE_PATH
         fi
+
         coverageFlags=""
         if [ "${{ inputs.generate_coverage }}" == "true" ]; then
           echo "Code Coverage is enabled!"
-          coverageFlags+="-derivedDataPath Build/ -clonedSourcePackagesDirPath "~/Library/Developer/Xcode/DerivedData/$SCHEME" -enableCodeCoverage YES"
+          coverageFlags+="-enableCodeCoverage YES"
         fi
 
         retryFlags=""
@@ -60,9 +71,21 @@ runs:
           retryFlags+="-retry-tests-on-failure"
         fi
 
+        clonedSourcePackagesPath=""
+        if [ ! -z "$CLONED_SOURCE_PACKAGES_PATH" ]; then
+          echo "Using custom cloned source packages path"
+          clonedSourcePackagesPath+="-clonedSourcePackagesDirPath $CLONED_SOURCE_PACKAGES_PATH"
+        fi       
+
+        derivedDataPath=""
+        if [ ! -z "$DERIVED_DATA_PATH" ]; then
+          echo "Using custom cloned source packages path"
+          derivedDataPath+="-derivedDataPath $DERIVED_DATA_PATH"
+        fi  
+
         xcode-select -p
         xcodebuild -version
-        xcodebuild test -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $coverageFlags $retryFlags | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
+        xcodebuild test -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $derivedDataPath $clonedSourcePackagesPath $coverageFlags $retryFlags | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
       shell: bash
 
     - name: Generate Coverage report

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -77,7 +77,7 @@ runs:
 
         xcode-select -p
         xcodebuild -version
-        xcodebuild test -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $clonedSourcePackagesPath $coverageFlags $retryFlags | xcpretty --simple --color --report html && exit ${PIPESTATUS[0]}
+        xcodebuild test -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $clonedSourcePackagesPath $coverageFlags $retryFlags | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
       shell: bash
 
     - name: Generate Coverage report

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -79,7 +79,7 @@ runs:
 
         derivedDataPath=""
         if [ ! -z "$DERIVED_DATA_PATH" ]; then
-          echo "Using custom cloned source packages path"
+          echo "Using custom DerivedData path"
           derivedDataPath+="-derivedDataPath $DERIVED_DATA_PATH"
         fi  
 

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -27,6 +27,10 @@ inputs:
     required: false
     type: boolean
     default: false
+  retry-on-failure:
+    required: false
+    type: boolean
+    default: false
 
 runs:
   using: "composite"
@@ -49,9 +53,16 @@ runs:
           echo "Code Coverage is enabled!"
           coverageFlags+="-derivedDataPath Build/ -clonedSourcePackagesDirPath "~/Library/Developer/Xcode/DerivedData/$SCHEME" -enableCodeCoverage YES"
         fi
+
+        retryFlags=""
+        if [ "${{ inputs.retry-on-failure }}" == "true" ]; then
+          echo "Retries are enabled"
+          retryFlags+="-retry-tests-on-failure"
+        fi
+
         xcode-select -p
         xcodebuild -version
-        xcodebuild test -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $coverageFlags | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
+        xcodebuild test -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $coverageFlags $retryFlags | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
       shell: bash
 
     - name: Generate Coverage report

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -39,6 +39,10 @@ inputs:
     required: false
     type: string
     default: ''
+  test_without_building:
+    required: false
+    type: boolean
+    default: false
 
 runs:
   using: "composite"
@@ -90,9 +94,17 @@ runs:
           retryFlags+="-retry-tests-on-failure"
         fi
 
+        action=""
+        if [ "${{ inputs.test_without_building }}" == "true" ]; then
+          echo "Testing without building..."
+          action="test-without-building"
+        else
+          action="test"
+        fi
+
         xcode-select -p
         xcodebuild -version
-        xcodebuild test -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $clonedSourcePackagesPath $derivedDataPath $coverageFlags $retryFlags | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
+        xcodebuild $action -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $clonedSourcePackagesPath $derivedDataPath $coverageFlags $retryFlags | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
       shell: bash
 
     - name: Generate Coverage report

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -66,7 +66,7 @@ runs:
         fi
 
         retryFlags=""
-        if [ "${{ inputs.retry-on-failure }}" == "true" ]; then
+        if [ "${{ inputs.retry_on_failure }}" == "true" ]; then
           echo "Retries are enabled"
           retryFlags+="-retry-tests-on-failure"
         fi

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -35,10 +35,6 @@ inputs:
     required: false
     type: string
     default: ''
-  derived_data_path:
-    required: false
-    type: string
-    default: ''
 
 runs:
   using: "composite"
@@ -49,7 +45,6 @@ runs:
         PROJECT_PATH: ${{ inputs.project_path }}
         XCODE_PATH: ${{ inputs.xcode_path }}
         CLONED_SOURCE_PACKAGES_PATH: ${{ inputs.cloned_source_packages_path }}
-        DERIVED_DATA_PATH: ${{ inputs.derived_data_path }}
       run: |
         if [ ! -z "$PROJECT_PATH" ]; then
           cd $PROJECT_PATH
@@ -59,10 +54,19 @@ runs:
           sudo xcode-select -s $XCODE_PATH
         fi
 
+        clonedSourcePackagesPath=""
+        if [ ! -z "$CLONED_SOURCE_PACKAGES_PATH" ]; then
+          echo "Using custom cloned source packages path"
+          clonedSourcePackagesPath+="-clonedSourcePackagesDirPath $CLONED_SOURCE_PACKAGES_PATH"
+        fi
+
         coverageFlags=""
         if [ "${{ inputs.generate_coverage }}" == "true" ]; then
           echo "Code Coverage is enabled!"
-          coverageFlags+="-enableCodeCoverage YES"
+          coverageFlags+="-derivedDataPath Build/ -enableCodeCoverage YES"
+          if [ -z "$clonedSourcePackagesPath" ]; then
+            clonedSourcePackagesPath+="-clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/$SCHEME"
+          fi
         fi
 
         retryFlags=""
@@ -71,21 +75,9 @@ runs:
           retryFlags+="-retry-tests-on-failure"
         fi
 
-        clonedSourcePackagesPath=""
-        if [ ! -z "$CLONED_SOURCE_PACKAGES_PATH" ]; then
-          echo "Using custom cloned source packages path"
-          clonedSourcePackagesPath+="-clonedSourcePackagesDirPath $CLONED_SOURCE_PACKAGES_PATH"
-        fi       
-
-        derivedDataPath=""
-        if [ ! -z "$DERIVED_DATA_PATH" ]; then
-          echo "Using custom DerivedData path"
-          derivedDataPath+="-derivedDataPath $DERIVED_DATA_PATH"
-        fi  
-
         xcode-select -p
         xcodebuild -version
-        xcodebuild test -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $derivedDataPath $clonedSourcePackagesPath $coverageFlags $retryFlags | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
+        xcodebuild test -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $clonedSourcePackagesPath $coverageFlags $retryFlags | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
       shell: bash
 
     - name: Generate Coverage report

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -19,6 +19,10 @@ inputs:
     required: false
     type: string
     default: 'iphonesimulator'
+  other_flags:
+    required: false
+    type: string
+    default: ''
   generate_coverage:
     required: false
     type: boolean
@@ -39,10 +43,6 @@ inputs:
     required: false
     type: boolean
     default: false
-  other_flags:
-    required: false
-    type: string
-    default: ''
 
 runs:
   using: "composite"
@@ -66,7 +66,7 @@ runs:
         clonedSourcePackagesPath=""
         if [ ! -z "$CLONED_SOURCE_PACKAGES_PATH" ]; then
           echo "Using custom cloned source packages path"
-          clonedSourcePackagesPath+="-clonedSourcePackagesDirPath $CLONED_SOURCE_PACKAGES_PATH -disableAutomaticPackageResolution"
+          clonedSourcePackagesPath+="-clonedSourcePackagesDirPath $CLONED_SOURCE_PACKAGES_PATH"
         fi
 
         derivedDataPath=""
@@ -93,12 +93,10 @@ runs:
           clonedSourcePackagesPath+=" -disableAutomaticPackageResolution"
         fi
 
-        action=""
+        action="test"
         if [ "${{ inputs.test_without_building }}" == "true" ]; then
           echo "Testing without building..."
-          action="test-without-building"
-        else
-          action="test"
+          action+="-without-building"
         fi
 
         xcode-select -p

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -35,6 +35,10 @@ inputs:
     required: false
     type: string
     default: ''
+  derived_data_path:
+    required: false
+    type: string
+    default: ''
 
 runs:
   using: "composite"
@@ -45,6 +49,7 @@ runs:
         PROJECT_PATH: ${{ inputs.project_path }}
         XCODE_PATH: ${{ inputs.xcode_path }}
         CLONED_SOURCE_PACKAGES_PATH: ${{ inputs.cloned_source_packages_path }}
+        DERIVED_DATA_PATH: ${{ inputs.derived_data_path }}
       run: |
         if [ ! -z "$PROJECT_PATH" ]; then
           cd $PROJECT_PATH
@@ -60,12 +65,22 @@ runs:
           clonedSourcePackagesPath+="-clonedSourcePackagesDirPath $CLONED_SOURCE_PACKAGES_PATH"
         fi
 
+        derivedDataPath=""
+        if [ ! -z "$DERIVED_DATA_PATH" ]; then
+          echo "Using custom DerivedData path"
+          derivedDataPath+="-derivedDataPath $DERIVED_DATA_PATH"
+        fi
+
         coverageFlags=""
         if [ "${{ inputs.generate_coverage }}" == "true" ]; then
           echo "Code Coverage is enabled!"
-          coverageFlags+="-derivedDataPath Build/ -enableCodeCoverage YES"
+          coverageFlags+="-enableCodeCoverage YES"
           if [ -z "$clonedSourcePackagesPath" ]; then
             clonedSourcePackagesPath+="-clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/$SCHEME"
+          fi
+
+          if [ -z "$derivedDataPath" ]; then
+            derivedDataPath+="-derivedDataPath Build/"
           fi
         fi
 
@@ -77,16 +92,27 @@ runs:
 
         xcode-select -p
         xcodebuild -version
-        xcodebuild test -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $clonedSourcePackagesPath $coverageFlags $retryFlags | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
+        xcodebuild test -scheme $SCHEME -sdk '${{ inputs.sdk }}' -destination '${{ inputs.destination }}' ${{ inputs.other_flags }} $clonedSourcePackagesPath $derivedDataPath $coverageFlags $retryFlags | xcpretty --simple --color --report junit && exit ${PIPESTATUS[0]}
       shell: bash
 
     - name: Generate Coverage report
       if: ${{ inputs.generate_coverage == 'true' }}
+      env:
+        SCHEME: ${{ inputs.scheme }}
+        DERIVED_DATA_PATH: ${{ inputs.derived_data_path }}
       run: |
         echo "Generating Coverage report..."
-        cd Build/Build/ProfileData
+
+        derivedDataPath=""
+        if [ ! -z "$DERIVED_DATA_PATH" ]; then
+          derivedDataPath="$DERIVED_DATA_PATH"
+        else
+          derivedDataPath="Build"
+        fi
+
+        cd $derivedDataPath/Build/ProfileData
         cd $(ls -d */|head -n 1)
         pathCoverage=Build/Build/ProfileData/${PWD##*/}/Coverage.profdata
         cd ${{ github.workspace }}
-        xcrun llvm-cov export -format="lcov" -instr-profile $pathCoverage Build/Build/Products/Debug-${{ inputs.sdk }}/$SCHEME.o > $SCHEME-Coverage.lcov
+        xcrun llvm-cov export -format="lcov" -instr-profile $pathCoverage $derivedDataPath/Build/Products/Debug-${{ inputs.sdk }}/$SCHEME.o > $SCHEME-Coverage.lcov
       shell: bash

--- a/.github/workflows/build_amplify_swift.yml
+++ b/.github/workflows/build_amplify_swift.yml
@@ -24,6 +24,7 @@ jobs:
           persist-credentials: false
       - name: Cache packages
         timeout-minutes: 4
+        continue-on-error: true
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify

--- a/.github/workflows/build_amplify_swift.yml
+++ b/.github/workflows/build_amplify_swift.yml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: ${{ runner.os }}-iOS-packages-${{ hashFiles('**/Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-iOS-packages-
+            amplify-packages-
       - name: Build Amplify Swift for iOS
         uses: ./.github/composite_actions/run_xcodebuild
         with:
@@ -54,9 +54,9 @@ jobs:
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: ${{ runner.os }}-macOS-packages-${{ hashFiles('**/Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-macOS-packages-
+            amplify-packages-
       - name: Build Amplify Swift for macOS
         uses: ./.github/composite_actions/run_xcodebuild
         with:
@@ -80,9 +80,9 @@ jobs:
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: ${{ runner.os }}-tvOS-packages-${{ hashFiles('**/Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-tvOS-packages-
+            amplify-packages-
       - name: Build Amplify Swift for tvOS
         uses: ./.github/composite_actions/run_xcodebuild
         with:
@@ -106,9 +106,9 @@ jobs:
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: ${{ runner.os }}-watchOS-packages-${{ hashFiles('**/Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-watchOS-packages-
+            amplify-packages-
       - name: Build Amplify Swift for watchOS
         uses: ./.github/composite_actions/run_xcodebuild
         with:

--- a/.github/workflows/build_amplify_swift.yml
+++ b/.github/workflows/build_amplify_swift.yml
@@ -22,11 +22,11 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
-      - name: Cache packages
+      - name: Attempt to restore dependencies cache
         id: cache-packages
         timeout-minutes: 4
         continue-on-error: true
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: amplify-packages-${{ hashFiles('Package.resolved') }}
@@ -40,6 +40,12 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           other_flags: '-derivedDataPath Build -clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/Amplify'
+      - name: Save the dependencies cache if necessary
+        if: steps.cache-packages.outputs.cache-hit != 'true' && github.ref_name == 'main'
+        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/Amplify
+          key: ${{ steps.cache-packages.outputs.cache-primary-key }}
 
   build-amplify-swift-macOS:
     runs-on: macos-13

--- a/.github/workflows/build_amplify_swift.yml
+++ b/.github/workflows/build_amplify_swift.yml
@@ -8,7 +8,7 @@ on:
       - release
 
 env:
-  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
 permissions:
   contents: read
@@ -27,18 +27,11 @@ jobs:
           persist-credentials: false
       - name: Cache packages
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        id: packages-cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: ${{ runner.os }}-iOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-iOS-packages-
-      - name: Cache build
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        id: build-cache
-        with:
-          path: Build
-          key: ${{ runner.os }}-iOS-build-${{ github.ref_name }}
       - name: Build Amplify Swift for iOS
         uses: ./.github/composite_actions/run_xcodebuild
         with:
@@ -56,18 +49,11 @@ jobs:
           persist-credentials: false
       - name: Cache packages
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        id: packages-cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: ${{ runner.os }}-macOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-macOS-packages-
-      - name: Cache build
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        id: build-cache
-        with:
-          path: Build
-          key: ${{ runner.os }}-macOS-build-${{ github.ref_name }}
       - name: Build Amplify Swift for macOS
         uses: ./.github/composite_actions/run_xcodebuild
         with:
@@ -86,18 +72,11 @@ jobs:
           persist-credentials: false
       - name: Cache packages
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        id: packages-cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: ${{ runner.os }}-tvOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-tvOS-packages-
-      - name: Cache build
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        id: build-cache
-        with:
-          path: Build
-          key: ${{ runner.os }}-tvOS-build-${{ github.ref_name }}
       - name: Build Amplify Swift for tvOS
         uses: ./.github/composite_actions/run_xcodebuild
         with:
@@ -116,18 +95,11 @@ jobs:
           persist-credentials: false
       - name: Cache packages
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        id: packages-cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: ${{ runner.os }}-watchOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-watchOS-packages-
-      - name: Cache build
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        id: build-cache
-        with:
-          path: Build
-          key: ${{ runner.os }}-watchOS-build-${{ github.ref_name }}
       - name: Build Amplify Swift for watchOS
         uses: ./.github/composite_actions/run_xcodebuild
         with:

--- a/.github/workflows/build_amplify_swift.yml
+++ b/.github/workflows/build_amplify_swift.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache packages
+        id: cache-packages
         timeout-minutes: 4
         continue-on-error: true
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -37,6 +38,7 @@ jobs:
           scheme: Amplify-Package
           destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
+          disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           other_flags: '-derivedDataPath Build -clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/Amplify'
 
   build-amplify-swift-macOS:
@@ -47,6 +49,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache packages
+        id: cache-packages
         timeout-minutes: 4
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
@@ -61,6 +64,7 @@ jobs:
           destination: platform=macOS,arch=x86_64
           sdk: macosx
           xcode_path: '/Applications/Xcode_14.3.app'
+          disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           other_flags: '-derivedDataPath Build -clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/Amplify'
 
   build-amplify-swift-tvOS:
@@ -72,6 +76,7 @@ jobs:
           persist-credentials: false
       - name: Cache packages
         timeout-minutes: 4
+        id: cache-packages
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
@@ -85,6 +90,7 @@ jobs:
           destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=16.4
           sdk: appletvsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           other_flags: '-derivedDataPath Build -clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/Amplify'
 
   build-amplify-swift-watchOS:
@@ -95,6 +101,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache packages
+        id: cache-packages
         timeout-minutes: 4
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
@@ -109,6 +116,7 @@ jobs:
           destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=9.4
           sdk: watchsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           other_flags: '-derivedDataPath Build -clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/Amplify'
 
   confirm-pass:

--- a/.github/workflows/build_amplify_swift.yml
+++ b/.github/workflows/build_amplify_swift.yml
@@ -2,17 +2,9 @@ name: Build | Amplify Swift
 on:
   workflow_call:
   workflow_dispatch:
-  push:
-    branches-ignore:
-      - main
-      - release
 
 permissions:
   contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref_name != 'main'}}
 
 jobs:
   build-amplify-swift-iOS:
@@ -22,12 +14,29 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
+      - name: Cache packages
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: packages-cache
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/Amplify
+          key: ${{ runner.os }}-iOS-packages-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-iOS-packages-
+      - name: Cache build
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: build-cache
+        with:
+          path: Build
+          key: ${{ runner.os }}-iOS-build-${{ github.sha }}
       - name: Build Amplify Swift for iOS
         uses: ./.github/composite_actions/run_xcodebuild
         with:
           scheme: Amplify-Package
           destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-derivedDataPath Build -clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/Amplify'
 
   build-amplify-swift-macOS:
     runs-on: macos-13
@@ -36,6 +45,22 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
+      - name: Cache packages
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: packages-cache
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/Amplify
+          key: ${{ runner.os }}-macOS-packages-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-macOS-packages-
+      - name: Cache build
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: build-cache
+        with:
+          path: Build
+          key: ${{ runner.os }}-macOS-build-${{ github.sha }}
       - name: Build Amplify Swift for macOS
         uses: ./.github/composite_actions/run_xcodebuild
         with:
@@ -43,6 +68,7 @@ jobs:
           destination: platform=macOS,arch=x86_64
           sdk: macosx
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-derivedDataPath Build -clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/Amplify'
 
   build-amplify-swift-tvOS:
     runs-on: macos-13
@@ -51,6 +77,22 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
+      - name: Cache packages
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: packages-cache
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/Amplify
+          key: ${{ runner.os }}-tvOS-packages-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-tvOS-packages-
+      - name: Cache build
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: build-cache
+        with:
+          path: Build
+          key: ${{ runner.os }}-tvOS-build-${{ github.sha }}
       - name: Build Amplify Swift for tvOS
         uses: ./.github/composite_actions/run_xcodebuild
         with:
@@ -58,6 +100,7 @@ jobs:
           destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=16.4
           sdk: appletvsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-derivedDataPath Build -clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/Amplify'
 
   build-amplify-swift-watchOS:
     runs-on: macos-13
@@ -66,6 +109,22 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
+      - name: Cache packages
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: packages-cache
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/Amplify
+          key: ${{ runner.os }}-watchOS-packages-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-watchOS-packages-
+      - name: Cache build
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: build-cache
+        with:
+          path: Build
+          key: ${{ runner.os }}-watchOS-build-${{ github.sha }}
       - name: Build Amplify Swift for watchOS
         uses: ./.github/composite_actions/run_xcodebuild
         with:
@@ -73,6 +132,7 @@ jobs:
           destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=9.4
           sdk: watchsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-derivedDataPath Build -clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/Amplify'
 
   confirm-pass:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_amplify_swift.yml
+++ b/.github/workflows/build_amplify_swift.yml
@@ -2,9 +2,20 @@ name: Build | Amplify Swift
 on:
   workflow_call:
   workflow_dispatch:
+  push:
+    branches-ignore:
+      - main
+      - release
+
+env:
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'main'}}
 
 jobs:
   build-amplify-swift-iOS:
@@ -17,8 +28,6 @@ jobs:
       - name: Cache packages
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         id: packages-cache
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: ${{ runner.os }}-iOS-packages-${{ hashFiles('**/Package.resolved') }}
@@ -29,7 +38,7 @@ jobs:
         id: build-cache
         with:
           path: Build
-          key: ${{ runner.os }}-iOS-build-${{ github.sha }}
+          key: ${{ runner.os }}-iOS-build-${{ github.ref_name }}
       - name: Build Amplify Swift for iOS
         uses: ./.github/composite_actions/run_xcodebuild
         with:
@@ -48,8 +57,6 @@ jobs:
       - name: Cache packages
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         id: packages-cache
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: ${{ runner.os }}-macOS-packages-${{ hashFiles('**/Package.resolved') }}
@@ -60,7 +67,7 @@ jobs:
         id: build-cache
         with:
           path: Build
-          key: ${{ runner.os }}-macOS-build-${{ github.sha }}
+          key: ${{ runner.os }}-macOS-build-${{ github.ref_name }}
       - name: Build Amplify Swift for macOS
         uses: ./.github/composite_actions/run_xcodebuild
         with:
@@ -80,8 +87,6 @@ jobs:
       - name: Cache packages
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         id: packages-cache
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: ${{ runner.os }}-tvOS-packages-${{ hashFiles('**/Package.resolved') }}
@@ -92,7 +97,7 @@ jobs:
         id: build-cache
         with:
           path: Build
-          key: ${{ runner.os }}-tvOS-build-${{ github.sha }}
+          key: ${{ runner.os }}-tvOS-build-${{ github.ref_name }}
       - name: Build Amplify Swift for tvOS
         uses: ./.github/composite_actions/run_xcodebuild
         with:
@@ -112,8 +117,6 @@ jobs:
       - name: Cache packages
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         id: packages-cache
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: ${{ runner.os }}-watchOS-packages-${{ hashFiles('**/Package.resolved') }}
@@ -124,7 +127,7 @@ jobs:
         id: build-cache
         with:
           path: Build
-          key: ${{ runner.os }}-watchOS-build-${{ github.sha }}
+          key: ${{ runner.os }}-watchOS-build-${{ github.ref_name }}
       - name: Build Amplify Swift for watchOS
         uses: ./.github/composite_actions/run_xcodebuild
         with:

--- a/.github/workflows/build_amplify_swift.yml
+++ b/.github/workflows/build_amplify_swift.yml
@@ -7,9 +7,6 @@ on:
       - main
       - release
 
-env:
-  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
-
 permissions:
   contents: read
 
@@ -26,6 +23,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache packages
+        timeout-minutes: 4
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
@@ -48,6 +46,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache packages
+        timeout-minutes: 4
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
@@ -71,6 +70,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache packages
+        timeout-minutes: 4
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
@@ -94,6 +94,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache packages
+        timeout-minutes: 4
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify

--- a/.github/workflows/build_amplify_swift.yml
+++ b/.github/workflows/build_amplify_swift.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
-          key: amplify-packages-${{ hashFiles('**/Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
             amplify-packages-
       - name: Build Amplify Swift for tvOS

--- a/.github/workflows/deploy_package.yml
+++ b/.github/workflows/deploy_package.yml
@@ -13,6 +13,10 @@ permissions:
   contents: write
 
 jobs:
+  build-amplify-swift:
+    name: Build Amplify package
+    uses: ./.github/workflows/build_amplify_swift.yml
+  
   unit-tests:
     name: Run Plugins Unit Tests
     uses: ./.github/workflows/unit_test.yml

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -38,7 +38,7 @@ jobs:
         continue-on-error: true
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
-          path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
             amplify-packages-
@@ -57,7 +57,7 @@ jobs:
           destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
           generate_coverage: ${{ inputs.generate_coverage_report }}
-          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
@@ -70,7 +70,7 @@ jobs:
           destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
           generate_coverage: ${{ inputs.generate_coverage_report }}
-          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: true
           test_without_building: true
@@ -104,7 +104,7 @@ jobs:
         continue-on-error: true
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
-          path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
             amplify-packages-
@@ -123,7 +123,7 @@ jobs:
           destination: platform=macOS,arch=x86_64
           sdk: macosx
           xcode_path: '/Applications/Xcode_14.3.app'
-          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
@@ -136,7 +136,7 @@ jobs:
           destination: platform=macOS,arch=x86_64
           sdk: macosx
           xcode_path: '/Applications/Xcode_14.3.app'
-          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: true
           test_without_building: true
@@ -161,7 +161,7 @@ jobs:
         continue-on-error: true
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
-          path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
             amplify-packages-
@@ -180,7 +180,7 @@ jobs:
           destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=16.4
           sdk: appletvsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
-          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
@@ -193,7 +193,7 @@ jobs:
           destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=16.4
           sdk: appletvsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
-          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: true
           test_without_building: true
@@ -218,7 +218,7 @@ jobs:
         continue-on-error: true
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
-          path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
             amplify-packages-
@@ -237,7 +237,7 @@ jobs:
           destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=9.4
           sdk: watchsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
-          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
@@ -250,7 +250,7 @@ jobs:
           destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=9.4
           sdk: watchsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
-          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: true
           test_without_building: true

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -41,6 +41,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-iOS-packages-
       - name: Attempt to restore the build cache
+        id: restore-build
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -55,6 +56,7 @@ jobs:
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: ${{ github.workspace }}/Build
+          test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Save the build cache for re-runs
         if: failure()
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -88,6 +90,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-macOS-packages-
       - name: Attempt to restore the build cache
+        id: restore-build
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -102,6 +105,7 @@ jobs:
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: ${{ github.workspace }}/Build
+          test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Save the build cache for re-runs
         if: failure()
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -126,6 +130,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-tvOS-packages-
       - name: Attempt to restore the build cache
+        id: restore-build
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -140,6 +145,7 @@ jobs:
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: ${{ github.workspace }}/Build
+          test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Save the build cache for re-runs
         if: failure()
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -164,6 +170,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-watchOS-packages-
       - name: Attempt to restore the build cache
+        id: restore-build
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -178,6 +185,7 @@ jobs:
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: ${{ github.workspace }}/Build
+          test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Save the build cache for re-runs
         if: failure()
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   SCHEME: ${{ inputs.scheme }}
-  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
 permissions:
     contents: read
@@ -35,18 +35,11 @@ jobs:
           persist-credentials: false
       - name: Restore packages cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        id: packages-cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: ${{ runner.os }}-iOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-iOS-packages-
-      - name: Restore build cache
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        id: build-cache
-        with:
-          path: Build
-          key: ${{ runner.os }}-iOS-build-${{ github.ref_name }}
       - name: Run iOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -56,7 +49,6 @@ jobs:
           generate_coverage: ${{ inputs.generate_coverage_report }}
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-          derived_data_path: Build
       - name: Upload Report File
         if: ${{ inputs.generate_coverage_report == true }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
@@ -77,18 +69,11 @@ jobs:
           persist-credentials: false
       - name: Restore packages cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        id: packages-cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: ${{ runner.os }}-macOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-macOS-packages-
-      - name: Restore build cache
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        id: build-cache
-        with:
-          path: Build
-          key: ${{ runner.os }}-macOS-build-${{ github.ref_name }}
       - name: Run macOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -98,7 +83,6 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-          derived_data_path: Build
 
   test-tvOS:
     name: ${{ inputs.scheme }} tvOS Tests
@@ -110,18 +94,11 @@ jobs:
           persist-credentials: false
       - name: Restore packages cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        id: packages-cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: ${{ runner.os }}-tvOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-tvOS-packages-
-      - name: Restore build cache
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        id: build-cache
-        with:
-          path: Build
-          key: ${{ runner.os }}-tvOS-build-${{ github.ref_name }}
       - name: Run tvOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -131,7 +108,6 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-          derived_data_path: Build
 
   test-watchOS:
     name: ${{ inputs.scheme }} watchOS Tests
@@ -143,18 +119,11 @@ jobs:
           persist-credentials: false
       - name: Restore packages cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        id: packages-cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: ${{ runner.os }}-watchOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-watchOS-packages-
-      - name: Restore build cache
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        id: build-cache
-        with:
-          path: Build
-          key: ${{ runner.os }}-watchOS-build-${{ github.ref_name }}
       - name: Run watchOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -164,4 +133,3 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-          derived_data_path: Build

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -61,9 +61,9 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
-      - name: Re-Run iOS Test Suite
+      - name: Retry iOS Test Suite if needed
         if: failure() && steps.run-tests.outcome=='failure'
-        id: rerun-tests
+        id: retry-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}
@@ -72,10 +72,10 @@ jobs:
           generate_coverage: ${{ inputs.generate_coverage_report }}
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: ${{ github.workspace }}/Build
-          disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
-          test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
+          disable_package_resolution: true
+          test_without_building: true
       - name: Save the build cache for re-runs
-        if: failure() && steps.rerun-tests.outcome=='failure'
+        if: failure() && steps.retry-tests.outcome=='failure'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -101,6 +101,7 @@ jobs:
       - name: Cache packages
         id: cache-packages
         timeout-minutes: 4
+        continue-on-error: true
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
@@ -115,6 +116,7 @@ jobs:
           key: ${{ runner.os }}-macOS-build-${{ github.sha }}
       - name: Run macOS Test Suite
         id: run-tests
+        continue-on-error: true
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}
@@ -125,8 +127,21 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
-      - name: Save the build cache for re-runs
+      - name: Retry macOS Test Suite if needed
         if: failure() && steps.run-tests.outcome=='failure'
+        id: retry-tests
+        uses: ./.github/composite_actions/run_xcodebuild_test
+        with:
+          scheme: ${{ env.SCHEME }}
+          destination: platform=macOS,arch=x86_64
+          sdk: macosx
+          xcode_path: '/Applications/Xcode_14.3.app'
+          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          derived_data_path: ${{ github.workspace }}/Build
+          disable_package_resolution: true
+          test_without_building: true
+      - name: Save the build cache for re-runs
+        if: failure() && steps.retry-tests.outcome=='failure'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -143,6 +158,7 @@ jobs:
       - name: Cache packages
         id: cache-packages
         timeout-minutes: 4
+        continue-on-error: true
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
@@ -157,6 +173,7 @@ jobs:
           key: ${{ runner.os }}-tvOS-build-${{ github.sha }}
       - name: Run tvOS Test Suite
         id: run-tests
+        continue-on-error: true
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}
@@ -167,8 +184,21 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
-      - name: Save the build cache for re-runs
+      - name: Retry tvOS Test Suite if needed
         if: failure() && steps.run-tests.outcome=='failure'
+        id: retry-tests
+        uses: ./.github/composite_actions/run_xcodebuild_test
+        with:
+          scheme: ${{ env.SCHEME }}
+          destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=16.4
+          sdk: appletvsimulator
+          xcode_path: '/Applications/Xcode_14.3.app'
+          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          derived_data_path: ${{ github.workspace }}/Build
+          disable_package_resolution: true
+          test_without_building: true
+      - name: Save the build cache for re-runs
+        if: failure() && steps.retry-tests.outcome=='failure'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -185,6 +215,7 @@ jobs:
       - name: Cache packages
         id: cache-packages
         timeout-minutes: 4
+        continue-on-error: true
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
@@ -199,6 +230,7 @@ jobs:
           key: ${{ runner.os }}-watchOS-build-${{ github.sha }}
       - name: Run watchOS Test Suite
         id: run-tests
+        continue-on-error: true
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}
@@ -209,8 +241,21 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
-      - name: Save the build cache for re-runs
+      - name: Retry watchOS Test Suite if needed
         if: failure() && steps.run-tests.outcome=='failure'
+        id: retry-tests
+        uses: ./.github/composite_actions/run_xcodebuild_test
+        with:
+          scheme: ${{ env.SCHEME }}
+          destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=9.4
+          sdk: watchsimulator
+          xcode_path: '/Applications/Xcode_14.3.app'
+          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          derived_data_path: ${{ github.workspace }}/Build
+          disable_package_resolution: true
+          test_without_building: true
+      - name: Save the build cache for re-runs
+        if: failure() && steps.retry-tests.outcome=='failure'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache packages
-        timeout-minutes: 1
+        timeout-minutes: 4
         continue-on-error: true
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
@@ -48,6 +48,7 @@ jobs:
           path: ${{ github.workspace }}/Build
           key: ${{ runner.os }}-iOS-build-${{ github.sha }}
       - name: Run iOS Test Suite
+        id: run-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}
@@ -59,7 +60,7 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Save the build cache for re-runs
-        if: failure()
+        if: failure() && steps.run-tests.outcome=='failure'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -97,6 +98,7 @@ jobs:
           path: ${{ github.workspace }}/Build
           key: ${{ runner.os }}-macOS-build-${{ github.sha }}
       - name: Run macOS Test Suite
+        id: run-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}
@@ -108,7 +110,7 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Save the build cache for re-runs
-        if: failure()
+        if: failure() && steps.run-tests.outcome=='failure'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -137,6 +139,7 @@ jobs:
           path: ${{ github.workspace }}/Build
           key: ${{ runner.os }}-tvOS-build-${{ github.sha }}
       - name: Run tvOS Test Suite
+        id: run-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}
@@ -148,7 +151,7 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Save the build cache for re-runs
-        if: failure()
+        if: failure() && steps.run-tests.outcome=='failure'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -177,6 +180,7 @@ jobs:
           path: ${{ github.workspace }}/Build
           key: ${{ runner.os }}-watchOS-build-${{ github.sha }}
       - name: Run watchOS Test Suite
+        id: run-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}
@@ -188,7 +192,7 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Save the build cache for re-runs
-        if: failure()
+        if: failure() && steps.run-tests.outcome=='failure'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -33,7 +33,8 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache packages
-        timeout-minutes: 4
+        timeout-minutes: 1
+        continue-on-error: true
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -32,6 +32,14 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
+      - name: Cache packages
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: packages-cache
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          key: ${{ runner.os }}-packages-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-packages-
       - name: Run iOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -39,6 +47,7 @@ jobs:
           destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
           generate_coverage: ${{ inputs.generate_coverage_report }}
+          retry-on-failure: true
       - name: Upload Report File
         if: ${{ inputs.generate_coverage_report == true }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
@@ -64,6 +73,7 @@ jobs:
           destination: platform=macOS,arch=x86_64
           sdk: macosx
           xcode_path: '/Applications/Xcode_14.3.app'
+          retry-on-failure: true
 
   test-tvOS:
     name: ${{ inputs.scheme }} tvOS Tests
@@ -80,6 +90,7 @@ jobs:
           destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=16.4
           sdk: appletvsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          retry-on-failure: true
 
   test-watchOS:
     name: ${{ inputs.scheme }} watchOS Tests
@@ -96,3 +107,4 @@ jobs:
           destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=9.4
           sdk: watchsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          retry-on-failure: true

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
-          key: ${{ runner.os }}-iOS-build-${{ github.sha }}
+          key: ${{ runner.os }}-${{ env.SCHEME }}-iOS-build-${{ github.sha }}
       - name: Run iOS Test Suite
         id: run-tests
         continue-on-error: true
@@ -79,7 +79,7 @@ jobs:
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
-          key: ${{ runner.os }}-iOS-build-${{ github.sha }}
+          key: ${{ runner.os }}-${{ env.SCHEME }}-iOS-build-${{ github.sha }}
       - name: Upload Report File
         if: ${{ inputs.generate_coverage_report == true }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
@@ -113,7 +113,7 @@ jobs:
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
-          key: ${{ runner.os }}-macOS-build-${{ github.sha }}
+          key: ${{ runner.os }}-${{ env.SCHEME }}-macOS-build-${{ github.sha }}
       - name: Run macOS Test Suite
         id: run-tests
         continue-on-error: true
@@ -145,7 +145,7 @@ jobs:
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
-          key: ${{ runner.os }}-macOS-build-${{ github.sha }}
+          key: ${{ runner.os }}-${{ env.SCHEME }}-macOS-build-${{ github.sha }}
 
   test-tvOS:
     name: ${{ inputs.scheme }} tvOS Tests
@@ -170,7 +170,7 @@ jobs:
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
-          key: ${{ runner.os }}-tvOS-build-${{ github.sha }}
+          key: ${{ runner.os }}-${{ env.SCHEME }}-tvOS-build-${{ github.sha }}
       - name: Run tvOS Test Suite
         id: run-tests
         continue-on-error: true
@@ -202,7 +202,7 @@ jobs:
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
-          key: ${{ runner.os }}-tvOS-build-${{ github.sha }}
+          key: ${{ runner.os }}-${{ env.SCHEME }}-tvOS-build-${{ github.sha }}
 
   test-watchOS:
     name: ${{ inputs.scheme }} watchOS Tests
@@ -227,7 +227,7 @@ jobs:
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
-          key: ${{ runner.os }}-watchOS-build-${{ github.sha }}
+          key: ${{ runner.os }}-${{ env.SCHEME }}-watchOS-build-${{ github.sha }}
       - name: Run watchOS Test Suite
         id: run-tests
         continue-on-error: true
@@ -259,4 +259,4 @@ jobs:
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
-          key: ${{ runner.os }}-watchOS-build-${{ github.sha }}
+          key: ${{ runner.os }}-${{ env.SCHEME }}-watchOS-build-${{ github.sha }}

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -19,6 +19,7 @@ on:
 
 env:
   SCHEME: ${{ inputs.scheme }}
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
 
 permissions:
     contents: read
@@ -32,22 +33,20 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
-      - name: Cache packages
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      - name: Restore packages cache
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         id: packages-cache
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: ${{ runner.os }}-iOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-iOS-packages-
-      - name: Cache build
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      - name: Restore build cache
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         id: build-cache
         with:
           path: Build
-          key: ${{ runner.os }}-iOS-build-${{ github.sha }}
+          key: ${{ runner.os }}-iOS-build-${{ github.ref_name }}
       - name: Run iOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -76,22 +75,20 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
-      - name: Cache packages
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      - name: Restore packages cache
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         id: packages-cache
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: ${{ runner.os }}-macOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-macOS-packages-
-      - name: Cache build
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      - name: Restore build cache
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         id: build-cache
         with:
           path: Build
-          key: ${{ runner.os }}-macOS-build-${{ github.sha }}
+          key: ${{ runner.os }}-macOS-build-${{ github.ref_name }}
       - name: Run macOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -111,22 +108,20 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
-      - name: Cache packages
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      - name: Restore packages cache
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         id: packages-cache
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: ${{ runner.os }}-tvOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-tvOS-packages-
-      - name: Cache build
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      - name: Restore build cache
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         id: build-cache
         with:
           path: Build
-          key: ${{ runner.os }}-tvOS-build-${{ github.sha }}
+          key: ${{ runner.os }}-tvOS-build-${{ github.ref_name }}
       - name: Run tvOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -146,22 +141,20 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
-      - name: Cache packages
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      - name: Restore packages cache
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         id: packages-cache
-        env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: ${{ runner.os }}-watchOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-watchOS-packages-
-      - name: Cache build
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      - name: Restore build cache
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         id: build-cache
         with:
           path: Build
-          key: ${{ runner.os }}-watchOS-build-${{ github.sha }}
+          key: ${{ runner.os }}-watchOS-build-${{ github.ref_name }}
       - name: Run watchOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -50,19 +50,32 @@ jobs:
           key: ${{ runner.os }}-iOS-build-${{ github.sha }}
       - name: Run iOS Test Suite
         id: run-tests
+        continue-on-error: true
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}
           destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
           generate_coverage: ${{ inputs.generate_coverage_report }}
-          retry_on_failure: true
+          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          derived_data_path: ${{ github.workspace }}/Build
+          disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
+          test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
+      - name: Re-Run iOS Test Suite
+        if: failure() && steps.run-tests.outcome=='failure'
+        id: rerun-tests
+        uses: ./.github/composite_actions/run_xcodebuild_test
+        with:
+          scheme: ${{ env.SCHEME }}
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
+          xcode_path: '/Applications/Xcode_14.3.app'
+          generate_coverage: ${{ inputs.generate_coverage_report }}
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Save the build cache for re-runs
-        if: failure() && steps.run-tests.outcome=='failure'
+        if: failure() && steps.rerun-tests.outcome=='failure'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -108,7 +121,6 @@ jobs:
           destination: platform=macOS,arch=x86_64
           sdk: macosx
           xcode_path: '/Applications/Xcode_14.3.app'
-          retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
@@ -151,7 +163,6 @@ jobs:
           destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=16.4
           sdk: appletvsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
-          retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
@@ -194,7 +205,6 @@ jobs:
           destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=9.4
           sdk: watchsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
-          retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache packages
+        id: cache-packages
         timeout-minutes: 4
         continue-on-error: true
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -58,6 +59,7 @@ jobs:
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: ${{ github.workspace }}/Build
+          disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Save the build cache for re-runs
         if: failure() && steps.run-tests.outcome=='failure'
@@ -84,6 +86,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache packages
+        id: cache-packages
         timeout-minutes: 4
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
@@ -108,6 +111,7 @@ jobs:
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: ${{ github.workspace }}/Build
+          disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Save the build cache for re-runs
         if: failure() && steps.run-tests.outcome=='failure'
@@ -125,6 +129,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache packages
+        id: cache-packages
         timeout-minutes: 4
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
@@ -149,6 +154,7 @@ jobs:
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: ${{ github.workspace }}/Build
+          disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Save the build cache for re-runs
         if: failure() && steps.run-tests.outcome=='failure'
@@ -166,6 +172,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Cache packages
+        id: cache-packages
         timeout-minutes: 4
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
@@ -190,6 +197,7 @@ jobs:
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: ${{ github.workspace }}/Build
+          disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Save the build cache for re-runs
         if: failure() && steps.run-tests.outcome=='failure'

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -62,7 +62,7 @@ jobs:
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Retry iOS Test Suite if needed
-        if: failure() && steps.run-tests.outcome=='failure'
+        if: steps.run-tests.outcome=='failure'
         id: retry-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -128,7 +128,7 @@ jobs:
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Retry macOS Test Suite if needed
-        if: failure() && steps.run-tests.outcome=='failure'
+        if: steps.run-tests.outcome=='failure'
         id: retry-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -185,7 +185,7 @@ jobs:
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Retry tvOS Test Suite if needed
-        if: failure() && steps.run-tests.outcome=='failure'
+        if: steps.run-tests.outcome=='failure'
         id: retry-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -242,7 +242,7 @@ jobs:
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
       - name: Retry watchOS Test Suite if needed
-        if: failure() && steps.run-tests.outcome=='failure'
+        if: steps.run-tests.outcome=='failure'
         id: retry-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -19,7 +19,6 @@ on:
 
 env:
   SCHEME: ${{ inputs.scheme }}
-  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
 permissions:
     contents: read
@@ -34,6 +33,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Restore packages cache
+        timeout-minutes: 4
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
@@ -49,6 +49,12 @@ jobs:
           generate_coverage: ${{ inputs.generate_coverage_report }}
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+      - name: Upload results
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
+        with:
+          name: ${{ env.SCHEME }}-iOS-TestResults-${{ github.sha }}.html
+          path: ${{ github.workspace }}/build/reports/tests.html
+          retention-days: 1
       - name: Upload Report File
         if: ${{ inputs.generate_coverage_report == true }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
@@ -68,6 +74,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Restore packages cache
+        timeout-minutes: 4
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
@@ -83,6 +90,12 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+      - name: Upload results
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
+        with:
+          name: ${{ env.SCHEME }}-macOS-TestResults-${{ github.sha }}.html
+          path: ${{ github.workspace }}/build/reports/tests.html
+          retention-days: 1
 
   test-tvOS:
     name: ${{ inputs.scheme }} tvOS Tests
@@ -93,6 +106,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Restore packages cache
+        timeout-minutes: 4
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
@@ -108,6 +122,12 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+      - name: Upload results
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
+        with:
+          name: ${{ env.SCHEME }}-tvOS-TestResults-${{ github.sha }}.html
+          path: ${{ github.workspace }}/build/reports/tests.html
+          retention-days: 1
 
   test-watchOS:
     name: ${{ inputs.scheme }} watchOS Tests
@@ -118,6 +138,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Restore packages cache
+        timeout-minutes: 4
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
@@ -133,3 +154,9 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+      - name: Upload results
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
+        with:
+          name: ${{ env.SCHEME }}-watchOS-TestResults-${{ github.sha }}.html
+          path: ${{ github.workspace }}/build/reports/tests.html
+          retention-days: 1

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -37,9 +37,15 @@ jobs:
         id: packages-cache
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-          key: ${{ runner.os }}-packages-${{ hashFiles('**/Package.resolved') }}
+          key: ${{ runner.os }}-iOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-packages-
+            ${{ runner.os }}-iOS-packages-
+      - name: Cache build
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: build-cache
+        with:
+          path: Build
+          key: ${{ runner.os }}-iOS-build-${{ github.sha }}
       - name: Run iOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -47,7 +53,9 @@ jobs:
           destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
           generate_coverage: ${{ inputs.generate_coverage_report }}
-          retry-on-failure: true
+          retry_on_failure: false
+          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          derived_data_path: Build
       - name: Upload Report File
         if: ${{ inputs.generate_coverage_report == true }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
@@ -66,6 +74,20 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
+      - name: Cache packages
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: packages-cache
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          key: ${{ runner.os }}-macOS-packages-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-macOS-packages-
+      - name: Cache build
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: build-cache
+        with:
+          path: Build
+          key: ${{ runner.os }}-macOS-build-${{ github.sha }}
       - name: Run macOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -73,7 +95,9 @@ jobs:
           destination: platform=macOS,arch=x86_64
           sdk: macosx
           xcode_path: '/Applications/Xcode_14.3.app'
-          retry-on-failure: true
+          retry_on_failure: false
+          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          derived_data_path: Build
 
   test-tvOS:
     name: ${{ inputs.scheme }} tvOS Tests
@@ -83,6 +107,20 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
+      - name: Cache packages
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: packages-cache
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          key: ${{ runner.os }}-tvOS-packages-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-tvOS-packages-
+      - name: Cache build
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: build-cache
+        with:
+          path: Build
+          key: ${{ runner.os }}-tvOS-build-${{ github.sha }}
       - name: Run tvOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -90,7 +128,9 @@ jobs:
           destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=16.4
           sdk: appletvsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
-          retry-on-failure: true
+          retry_on_failure: false
+          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          derived_data_path: Build
 
   test-watchOS:
     name: ${{ inputs.scheme }} watchOS Tests
@@ -100,6 +140,20 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
+      - name: Cache packages
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: packages-cache
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          key: ${{ runner.os }}-watchOS-packages-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-watchOS-packages-
+      - name: Cache build
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        id: build-cache
+        with:
+          path: Build
+          key: ${{ runner.os }}-watchOS-build-${{ github.sha }}
       - name: Run watchOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -107,4 +161,6 @@ jobs:
           destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=9.4
           sdk: watchsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
-          retry-on-failure: true
+          retry_on_failure: false
+          cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+          derived_data_path: Build

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -40,6 +40,11 @@ jobs:
           key: ${{ runner.os }}-iOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-iOS-packages-
+      - name: Restore build cache
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: ${{ github.workspace }}/Build
+          key: ${{ runner.os }}-iOS-build-${{ github.sha }}
       - name: Run iOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -49,6 +54,12 @@ jobs:
           generate_coverage: ${{ inputs.generate_coverage_report }}
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+      - name: Save the build cache
+        if: failure()
+        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: ${{ github.workspace }}/Build
+          key: ${{ runner.os }}-iOS-build-${{ github.sha }}
       - name: Upload Report File
         if: ${{ inputs.generate_coverage_report == true }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
@@ -75,6 +86,11 @@ jobs:
           key: ${{ runner.os }}-macOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-macOS-packages-
+      - name: Restore build cache
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: ${{ github.workspace }}/Build
+          key: ${{ runner.os }}-macOS-build-${{ github.sha }}
       - name: Run macOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -84,6 +100,12 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+      - name: Save the build cache
+        if: failure()
+        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: ${{ github.workspace }}/Build
+          key: ${{ runner.os }}-macOS-build-${{ github.sha }}
 
   test-tvOS:
     name: ${{ inputs.scheme }} tvOS Tests
@@ -101,6 +123,11 @@ jobs:
           key: ${{ runner.os }}-tvOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-tvOS-packages-
+      - name: Restore build cache
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: ${{ github.workspace }}/Build
+          key: ${{ runner.os }}-tvOS-build-${{ github.sha }}
       - name: Run tvOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -110,6 +137,12 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+      - name: Save the build cache
+        if: failure()
+        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: ${{ github.workspace }}/Build
+          key: ${{ runner.os }}-tvOS-build-${{ github.sha }}
 
   test-watchOS:
     name: ${{ inputs.scheme }} watchOS Tests
@@ -127,6 +160,11 @@ jobs:
           key: ${{ runner.os }}-watchOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-watchOS-packages-
+      - name: Restore build cache
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: ${{ github.workspace }}/Build
+          key: ${{ runner.os }}-watchOS-build-${{ github.sha }}
       - name: Run watchOS Test Suite
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -136,3 +174,9 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
+      - name: Save the build cache
+        if: failure()
+        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: ${{ github.workspace }}/Build
+          key: ${{ runner.os }}-watchOS-build-${{ github.sha }}

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -32,15 +32,15 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
-      - name: Restore packages cache
+      - name: Cache packages
         timeout-minutes: 4
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: ${{ runner.os }}-iOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-iOS-packages-
-      - name: Restore build cache
+      - name: Attempt to restore the build cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -54,7 +54,8 @@ jobs:
           generate_coverage: ${{ inputs.generate_coverage_report }}
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-      - name: Save the build cache
+          derived_data_path: ${{ github.workspace }}/Build
+      - name: Save the build cache for re-runs
         if: failure()
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
@@ -78,15 +79,15 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
-      - name: Restore packages cache
+      - name: Cache packages
         timeout-minutes: 4
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: ${{ runner.os }}-macOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-macOS-packages-
-      - name: Restore build cache
+      - name: Attempt to restore the build cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -100,7 +101,8 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-      - name: Save the build cache
+          derived_data_path: ${{ github.workspace }}/Build
+      - name: Save the build cache for re-runs
         if: failure()
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
@@ -115,15 +117,15 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
-      - name: Restore packages cache
+      - name: Cache packages
         timeout-minutes: 4
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: ${{ runner.os }}-tvOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-tvOS-packages-
-      - name: Restore build cache
+      - name: Attempt to restore the build cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -137,7 +139,8 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-      - name: Save the build cache
+          derived_data_path: ${{ github.workspace }}/Build
+      - name: Save the build cache for re-runs
         if: failure()
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
@@ -152,15 +155,15 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
-      - name: Restore packages cache
+      - name: Cache packages
         timeout-minutes: 4
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: ${{ runner.os }}-watchOS-packages-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-watchOS-packages-
-      - name: Restore build cache
+      - name: Attempt to restore the build cache
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -174,7 +177,8 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-      - name: Save the build cache
+          derived_data_path: ${{ github.workspace }}/Build
+      - name: Save the build cache for re-runs
         if: failure()
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -32,11 +32,11 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
-      - name: Cache packages
+      - name: Attempt to restore dependencies cache
         id: cache-packages
         timeout-minutes: 4
         continue-on-error: true
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: amplify-packages-${{ hashFiles('Package.resolved') }}
@@ -98,11 +98,11 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
-      - name: Cache packages
+      - name: Attempt to restore dependencies cache
         id: cache-packages
         timeout-minutes: 4
         continue-on-error: true
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: amplify-packages-${{ hashFiles('Package.resolved') }}
@@ -155,11 +155,11 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
-      - name: Cache packages
+      - name: Attempt to restore dependencies cache
         id: cache-packages
         timeout-minutes: 4
         continue-on-error: true
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: amplify-packages-${{ hashFiles('Package.resolved') }}
@@ -212,11 +212,11 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
-      - name: Cache packages
+      - name: Attempt to restore dependencies cache
         id: cache-packages
         timeout-minutes: 4
         continue-on-error: true
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: amplify-packages-${{ hashFiles('Package.resolved') }}

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Cache packages
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         id: packages-cache
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: ${{ runner.os }}-iOS-packages-${{ hashFiles('**/Package.resolved') }}
@@ -53,7 +55,7 @@ jobs:
           destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
           generate_coverage: ${{ inputs.generate_coverage_report }}
-          retry_on_failure: false
+          retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: Build
       - name: Upload Report File
@@ -77,6 +79,8 @@ jobs:
       - name: Cache packages
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         id: packages-cache
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: ${{ runner.os }}-macOS-packages-${{ hashFiles('**/Package.resolved') }}
@@ -95,7 +99,7 @@ jobs:
           destination: platform=macOS,arch=x86_64
           sdk: macosx
           xcode_path: '/Applications/Xcode_14.3.app'
-          retry_on_failure: false
+          retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: Build
 
@@ -110,6 +114,8 @@ jobs:
       - name: Cache packages
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         id: packages-cache
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: ${{ runner.os }}-tvOS-packages-${{ hashFiles('**/Package.resolved') }}
@@ -128,7 +134,7 @@ jobs:
           destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=16.4
           sdk: appletvsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
-          retry_on_failure: false
+          retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: Build
 
@@ -143,6 +149,8 @@ jobs:
       - name: Cache packages
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         id: packages-cache
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 4
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           key: ${{ runner.os }}-watchOS-packages-${{ hashFiles('**/Package.resolved') }}
@@ -161,6 +169,6 @@ jobs:
           destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=9.4
           sdk: watchsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
-          retry_on_failure: false
+          retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
           derived_data_path: Build

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -49,12 +49,6 @@ jobs:
           generate_coverage: ${{ inputs.generate_coverage_report }}
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-      - name: Upload results
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
-        with:
-          name: ${{ env.SCHEME }}-iOS-TestResults-${{ github.sha }}.html
-          path: ${{ github.workspace }}/build/reports/tests.html
-          retention-days: 1
       - name: Upload Report File
         if: ${{ inputs.generate_coverage_report == true }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
@@ -90,12 +84,6 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-      - name: Upload results
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
-        with:
-          name: ${{ env.SCHEME }}-macOS-TestResults-${{ github.sha }}.html
-          path: ${{ github.workspace }}/build/reports/tests.html
-          retention-days: 1
 
   test-tvOS:
     name: ${{ inputs.scheme }} tvOS Tests
@@ -122,12 +110,6 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-      - name: Upload results
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
-        with:
-          name: ${{ env.SCHEME }}-tvOS-TestResults-${{ github.sha }}.html
-          path: ${{ github.workspace }}/build/reports/tests.html
-          retention-days: 1
 
   test-watchOS:
     name: ${{ inputs.scheme }} watchOS Tests
@@ -154,9 +136,3 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           retry_on_failure: true
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-      - name: Upload results
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
-        with:
-          name: ${{ env.SCHEME }}-watchOS-TestResults-${{ github.sha }}.html
-          path: ${{ github.workspace }}/build/reports/tests.html
-          retention-days: 1

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -39,15 +39,15 @@ jobs:
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-          key: ${{ runner.os }}-iOS-packages-${{ hashFiles('**/Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-iOS-packages-
+            amplify-packages-
       - name: Attempt to restore the build cache
         id: restore-build
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
-          key: ${{ runner.os }}-${{ env.SCHEME }}-iOS-build-${{ github.sha }}
+          key: ${{ env.SCHEME }}-iOS-build-${{ github.sha }}
       - name: Run iOS Test Suite
         id: run-tests
         continue-on-error: true
@@ -79,7 +79,7 @@ jobs:
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
-          key: ${{ runner.os }}-${{ env.SCHEME }}-iOS-build-${{ github.sha }}
+          key: ${{ env.SCHEME }}-iOS-build-${{ github.sha }}
       - name: Upload Report File
         if: ${{ inputs.generate_coverage_report == true }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce #v3.1.2
@@ -105,15 +105,15 @@ jobs:
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-          key: ${{ runner.os }}-macOS-packages-${{ hashFiles('**/Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-macOS-packages-
+            amplify-packages-
       - name: Attempt to restore the build cache
         id: restore-build
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
-          key: ${{ runner.os }}-${{ env.SCHEME }}-macOS-build-${{ github.sha }}
+          key: ${{ env.SCHEME }}-macOS-build-${{ github.sha }}
       - name: Run macOS Test Suite
         id: run-tests
         continue-on-error: true
@@ -145,7 +145,7 @@ jobs:
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
-          key: ${{ runner.os }}-${{ env.SCHEME }}-macOS-build-${{ github.sha }}
+          key: ${{ env.SCHEME }}-macOS-build-${{ github.sha }}
 
   test-tvOS:
     name: ${{ inputs.scheme }} tvOS Tests
@@ -162,15 +162,15 @@ jobs:
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-          key: ${{ runner.os }}-tvOS-packages-${{ hashFiles('**/Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-tvOS-packages-
+            amplify-packages-
       - name: Attempt to restore the build cache
         id: restore-build
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
-          key: ${{ runner.os }}-${{ env.SCHEME }}-tvOS-build-${{ github.sha }}
+          key: ${{ env.SCHEME }}-tvOS-build-${{ github.sha }}
       - name: Run tvOS Test Suite
         id: run-tests
         continue-on-error: true
@@ -202,7 +202,7 @@ jobs:
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
-          key: ${{ runner.os }}-${{ env.SCHEME }}-tvOS-build-${{ github.sha }}
+          key: ${{ env.SCHEME }}-tvOS-build-${{ github.sha }}
 
   test-watchOS:
     name: ${{ inputs.scheme }} watchOS Tests
@@ -219,15 +219,15 @@ jobs:
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/${{ env.SCHEME }}
-          key: ${{ runner.os }}-watchOS-packages-${{ hashFiles('**/Package.resolved') }}
+          key: amplify-packages-${{ hashFiles('Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-watchOS-packages-
+            amplify-packages-
       - name: Attempt to restore the build cache
         id: restore-build
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
-          key: ${{ runner.os }}-${{ env.SCHEME }}-watchOS-build-${{ github.sha }}
+          key: ${{ env.SCHEME }}-watchOS-build-${{ github.sha }}
       - name: Run watchOS Test Suite
         id: run-tests
         continue-on-error: true
@@ -259,4 +259,4 @@ jobs:
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
-          key: ${{ runner.os }}-${{ env.SCHEME }}-watchOS-build-${{ github.sha }}
+          key: ${{ env.SCHEME }}-watchOS-build-${{ github.sha }}

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -20,13 +20,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'main'}}
 
 jobs:
-  build-amplify:
-    name: Build Amplify-Package
-    uses: ./.github/workflows/build_amplify_swift.yml
-
   unit-tests-without-coverage:
     name: ${{ matrix.scheme }} Unit Tests
-    needs: [build-amplify]
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +35,6 @@ jobs:
 
   unit-tests-with-coverage:
     name: ${{ matrix.scheme }} Unit Tests
-    needs: [build-amplify]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -20,8 +20,13 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'main'}}
 
 jobs:
+  build-amplify:
+    name: Build Amplify-Package
+    uses: ./.github/workflows/build_amplify_swift.yml
+
   unit-tests-without-coverage:
     name: ${{ matrix.scheme }} Unit Tests
+    needs: [build-amplify]
     strategy:
       fail-fast: false
       matrix:
@@ -35,6 +40,7 @@ jobs:
 
   unit-tests-with-coverage:
     name: ${{ matrix.scheme }} Unit Tests
+    needs: [build-amplify]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/upload_coverage_report.yml
+++ b/.github/workflows/upload_coverage_report.yml
@@ -18,7 +18,8 @@ permissions:
 jobs:
   upload-coverage:
     name: ${{ inputs.scheme }} Coverage Report
-    runs-on: macos-13
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:


### PR DESCRIPTION
## Description
This PR makes several changes in our workflows in order to:
- Cache the Amplify package's dependencies, so we save some time when building/testing
  - Add new inputs to both `run_xcodebuild` and `run_xcodebuild_test` actions to support the new behaviour
  - GitHub stores caches per branch. A workflow will first look the cache in its branch and if not found will look in `main`, so we're only explicitly saving the cache when running in `main`,  otherwise we'll have many caches as we have many branches for dev.
- Immediately retry a failing test run. This is probably not the _correct™_ thing to do to deal with our flaky tests, but it is what it is until we actually fix them/upgrade the runners. It's also significantly faster because we already have everything we need and don't have to build again.
  - As a last resort, if the retry also fails we now cache the build folder, so that a job re-run is able to do a `test-without-building` and also save time.
- Set several `timeout`s in various steps to prevent jobs from either hanging or wasting time (e.g. if restoring the cache takes longer than ~4 minutes, then any gain in speed for test/build is irrelevant anyway)
- Run the coverage reporting in an ubuntu instance, which is faster than a macos one.

---
Here's a totally arbitrary conclusion based running the `AWSCloudWatchLoggingPlugin` unit tests on watchOS:
- Without cached dependencies/build: ~10 minutes
- With only cached dependencies: ~7 minutes (42.8% faster)
- With cached dependencies and build: ~3 minutes (233.3% faster )

#### Why don't we always cache the build then?
Caching the build is only useful when re-running a job with the same code, as any commit might introduce changes that we should then build. Each build is different per scheme, platform and commit, so it's unrealistic to believe we can maintain a proper cache.
We could explore in the future having a cache for each scheme/platform on the latest main commit, restore that and let xcodebuild attempt to incrementally build. But having so many caches would probably fill up the space pretty soon and might become useles. But we can keep it in our minds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
