### PR TITLE
fix(Auth): Adding the ability to keep old preferred methods

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/MFAPreference.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/MFAPreference.swift
@@ -27,10 +27,10 @@ public enum MFAPreference {
 
 extension MFAPreference {
 
-    func smsSetting(isCurrentlyPreferred: Bool? = nil) -> CognitoIdentityProviderClientTypes.SMSMfaSettingsType? {
+    func smsSetting(isCurrentlyPreferred: Bool = false) -> CognitoIdentityProviderClientTypes.SMSMfaSettingsType {
         switch self {
         case .enabled:
-            return .init(enabled: true, preferredMfa: isCurrentlyPreferred ?? false)
+            return .init(enabled: true, preferredMfa: isCurrentlyPreferred)
         case .preferred:
             return .init(enabled: true, preferredMfa: true)
         case .notPreferred:
@@ -40,7 +40,7 @@ extension MFAPreference {
         }
     }
 
-    func softwareTokenSetting(isCurrentlyPreferred: Bool? = nil) -> CognitoIdentityProviderClientTypes.SoftwareTokenMfaSettingsType? {
+    func softwareTokenSetting(isCurrentlyPreferred: Bool? = nil) -> CognitoIdentityProviderClientTypes.SoftwareTokenMfaSettingsType {
         switch self {
         case .enabled:
             return .init(enabled: true, preferredMfa: isCurrentlyPreferred ?? false)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/MFAPreference.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/MFAPreference.swift
@@ -26,11 +26,11 @@ public enum MFAPreference {
 }
 
 extension MFAPreference {
-    
-    var smsSetting: CognitoIdentityProviderClientTypes.SMSMfaSettingsType? {
+
+    func smsSetting(isCurrentlyPreferred: Bool? = nil) -> CognitoIdentityProviderClientTypes.SMSMfaSettingsType? {
         switch self {
         case .enabled:
-            return .init(enabled: true)
+            return .init(enabled: true, preferredMfa: isCurrentlyPreferred ?? false)
         case .preferred:
             return .init(enabled: true, preferredMfa: true)
         case .notPreferred:
@@ -39,11 +39,11 @@ extension MFAPreference {
             return .init(enabled: false)
         }
     }
-    
-    var softwareTokenSetting: CognitoIdentityProviderClientTypes.SoftwareTokenMfaSettingsType? {
+
+    func softwareTokenSetting(isCurrentlyPreferred: Bool? = nil) -> CognitoIdentityProviderClientTypes.SoftwareTokenMfaSettingsType? {
         switch self {
         case .enabled:
-            return .init(enabled: true)
+            return .init(enabled: true, preferredMfa: isCurrentlyPreferred ?? false)
         case .preferred:
             return .init(enabled: true, preferredMfa: true)
         case .notPreferred:

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/MFAPreference.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/MFAPreference.swift
@@ -40,10 +40,10 @@ extension MFAPreference {
         }
     }
 
-    func softwareTokenSetting(isCurrentlyPreferred: Bool? = nil) -> CognitoIdentityProviderClientTypes.SoftwareTokenMfaSettingsType {
+    func softwareTokenSetting(isCurrentlyPreferred: Bool = false) -> CognitoIdentityProviderClientTypes.SoftwareTokenMfaSettingsType {
         switch self {
         case .enabled:
-            return .init(enabled: true, preferredMfa: isCurrentlyPreferred ?? false)
+            return .init(enabled: true, preferredMfa: isCurrentlyPreferred)
         case .preferred:
             return .init(enabled: true, preferredMfa: true)
         case .notPreferred:

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UpdateMFAPreferenceTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UpdateMFAPreferenceTask.swift
@@ -62,7 +62,7 @@ class UpdateMFAPreferenceTask: AuthUpdateMFAPreferenceTask, DefaultLogger {
     func updateMFAPreference(with accessToken: String) async throws {
         let userPoolService = try userPoolFactory()
         let currentPreference = try await userPoolService.getUser(input: .init(accessToken: accessToken))
-        let preferredMFAType = MFAType(rawValue: currentPreference.preferredMfaSetting ?? "")
+        let preferredMFAType = currentPreference.preferredMfaSetting.map(MFAType.init(rawValue:))
         let input = SetUserMFAPreferenceInput(
             accessToken: accessToken,
             smsMfaSettings: smsPreference?.smsSetting(isCurrentlyPreferred: preferredMFAType == .sms),

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UpdateMFAPreferenceTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UpdateMFAPreferenceTask.swift
@@ -61,10 +61,12 @@ class UpdateMFAPreferenceTask: AuthUpdateMFAPreferenceTask, DefaultLogger {
 
     func updateMFAPreference(with accessToken: String) async throws {
         let userPoolService = try userPoolFactory()
+        let currentPreference = try await userPoolService.getUser(input: .init(accessToken: accessToken))
+        let preferredMFAType = MFAType(rawValue: currentPreference.preferredMfaSetting ?? "")
         let input = SetUserMFAPreferenceInput(
             accessToken: accessToken,
-            smsMfaSettings: smsPreference?.smsSetting,
-            softwareTokenMfaSettings: totpPreference?.softwareTokenSetting)
+            smsMfaSettings: smsPreference?.smsSetting(isCurrentlyPreferred: preferredMFAType == .sms),
+            softwareTokenMfaSettings: totpPreference?.softwareTokenSetting(isCurrentlyPreferred: preferredMFAType == .totp))
         _ = try await userPoolService.setUserMFAPreference(input: input)
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/MFA/UpdateMFAPreferenceTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/MFA/UpdateMFAPreferenceTaskTests.swift
@@ -33,13 +33,18 @@ class UpdateMFAPreferenceTaskTests: BasePluginTest {
         for smsPreference in allSMSPreferences {
             for totpPreference in allTOTPPreference {
                 self.mockIdentityProvider = MockIdentityProvider(
+                    mockGetUserAttributeResponse: { request in
+                        return .init(
+                            userMFASettingList: ["SOFTWARE_TOKEN_MFA", "SMS_MFA"]
+                        )
+                    },
                     mockSetUserMFAPreferenceResponse: { request in
                         XCTAssertEqual(
                             request.smsMfaSettings,
-                            smsPreference.smsSetting)
+                            smsPreference.smsSetting())
                         XCTAssertEqual(
                             request.softwareTokenMfaSettings,
-                            totpPreference.softwareTokenSetting)
+                            totpPreference.softwareTokenSetting())
 
                         return .init()
                     })
@@ -67,9 +72,17 @@ class UpdateMFAPreferenceTaskTests: BasePluginTest {
     ///
     func testUpdateMFAPreferenceWithInternalErrorException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockSetUserMFAPreferenceResponse: { _ in
-            throw SetUserMFAPreferenceOutputError.unknown(.init(httpResponse: .init(body: .empty, statusCode: .ok)))
-        })
+        mockIdentityProvider = MockIdentityProvider(
+            mockGetUserAttributeResponse: { request in
+                return .init(
+                    preferredMfaSetting: "SOFTWARE_TOKEN_MFA",
+                    userMFASettingList: ["SOFTWARE_TOKEN_MFA", "SMS_MFA"]
+                )
+            },
+            mockSetUserMFAPreferenceResponse: { _ in
+                throw SetUserMFAPreferenceOutputError.unknown(.init(httpResponse: .init(body: .empty, statusCode: .ok)))
+            }
+        )
 
         do {
             _ = try await plugin.updateMFAPreference(sms: .enabled, totp: .enabled)
@@ -92,9 +105,17 @@ class UpdateMFAPreferenceTaskTests: BasePluginTest {
     ///
     func testUpdateMFAPreferenceWithInvalidParameterException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockSetUserMFAPreferenceResponse: { _ in
-            throw SetUserMFAPreferenceOutputError.invalidParameterException(.init())
-        })
+        mockIdentityProvider = MockIdentityProvider(
+            mockGetUserAttributeResponse: { request in
+                return .init(
+                    preferredMfaSetting: "SOFTWARE_TOKEN_MFA",
+                    userMFASettingList: ["SOFTWARE_TOKEN_MFA", "SMS_MFA"]
+                )
+            },
+            mockSetUserMFAPreferenceResponse: { _ in
+                throw SetUserMFAPreferenceOutputError.invalidParameterException(.init())
+            }
+        )
 
         do {
             _ = try await plugin.updateMFAPreference(sms: .enabled, totp: .enabled)
@@ -121,9 +142,17 @@ class UpdateMFAPreferenceTaskTests: BasePluginTest {
     ///
     func testUpdateMFAPreferenceWithNotAuthorizedException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockSetUserMFAPreferenceResponse: { _ in
-            throw SetUserMFAPreferenceOutputError.notAuthorizedException(.init(message: "message"))
-        })
+        mockIdentityProvider = MockIdentityProvider(
+            mockGetUserAttributeResponse: { request in
+                return .init(
+                    preferredMfaSetting: "SOFTWARE_TOKEN_MFA",
+                    userMFASettingList: ["SOFTWARE_TOKEN_MFA", "SMS_MFA"]
+                )
+            },
+            mockSetUserMFAPreferenceResponse: { _ in
+                throw SetUserMFAPreferenceOutputError.notAuthorizedException(.init(message: "message"))
+            }
+        )
 
         do {
             _ = try await plugin.updateMFAPreference(sms: .enabled, totp: .enabled)
@@ -148,9 +177,17 @@ class UpdateMFAPreferenceTaskTests: BasePluginTest {
     ///
     func testUpdateMFAPreferenceWithPasswordResetRequiredException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockSetUserMFAPreferenceResponse: { _ in
-            throw SetUserMFAPreferenceOutputError.passwordResetRequiredException(.init())
-        })
+        mockIdentityProvider = MockIdentityProvider(
+            mockGetUserAttributeResponse: { request in
+                return .init(
+                    preferredMfaSetting: "SOFTWARE_TOKEN_MFA",
+                    userMFASettingList: ["SOFTWARE_TOKEN_MFA", "SMS_MFA"]
+                )
+            },
+            mockSetUserMFAPreferenceResponse: { _ in
+                throw SetUserMFAPreferenceOutputError.passwordResetRequiredException(.init())
+            }
+        )
 
         do {
             _ = try await plugin.updateMFAPreference(sms: .enabled, totp: .enabled)
@@ -179,9 +216,17 @@ class UpdateMFAPreferenceTaskTests: BasePluginTest {
     ///
     func testUpdateMFAPreferenceWithResourceNotFoundException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockSetUserMFAPreferenceResponse: { _ in
-            throw SetUserMFAPreferenceOutputError.resourceNotFoundException(.init())
-        })
+        mockIdentityProvider = MockIdentityProvider(
+            mockGetUserAttributeResponse: { request in
+                return .init(
+                    preferredMfaSetting: "SOFTWARE_TOKEN_MFA",
+                    userMFASettingList: ["SOFTWARE_TOKEN_MFA", "SMS_MFA"]
+                )
+            },
+            mockSetUserMFAPreferenceResponse: { _ in
+                throw SetUserMFAPreferenceOutputError.resourceNotFoundException(.init())
+            }
+        )
 
         do {
             _ = try await plugin.updateMFAPreference(sms: .enabled, totp: .enabled)
@@ -210,9 +255,17 @@ class UpdateMFAPreferenceTaskTests: BasePluginTest {
     ///
     func testUpdateMFAPreferenceWithForbiddenException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockSetUserMFAPreferenceResponse: { _ in
-            throw SetUserMFAPreferenceOutputError.forbiddenException(.init())
-        })
+        mockIdentityProvider = MockIdentityProvider(
+            mockGetUserAttributeResponse: { request in
+                return .init(
+                    preferredMfaSetting: "SOFTWARE_TOKEN_MFA",
+                    userMFASettingList: ["SOFTWARE_TOKEN_MFA", "SMS_MFA"]
+                )
+            },
+            mockSetUserMFAPreferenceResponse: { _ in
+                throw SetUserMFAPreferenceOutputError.forbiddenException(.init())
+            }
+        )
 
         do {
             _ = try await plugin.updateMFAPreference(sms: .enabled, totp: .enabled)
@@ -237,9 +290,17 @@ class UpdateMFAPreferenceTaskTests: BasePluginTest {
     ///
     func testUpdateMFAPreferenceWithUserNotConfirmedException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockSetUserMFAPreferenceResponse: { _ in
-            throw SetUserMFAPreferenceOutputError.userNotConfirmedException(.init())
-        })
+        mockIdentityProvider = MockIdentityProvider(
+            mockGetUserAttributeResponse: { request in
+                return .init(
+                    preferredMfaSetting: "SOFTWARE_TOKEN_MFA",
+                    userMFASettingList: ["SOFTWARE_TOKEN_MFA", "SMS_MFA"]
+                )
+            },
+            mockSetUserMFAPreferenceResponse: { _ in
+                throw SetUserMFAPreferenceOutputError.userNotConfirmedException(.init())
+            }
+        )
         do {
             _ = try await plugin.updateMFAPreference(sms: .enabled, totp: .enabled)
             XCTFail("Should return an error if the result from service is invalid")
@@ -267,9 +328,17 @@ class UpdateMFAPreferenceTaskTests: BasePluginTest {
     ///
     func testUpdateMFAPreferenceWithUserNotFoundException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockSetUserMFAPreferenceResponse: { _ in
-            throw SetUserMFAPreferenceOutputError.userNotFoundException(.init())
-        })
+        mockIdentityProvider = MockIdentityProvider(
+            mockGetUserAttributeResponse: { request in
+                return .init(
+                    preferredMfaSetting: "SOFTWARE_TOKEN_MFA",
+                    userMFASettingList: ["SOFTWARE_TOKEN_MFA", "SMS_MFA"]
+                )
+            },
+            mockSetUserMFAPreferenceResponse: { _ in
+                throw SetUserMFAPreferenceOutputError.userNotFoundException(.init())
+            }
+        )
         do {
             _ = try await plugin.updateMFAPreference(sms: .enabled, totp: .enabled)
             XCTFail("Should return an error if the result from service is invalid")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,7 @@
 
 ### Features
 
-- **Auth**: Updating the Sign In resolver to add new cases  (#3104)
-- **Auth**: Remove options from API's (#3075)
-- **Auth**: Removed deviceNotFound TODO which is not applicable for TOTP (#3074)
-- **Auth**: Enable tests for watchOS and tvOS (#3073)
-- **Auth**: Worked on review comments and cleaning up unit tests (#3071)
-- **Auth**: Adding TOTP integration tests (#3047)
-- **Auth**: Add unit tests for TOTP (#3046)
-- **Auth**: Adding TOTP states, events, data models and resolvers (#3045)
-- **Auth**: Adding TOTP state machine actions (#3044)
-- **Auth**: Adding TOTP tasks and requests to AWSAuthCognitoPlugin (#3043)
-- **Auth**: Adding TOTP service behaviour (#3042)
-- **Auth**: Adding TOTP related models to AWSCognitoPlugin (#3041)
-- **Auth**: Adding TOTP support in Amplify Auth category (#3040)
+- **Auth**: Added TOTP support in Auth plugin (#3072)
 
 ## 2.15.5 (2023-08-28)
 


### PR DESCRIPTION
## Description
Fixing the logic of the udpateMFAPreference API to make sure old preferred values stay intact. 

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
