### PR TITLE
fix(logging): fix issue with logger namespace not being set

### DIFF
--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingCategoryClient.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingCategoryClient.swift
@@ -105,6 +105,14 @@ final class AWSCloudWatchLoggingCategoryClient {
             loggersByKey = [:]
         }
     }
+    
+    func getLoggerSessionController(forCategory category: String,  logLevel: LogLevel) -> AWSCloudWatchLoggingSessionController? {
+        let key = LoggerKey(category: category, logLevel: logLevel)
+        if let existing = loggersByKey[key] {
+            return existing
+        }
+        return nil
+    }
 }
 
 extension AWSCloudWatchLoggingCategoryClient: LoggingCategoryClientBehavior {

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingPlugin.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingPlugin.swift
@@ -72,7 +72,7 @@ public class AWSCloudWatchLoggingPlugin: LoggingCategoryPlugin {
     }
     
     public func logger(forCategory category: String, forNamespace namespace: String) -> Logger {
-        return loggingClient.logger(forCategory: category)
+        return loggingClient.logger(forCategory: category, forNamespace: namespace)
     }
     
     /// enable plugin

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
@@ -20,13 +20,13 @@ import Network
 final class AWSCloudWatchLoggingSessionController {
     
     var client: CloudWatchLogsClientProtocol?
+    let namespace: String?
     private let logGroupName: String
     private let region: String
     private let localStoreMaxSizeInMB: Int
     private let credentialsProvider: CredentialsProvider
     private let authentication: AuthCategoryUserBehavior
     private let category: String
-    private let namespace: String?
     private var session: AWSCloudWatchLoggingSession?
     private var consumer: LogBatchConsumer?
     private let logFilter: AWSCloudWatchLoggingFilterBehavior

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingPluginTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingPluginTests.swift
@@ -43,6 +43,21 @@ final class AWSCloudWatchLoggingPluginTests: XCTestCase {
 
         let defaultLogger = plugin.logger(forNamespace: "test")
         XCTAssertEqual(defaultLogger.logLevel.rawValue, 0)
-
+    }
+    
+    /// Given: a AWSCloudWatchLoggingPlugin
+    /// When: a logger is requested with a namespace
+    /// Then: the namespace is set in the logger session controller
+    func testPluginLoggerNamespace() throws {
+        let configuration = AWSCloudWatchLoggingPluginConfiguration(logGroupName: "testLogGroup", region: "us-east-1")
+        let plugin = AWSCloudWatchLoggingPlugin(loggingPluginConfiguration: configuration)
+        _ = plugin.logger(forCategory: "Test")
+        var sessionController = plugin.loggingClient.getLoggerSessionController(forCategory: "Test", logLevel: .error)
+        XCTAssertEqual(sessionController?.namespace, nil)
+        
+        _ = plugin.logger(forCategory: "Test2", forNamespace: "test2")
+        sessionController = plugin.loggingClient.getLoggerSessionController(forCategory: "Test2", logLevel: .error)
+        XCTAssertEqual(sessionController?.namespace, "test2")
+        
     }
 }

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingPluginTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingPluginTests.swift
@@ -51,13 +51,13 @@ final class AWSCloudWatchLoggingPluginTests: XCTestCase {
     func testPluginLoggerNamespace() throws {
         let configuration = AWSCloudWatchLoggingPluginConfiguration(logGroupName: "testLogGroup", region: "us-east-1")
         let plugin = AWSCloudWatchLoggingPlugin(loggingPluginConfiguration: configuration)
-        _ = plugin.logger(forCategory: "Test")
-        var sessionController = plugin.loggingClient.getLoggerSessionController(forCategory: "Test", logLevel: .error)
+        _ = plugin.logger(forCategory: "Category1")
+        var sessionController = plugin.loggingClient.getLoggerSessionController(forCategory: "Category1", logLevel: .error)
         XCTAssertEqual(sessionController?.namespace, nil)
         
-        _ = plugin.logger(forCategory: "Test2", forNamespace: "test2")
-        sessionController = plugin.loggingClient.getLoggerSessionController(forCategory: "Test2", logLevel: .error)
-        XCTAssertEqual(sessionController?.namespace, "test2")
+        _ = plugin.logger(forCategory: "Category2", forNamespace: "testNamespace")
+        sessionController = plugin.loggingClient.getLoggerSessionController(forCategory: "Category2", logLevel: .error)
+        XCTAssertEqual(sessionController?.namespace, "testNamespace")
         
     }
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
* Fix issue where creating a logger with a category and namespace doesn't set the namespace value

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
