### PR TITLE
chore: Only cache dependencies on main

### DIFF
--- a/.github/workflows/build_amplify_swift.yml
+++ b/.github/workflows/build_amplify_swift.yml
@@ -58,10 +58,11 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
-      - name: Cache packages
+      - name: Attempt to restore dependencies cache
         id: cache-packages
         timeout-minutes: 4
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        continue-on-error: true
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: amplify-packages-${{ hashFiles('Package.resolved') }}
@@ -76,6 +77,12 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           other_flags: '-derivedDataPath Build -clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/Amplify'
+      - name: Save the dependencies cache if necessary
+        if: steps.cache-packages.outputs.cache-hit != 'true' && github.ref_name == 'main'
+        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/Amplify
+          key: ${{ steps.cache-packages.outputs.cache-primary-key }}
 
   build-amplify-swift-tvOS:
     runs-on: macos-13
@@ -84,10 +91,10 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
-      - name: Cache packages
+      - name: Attempt to restore dependencies cache
         timeout-minutes: 4
         id: cache-packages
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: amplify-packages-${{ hashFiles('Package.resolved') }}
@@ -102,6 +109,12 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           other_flags: '-derivedDataPath Build -clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/Amplify'
+      - name: Save the dependencies cache if necessary
+        if: steps.cache-packages.outputs.cache-hit != 'true' && github.ref_name == 'main'
+        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/Amplify
+          key: ${{ steps.cache-packages.outputs.cache-primary-key }}
 
   build-amplify-swift-watchOS:
     runs-on: macos-13
@@ -110,10 +123,10 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
         with:
           persist-credentials: false
-      - name: Cache packages
+      - name: Attempt to restore dependencies cache
         id: cache-packages
         timeout-minutes: 4
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: amplify-packages-${{ hashFiles('Package.resolved') }}
@@ -128,6 +141,12 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           other_flags: '-derivedDataPath Build -clonedSourcePackagesDirPath ~/Library/Developer/Xcode/DerivedData/Amplify'
+      - name: Save the dependencies cache if necessary
+        if: steps.cache-packages.outputs.cache-hit != 'true' && github.ref_name == 'main'
+        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/Amplify
+          key: ${{ steps.cache-packages.outputs.cache-primary-key }}
 
   confirm-pass:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_amplify_swift.yml
+++ b/.github/workflows/build_amplify_swift.yml
@@ -94,6 +94,7 @@ jobs:
       - name: Attempt to restore dependencies cache
         timeout-minutes: 4
         id: cache-packages
+        continue-on-error: true
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
@@ -126,6 +127,7 @@ jobs:
       - name: Attempt to restore dependencies cache
         id: cache-packages
         timeout-minutes: 4
+        continue-on-error: true
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify


### PR DESCRIPTION
## Description

We only want to save the dependencies to the cache when building in `main`. This was done for iOS, but not for the other platforms.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
