### PR TITLE
fix(api): change request interceptors applying logic

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPICategoryPluginConfiguration.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPICategoryPluginConfiguration.swift
@@ -72,7 +72,7 @@ public struct AWSAPICategoryPluginConfiguration {
         self.authService = authService
     }
 
-    /// Registers an interceptor for the provided API endpoint
+    /// Registers an customer interceptor for the provided API endpoint
     /// - Parameter interceptor: operation interceptor used to decorate API requests
     /// - Parameter toEndpoint: API endpoint name
     mutating func addInterceptor(_ interceptor: URLRequestInterceptor,
@@ -84,18 +84,17 @@ public struct AWSAPICategoryPluginConfiguration {
         interceptors[apiName]?.addInterceptor(interceptor)
     }
 
-    /// Returns all the customer defined interceptors registered for `apiName` API endpoint
+    /// Returns all the interceptors registered for `apiName` API endpoint
     /// - Parameter apiName: API endpoint name
-    /// - Returns: request interceptors
+    /// - Returns: Optional AWSAPIEndpointInterceptors for the apiName
     internal func interceptorsForEndpoint(named apiName: APIEndpointName) -> AWSAPIEndpointInterceptors? {
         return interceptors[apiName]
     }
 
-    /// Returns customer defined interceptors for the provided endpointConfig
+    /// Returns the interceptors for the provided endpointConfig
     /// - Parameters:
     ///   - endpointConfig: endpoint configuration
-    /// - Throws: PluginConfigurationError in case of failure building an instance of AWSAuthorizationConfiguration
-    /// - Returns: An array of URLRequestInterceptor
+    /// - Returns: Optional AWSAPIEndpointInterceptors for the endpointConfig
     internal func interceptorsForEndpoint(withConfig endpointConfig: EndpointConfig) -> AWSAPIEndpointInterceptors? {
         return interceptorsForEndpoint(named: endpointConfig.name)
     }
@@ -105,7 +104,7 @@ public struct AWSAPICategoryPluginConfiguration {
     ///   - endpointConfig: endpoint configuration
     ///   - authType: overrides the registered auth interceptor
     /// - Throws: PluginConfigurationError in case of failure building an instance of AWSAuthorizationConfiguration
-    /// - Returns: An array of URLRequestInterceptor
+    /// - Returns: Optional AWSAPIEndpointInterceptors for the endpointConfig and authType
     internal func interceptorsForEndpoint(
         withConfig endpointConfig: EndpointConfig,
         authType: AWSAuthorizationType

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPIEndpointInterceptors.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPIEndpointInterceptors.swift
@@ -16,6 +16,10 @@ struct AWSAPIEndpointInterceptors {
     let apiAuthProviderFactory: APIAuthProviderFactory
     let authService: AWSAuthServiceBehavior?
 
+    var amplifyInterceptors: [URLRequestInterceptor] = []
+
+    var checksumInterceptors: [URLRequestInterceptor] = []
+
     var interceptors: [URLRequestInterceptor] = []
 
     init(endpointName: APIEndpointName,
@@ -42,7 +46,7 @@ struct AWSAPIEndpointInterceptors {
         case .apiKey(let apiKeyConfig):
             let provider = BasicAPIKeyProvider(apiKey: apiKeyConfig.apiKey)
             let interceptor = APIKeyURLRequestInterceptor(apiKeyProvider: provider)
-            addInterceptor(interceptor)
+            amplifyInterceptors.append(interceptor)
         case .awsIAM(let iamConfig):
             guard let authService = authService else {
                 throw PluginError.pluginConfigurationError("AuthService is not set for IAM",
@@ -52,7 +56,7 @@ struct AWSAPIEndpointInterceptors {
             let interceptor = IAMURLRequestInterceptor(iamCredentialsProvider: provider,
                                                        region: iamConfig.region,
                                                        endpointType: endpointType)
-            addInterceptor(interceptor)
+            checksumInterceptors.append(interceptor)
         case .amazonCognitoUserPools:
             guard let authService = authService else {
                 throw PluginError.pluginConfigurationError("AuthService not set for cognito user pools",
@@ -60,7 +64,7 @@ struct AWSAPIEndpointInterceptors {
             }
             let provider = BasicUserPoolTokenProvider(authService: authService)
             let interceptor = AuthTokenURLRequestInterceptor(authTokenProvider: provider)
-            addInterceptor(interceptor)
+            amplifyInterceptors.append(interceptor)
         case .openIDConnect:
             guard let oidcAuthProvider = apiAuthProviderFactory.oidcAuthProvider() else {
                 throw PluginError.pluginConfigurationError("AuthService not set for OIDC",
@@ -68,7 +72,7 @@ struct AWSAPIEndpointInterceptors {
             }
             let wrappedAuthProvider = AuthTokenProviderWrapper(tokenAuthProvider: oidcAuthProvider)
             let interceptor = AuthTokenURLRequestInterceptor(authTokenProvider: wrappedAuthProvider)
-            addInterceptor(interceptor)
+            amplifyInterceptors.append(interceptor)
         case .function:
             guard let functionAuthProvider = apiAuthProviderFactory.functionAuthProvider() else {
                 throw PluginError.pluginConfigurationError("AuthService not set for function auth",
@@ -76,7 +80,7 @@ struct AWSAPIEndpointInterceptors {
             }
             let wrappedAuthProvider = AuthTokenProviderWrapper(tokenAuthProvider: functionAuthProvider)
             let interceptor = AuthTokenURLRequestInterceptor(authTokenProvider: wrappedAuthProvider)
-            addInterceptor(interceptor)
+            amplifyInterceptors.append(interceptor)
         }
     }
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPIEndpointInterceptors.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPIEndpointInterceptors.swift
@@ -9,6 +9,14 @@ import Amplify
 import Foundation
 import AWSPluginsCore
 
+/// The order of interceptor decoration is as follows:
+/// 1. **prelude interceptors**
+/// 2. **cutomize headers**
+/// 3. **customer interceptors**
+/// 4. **postlude interceptors**
+///
+/// **Prelude** and **postlude** interceptors are used by library maintainers to
+/// integrate essential functionality for a variety of authentication types.
 struct AWSAPIEndpointInterceptors {
     // API name
     let apiEndpointName: APIEndpointName
@@ -16,11 +24,6 @@ struct AWSAPIEndpointInterceptors {
     let apiAuthProviderFactory: APIAuthProviderFactory
     let authService: AWSAuthServiceBehavior?
 
-    /// The order of interceptor decoration is as follows:
-    /// 1. **prelude interceptors**: append default auth info
-    /// 2. **cutomize headers**: headers provided when constructing the request
-    /// 3. **customer interceptors**: customer defined interceptors
-    /// 4. **postlude interceptors**: calculate checksums, signatures
     var preludeInterceptors: [URLRequestInterceptor] = []
 
     var interceptors: [URLRequestInterceptor] = []

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenURLRequestInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenURLRequestInterceptor.swift
@@ -32,9 +32,7 @@ struct AuthTokenURLRequestInterceptor: URLRequestInterceptor {
 
         mutableRequest.setValue(amzDate,
                                 forHTTPHeaderField: URLRequestConstants.Header.xAmzDate)
-        mutableRequest.setValue(URLRequestConstants.ContentType.applicationJson,
-                                forHTTPHeaderField: URLRequestConstants.Header.contentType)
-        mutableRequest.setValue(userAgent,
+        mutableRequest.addValue(userAgent,
                                 forHTTPHeaderField: URLRequestConstants.Header.userAgent)
         
         let token: String

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/IAMURLRequestInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/IAMURLRequestInterceptor.swift
@@ -36,7 +36,6 @@ struct IAMURLRequestInterceptor: URLRequestInterceptor {
             throw APIError.unknown("Could not get host from mutable request", "")
         }
 
-        request.setValue(URLRequestConstants.ContentType.applicationJson, forHTTPHeaderField: URLRequestConstants.Header.contentType)
         request.setValue(host, forHTTPHeaderField: "host")
         request.setValue(userAgent, forHTTPHeaderField: URLRequestConstants.Header.userAgent)
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLOperation.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLOperation.swift
@@ -41,95 +41,39 @@ final public class AWSGraphQLOperation<R: Decodable>: GraphQLOperation<R> {
             return
         }
 
-        // Validate the request
-        do {
-            try request.validate()
-        } catch let error as APIError {
-            dispatch(result: .failure(error))
-            finish()
-            return
-        } catch {
-            dispatch(result: .failure(APIError.unknown("Could not validate request", "", nil)))
-            finish()
-            return
-        }
-
-        // Retrieve endpoint configuration
-        let endpointConfig: AWSAPICategoryPluginConfiguration.EndpointConfig
-        let requestInterceptors: AWSAPIEndpointInterceptors?
-
-        do {
-            endpointConfig = try pluginConfig.endpoints.getConfig(for: request.apiName, endpointType: .graphQL)
-
-            if let pluginOptions = request.options.pluginOptions as? AWSPluginOptions,
-               let authType = pluginOptions.authType {
-                requestInterceptors = try pluginConfig.interceptorsForEndpoint(withConfig: endpointConfig,
-                                                                               authType: authType)
-            } else {
-                requestInterceptors = pluginConfig.interceptorsForEndpoint(withConfig: endpointConfig)
-            }
-        } catch let error as APIError {
-            dispatch(result: .failure(error))
-            finish()
-            return
-        } catch {
-            dispatch(result: .failure(APIError.unknown("Could not get endpoint configuration", "", nil)))
-            finish()
-            return
-        }
-
-        // Prepare request payload
-        let queryDocument = GraphQLOperationRequestUtils.getQueryDocument(document: request.document,
-                                                                          variables: request.variables)
-        if Amplify.API.log.logLevel == .verbose,
-           let serializedJSON = try? JSONSerialization.data(withJSONObject: queryDocument,
-                                                            options: .prettyPrinted),
-           let prettyPrintedQueryDocument = String(data: serializedJSON, encoding: .utf8) {
-            Amplify.API.log.verbose("\(prettyPrintedQueryDocument)")
-        }
-        let requestPayload: Data
-        do {
-            requestPayload = try JSONSerialization.data(withJSONObject: queryDocument)
-        } catch {
-            dispatch(result: .failure(APIError.operationError("Failed to serialize query document",
-                                                              "fix the document or variables",
-                                                              error)))
-            finish()
-            return
-        }
-
-        // Create request
-        let urlRequest = GraphQLOperationRequestUtils.constructRequest(with: endpointConfig.baseURL,
-                                                                       requestPayload: requestPayload)
-        let amplifyInterceptors = requestInterceptors?.amplifyInterceptors ?? []
-        let customerInterceptors = requestInterceptors?.interceptors ?? []
-        let checksumInterceptors = requestInterceptors?.checksumInterceptors ?? []
         Task {
-            var finalResult: Result<URLRequest, APIError> = .success(urlRequest)
-            // apply amplify interceptors
-            for interceptor in amplifyInterceptors {
-                finalResult = await finalResult.flatMapAsync { request in
-                    await applyInterceptor(interceptor, request: request)
+            let urlRequest = validateRequest(request).flatMap(buildURLRequest(from:))
+            let finalRequest = await getEndpointInterceptors(from: request).flatMapAsync { requestInterceptors in
+                var finalResult = urlRequest
+                let amplifyInterceptors = requestInterceptors?.amplifyInterceptors ?? []
+                let customerInterceptors = requestInterceptors?.interceptors ?? []
+                let checksumInterceptors = requestInterceptors?.checksumInterceptors ?? []
+                // apply amplify interceptors
+                for interceptor in amplifyInterceptors {
+                    finalResult = await finalResult.flatMapAsync { request in
+                        await applyInterceptor(interceptor, request: request)
+                    }
                 }
+
+                // there is no customer headers for GraphQLOperationRequest
+
+                // apply customer interceptors
+                for interceptor in customerInterceptors {
+                    finalResult = await finalResult.flatMapAsync { request in
+                        await applyInterceptor(interceptor, request: request)
+                    }
+                }
+
+                // apply checksum interceptor
+                for interceptor in checksumInterceptors {
+                    finalResult = await finalResult.flatMapAsync { request in
+                        await applyInterceptor(interceptor, request: request)
+                    }
+                }
+                return finalResult
             }
 
-            // there is no customer headers for GraphQLOperationRequest
-
-            // apply customer interceptors
-            for interceptor in customerInterceptors {
-                finalResult = await finalResult.flatMapAsync { request in
-                    await applyInterceptor(interceptor, request: request)
-                }
-            }
-
-            // apply checksum interceptor
-            for interceptor in checksumInterceptors {
-                finalResult = await finalResult.flatMapAsync { request in
-                    await applyInterceptor(interceptor, request: request)
-                }
-            }
-
-            switch finalResult {
+            switch finalRequest {
             case .success(let finalRequest):
                 if isCancelled {
                     finish()
@@ -144,6 +88,83 @@ final public class AWSGraphQLOperation<R: Decodable>: GraphQLOperation<R> {
             case .failure(let error):
                 dispatch(result: .failure(error))
                 cancel()
+            }
+        }
+
+    }
+
+    private func validateRequest(_ request: GraphQLOperationRequest<R>) -> Result<GraphQLOperationRequest<R>, APIError> {
+        do {
+            try request.validate()
+            return .success(request)
+        } catch let error as APIError {
+            return .failure(error)
+        } catch {
+            return .failure(APIError.unknown("Could not validate request", "", nil))
+        }
+    }
+
+    private func buildURLRequest(from request: GraphQLOperationRequest<R>) -> Result<URLRequest, APIError> {
+        getEndpointConfig(from: request).flatMap { endpointConfig in
+            getRequestPayload(from: request).map { requestPayload in
+                GraphQLOperationRequestUtils.constructRequest(
+                    with: endpointConfig.baseURL,
+                    requestPayload: requestPayload
+                )
+            }
+        }
+    }
+
+    private func getRequestPayload(from request: GraphQLOperationRequest<R>) -> Result<Data, APIError> {
+        // Prepare request payload
+        let queryDocument = GraphQLOperationRequestUtils.getQueryDocument(document: request.document,
+                                                                          variables: request.variables)
+        if Amplify.API.log.logLevel == .verbose,
+           let serializedJSON = try? JSONSerialization.data(withJSONObject: queryDocument,
+                                                            options: .prettyPrinted),
+           let prettyPrintedQueryDocument = String(data: serializedJSON, encoding: .utf8) {
+            Amplify.API.log.verbose("\(prettyPrintedQueryDocument)")
+        }
+
+        do {
+            return .success(try JSONSerialization.data(withJSONObject: queryDocument))
+        } catch {
+            return .failure(APIError.operationError(
+                "Failed to serialize query document",
+                "fix the document or variables",
+                error
+            ))
+        }
+    }
+
+    private func getEndpointConfig(from request: GraphQLOperationRequest<R>) -> Result<AWSAPICategoryPluginConfiguration.EndpointConfig, APIError> {
+        do {
+            return .success(try pluginConfig.endpoints.getConfig(for: request.apiName, endpointType: .graphQL))
+        } catch let error as APIError {
+            return .failure(error)
+
+        } catch {
+            return .failure(APIError.unknown("Could not get endpoint configuration", "", nil))
+        }
+    }
+
+    private func getEndpointInterceptors(from request: GraphQLOperationRequest<R>) -> Result<AWSAPIEndpointInterceptors?, APIError> {
+        getEndpointConfig(from: request).flatMap { endpointConfig in
+            do {
+                if let pluginOptions = request.options.pluginOptions as? AWSPluginOptions,
+                   let authType = pluginOptions.authType
+                {
+                    return .success(try pluginConfig.interceptorsForEndpoint(
+                        withConfig: endpointConfig,
+                        authType: authType
+                    ))
+                } else {
+                    return .success(pluginConfig.interceptorsForEndpoint(withConfig: endpointConfig))
+                }
+            } catch let error as APIError {
+                return .failure(error)
+            } catch {
+                return .failure(APIError.unknown("Could not get endpoint interceptors", "", nil))
             }
         }
     }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLOperation.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLOperation.swift
@@ -87,7 +87,7 @@ final public class AWSGraphQLOperation<R: Decodable>: GraphQLOperation<R> {
                 task.resume()
             case .failure(let error):
                 dispatch(result: .failure(error))
-                cancel()
+                finish()
             }
         }
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLOperation.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLOperation.swift
@@ -179,8 +179,8 @@ final public class AWSGraphQLOperation<R: Decodable>: GraphQLOperation<R> {
         } catch {
             return .failure(
                 APIError.operationError(
-                    "Failed to intercept request fully.",
-                    "Something wrong with the interceptor",
+                    "Failed to intercept request with \(type(of: interceptor)). Error message: \(error.localizedDescription).",
+                    "See underlying error for more details",
                     error
                 )
             )

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSRESTOperation.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSRESTOperation.swift
@@ -116,6 +116,9 @@ final public class AWSRESTOperation: AmplifyOperation<
                 }
             }
 
+            // apply customized request headers
+            finalRequest = RESTOperationRequestUtils.applyCustomizeRequestHeaders(request.headers, on: finalRequest)
+
             if isCancelled {
                 finish()
                 return

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSRESTOperation.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSRESTOperation.swift
@@ -160,8 +160,8 @@ final public class AWSRESTOperation: AmplifyOperation<
         } catch {
             return .failure(
                 APIError.operationError(
-                    "Failed to intercept request fully.",
-                    "Something wrong with the interceptor",
+                    "Failed to intercept request with \(type(of: interceptor)). Error message: \(error.localizedDescription).",
+                    "See underlying error for more details",
                     error
                 )
             )

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSRESTOperation.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSRESTOperation.swift
@@ -40,69 +40,71 @@ final public class AWSRESTOperation: AmplifyOperation<
 
     /// The work to execute for this operation
     override public func main() {
+        Task { await mainAsync() }
+    }
+
+    private func mainAsync() async {
         if isCancelled {
             finish()
             return
         }
 
-        Task {
-            let urlRequest = validateRequest(request).flatMap(buildURLRequest(from:))
-            let finalRequest = await getEndpointConfig(from: request).flatMapAsync { endpointConfig in
-                let interceptorConfig = pluginConfig.interceptorsForEndpoint(withConfig: endpointConfig)
-                let amplifyInterceptors = interceptorConfig?.amplifyInterceptors ?? []
-                let customerInterceptors = interceptorConfig?.interceptors ?? []
-                let checksumInterceptors = interceptorConfig?.checksumInterceptors ?? []
+        let urlRequest = validateRequest(request).flatMap(buildURLRequest(from:))
+        let finalRequest = await getEndpointConfig(from: request).flatMapAsync { endpointConfig in
+            let interceptorConfig = pluginConfig.interceptorsForEndpoint(withConfig: endpointConfig)
+            let preludeInterceptors = interceptorConfig?.preludeInterceptors ?? []
+            let customerInterceptors = interceptorConfig?.interceptors ?? []
+            let postludeInterceptors = interceptorConfig?.postludeInterceptors ?? []
 
-                var finalResult = urlRequest
-                // apply amplify interceptors
-                for interceptor in amplifyInterceptors {
-                    finalResult = await finalResult.flatMapAsync { request in
-                        await applyInterceptor(interceptor, request: request)
-                    }
+            var finalResult = urlRequest
+            // apply prelude interceptors
+            for interceptor in preludeInterceptors {
+                finalResult = await finalResult.flatMapAsync { request in
+                    await applyInterceptor(interceptor, request: request)
                 }
-
-                // apply customer headers
-                finalResult = finalResult.map { urlRequest in
-                    var mutableRequest = urlRequest
-                    for (key, value) in request.headers ?? [:] {
-                        mutableRequest.setValue(value, forHTTPHeaderField: key)
-                    }
-                    return mutableRequest
-                }
-
-                // apply customer interceptors
-                for interceptor in customerInterceptors {
-                    finalResult = await finalResult.flatMapAsync { request in
-                        await applyInterceptor(interceptor, request: request)
-                    }
-                }
-
-                // apply checksum interceptor
-                for interceptor in checksumInterceptors {
-                    finalResult = await finalResult.flatMapAsync { request in
-                        await applyInterceptor(interceptor, request: request)
-                    }
-                }
-                return finalResult
             }
 
-            switch finalRequest {
-            case .success(let finalRequest):
-                if isCancelled {
-                    finish()
-                    return
+            // apply customize headers
+            finalResult = finalResult.map { urlRequest in
+                var mutableRequest = urlRequest
+                for (key, value) in request.headers ?? [:] {
+                    mutableRequest.setValue(value, forHTTPHeaderField: key)
                 }
+                return mutableRequest
+            }
 
-                // Begin network task
-                Amplify.API.log.debug("Starting network task for \(request.operationType) \(id)")
-                let task = session.dataTaskBehavior(with: finalRequest)
-                mapper.addPair(operation: self, task: task)
-                task.resume()
-            case .failure(let error):
-                Amplify.API.log.debug("Dispatching error \(error)")
-                dispatch(result: .failure(error))
+            // apply customer interceptors
+            for interceptor in customerInterceptors {
+                finalResult = await finalResult.flatMapAsync { request in
+                    await applyInterceptor(interceptor, request: request)
+                }
+            }
+
+            // apply postlude interceptor
+            for interceptor in postludeInterceptors {
+                finalResult = await finalResult.flatMapAsync { request in
+                    await applyInterceptor(interceptor, request: request)
+                }
+            }
+            return finalResult
+        }
+
+        switch finalRequest {
+        case .success(let finalRequest):
+            if isCancelled {
                 finish()
+                return
             }
+
+            // Begin network task
+            Amplify.API.log.debug("Starting network task for \(request.operationType) \(id)")
+            let task = session.dataTaskBehavior(with: finalRequest)
+            mapper.addPair(operation: self, task: task)
+            task.resume()
+        case .failure(let error):
+            Amplify.API.log.debug("Dispatching error \(error)")
+            dispatch(result: .failure(error))
+            finish()
         }
     }
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSRESTOperation.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSRESTOperation.swift
@@ -116,7 +116,7 @@ final public class AWSRESTOperation: AmplifyOperation<
                 }
             }
 
-            // apply customized request headers
+            // The headers from the request object should override any of the same header modifications done by the intercepters above
             finalRequest = RESTOperationRequestUtils.applyCustomizeRequestHeaders(request.headers, on: finalRequest)
 
             if isCancelled {

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/GraphQLOperationRequestUtils.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/GraphQLOperationRequestUtils.swift
@@ -22,8 +22,8 @@ class GraphQLOperationRequestUtils {
     // Construct a graphQL specific HTTP POST request with the request payload
     static func constructRequest(with baseUrl: URL, requestPayload: Data) -> URLRequest {
         var baseRequest = URLRequest(url: baseUrl)
-        let headers = ["content-type": "application/json", "Cache-Control": "no-store"]
-        baseRequest.allHTTPHeaderFields = headers
+        baseRequest.setValue("application/json", forHTTPHeaderField: "content-type")
+        baseRequest.setValue("no-store", forHTTPHeaderField: "cache-control")
         baseRequest.httpMethod = "POST"
         baseRequest.httpBody = requestPayload
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/RESTOperationRequestUtils.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/RESTOperationRequestUtils.swift
@@ -52,34 +52,16 @@ final class RESTOperationRequestUtils {
     }
 
     // Construct a request specific to the `RESTOperationType`
-    static func constructURLRequest(with url: URL,
-                                    operationType: RESTOperationType,
-                                    headers: [String: String]?,
-                                    requestPayload: Data?) -> URLRequest {
-
-        let baseHeaders = ["content-type": "application/json"]
+    static func constructURLRequest(
+        with url: URL,
+        operationType: RESTOperationType,
+        requestPayload: Data?
+    ) -> URLRequest {
         var baseRequest = URLRequest(url: url)
-        baseRequest = applyCustomizeRequestHeaders(
-            baseHeaders.merging(headers ?? [:], uniquingKeysWith: { _, new in new }),
-            on: baseRequest
-        )
+        baseRequest.setValue("application/json", forHTTPHeaderField: "content-type")
         baseRequest.httpMethod = operationType.rawValue
         baseRequest.httpBody = requestPayload
         return baseRequest
-    }
-
-    static func applyCustomizeRequestHeaders(_ headers: [String: String]?, on request: URLRequest) -> URLRequest {
-        guard let headers = headers,
-              let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest
-        else {
-            return request
-        }
-
-        for (key, value) in headers {
-            mutableRequest.setValue(value, forHTTPHeaderField: key)
-        }
-
-        return mutableRequest as URLRequest
     }
 
     private static let permittedQueryParamCharacters = CharacterSet.alphanumerics

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/RESTOperationRequestUtils.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/RESTOperationRequestUtils.swift
@@ -57,17 +57,29 @@ final class RESTOperationRequestUtils {
                                     headers: [String: String]?,
                                     requestPayload: Data?) -> URLRequest {
 
+        let baseHeaders = ["content-type": "application/json"]
         var baseRequest = URLRequest(url: url)
-        var requestHeaders = ["content-type": "application/json"]
-        if let headers = headers {
-            for (key, value) in headers {
-                requestHeaders[key] = value
-            }
-        }
-        baseRequest.allHTTPHeaderFields = requestHeaders
+        baseRequest = applyCustomizeRequestHeaders(
+            baseHeaders.merging(headers ?? [:], uniquingKeysWith: { _, new in new }),
+            on: baseRequest
+        )
         baseRequest.httpMethod = operationType.rawValue
         baseRequest.httpBody = requestPayload
         return baseRequest
+    }
+
+    static func applyCustomizeRequestHeaders(_ headers: [String: String]?, on request: URLRequest) -> URLRequest {
+        guard let headers = headers,
+              let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest
+        else {
+            return request
+        }
+
+        for (key, value) in headers {
+            mutableRequest.setValue(value, forHTTPHeaderField: key)
+        }
+
+        return mutableRequest as URLRequest
     }
 
     private static let permittedQueryParamCharacters = CharacterSet.alphanumerics

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/Result+Async.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/Result+Async.swift
@@ -1,0 +1,20 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+
+extension Result {
+    func flatMapAsync<NewSuccess>(_ f: (Success) async -> Result<NewSuccess, Failure>) async -> Result<NewSuccess, Failure> {
+        switch self {
+        case .success(let value):
+            return await f(value)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario4Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario4Tests.swift
@@ -213,7 +213,7 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
         }
         let predicate = field("postID").eq(post.id)
         var results: List<Comment4>?
-        let result = try await Amplify.API.query(request: .list(Comment4.self, where: predicate, limit: 1))
+        let result = try await Amplify.API.query(request: .list(Comment4.self, where: predicate, limit: 3000))
         switch result {
         case .success(let comments):
             results = comments

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests+List.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests+List.swift
@@ -39,7 +39,7 @@ extension GraphQLModelBasedTests {
         let post = Post.keys
         let predicate = post.id == uuid1 || post.id == uuid2
         var results: List<Post>?
-        let response = try await Amplify.API.query(request: .list(Post.self, where: predicate, limit: 1))
+        let response = try await Amplify.API.query(request: .list(Post.self, where: predicate, limit: 3000))
         
         guard case .success(let graphQLresponse) = response else {
             XCTFail("Missing successful response")

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginRESTIAMTests/RESTWithIAMIntegrationTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginRESTIAMTests/RESTWithIAMIntegrationTests.swift
@@ -164,7 +164,6 @@ class RESTWithIAMIntegrationTests: XCTestCase {
         let request = RESTRequest(path: "/items", headers: ["Content-Type": "text/plain"])
         do {
             _ = try await Amplify.API.get(request: request)
-            XCTFail("Should catch error")
         } catch {
             guard let apiError = error as? APIError else {
                 XCTFail("Error should be APIError")

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginRESTIAMTests/RESTWithIAMIntegrationTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginRESTIAMTests/RESTWithIAMIntegrationTests.swift
@@ -159,6 +159,25 @@ class RESTWithIAMIntegrationTests: XCTestCase {
             XCTAssertEqual(statusCode, 404)
         }
     }
+
+    func testRestRequest_withCustomizeHeaders_succefullyOverride() async throws {
+        let request = RESTRequest(path: "/items", headers: ["Content-Type": "text/plain"])
+        do {
+            _ = try await Amplify.API.get(request: request)
+            XCTFail("Should catch error")
+        } catch {
+            guard let apiError = error as? APIError else {
+                XCTFail("Error should be APIError")
+                return
+            }
+            guard case let .httpStatusError(statusCode, _) = apiError else {
+                XCTFail("Error should be httpStatusError")
+                return
+            }
+
+            XCTAssertEqual(statusCode, 403)
+        }
+    }
 }
 
 extension RESTWithIAMIntegrationTests: DefaultLogger { }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+InterceptorBehaviorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+InterceptorBehaviorTests.swift
@@ -14,16 +14,16 @@ class AWSAPICategoryPluginInterceptorBehaviorTests: AWSAPICategoryPluginTestBase
 
     func testAddInterceptor() throws {
         XCTAssertNotNil(apiPlugin.pluginConfig.endpoints[apiName])
-        XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName)?.amplifyInterceptors.count, 0)
+        XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName)?.preludeInterceptors.count, 0)
         XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName)?.interceptors.count, 0)
-        XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName)?.checksumInterceptors.count, 0)
+        XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName)?.postludeInterceptors.count, 0)
 
         let provider = BasicUserPoolTokenProvider(authService: authService)
         let requestInterceptor = AuthTokenURLRequestInterceptor(authTokenProvider: provider)
         try apiPlugin.add(interceptor: requestInterceptor, for: apiName)
 
-        XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName)?.amplifyInterceptors.count, 0)
+        XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName)?.preludeInterceptors.count, 0)
         XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName)?.interceptors.count, 1)
-        XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName)?.checksumInterceptors.count, 0)
+        XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName)?.postludeInterceptors.count, 0)
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+InterceptorBehaviorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+InterceptorBehaviorTests.swift
@@ -14,12 +14,16 @@ class AWSAPICategoryPluginInterceptorBehaviorTests: AWSAPICategoryPluginTestBase
 
     func testAddInterceptor() throws {
         XCTAssertNotNil(apiPlugin.pluginConfig.endpoints[apiName])
-        XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName).count, 0)
+        XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName)?.amplifyInterceptors.count, 0)
+        XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName)?.interceptors.count, 0)
+        XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName)?.checksumInterceptors.count, 0)
 
         let provider = BasicUserPoolTokenProvider(authService: authService)
         let requestInterceptor = AuthTokenURLRequestInterceptor(authTokenProvider: provider)
         try apiPlugin.add(interceptor: requestInterceptor, for: apiName)
 
-        XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName).count, 1)
+        XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName)?.amplifyInterceptors.count, 0)
+        XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName)?.interceptors.count, 1)
+        XCTAssertEqual(apiPlugin.pluginConfig.interceptorsForEndpoint(named: apiName)?.checksumInterceptors.count, 0)
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -58,9 +58,9 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
     func testAddInterceptors() {
         let apiKeyInterceptor = APIKeyURLRequestInterceptor(apiKeyProvider: BasicAPIKeyProvider(apiKey: apiKey))
         config?.addInterceptor(apiKeyInterceptor, toEndpoint: graphQLAPI)
-        XCTAssertEqual(config?.interceptorsForEndpoint(named: graphQLAPI)?.amplifyInterceptors.count, 0)
+        XCTAssertEqual(config?.interceptorsForEndpoint(named: graphQLAPI)?.preludeInterceptors.count, 0)
         XCTAssertEqual(config?.interceptorsForEndpoint(named: graphQLAPI)?.interceptors.count, 1)
-        XCTAssertEqual(config?.interceptorsForEndpoint(named: graphQLAPI)?.checksumInterceptors.count, 0)
+        XCTAssertEqual(config?.interceptorsForEndpoint(named: graphQLAPI)?.postludeInterceptors.count, 0)
     }
 
     /// Given: multiple interceptors conforming to URLRequestInterceptor and an EndpointConfig
@@ -71,9 +71,9 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
         config?.addInterceptor(apiKeyInterceptor, toEndpoint: graphQLAPI)
         config?.addInterceptor(CustomURLInterceptor(), toEndpoint: graphQLAPI)
         let interceptors = config?.interceptorsForEndpoint(withConfig: endpointConfig!)
-        XCTAssertEqual(interceptors!.amplifyInterceptors.count, 0)
+        XCTAssertEqual(interceptors!.preludeInterceptors.count, 0)
         XCTAssertEqual(interceptors!.interceptors.count, 2)
-        XCTAssertEqual(interceptors!.checksumInterceptors.count, 0)
+        XCTAssertEqual(interceptors!.postludeInterceptors.count, 0)
     }
 
     /// Given: multiple interceptors conforming to URLRequestInterceptor
