### PR TITLE
chore: Fixing the nightly unit tests workflow

### DIFF
--- a/.github/workflows/nightly_repeated_unittest.yml
+++ b/.github/workflows/nightly_repeated_unittest.yml
@@ -34,6 +34,7 @@ jobs:
     uses: ./.github/workflows/run_xcodebuild_test_platforms.yml
     with:
       scheme: ${{ matrix.scheme }}
+      timeout-minutes: 50
       generate_coverage_report: false
       retry_on_error: false
       other_flags: -test-iterations 100 -run-tests-until-failure

--- a/.github/workflows/nightly_repeated_unittest.yml
+++ b/.github/workflows/nightly_repeated_unittest.yml
@@ -15,6 +15,7 @@ jobs:
   unit_tests:
     name: ${{ matrix.scheme }} Repeated Unit Tests
     strategy:
+      fail-fast: false
       matrix:
         scheme: [
           Amplify,

--- a/.github/workflows/nightly_repeated_unittest.yml
+++ b/.github/workflows/nightly_repeated_unittest.yml
@@ -12,35 +12,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  unit_test_ios:
-    runs-on: macos-12
+  unit_tests:
+    name: ${{ matrix.scheme }} Repeated Unit Tests
     strategy:
       matrix:
-        scheme: [Amplify, AWSPluginsCore, AWSPinpointAnalyticsPlugin, AWSAPIPlugin, AWSCognitoAuthPlugin, AWSDataStorePlugin, AWSLocationGeoPlugin, AWSS3StoragePlugin]
-    steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-
-      - name: Run repeated unit test iOS
-        uses: ./.github/composite_actions/run_xcodebuild_test
-        with:
-          project_path: .
-          scheme: ${{ matrix.scheme }}
-          other_flags: -test-iterations 100 -run-tests-until-failure
-
-  unit_test_macos:
-    runs-on: macos-12
-    strategy:
-      matrix:
-        scheme: [Amplify, AWSPluginsCore, AWSPinpointAnalyticsPlugin, AWSAPIPlugin, AWSCognitoAuthPlugin, AWSDataStorePlugin, AWSLocationGeoPlugin, AWSS3StoragePlugin]
-    steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-
-      - name: Run repeated unit test macOS
-        uses: ./.github/composite_actions/run_xcodebuild_test
-        with:
-          project_path: .
-          scheme: ${{ matrix.scheme }}
-          sdk: macosx
-          destination: platform=macOS,arch=x86_64
-          other_flags: -test-iterations 100 -run-tests-until-failure
-      
+        scheme: [
+          Amplify,
+          AWSPluginsCore,
+          AWSAPIPlugin,
+          AWSCloudWatchLoggingPlugin,
+          AWSCognitoAuthPlugin,
+          AWSDataStorePlugin,
+          AWSLocationGeoPlugin,
+          AWSPredictionsPlugin,
+          AWSPinpointAnalyticsPlugin,
+          AWSPinpointPushNotificationsPlugin,
+          AWSS3StoragePlugin,
+          CoreMLPredictionsPlugin,
+          InternalAWSPinpointUnitTests
+        ]
+    uses: ./.github/workflows/run_xcodebuild_test_platforms.yml
+    with:
+      scheme: ${{ matrix.scheme }}
+      generate_coverage_report: false
+      retry_on_error: false
+      other_flags: -test-iterations 100 -run-tests-until-failure

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -59,7 +59,7 @@ jobs:
           key: ${{ env.SCHEME }}-iOS-build-${{ github.sha }}
       - name: Run iOS Test Suite
         id: run-tests
-        continue-on-error: true
+        continue-on-error: ${{ inputs.retry_on_error == 'true' }}
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}
@@ -127,7 +127,7 @@ jobs:
           key: ${{ env.SCHEME }}-macOS-build-${{ github.sha }}
       - name: Run macOS Test Suite
         id: run-tests
-        continue-on-error: true
+        continue-on-error: ${{ inputs.retry_on_error == 'true' }}
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}
@@ -186,7 +186,7 @@ jobs:
           key: ${{ env.SCHEME }}-tvOS-build-${{ github.sha }}
       - name: Run tvOS Test Suite
         id: run-tests
-        continue-on-error: true
+        continue-on-error: ${{ inputs.retry_on_error == 'true' }}
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}
@@ -245,7 +245,7 @@ jobs:
           key: ${{ env.SCHEME }}-watchOS-build-${{ github.sha }}
       - name: Run watchOS Test Suite
         id: run-tests
-        continue-on-error: true
+        continue-on-error: ${{ inputs.retry_on_error == 'true' }}
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -16,6 +16,15 @@ on:
         required: false
         type: boolean
         default: false
