### PR TITLE
test(storage): update storage integration test with longer expiration duration

### DIFF
--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginOptionsUsabilityTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginOptionsUsabilityTests.swift
@@ -24,7 +24,7 @@ class AWSS3StoragePluginOptionsUsabilityTests: AWSS3StoragePluginTestBase {
         await uploadData(key: key, dataString: key)
 
     #if os(iOS)
-        let expires = 10
+        let expires = 20
     #else
         let expires = 1
     #endif
@@ -69,7 +69,7 @@ class AWSS3StoragePluginOptionsUsabilityTests: AWSS3StoragePluginTestBase {
         task.resume()
         await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
 
-        try await Task.sleep(seconds: 15)
+        try await Task.sleep(seconds: 30)
     #else
         try await Task.sleep(seconds: 2)
     #endif


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
Fix flakey storage integration test in GH actions by increasing url expiration duration

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