@@ -88,8 +88,8 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
         let interceptors = try config?.interceptorsForEndpoint(withConfig: endpointConfig!,
                                                                authType: .amazonCognitoUserPools)
 
-        XCTAssertEqual(interceptors!.amplifyInterceptors.count, 1)
-        XCTAssertNotNil(interceptors!.amplifyInterceptors[0] as? AuthTokenURLRequestInterceptor)
+        XCTAssertEqual(interceptors!.preludeInterceptors.count, 1)
+        XCTAssertNotNil(interceptors!.preludeInterceptors[0] as? AuthTokenURLRequestInterceptor)
         XCTAssertNotNil(interceptors!.interceptors[1] as? CustomURLInterceptor)
     }
 
@@ -103,8 +103,8 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
 
         let interceptors = try config?.interceptorsForEndpoint(withConfig: endpointConfig!, authType: .apiKey)
 
-        XCTAssertEqual(interceptors!.amplifyInterceptors.count, 1)
-        XCTAssertNotNil(interceptors!.amplifyInterceptors[0] as? APIKeyURLRequestInterceptor)
+        XCTAssertEqual(interceptors!.preludeInterceptors.count, 1)
+        XCTAssertNotNil(interceptors!.preludeInterceptors[0] as? APIKeyURLRequestInterceptor)
     }
 
     // MARK: - Helpers

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -58,18 +58,22 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
     func testAddInterceptors() {
         let apiKeyInterceptor = APIKeyURLRequestInterceptor(apiKeyProvider: BasicAPIKeyProvider(apiKey: apiKey))
         config?.addInterceptor(apiKeyInterceptor, toEndpoint: graphQLAPI)
-        XCTAssertEqual(config?.interceptorsForEndpoint(named: graphQLAPI).count, 1)
+        XCTAssertEqual(config?.interceptorsForEndpoint(named: graphQLAPI)?.amplifyInterceptors.count, 0)
+        XCTAssertEqual(config?.interceptorsForEndpoint(named: graphQLAPI)?.interceptors.count, 1)
+        XCTAssertEqual(config?.interceptorsForEndpoint(named: graphQLAPI)?.checksumInterceptors.count, 0)
     }
 
     /// Given: multiple interceptors conforming to URLRequestInterceptor and an EndpointConfig
     /// When: interceptorsForEndpoint is called with the given EndpointConfig
     /// Then: the registered interceptors are returned
