### PR TITLE
fix(auth): hostedui extract error_description query pararm

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUIASWebAuthenticationSession.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUIASWebAuthenticationSession.swift
@@ -33,9 +33,9 @@ class HostedUIASWebAuthenticationSession: NSObject, HostedUISessionBehavior {
                     if let error = queryItems.first(where: { $0.name == "error" })?.value {
                         let errorDescription = queryItems.first(
                             where: { $0.name == "error_description" }
-                        )?.value?.trim() ?? error
-
-                        callback(.failure(.serviceMessage(errorDescription)))
+                        )?.value?.trim() ?? ""
+                        let message = "\(error) \(errorDescription)"
+                        callback(.failure(.serviceMessage(message)))
                         return
                     }
                     callback(.success(queryItems))

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUIASWebAuthenticationSession.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUIASWebAuthenticationSession.swift
@@ -31,7 +31,11 @@ class HostedUIASWebAuthenticationSession: NSObject, HostedUISessionBehavior {
                     let queryItems = urlComponents?.queryItems ?? []
 
                     if let error = queryItems.first(where: { $0.name == "error" })?.value {
-                        callback(.failure(.serviceMessage(error)))
+                        let errorDescription = queryItems.first(
+                            where: { $0.name == "error_description" }
+                        )?.value?.trim() ?? error
+
+                        callback(.failure(.serviceMessage(errorDescription)))
                         return
                     }
                     callback(.success(queryItems))

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
@@ -258,15 +258,18 @@ class AWSAuthHostedUISignInTests: XCTestCase {
     }
 
     @MainActor
-    func testTokenErrorResponse() async {
+    func testTokenErrorResponse() async throws {
         mockHostedUIResult = .success([
             .init(name: "state", value: mockState),
             .init(name: "code", value: mockProof)
         ])
+
+        let (errorMessage, errorDescription) = ("invalid_grant", "Some error")
         mockTokenResult = [
-            "error": "invalid_grant",
-            "error_description": "Some error"] as [String: Any]
-        mockJson = try! JSONSerialization.data(withJSONObject: mockTokenResult)
+            "error": errorMessage,
+            "error_description": errorDescription
+        ]
+        mockJson = try JSONSerialization.data(withJSONObject: mockTokenResult)
         MockURLProtocol.requestHandler = { _ in
             return (HTTPURLResponse(), self.mockJson)
         }
@@ -276,13 +279,15 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             _ = try await plugin.signInWithWebUI(presentationAnchor: ASPresentationAnchor(), options: nil)
             XCTFail("Should not succeed")
         } catch {
-            guard case AuthError.service = error else {
+            guard case AuthError.service(let message, _, _) = error else {
                 XCTFail("Should not fail with error = \(error)")
                 return
             }
+            let expectedErrorDescription = "\(errorMessage) \(errorDescription)"
+            XCTAssertEqual(expectedErrorDescription, message)
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: networkTimeout)
+        await fulfillment(of: [expectation], timeout: networkTimeout)
     }
 
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
@@ -258,6 +258,10 @@ class AWSAuthHostedUISignInTests: XCTestCase {
     }
 
     @MainActor
+    /// Given: A HostedUI response with `error` and `error_description` query parameters.
+    /// When: Invoking `signInWithWebUI`
+    /// Then: The caller should receive an `AuthError.service` where the `errorDescription`
+    /// is `"\(error) \(error_description)"`
     func testTokenErrorResponse() async throws {
         mockHostedUIResult = .success([
             .init(name: "state", value: mockState),


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
- https://github.com/aws-amplify/amplify-swift/issues/3176

## Description
<!-- Why is this change required? What problem does it solve? -->
If an `error` query parameter is included in the HostedUI callback, we currently throw a `.service` error with the value of the `error` key, omitting important information that may be needed by the caller. With this change, we now attempt to extract and use the value from `error_description`; if it doesn't exist, we fall back to the `error` we know is there. The fall back to `error` is necessary because `error_description` is optional according to the [spec](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1).

This change brings Amplify Swift in parity with Android, Flutter, and JS.

- [Amplify Android](https://github.com/aws-amplify/amplify-android/blob/aac074ab49b44ccea0c9eb12d996f7033c20e3b7/aws-auth-cognito/src/main/java/com/amplifyframework/auth/cognito/HostedUIClient.kt#L105-L108)
- [Amplify Flutter](https://github.com/aws-amplify/amplify-flutter/blob/cd8c84a5f9cc4db998b1befa03145ff8f5a73cd3/packages/auth/amplify_auth_cognito_dart/lib/src/flows/hosted_ui/hosted_ui_platform.dart#L205-L212)
- [Amplify JS](https://github.com/aws-amplify/amplify-js/blob/8d1f79a936a2a07c4ea893957b2c2703011c39dc/packages/auth/src/OAuth/OAuth.ts#L237-L239)


In the linked issue, we can see a specific use case the current behavior is blocking - client side logic based on information contained in an error thrown by a `PreSignUp_ExternalProvider` Lambda trigger. [[Service Documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-sign-up.html#aws-lambda-triggers-pre-registration-example-3)]


### Testing
In addition to the added test cases, this change we manually tested with a `PreSignUp` Lambda trigger:
```js
exports.handler = (event, context, callback) => {
    const payload = JSON.stringify(
        { code: "409", custom_code: "002", message: "<placeholder>" }
    );
    const error = Error(payload);
    callback(error, event);
};
```
and the following client side code:
```swift
do {
    _ = try await Amplify.Auth.signInWithWebUI(
        for: .google, // this can be any social provider
        presentationAnchor: window
    )
} catch let error as AuthError {
>> breakpoint
} catch {
    print("Unexpected error: \(error)")
}
```
Breaking in the first `catch` block and `po`'ing  the error -

Targeting v2.16.0 (current latest release), we see:
```
(lldb) po error
▿ AuthError: invalid_request
Recovery suggestion: Received an error message from the service
  ▿ service : 3 elements
    - .0 : "invalid_request"
    - .1 : "Received an error message from the service"
    - .2 : nil
```

Targeting branch `hostedui_errordescription`, we see:
```
(lldb) po error
▿ AuthError: invalid_request PreSignUp+failed+with+error+{"code":"409","custom_code":"002","message":"<placeholder>"}.+
Recovery suggestion: Received an error message from the service
  ▿ service : 3 elements
    - .0 : "invalid_request PreSignUp+failed+with+error+{\"code\":\"409\",\"custom_code\":\"002\",\"message\":\"<placeholder>\"}.+"
    - .1 : "Received an error message from the service"
    - .2 : nil
```

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
