### PR TITLE
fix(PushNotifications): Adding missing escape hatch to the plugin.

### DIFF
--- a/AmplifyPlugins/Notifications/Push/Sources/AWSPinpointPushNotificationsPlugin/AWSPinpointPushNotificationsPlugin+ClientBehaviour.swift
+++ b/AmplifyPlugins/Notifications/Push/Sources/AWSPinpointPushNotificationsPlugin/AWSPinpointPushNotificationsPlugin+ClientBehaviour.swift
@@ -6,6 +6,7 @@
 //
 
 import Amplify
+import AWSPinpoint
 import Foundation
 @_spi(InternalAWSPinpoint) import InternalAWSPinpoint
 import UserNotifications
@@ -58,6 +59,13 @@ extension AWSPinpointPushNotificationsPlugin {
         )
     }
 #endif
+
+    /// Retrieves the escape hatch to perform actions directly on PinpointClient.
+    ///
+    /// - Returns: PinpointClientProtocol instance
+    public func getEscapeHatch() -> PinpointClientProtocol {
+        pinpoint.pinpointClient
+    }
 
     private func recordNotification(_ userInfo: [String: Any],
                                     applicationState: ApplicationState,

--- a/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginClientBehaviourTests.swift
+++ b/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginClientBehaviourTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Amplify
+import AWSPinpoint
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 @testable import AWSPinpointPushNotificationsPlugin
 import UserNotifications
@@ -205,6 +206,19 @@ class AWSPinpointPushNotificationsPluginClientBehaviourTests: AWSPinpointPushNot
         XCTAssertEqual(mockPinpoint.recordCount, 0)
     }
 #endif
+    
+    // - MARK: Escape Hatch tests
+    /// Given: A configured AWSPinpointPushNotificationsPlugin instance
+    /// When: The getEscapeHatch API is invoked
+    /// Then: The underlying PinpointClientProtocol instance is retrieved
+    func testGetEscapeHatch_shouldReturnPinpointClient() {
+        guard let escapeHatch = plugin.getEscapeHatch() as? PinpointClient else {
+            XCTFail("Unable to retrieve PinpointClient")
+            return
+        }
+        
+        XCTAssertTrue(escapeHatch === (mockPinpoint.pinpointClient as? PinpointClient))
+    }
     
     private func createUserInfo(for source: PushNotification.Source) -> Notifications.Push.UserInfo {
         return [


### PR DESCRIPTION
## Issue \#
- https://github.com/aws-amplify/amplify-swift/issues/3181
## Description

This PR adds the missing `getEscapeHatch()` API to the `AWSPinpointPushNotificationsPlugin`

## General Checklist
<!-- Check or cross out if not relevant -->

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
