### PR TITLE
fix(datastore): wrap failures to result when applying remote update events

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -832,11 +832,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    func testApplyRemoteModels_saveFail() throws {
-        if skipBrokenTests {
-            throw XCTSkip("TODO: fix this test")
-        }
-        
+    func testApplyRemoteModels_skipFailedOperations() throws {
         let dispositions: [RemoteSyncReconciler.Disposition] = [.create(anyPostMutationSync),
                                                                 .create(anyPostMutationSync),
                                                                 .update(anyPostMutationSync),
@@ -846,7 +842,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
                                                                 .create(anyPostMutationSync),
                                                                 .update(anyPostMutationSync),
                                                                 .delete(anyPostMutationSync)]
-        let expect = expectation(description: "should fail")
+        let expect = expectation(description: "should complete")
         let expectedDeleteSuccess = expectation(description: "delete should be successful")
         expectedDeleteSuccess.expectedFulfillmentCount = 3 // 3 delete depositions
         let expectedDropped = expectation(description: "mutationEventDropped received")
@@ -881,12 +877,12 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .failure:
-                    expect.fulfill()
+                    XCTFail("Unexpected failure completion")
                 case .finished:
-                    XCTFail("Unexpected successfully completion")
+                    expect.fulfill()
                 }
             }, receiveValue: { _ in
-                XCTFail("Unexpected value received")
+
             }).store(in: &cancellables)
         waitForExpectations(timeout: 1)
     }
@@ -949,20 +945,18 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
     }
 
     func testApplyRemoteModels_deleteFail() throws {
-        if skipBrokenTests {
-            throw XCTSkip("TODO: fix this test")
-        }
-        
-        let dispositions: [RemoteSyncReconciler.Disposition] = [.create(anyPostMutationSync),
-                                                                .create(anyPostMutationSync),
-                                                                .update(anyPostMutationSync),
-                                                                .update(anyPostMutationSync),
-                                                                .delete(anyPostMutationSync),
-                                                                .delete(anyPostMutationSync),
-                                                                .create(anyPostMutationSync),
-                                                                .update(anyPostMutationSync),
-                                                                .delete(anyPostMutationSync)]
-        let expect = expectation(description: "should fail")
+        let dispositions: [RemoteSyncReconciler.Disposition] = [
+            .create(anyPostMutationSync),
+            .create(anyPostMutationSync),
+            .update(anyPostMutationSync),
+            .update(anyPostMutationSync),
+            .delete(anyPostMutationSync),
+            .delete(anyPostMutationSync),
+            .create(anyPostMutationSync),
+            .update(anyPostMutationSync),
+            .delete(anyPostMutationSync)
+        ]
+        let expect = expectation(description: "should success")
         let expectedCreateAndUpdateSuccess = expectation(description: "create and updates should be successful")
         expectedCreateAndUpdateSuccess.expectedFulfillmentCount = 6 // 3 creates and 3 updates
         let expectedDropped = expectation(description: "mutationEventDropped received")
@@ -997,31 +991,29 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .failure:
-                    expect.fulfill()
+                    XCTFail("Unexpected failure completion")
                 case .finished:
-                    XCTFail("Unexpected successfully completion")
+                    expect.fulfill()
                 }
             }, receiveValue: { _ in
-                XCTFail("Unexpected value received")
+
             }).store(in: &cancellables)
         waitForExpectations(timeout: 1)
     }
 
     func testApplyRemoteModels_saveMetadataFail() throws {
-        if skipBrokenTests {
-            throw XCTSkip("TODO: fix this test")
-        }
-        
-        let dispositions: [RemoteSyncReconciler.Disposition] = [.create(anyPostMutationSync),
-                                                                .create(anyPostMutationSync),
-                                                                .update(anyPostMutationSync),
-                                                                .update(anyPostMutationSync),
-                                                                .delete(anyPostMutationSync),
-                                                                .delete(anyPostMutationSync),
-                                                                .create(anyPostMutationSync),
-                                                                .update(anyPostMutationSync),
-                                                                .delete(anyPostMutationSync)]
-        let expect = expectation(description: "should fail")
+        let dispositions: [RemoteSyncReconciler.Disposition] = [
+            .create(anyPostMutationSync),
+            .create(anyPostMutationSync),
+            .update(anyPostMutationSync),
+            .update(anyPostMutationSync),
+            .delete(anyPostMutationSync),
+            .delete(anyPostMutationSync),
+            .create(anyPostMutationSync),
+            .update(anyPostMutationSync),
+            .delete(anyPostMutationSync)
+        ]
+        let expect = expectation(description: "should success")
         let expectedDropped = expectation(description: "mutationEventDropped received")
         expectedDropped.expectedFulfillmentCount = 9 // 1 for each of the 9 dispositions
         let saveResponder = SaveUntypedModelResponder { _, completion in
@@ -1053,12 +1045,12 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .failure:
-                    expect.fulfill()
+                    XCTFail("Unexpected failure completion")
                 case .finished:
-                    XCTFail("Unexpected successfully completion")
+                    expect.fulfill()
                 }
             }, receiveValue: { _ in
-                XCTFail("Unexpected value received")
+
             }).store(in: &cancellables)
         waitForExpectations(timeout: 1)
     }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/1903

## Description
<!-- Why is this change required? What problem does it solve? -->

We apply remote update events in batch. The existing code converts all the update operations into `Future<Void, DataStoreError>`, and merge them into one stream. The problem arises when a `Future` completes with an error; it causes the entire stream to terminate as an error. This behavior is unintentional and results in some update operations being silently discarded.

The solution here is simply change `Future<Void, DataStoreError>` to `Future<Result<Void, DataStoreError>, Never>`, which wraps the failure to a result type and makes the operation stream never fail.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