-    func testInterceptorsForEndpointWithConfig() throws {
+    func testInterceptorsForEndpointWithConfig() {
         let apiKeyInterceptor = APIKeyURLRequestInterceptor(apiKeyProvider: BasicAPIKeyProvider(apiKey: apiKey))
         config?.addInterceptor(apiKeyInterceptor, toEndpoint: graphQLAPI)
         config?.addInterceptor(CustomURLInterceptor(), toEndpoint: graphQLAPI)
-        let interceptors = try config?.interceptorsForEndpoint(withConfig: endpointConfig!)
-        XCTAssertEqual(interceptors!.count, 2)
+        let interceptors = config?.interceptorsForEndpoint(withConfig: endpointConfig!)
+        XCTAssertEqual(interceptors!.amplifyInterceptors.count, 0)
+        XCTAssertEqual(interceptors!.interceptors.count, 2)
+        XCTAssertEqual(interceptors!.checksumInterceptors.count, 0)
     }
 
     /// Given: multiple interceptors conforming to URLRequestInterceptor
@@ -84,9 +88,9 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
         let interceptors = try config?.interceptorsForEndpoint(withConfig: endpointConfig!,
                                                                authType: .amazonCognitoUserPools)
 
-        XCTAssertEqual(interceptors!.count, 2)
-        XCTAssertNotNil(interceptors![0] as? AuthTokenURLRequestInterceptor)
-        XCTAssertNotNil(interceptors![1] as? CustomURLInterceptor)
+        XCTAssertEqual(interceptors!.amplifyInterceptors.count, 1)
+        XCTAssertNotNil(interceptors!.amplifyInterceptors[0] as? AuthTokenURLRequestInterceptor)
+        XCTAssertNotNil(interceptors!.interceptors[1] as? CustomURLInterceptor)
     }
 
     /// Given: an auth interceptor conforming to URLRequestInterceptor
