### PR TITLE
chore: Adding dependency to build-amplify-swift in release workflow. …

### DIFF
--- a/.github/workflows/build_amplify_swift.yml
+++ b/.github/workflows/build_amplify_swift.yml
@@ -1,6 +1,10 @@
 name: Build | Amplify Swift
 on:
   workflow_call:
+    inputs:
+      identifier:
+        required: true
+        type: string
   workflow_dispatch:
   push:
     branches-ignore:
@@ -11,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ inputs.identifier || github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref_name != 'main'}}
 
 jobs:

--- a/.github/workflows/deploy_package.yml
+++ b/.github/workflows/deploy_package.yml
@@ -16,6 +16,8 @@ jobs:
   build-amplify-swift:
     name: Build Amplify package
     uses: ./.github/workflows/build_amplify_swift.yml
+    with:
+      identifier: 'workflow-call-build-amplify-swift'
   
   unit-tests:
     name: Run Plugins Unit Tests
@@ -33,7 +35,7 @@ jobs:
   release:
     environment: Release
     name: Release new ${{ inputs.type }} version
-    needs: [unit-tests, fortify]
+    needs: [unit-tests, fortify, build-amplify-swift]
     runs-on: macos-latest
     env:
       GITHUB_EMAIL: aws-amplify-ops@amazon.com

--- a/.github/workflows/fortify_scan.yml
+++ b/.github/workflows/fortify_scan.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ inputs.identifier || github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref_name != 'main'}}
 
 jobs:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -16,7 +16,7 @@ permissions:
     contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ inputs.identifier || github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref_name != 'main'}}
 
 jobs:


### PR DESCRIPTION
## Description
This PR adds the `build-amplify-swift` job as a  `release` dependency in the `deploy_package` workflow.

I'm also adding the missing `inputs.identifier` to the concurrency groups in the `unit_tests`,  `fortify_scan` and `build_amplify_swift` workflows

## General Checklist
- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
