### PR TITLE
fix(datastore): observequery local only collect

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine+SyncRequirement.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine+SyncRequirement.swift
@@ -74,6 +74,12 @@ extension StorageEngine {
         }
     }
 
+    /// Expresses whether the `StorageEngine` syncs from a remote source
+    /// based on whether the `AWSAPIPlugin` is present.
+    var syncsFromRemote: Bool {
+        tryGetAPIPlugin() != nil
+    }
+
     private func tryGetAPIPlugin() -> APICategoryPlugin? {
         do {
             return try Amplify.API.getPlugin(for: validAPIPluginKey)

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngineBehavior.swift
@@ -31,4 +31,7 @@ protocol StorageEngineBehavior: AnyObject, ModelStorageBehavior {
     func startSync() -> Result<SyncEngineInitResult, DataStoreError>
     func stopSync(completion: @escaping DataStoreCallback<Void>)
     func clear(completion: @escaping DataStoreCallback<Void>)
+
+    /// expresses whether the conforming type is syncing from a remote source.
+    var syncsFromRemote: Bool { get }
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStoreObserveQueryOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStoreObserveQueryOperation.swift
@@ -239,7 +239,7 @@ class ObserveQueryTaskRunner<M: Model>: InternalTaskRunner, InternalTaskAsyncThr
                     .byTimeOrCount(
                         self.serialQueue,
                         self.itemsChangedPeriodicPublishTimeInSeconds,
-                        shouldBatchDuringSync ? self.itemsChangedMaxSize : 1
+                        self.shouldBatchDuringSync ? self.itemsChangedMaxSize : 1
                     )
                 )
                 .sink(receiveCompletion: self.onReceiveCompletion(completed:),

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -301,6 +301,8 @@ class MockStorageEngineBehavior: StorageEngineBehavior {
 
     }
 
+    var syncsFromRemote: Bool { true }
+
     var mockSyncEnginePublisher: PassthroughSubject<RemoteSyncEngineEvent, DataStoreError>!
     var mockSyncEngineSubscription: AnyCancellable! {
         willSet {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
- https://github.com/aws-amplify/amplify-swift/issues/3100

## Description
<!-- Why is this change required? What problem does it solve? -->
`DataStore.observeQuery(...)` has some internal logic to batch snapshots received based on total count or time elapsed while syncing. This logic is applied when `DataStore` thinks it is hasn't yet completed syncing. 

When `DataStore` is in local only mode (i.e. when `AWSAPIPlugin` isn't being used), it is never "completed syncing", leading to the same throttling logic.

This change ensures that the throttling / collect logic is **not** applied when `DataStore` is in local only mode.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
