### PR TITLE
fix(datastore): use unwrapped storageEngine to perform datastore operations

### DIFF
--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,42 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "amplify-swift-utils-notifications",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/aws-amplify/amplify-swift-utils-notifications.git",
-      "state" : {
-        "revision" : "f970384ad1035732f99259255cd2f97564807e41",
-        "version" : "1.1.0"
-      }
-    },
-    {
-      "identity" : "aws-appsync-realtime-client-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
-      "state" : {
-        "revision" : "b036e83716789c13a3480eeb292b70caa54114f2",
-        "version" : "3.1.0"
-      }
-    },
-    {
-      "identity" : "aws-crt-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/awslabs/aws-crt-swift",
-      "state" : {
-        "revision" : "6feec6c3787877807aa9a00fad09591b96752376",
-        "version" : "0.6.1"
-      }
-    },
-    {
-      "identity" : "aws-sdk-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/awslabs/aws-sdk-swift.git",
-      "state" : {
-        "revision" : "24bae88a2391fe75da8a940a544d1ef6441f5321",
-        "version" : "0.13.0"
-      }
-    },
-    {
       "identity" : "cwlcatchexception",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlCatchException.git",
@@ -52,60 +16,6 @@
       "state" : {
         "revision" : "a23ded2c91df9156628a6996ab4f347526f17b6b",
         "version" : "2.1.2"
-      }
-    },
-    {
-      "identity" : "smithy-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/awslabs/smithy-swift",
-      "state" : {
-        "revision" : "7b28da158d92cd06a3549140d43b8fbcf64a94a6",
-        "version" : "0.15.0"
-      }
-    },
-    {
-      "identity" : "sqlite.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stephencelis/SQLite.swift.git",
-      "state" : {
-        "revision" : "5f5ad81ac0d0a0f3e56e39e646e8423c617df523",
-        "version" : "0.13.2"
-      }
-    },
-    {
-      "identity" : "starscream",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/daltoniam/Starscream",
-      "state" : {
-        "revision" : "df8d82047f6654d8e4b655d1b1525c64e1059d21",
-        "version" : "4.0.4"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections",
-      "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
-      }
-    },
-    {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
-      "state" : {
-        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
-        "version" : "1.5.2"
-      }
-    },
-    {
-      "identity" : "xmlcoder",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MaxDesiatov/XMLCoder.git",
-      "state" : {
-        "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
-        "version" : "0.17.1"
       }
     }
   ],

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
@@ -29,7 +29,7 @@ extension AWSDataStorePlugin: DataStoreSubscribeBehavior {
     public func observeQuery<M: Model>(for modelType: M.Type,
                                        where predicate: QueryPredicate?,
                                        sort sortInput: QuerySortInput?) -> AmplifyAsyncThrowingSequence<DataStoreQuerySnapshot<M>> {
-        switch initStorageEngineAndStartSync() {
+        switch initStorageEngineAndTryStartSync() {
         case .success(let storageEngineBehavior):
             let modelSchema = modelType.schema
             guard let dataStorePublisher = dataStorePublisher else {

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin.swift
@@ -145,23 +145,20 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
     }
 
     /// Initializes the underlying storage engine and starts the syncing process
-    /// - Parameter completion: completion handler called with a success if the sync process started
-    ///                         or with a DataStoreError in case of failure
-    func initStorageEngineAndStartSync(completion: @escaping DataStoreCallback<Void> = { _ in }) {
+    /// - Return:
+    func initStorageEngineAndStartSync() -> Result<StorageEngineBehavior, DataStoreError> {
         storageEngineInitQueue.sync {
-            completion(
-                initStorageEngine().flatMap { $0.startSync() }.flatMap { result in
-                    switch result {
-                    case .alreadyInitialized:
-                        return .successfulVoid
-                    case .successfullyInitialized:
-                        self.dataStoreStateSubject.send(.start(storageEngine: self.storageEngine))
-                        return .successfulVoid
-                    case .failure(let error):
-                        return .failure(error)
-                    }
+            initStorageEngine().flatMap { $0.startSync() }.flatMap { result in
+                switch result {
+                case .alreadyInitialized:
+                    return .success(storageEngine)
+                case .successfullyInitialized:
+                    self.dataStoreStateSubject.send(.start(storageEngine: self.storageEngine))
+                    return .success(storageEngine)
+                case .failure(let error):
+                    return .failure(error)
                 }
-            )
+            }
         }
     }
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/3198
## Description
<!-- Why is this change required? What problem does it solve? -->

Made datastore local operations (`save`, `query`, `delete`) using the instance of initStorageEngine result.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