+      retry_on_error:
+        description: 'Whether to automatically retry if the tests fail'
+        required: false
+        type: boolean
+        default: true
+      other_flags:
+        required: false
+        type: string
+        default: ''
 
 env:
   SCHEME: ${{ inputs.scheme }}
@@ -61,8 +70,9 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
+          other_flags: ${{ inputs.other_flags }}
       - name: Retry iOS Test Suite if needed
-        if: steps.run-tests.outcome=='failure'
+        if: inputs.retry_on_error == 'true' && steps.run-tests.outcome=='failure'
         id: retry-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -74,6 +84,7 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: true
           test_without_building: true
+          other_flags: ${{ inputs.other_flags }}
       - name: Save the build cache for re-runs
         if: failure() && steps.retry-tests.outcome=='failure'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -127,8 +138,9 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
+          other_flags: ${{ inputs.other_flags }}
       - name: Retry macOS Test Suite if needed
-        if: steps.run-tests.outcome=='failure'
+        if: inputs.retry_on_error == 'true' && steps.run-tests.outcome=='failure'
         id: retry-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -140,6 +152,7 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: true
           test_without_building: true
+          other_flags: ${{ inputs.other_flags }}
       - name: Save the build cache for re-runs
         if: failure() && steps.retry-tests.outcome=='failure'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -184,8 +197,9 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
+          other_flags: ${{ inputs.other_flags }}
       - name: Retry tvOS Test Suite if needed
-        if: steps.run-tests.outcome=='failure'
+        if: inputs.retry_on_error == 'true' && steps.run-tests.outcome=='failure'
         id: retry-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -197,6 +211,7 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: true
           test_without_building: true
+          other_flags: ${{ inputs.other_flags }}
       - name: Save the build cache for re-runs
         if: failure() && steps.retry-tests.outcome=='failure'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -241,8 +256,9 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.cache-packages.outputs.cache-hit }}
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
+          other_flags: ${{ inputs.other_flags }}
       - name: Retry watchOS Test Suite if needed
-        if: steps.run-tests.outcome=='failure'
+        if: inputs.retry_on_error == 'true' && steps.run-tests.outcome=='failure'
         id: retry-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -254,6 +270,7 @@ jobs:
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: true
           test_without_building: true
+          other_flags: ${{ inputs.other_flags }}
       - name: Save the build cache for re-runs
         if: failure() && steps.retry-tests.outcome=='failure'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1

--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -28,6 +28,7 @@ on:
 
 env:
   SCHEME: ${{ inputs.scheme }}
+  RETRY_ON_ERROR: ${{ inputs.retry_on_error }}
 
 permissions:
     contents: read
@@ -59,7 +60,7 @@ jobs:
           key: ${{ env.SCHEME }}-iOS-build-${{ github.sha }}
       - name: Run iOS Test Suite
         id: run-tests
-        continue-on-error: ${{ inputs.retry_on_error == 'true' }}
+        continue-on-error: ${{ env.RETRY_ON_ERROR == 'true' }}
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}
@@ -127,7 +128,7 @@ jobs:
           key: ${{ env.SCHEME }}-macOS-build-${{ github.sha }}
       - name: Run macOS Test Suite
         id: run-tests
-        continue-on-error: ${{ inputs.retry_on_error == 'true' }}
+        continue-on-error: ${{ env.RETRY_ON_ERROR == 'true' }}
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}
@@ -186,7 +187,7 @@ jobs:
           key: ${{ env.SCHEME }}-tvOS-build-${{ github.sha }}
       - name: Run tvOS Test Suite
         id: run-tests
-        continue-on-error: ${{ inputs.retry_on_error == 'true' }}
+        continue-on-error: ${{ env.RETRY_ON_ERROR == 'true' }}
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}
@@ -245,7 +246,7 @@ jobs:
           key: ${{ env.SCHEME }}-watchOS-build-${{ github.sha }}
       - name: Run watchOS Test Suite
         id: run-tests
-        continue-on-error: ${{ inputs.retry_on_error == 'true' }}
+        continue-on-error: ${{ env.RETRY_ON_ERROR == 'true' }}
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
           scheme: ${{ env.SCHEME }}


### PR DESCRIPTION
## Description
This job was always failing because it's using an unsupported Xcode version. 
Now it still fails, but because some of the test do eventually fail after running them 100 times :P

Additional changes:
- Adding the missing schemes
- I'm now using `run_xcodebuild_test_platforms` to take advantage of its awesome caching features, but had to tweak it a little bit to disable automatic retrying and to accept custom input flags as well.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