@@ -99,8 +103,8 @@ class AWSAPICategoryPluginConfigurationTests: XCTestCase {
 
         let interceptors = try config?.interceptorsForEndpoint(withConfig: endpointConfig!, authType: .apiKey)
 
-        XCTAssertEqual(interceptors!.count, 1)
-        XCTAssertNotNil(interceptors![0] as? APIKeyURLRequestInterceptor)
+        XCTAssertEqual(interceptors!.amplifyInterceptors.count, 1)
+        XCTAssertNotNil(interceptors!.amplifyInterceptors[0] as? APIKeyURLRequestInterceptor)
     }
 
     // MARK: - Helpers

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPIEndpointInterceptorsTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPIEndpointInterceptorsTests.swift
@@ -31,9 +31,9 @@ class AWSAPIEndpointInterceptorsTests: XCTestCase {
 
         try interceptorConfig.addAuthInterceptorsToEndpoint(endpointType: .graphQL, authConfiguration: config!)
 
-        XCTAssertEqual(interceptorConfig.amplifyInterceptors.count, 1)
+        XCTAssertEqual(interceptorConfig.preludeInterceptors.count, 1)
         XCTAssertEqual(interceptorConfig.interceptors.count, 0)
-        XCTAssertEqual(interceptorConfig.checksumInterceptors.count, 0)
+        XCTAssertEqual(interceptorConfig.postludeInterceptors.count, 0)
     }
 
     /// Given: an AWSAPIEndpointInterceptors
