### PR TITLE
chore: Fixing retry step when running the tests workflow

### DIFF
--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -73,7 +73,7 @@ jobs:
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
           other_flags: ${{ inputs.other_flags }}
       - name: Retry iOS Test Suite if needed
-        if: inputs.retry_on_error == 'true' && steps.run-tests.outcome=='failure'
+        if: inputs.retry_on_error == true && steps.run-tests.outcome=='failure'
         id: retry-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -141,7 +141,7 @@ jobs:
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
           other_flags: ${{ inputs.other_flags }}
       - name: Retry macOS Test Suite if needed
-        if: inputs.retry_on_error == 'true' && steps.run-tests.outcome=='failure'
+        if: inputs.retry_on_error == true && steps.run-tests.outcome=='failure'
         id: retry-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -200,7 +200,7 @@ jobs:
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
           other_flags: ${{ inputs.other_flags }}
       - name: Retry tvOS Test Suite if needed
-        if: inputs.retry_on_error == 'true' && steps.run-tests.outcome=='failure'
+        if: inputs.retry_on_error == true && steps.run-tests.outcome=='failure'
         id: retry-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:
@@ -259,7 +259,7 @@ jobs:
           test_without_building: ${{ steps.restore-build.outputs.cache-hit }}
           other_flags: ${{ inputs.other_flags }}
       - name: Retry watchOS Test Suite if needed
-        if: inputs.retry_on_error == 'true' && steps.run-tests.outcome=='failure'
+        if: inputs.retry_on_error == true && steps.run-tests.outcome=='failure'
         id: retry-tests
         uses: ./.github/composite_actions/run_xcodebuild_test
         with:


### PR DESCRIPTION
## Description

As `inputs.retry_on_error` is a `boolean`, comparing its value with the string `'true'` always returns `false` 🤦‍♂️ .
Fixing that.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
