### PR TITLE
feat(auth): add userID property to AuthSignUpResult

### DIFF
--- a/Amplify/Categories/Auth/Result/AuthSignUpResult.swift
+++ b/Amplify/Categories/Auth/Result/AuthSignUpResult.swift
@@ -27,7 +27,7 @@ public struct AuthSignUpResult {
 
     public init(
         nextStep: AuthSignUpStep,
-        userID: String?
+        userID: String? = nil
     ) {
         self.nextStep = nextStep
         self.userID = userID

--- a/Amplify/Categories/Auth/Result/AuthSignUpResult.swift
+++ b/Amplify/Categories/Auth/Result/AuthSignUpResult.swift
@@ -26,7 +26,7 @@ public struct AuthSignUpResult {
     public let userID: String?
 
     public init(
-        nextStep: AuthSignUpStep,
+        _ nextStep: AuthSignUpStep,
         userID: String? = nil
     ) {
         self.nextStep = nextStep

--- a/Amplify/Categories/Auth/Result/AuthSignUpResult.swift
+++ b/Amplify/Categories/Auth/Result/AuthSignUpResult.swift
@@ -23,7 +23,13 @@ public struct AuthSignUpResult {
     ///
     public let nextStep: AuthSignUpStep
 
-    public init(_ nextStep: AuthSignUpStep) {
+    public let userID: String?
+
+    public init(
+        nextStep: AuthSignUpStep,
+        userID: String?
+    ) {
         self.nextStep = nextStep
+        self.userID = userID
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/Helpers/SignUpOutputResponse+Helper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/Helpers/SignUpOutputResponse+Helper.swift
@@ -13,14 +13,15 @@ extension SignUpOutputResponse {
 
     var authResponse: AuthSignUpResult {
         if self.userConfirmed {
-            return .init(.done)
+            return .init(nextStep: .done, userID: userSub)
         }
         return AuthSignUpResult(
-            .confirmUser(
+            nextStep: .confirmUser(
                 codeDeliveryDetails?.toAuthCodeDeliveryDetails(),
                 nil,
                 userSub
-            )
+            ),
+            userID: userSub
         )
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/Helpers/SignUpOutputResponse+Helper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/Helpers/SignUpOutputResponse+Helper.swift
@@ -13,10 +13,10 @@ extension SignUpOutputResponse {
 
     var authResponse: AuthSignUpResult {
         if self.userConfirmed {
-            return .init(nextStep: .done, userID: userSub)
+            return .init(.done, userID: userSub)
         }
         return AuthSignUpResult(
-            nextStep: .confirmUser(
+            .confirmUser(
                 codeDeliveryDetails?.toAuthCodeDeliveryDetails(),
                 nil,
                 userSub

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignUpTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignUpTask.swift
@@ -41,7 +41,7 @@ class AWSAuthConfirmSignUpTask: AuthConfirmSignUpTask, DefaultLogger {
                                            environment: userPoolEnvironment)
             _ = try await client.confirmSignUp(input: input)
             log.verbose("Received success")
-            return AuthSignUpResult.init(nextStep: .done, userID: nil)
+            return AuthSignUpResult(.done, userID: nil)
         } catch let error as AuthError {
             throw error
         } catch let error as AuthErrorConvertible {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignUpTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignUpTask.swift
@@ -41,7 +41,7 @@ class AWSAuthConfirmSignUpTask: AuthConfirmSignUpTask, DefaultLogger {
                                            environment: userPoolEnvironment)
             _ = try await client.confirmSignUp(input: input)
             log.verbose("Received success")
-            return AuthSignUpResult(.done)
+            return AuthSignUpResult.init(nextStep: .done, userID: nil)
         } catch let error as AuthError {
             throw error
         } catch let error as AuthErrorConvertible {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignUp/AWSAuthConfirmSignUpTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignUp/AWSAuthConfirmSignUpTaskTests.swift
@@ -45,7 +45,7 @@ class AWSAuthConfirmSignUpTaskTests: XCTestCase {
         let task = AWSAuthConfirmSignUpTask(request, authEnvironment: authEnvironment)
         let confirmSignUpResult = try await task.value
         print("Confirm Sign Up Result: \(confirmSignUpResult)")
-        wait(for: [functionExpectation], timeout: 1)
+        await fulfillment(of: [functionExpectation], timeout: 1)
     }
 
     func testConfirmSignUpOperationFailure() async throws {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignUp/AWSAuthSignUpAPITests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignUp/AWSAuthSignUpAPITests.swift
@@ -179,7 +179,9 @@ class AWSAuthSignUpAPITests: BasePluginTest {
             options: nil
         )
 
-        guard case .confirmUser(_, _, let userID) = result.nextStep else { return }
+        guard case .confirmUser(_, _, let userID) = result.nextStep else {
+            return XCTFail("expected .confirmUser nextStep")
+        }
         XCTAssertEqual(result.userID, userID)
     }
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignUp/AWSAuthSignUpTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignUp/AWSAuthSignUpTaskTests.swift
@@ -41,7 +41,7 @@ class AWSAuthSignUpTaskTests: XCTestCase {
         let task = AWSAuthSignUpTask(request, authEnvironment: authEnvironment)
         let signUpResult = try await task.value
         print("Sign Up Result: \(signUpResult)")
-        wait(for: [functionExpectation], timeout: 1)
+        await fulfillment(of: [functionExpectation], timeout: 1)
     }
 
     /// Given: Configured AuthState machine


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

Adds a `userID` property to `AuthSignUpResult`. 

Currently, this property is accessible when the `AuthSignUpResult().nextStep` is `AuthSignUpStep.confirmUser` through the case's associated values. 

The typical flow is `signUp() --> .confirmUser --> confirmSignUp() --> .done`.  

`confirmSignUp` ([ConfirmSignUp](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ConfirmSignUp.html)) doesn't return a `userID` (`UserSub`). However, `signUp() --> .done` is also a valid flow with the use of a custom verification flow. In this case, we receive the `userID` but we're preventing the caller from accessing it. This change provides the `userID` in the `AuthSignUpResult` if it's returned by the service, regardless of the `nextStep`.


### Platform Parity
This change brings Amplify Swift in parity with Android, Flutter, and JS.
- [Android - AuthSignUpResult.getUserId()](https://github.com/aws-amplify/amplify-android/blob/main/core/src/main/java/com/amplifyframework/auth/result/AuthSignUpResult.java#L67-L74)
- [Flutter - SignUpResult.userId](https://github.com/aws-amplify/amplify-flutter/blob/main/packages/amplify_core/lib/src/types/auth/sign_up/sign_up_result.dart#L28)
- [JS - AuthSignUpResult.userId](https://github.com/aws-amplify/amplify-js/blob/next/packages/auth/src/types/results.ts#L32)

**NOTE**:
This change can be confusing because `AuthSignUpResult` and `AuthSignUpStep.confirmUser` both contain the same `userID` value.
```swift
let result = try await Amplify.Auth.signUp(...)

result.userID // "abc123"
switch result {
case .confirmUser(_, _, let userID):
  userID // "abc123"
...
}
```
The associated value on `.confirmUser` is no longer necessary, but removing would be a breaking change. Something to consider for vNext.

#### Misc. Changes
Moved from `wait(for:)` to `await fulfillment(of:)` for two test cases that were being problematic. 

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