@@ -45,9 +45,9 @@ class AWSAPIEndpointInterceptorsTests: XCTestCase {
         try interceptorConfig.addAuthInterceptorsToEndpoint(endpointType: .graphQL, authConfiguration: config!)
         interceptorConfig.addInterceptor(CustomInterceptor())
 
-        XCTAssertEqual(interceptorConfig.amplifyInterceptors.count, 1)
+        XCTAssertEqual(interceptorConfig.preludeInterceptors.count, 1)
         XCTAssertEqual(interceptorConfig.interceptors.count, 1)
-        XCTAssertEqual(interceptorConfig.checksumInterceptors.count, 0)
+        XCTAssertEqual(interceptorConfig.postludeInterceptors.count, 0)
     }
 
     func testaddMultipleAuthInterceptors() throws {
@@ -72,12 +72,12 @@ class AWSAPIEndpointInterceptorsTests: XCTestCase {
         try interceptorConfig.addAuthInterceptorsToEndpoint(endpointType: .graphQL,
                                                             authConfiguration: userPoolConfig)
 
-        XCTAssertEqual(interceptorConfig.amplifyInterceptors.count, 2)
+        XCTAssertEqual(interceptorConfig.preludeInterceptors.count, 2)
         XCTAssertEqual(interceptorConfig.interceptors.count, 0)
-        XCTAssertEqual(interceptorConfig.checksumInterceptors.count, 1)
-        XCTAssertNotNil(interceptorConfig.amplifyInterceptors[0] as? APIKeyURLRequestInterceptor)
-        XCTAssertNotNil(interceptorConfig.amplifyInterceptors[1] as? AuthTokenURLRequestInterceptor)
-        XCTAssertNotNil(interceptorConfig.checksumInterceptors[0] as? IAMURLRequestInterceptor)
+        XCTAssertEqual(interceptorConfig.postludeInterceptors.count, 1)
+        XCTAssertNotNil(interceptorConfig.preludeInterceptors[0] as? APIKeyURLRequestInterceptor)
+        XCTAssertNotNil(interceptorConfig.preludeInterceptors[1] as? AuthTokenURLRequestInterceptor)
+        XCTAssertNotNil(interceptorConfig.postludeInterceptors[0] as? IAMURLRequestInterceptor)
     }
 
     // MARK: - Test Helpers

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPIEndpointInterceptorsTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPIEndpointInterceptorsTests.swift
@@ -31,8 +31,9 @@ class AWSAPIEndpointInterceptorsTests: XCTestCase {
 
         try interceptorConfig.addAuthInterceptorsToEndpoint(endpointType: .graphQL, authConfiguration: config!)
 
-        XCTAssertEqual(interceptorConfig.interceptors.count, 1)
-
+        XCTAssertEqual(interceptorConfig.amplifyInterceptors.count, 1)
+        XCTAssertEqual(interceptorConfig.interceptors.count, 0)
+        XCTAssertEqual(interceptorConfig.checksumInterceptors.count, 0)
     }
 
     /// Given: an AWSAPIEndpointInterceptors
@@ -44,7 +45,9 @@ class AWSAPIEndpointInterceptorsTests: XCTestCase {
         try interceptorConfig.addAuthInterceptorsToEndpoint(endpointType: .graphQL, authConfiguration: config!)
         interceptorConfig.addInterceptor(CustomInterceptor())
 
-        XCTAssertEqual(interceptorConfig.interceptors.count, 2)
+        XCTAssertEqual(interceptorConfig.amplifyInterceptors.count, 1)
+        XCTAssertEqual(interceptorConfig.interceptors.count, 1)
+        XCTAssertEqual(interceptorConfig.checksumInterceptors.count, 0)
     }
 
     func testaddMultipleAuthInterceptors() throws {
@@ -69,10 +72,12 @@ class AWSAPIEndpointInterceptorsTests: XCTestCase {
         try interceptorConfig.addAuthInterceptorsToEndpoint(endpointType: .graphQL,
                                                             authConfiguration: userPoolConfig)
 
-        XCTAssertEqual(interceptorConfig.interceptors.count, 3)
-        XCTAssertNotNil(interceptorConfig.interceptors[0] as? APIKeyURLRequestInterceptor)
-        XCTAssertNotNil(interceptorConfig.interceptors[1] as? IAMURLRequestInterceptor)
-        XCTAssertNotNil(interceptorConfig.interceptors[2] as? AuthTokenURLRequestInterceptor)
+        XCTAssertEqual(interceptorConfig.amplifyInterceptors.count, 2)
+        XCTAssertEqual(interceptorConfig.interceptors.count, 0)
+        XCTAssertEqual(interceptorConfig.checksumInterceptors.count, 1)
+        XCTAssertNotNil(interceptorConfig.amplifyInterceptors[0] as? APIKeyURLRequestInterceptor)
+        XCTAssertNotNil(interceptorConfig.amplifyInterceptors[1] as? AuthTokenURLRequestInterceptor)
+        XCTAssertNotNil(interceptorConfig.checksumInterceptors[0] as? IAMURLRequestInterceptor)
     }
 
     // MARK: - Test Helpers

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -15,7 +15,11 @@ class AuthTokenURLRequestInterceptorTests: XCTestCase {
     func testAuthTokenInterceptor() async throws {
         let mockTokenProvider = MockTokenProvider()
         let interceptor = AuthTokenURLRequestInterceptor(authTokenProvider: mockTokenProvider)
-        let request = URLRequest(url: URL(string: "http://anapiendpoint.ca")!)
+        let request = RESTOperationRequestUtils.constructURLRequest(
+            with: URL(string: "http://anapiendpoint.ca")!,
+            operationType: .get,
+            requestPayload: nil
+        )
 
         guard let headers = try await interceptor.intercept(request).allHTTPHeaderFields else {
             XCTFail("Failed retrieving headers")

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/RESTRequestUtilsTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/RESTRequestUtilsTests.swift
@@ -70,7 +70,6 @@ class RESTRequestUtilsTests: XCTestCase {
         let urlRequest = RESTOperationRequestUtils.constructURLRequest(
             with: url,
             operationType: .get,
-            headers: nil,
             requestPayload: nil
         )
 
@@ -95,18 +94,6 @@ class RESTRequestUtilsTests: XCTestCase {
             )
         )
     }
-
-    func testApplyCustomizeRequestHeaders_withCutomeHeaders_successfullyOverride() {
-        var request = URLRequest(url: URL(string: "https://aws.amazon.com")!)
-        request.allHTTPHeaderFields = ["Content-Type": "application/json"]
-        let headers = ["Content-Type": "text/plain"]
-        let requestWithHeaders = RESTOperationRequestUtils.applyCustomizeRequestHeaders(headers, on: request)
-        XCTAssertNotNil(requestWithHeaders.allHTTPHeaderFields)
-        for (key, value) in headers {
-            XCTAssertEqual(requestWithHeaders.allHTTPHeaderFields![key], value)
-        }
-    }
-
 }
 
 extension RESTRequestUtilsTests {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/RESTRequestUtilsTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/RESTRequestUtilsTests.swift
@@ -95,6 +95,18 @@ class RESTRequestUtilsTests: XCTestCase {
             )
         )
     }
+
+    func testApplyCustomizeRequestHeaders_withCutomeHeaders_successfullyOverride() {
+        var request = URLRequest(url: URL(string: "https://aws.amazon.com")!)
+        request.allHTTPHeaderFields = ["Content-Type": "application/json"]
+        let headers = ["Content-Type": "text/plain"]
+        let requestWithHeaders = RESTOperationRequestUtils.applyCustomizeRequestHeaders(headers, on: request)
+        XCTAssertNotNil(requestWithHeaders.allHTTPHeaderFields)
+        for (key, value) in headers {
+            XCTAssertEqual(requestWithHeaders.allHTTPHeaderFields![key], value)
+        }
+    }
+
 }
 
 extension RESTRequestUtilsTests {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/Result+AsyncTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/Result+AsyncTests.swift
@@ -46,6 +46,7 @@ class ResultAsyncTests: XCTestCase {
             XCTFail("Should fail")
         case .failure(let error):
             XCTAssertTrue(error is TestError)
+            XCTAssertEqual(ObjectIdentifier(expectedError), ObjectIdentifier(error as! TestError))
         }
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/Result+AsyncTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/Result+AsyncTests.swift
@@ -1,0 +1,53 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import XCTest
+@testable import AWSAPIPlugin
+
+class ResultAsyncTests: XCTestCase {
+
+    func testFlatMapAsync_withSuccess_applyFunction() async {
+        func plus1(_ number: Int) async -> Int {
+            return number + 1
+        }
+
+        let result = Result<Int, Error>.success(0)
+        let plus1Result = await result.flatMapAsync {
+            .success(await plus1($0))
+        }
+
+        switch plus1Result {
+        case .success(let plus1Result):
+            XCTAssertEqual(plus1Result, 1)
+        case .failure(let error):
+            XCTFail("Failed with error \(error)")
+        }
+    }
+
+    func testFlatMapAsync_withFailure_notApplyFunction() async {
+        func arrayCount(_ array: [Int]) async -> Int {
+            return array.count
+        }
+
+
+        let expectedError = TestError()
+        let result = Result<[Int], Error>.failure(expectedError)
+        let count = await result.flatMapAsync {
+            .success(await arrayCount($0))
+        }
+
+        switch count {
+        case .success:
+            XCTFail("Should fail")
+        case .failure(let error):
+            XCTAssertTrue(error is TestError)
+        }
+    }
+}
+
+fileprivate class TestError: Error { }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/3184
## Description
<!-- Why is this change required? What problem does it solve? -->

The existing implementation of the URLRequest interceptor proceeds as follows:

1. Applying customized headers.
2. Applying library predefined interceptors.
3. Applying user-defined interceptors.

However, this approach has certain issues. For instance, one of the Amplify predefined interceptors requires the calculation of the Sigv4 authentication header for the request. This calculation involves certain headers. Making it impossible for customers to modify these header fields within their own custom interceptors.

After some discussions, we have divided the library predefined interceptors into prelude and postlude interceptors, and the interceptor logic should be as follows:

1. Applying Amplify prelude interceptors.
2. Applying customized headers.
3. Applying customer-defined interceptors.
4. Applying Amplify postlude interceptors.

This updated logic ensures that customer-defined interceptors will be applied with the expected customized headers and the postlude interceptors will operate on the correct request after customer-defined interceptors have been applied.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
