### PR TITLE
fix(datastore): using URLProtocol monitor auth request headers

### DIFF
--- a/.github/workflows/integ_test_datastore_auth_iam.yml
+++ b/.github/workflows/integ_test_datastore_auth_iam.yml
@@ -5,12 +5,12 @@ on:
 
 permissions:
     id-token: write
-    contents: read 
+    contents: read
 
 jobs:
   datastore-integration-auth-iam-test-iOS:
     timeout-minutes: 30
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -33,6 +33,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginAuthIAMTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-iam-test-tvOS:
     timeout-minutes: 30

--- a/.github/workflows/integ_test_datastore_multi_auth.yml
+++ b/.github/workflows/integ_test_datastore_multi_auth.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   datastore-integration-multi-auth-test-iOS:
     timeout-minutes: 30
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -33,6 +33,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginMultiAuthTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-multi-auth-test-tvOS:
     timeout-minutes: 30

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthIAMTests/AWSDataStoreCategoryPluginIAMAuthIntegrationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthIAMTests/AWSDataStoreCategoryPluginIAMAuthIntegrationTests.swift
@@ -16,7 +16,7 @@ class AWSDataStoreCategoryPluginIAMAuthIntegrationTests: AWSDataStoreAuthBaseTes
     /// Then: DataStore is successfully initialized, query returns a result,
     ///      mutation is processed for authenticated users
     func testIAMAllowPrivate() async {
-        let testId = UUID().uuidString;
+        let testId = UUID().uuidString
         await setup(withModels: IAMPrivateModelRegistration(),
                     testType: .defaultAuthIAM,
                     testId: testId)
@@ -50,7 +50,7 @@ class AWSDataStoreCategoryPluginIAMAuthIntegrationTests: AWSDataStoreAuthBaseTes
     /// Then: DataStore is successfully initialized, query returns a result,
     ///      mutation is processed for unauthenticated users
     func testIAMAllowPublic() async {
-        let testId = UUID().uuidString;
+        let testId = UUID().uuidString
         await setup(withModels: IAMPublicModelRegistration(),
                     testType: .defaultAuthIAM,
                     testId: testId)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthIAMTests/AWSDataStoreCategoryPluginIAMAuthIntegrationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthIAMTests/AWSDataStoreCategoryPluginIAMAuthIntegrationTests.swift
@@ -16,14 +16,18 @@ class AWSDataStoreCategoryPluginIAMAuthIntegrationTests: AWSDataStoreAuthBaseTes
     /// Then: DataStore is successfully initialized, query returns a result,
     ///      mutation is processed for authenticated users
     func testIAMAllowPrivate() async {
+        let testId = UUID().uuidString;
         await setup(withModels: IAMPrivateModelRegistration(),
-              testType: .defaultAuthIAM)
+                    testType: .defaultAuthIAM,
+                    testId: testId)
 
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpectation = assertUsedAuthTypes(testId: testId, authTypes: [.awsIAM])
 
         // Query
         await assertQuerySuccess(modelType: TodoIAMPrivate.self,
@@ -38,20 +42,24 @@ class AWSDataStoreCategoryPluginIAMAuthIntegrationTests: AWSDataStoreAuthBaseTes
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.awsIAM])
+        await fulfillment(of: [authTypeExpectation], timeout: 5)
     }
 
     /// Given: a guest user,  a model with `allow public` auth rule with IAM as provider
     /// When: DataStore query/mutation operations are sent with IAM
     /// Then: DataStore is successfully initialized, query returns a result,
     ///      mutation is processed for unauthenticated users
-    func testIAMAllowPublic() async{
+    func testIAMAllowPublic() async {
+        let testId = UUID().uuidString;
         await setup(withModels: IAMPublicModelRegistration(),
-              testType: .defaultAuthIAM)
+                    testType: .defaultAuthIAM,
+                    testId: testId)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpectation = assertUsedAuthTypes(testId: testId, authTypes: [.awsIAM])
 
         // Query
         await assertQuerySuccess(modelType: TodoIAMPublic.self,
@@ -66,7 +74,7 @@ class AWSDataStoreCategoryPluginIAMAuthIntegrationTests: AWSDataStoreAuthBaseTes
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.awsIAM])
+        await fulfillment(of: [authTypeExpectation], timeout: 5)
     }
 }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreAuthBaseTest.swift
@@ -10,7 +10,7 @@ import XCTest
 import Combine
 import AWSDataStorePlugin
 import AWSPluginsCore
-import AWSAPIPlugin
+@testable import AWSAPIPlugin
 import AWSCognitoAuthPlugin
 
 #if !os(watchOS)
@@ -23,47 +23,81 @@ struct TestUser {
     let password: String
 }
 
-class AuthRecorderInterceptor: URLRequestInterceptor {
-    let awsAuthService: AWSAuthService = AWSAuthService()
-    var consumedAuthTypes: Set<AWSAuthorizationType> = []
-    private let accessQueue = DispatchQueue(label: "com.amazon.AuthRecorderInterceptor.consumedAuthTypes")
 
-    private func recordAuthType(_ authType: AWSAuthorizationType) {
-        accessQueue.async {
-            self.consumedAuthTypes.insert(authType)
+class DataStoreAuthBaseTestURLSessionFactory: URLSessionBehaviorFactory {
+    static let testIdHeaderKey = "x-amplify-test"
+
+    static let subject = PassthroughSubject<(String, Set<AWSAuthorizationType>), Never>()
+
+    class Sniffer: URLProtocol {
+
+        override class func canInit(with request: URLRequest) -> Bool {
+            guard let headers = request.allHTTPHeaderFields else {
+                fatalError("No headers found in request \(request)")
+            }
+
+            guard let testId = headers[DataStoreAuthBaseTestURLSessionFactory.testIdHeaderKey] else {
+                return false
+            }
+
+            var result: Set<AWSAuthorizationType> = []
+            let authHeaderValue = headers["Authorization"]
+            let apiKeyHeaderValue = headers["x-api-key"]
+
+            if apiKeyHeaderValue != nil {
+                result.insert(.apiKey)
+            }
+
+            if let authHeaderValue = authHeaderValue,
+               case let .success(claims) = AWSAuthService().getTokenClaims(tokenString: authHeaderValue),
+               let cognitoIss = claims["iss"] as? String, cognitoIss.contains("cognito") {
+                result.insert(.amazonCognitoUserPools)
+            }
+
+            if let authHeaderValue = authHeaderValue,
+               authHeaderValue.starts(with: "AWS4-HMAC-SHA256") {
+                result.insert(.awsIAM)
+            }
+
+            DataStoreAuthBaseTestURLSessionFactory.subject.send((testId, result))
+            return false
+        }
+
+    }
+
+    class Interceptor: URLRequestInterceptor {
+        let testId: String?
+
+        init(testId: String?) {
+            self.testId = testId
+        }
+
+        func intercept(_ request: URLRequest) async throws -> URLRequest {
+            if let testId {
+                var mutableRequest = request
+                mutableRequest.setValue(testId, forHTTPHeaderField: DataStoreAuthBaseTestURLSessionFactory.testIdHeaderKey)
+                return mutableRequest
+            }
+            return request
         }
     }
 
-    func intercept(_ request: URLRequest) throws -> URLRequest {
-        guard let headers = request.allHTTPHeaderFields else {
-            fatalError("No headers found in request \(request)")
-        }
+    func makeSession(withDelegate delegate: URLSessionBehaviorDelegate?) -> URLSessionBehavior {
+        let urlSessionDelegate = delegate?.asURLSessionDelegate
+        let configuration = URLSessionConfiguration.default
+        configuration.tlsMinimumSupportedProtocolVersion = .TLSv12
+        configuration.tlsMaximumSupportedProtocolVersion = .TLSv13
+        configuration.protocolClasses?.insert(Sniffer.self, at: 0)
 
-        let authHeaderValue = headers["Authorization"]
-        let apiKeyHeaderValue = headers["x-api-key"]
-
-        if apiKeyHeaderValue != nil {
-            recordAuthType(.apiKey)
-        }
-
-        if let authHeaderValue = authHeaderValue,
-           case let .success(claims) = awsAuthService.getTokenClaims(tokenString: authHeaderValue),
-           let cognitoIss = claims["iss"] as? String, cognitoIss.contains("cognito") {
-            recordAuthType(.amazonCognitoUserPools)
-        }
-
-        if let authHeaderValue = authHeaderValue,
-           authHeaderValue.starts(with: "AWS4-HMAC-SHA256") {
-            recordAuthType(.awsIAM)
-        }
-
-        return request
+        let session = URLSession(configuration: configuration,
+                                 delegate: urlSessionDelegate,
+                                 delegateQueue: nil)
+        return AmplifyURLSession(session: session)
     }
 
-    func reset() {
-        consumedAuthTypes = []
-    }
+
 }
+
 
 class AWSDataStoreAuthBaseTest: XCTestCase {
     var requests: Set<AnyCancellable> = []
@@ -71,7 +105,6 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
     var amplifyConfig: AmplifyConfiguration!
     var user1: TestUser?
     var user2: TestUser?
-    var authRecorderInterceptor: AuthRecorderInterceptor!
 
     override func setUp() {
         continueAfterFailure = false
@@ -138,8 +171,6 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
             self.user1 = TestUser(username: user1, password: passwordUser1)
             self.user2 = TestUser(username: user2, password: passwordUser2)
 
-            authRecorderInterceptor = AuthRecorderInterceptor()
-
             amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: configFile)
 
         } catch {
@@ -161,7 +192,8 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
     func setup(
         withModels models: AmplifyModelRegistration,
         testType: DataStoreAuthTestType,
-        apiPluginFactory: () -> AWSAPIPlugin = { AWSAPIPlugin(sessionFactory: AmplifyURLSessionFactory()) }
+        testId: String? = nil,
+        apiPluginFactory: () -> AWSAPIPlugin = { AWSAPIPlugin(sessionFactory: DataStoreAuthBaseTestURLSessionFactory()) }
     ) async {
         do {
             setupCredentials(forAuthStrategy: testType)
@@ -182,7 +214,10 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
 
             // register auth recorder interceptor
             let apiName = try apiEndpointName()
-            try apiPlugin.add(interceptor: authRecorderInterceptor, for: apiName)
+            try apiPlugin.add(
+                interceptor: DataStoreAuthBaseTestURLSessionFactory.Interceptor(testId: testId),
+                for: apiName
+            )
 
             await signOut()
         } catch {
@@ -487,13 +522,27 @@ extension AWSDataStoreAuthBaseTest {
         await waitForExpectations([expectations.mutationDelete, expectations.mutationDeleteProcessed], timeout: 60)
     }
     
-    func assertUsedAuthTypes(_ authTypes: [AWSAuthorizationType],
-                             file: StaticString = #file,
-                             line: UInt = #line) {
-        XCTAssertEqual(authRecorderInterceptor.consumedAuthTypes,
-                       Set(authTypes),
-                       file: file,
-                       line: line)
+    func assertUsedAuthTypes(
+        testId: String,
+        authTypes: [AWSAuthorizationType],
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> XCTestExpectation {
+        let expectation = expectation(description: "Should have expected auth types")
+        expectation.assertForOverFulfill = false
+        DataStoreAuthBaseTestURLSessionFactory.subject
+        .filter { $0.0 == testId }
+        .map { $0.1 }
+        .collect(.byTime(DispatchQueue.global(), .milliseconds(3500)))
+        .sink {
+            let result = $0.reduce(Set<AWSAuthorizationType>()) { partialResult, data in
+                partialResult.union(data)
+            }
+            XCTAssertEqual(result, Set(authTypes), file: file, line: line)
+            expectation.fulfill()
+        }
+        .store(in: &requests)
+        return expectation
     }
 }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthSingleRuleTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthSingleRuleTests.swift
@@ -17,13 +17,16 @@ class AWSDataStoreMultiAuthSingleRuleTests: AWSDataStoreAuthBaseTest {
     /// Then: DataStore is successfully initialized, query returns a result,
     ///      mutation is processed for an authenticated users
     func testOwnerUserPools() async {
-        await setup(withModels: UserPoolsOwnerModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: UserPoolsOwnerModels(), testType: .multiAuth, testId: testId)
 
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
 
         // Query
         await assertQuerySuccess(modelType: OwnerUPPost.self,
@@ -36,7 +39,7 @@ class AWSDataStoreMultiAuthSingleRuleTests: AWSDataStoreAuthBaseTest {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     /// Given: a user signed in with OIDC
@@ -53,13 +56,16 @@ class AWSDataStoreMultiAuthSingleRuleTests: AWSDataStoreAuthBaseTest {
     /// Then: DataStore is successfully initialized, query returns a result,
     ///      mutation is processed for an authenticated users
     func testGroupUserPools() async {
-        await setup(withModels: UserPoolsGroupModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: UserPoolsGroupModels(), testType: .multiAuth, testId: testId)
 
         // user1 is part of the "Admins" group
         await signIn(user: user1)
 
         let expectations = makeExpectations()
         await assertDataStoreReady(expectations)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
 
         // Query
         await assertQuerySuccess(modelType: GroupUPPost.self,
@@ -73,14 +79,17 @@ class AWSDataStoreMultiAuthSingleRuleTests: AWSDataStoreAuthBaseTest {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     /// Given: a user who doesn't belong to "Admins" groups signed in with CognitoUserPools
     /// When: DataStore.start is called
     /// Then: DataStore is successfully initialized
     func testGroupUserPoolsWithNonAdminsUser() async {
-        await setup(withModels: UserPoolsGroupModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: UserPoolsGroupModels(), testType: .multiAuth, testId: testId)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
 
         // user2 is not part of the "Admins" group
         await signIn(user: user2)
@@ -99,14 +108,14 @@ class AWSDataStoreMultiAuthSingleRuleTests: AWSDataStoreAuthBaseTest {
         await expectations.modelsSynced.fulfill()
         await assertDataStoreReady(expectations, expectedModelSynced: 0)
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
-
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
         await waitForExpectations([
                 expectations.query,
                 expectations.mutationSave,
                 expectations.mutationSaveProcessed,
                 expectations.mutationDelete,
                 expectations.mutationDeleteProcessed], timeout: TestCommonConstants.networkTimeout)
+
     }
 
     func testGroupOIDC() throws {
@@ -119,13 +128,16 @@ class AWSDataStoreMultiAuthSingleRuleTests: AWSDataStoreAuthBaseTest {
     /// Then: DataStore is successfully initialized, query returns a result,
     ///      mutation is processed for authenticated users
     func testPrivateUserPools() async {
-        await setup(withModels: UserPoolsPrivateModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: UserPoolsPrivateModels(), testType: .multiAuth, testId: testId)
 
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
 
         await assertQuerySuccess(modelType: PrivateUPPost.self,
                            expectations) { error in
@@ -138,7 +150,7 @@ class AWSDataStoreMultiAuthSingleRuleTests: AWSDataStoreAuthBaseTest {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     /// Given: a user signed in with IAM
@@ -146,13 +158,16 @@ class AWSDataStoreMultiAuthSingleRuleTests: AWSDataStoreAuthBaseTest {
     /// Then: DataStore is successfully initialized, query returns a result,
     ///      mutation is processed for authenticated users
     func testPrivateIAM() async {
-        await setup(withModels: IAMPrivateModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: IAMPrivateModels(), testType: .multiAuth, testId: testId)
 
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.awsIAM])
 
         await assertQuerySuccess(modelType: PrivateIAMPost.self,
                            expectations, onFailure: { error in
@@ -165,7 +180,7 @@ class AWSDataStoreMultiAuthSingleRuleTests: AWSDataStoreAuthBaseTest {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.awsIAM])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     /// Given: a schema with a single IAM rule
@@ -173,11 +188,14 @@ class AWSDataStoreMultiAuthSingleRuleTests: AWSDataStoreAuthBaseTest {
     /// Then: DataStore is successfully initialized, query returns a result,
     ///      mutation is processed for all users
     func testPublicIAM() async {
-        await setup(withModels: IAMPublicModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: IAMPublicModels(), testType: .multiAuth, testId: testId)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.awsIAM])
 
         // Query
         await assertQuerySuccess(modelType: PublicIAMPost.self,
@@ -191,19 +209,22 @@ class AWSDataStoreMultiAuthSingleRuleTests: AWSDataStoreAuthBaseTest {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.awsIAM])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     /// Given: a schema with a single API key rule
     /// When: DataStore query/mutation operations are sent with API key for all users
     /// Then: DataStore is successfully initialized, query returns a result,
     ///      mutation is processed
-    func testPublicAPIKey() async{
-        await setup(withModels: APIKeyPublicModels(), testType: .multiAuth)
+    func testPublicAPIKey() async {
+        let testId = UUID().uuidString
+        await setup(withModels: APIKeyPublicModels(), testType: .multiAuth, testId: testId)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.apiKey])
 
         // Query
         await assertQuerySuccess(modelType: PublicAPIPost.self,
@@ -217,7 +238,7 @@ class AWSDataStoreMultiAuthSingleRuleTests: AWSDataStoreAuthBaseTest {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.apiKey])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthThreeRulesTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthThreeRulesTests.swift
@@ -23,13 +23,17 @@ class AWSDataStoreMultiAuthThreeRulesTests: AWSDataStoreAuthBaseTest {
     /// Note: IAM auth would likely not be used on the client, since it is unlikely that the request would
     /// fail with User Pool auth but succeed with IAM auth for an authenticated user.
     func testOwnerPrivatePublicUserPoolsIAMAPIKeyAuthenticatedUsers() async {
+        let testId = UUID().uuidString
         await setup(withModels: OwnerPrivatePublicUserPoolsAPIKeyModels(),
-              testType: .multiAuth)
+                    testType: .multiAuth,
+                    testId: testId)
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
 
         // Query
         await assertQuerySuccess(modelType: OwnerPrivatePublicUPIAMAPIPost.self,
@@ -44,7 +48,7 @@ class AWSDataStoreMultiAuthThreeRulesTests: AWSDataStoreAuthBaseTest {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     /// Given: an unauthenticated user
@@ -52,12 +56,16 @@ class AWSDataStoreMultiAuthThreeRulesTests: AWSDataStoreAuthBaseTest {
     /// Then:
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent with API Key
     func testOwnerPrivatePublicUserPoolsIAMAPIKeyUnauthenticatedUsers() async {
+        let testId = UUID().uuidString
         await setup(withModels: OwnerPrivatePublicUserPoolsAPIKeyModels(),
-              testType: .multiAuth)
+                    testType: .multiAuth,
+                    testId: testId)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.apiKey])
 
         // Query
         await assertQuerySuccess(modelType: OwnerPrivatePublicUPIAMAPIPost.self,
@@ -72,7 +80,7 @@ class AWSDataStoreMultiAuthThreeRulesTests: AWSDataStoreAuthBaseTest {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.apiKey])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 }
 
@@ -85,13 +93,17 @@ extension AWSDataStoreMultiAuthThreeRulesTests {
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent
     ///   with Cognito auth for authenticated users
     func testGroupPrivatePublicUserPoolsIAMAPIKeyAuthenticatedUsers() async {
+        let testId = UUID().uuidString
         await setup(withModels: GroupPrivatePublicUserPoolsAPIKeyModels(),
-              testType: .multiAuth)
+                    testType: .multiAuth,
+                    testId: testId)
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
 
         // Query
         await assertQuerySuccess(modelType: GroupPrivatePublicUPIAMAPIPost.self,
@@ -106,7 +118,7 @@ extension AWSDataStoreMultiAuthThreeRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     /// Given: an unauthenticated user
@@ -114,12 +126,16 @@ extension AWSDataStoreMultiAuthThreeRulesTests {
     /// Then:
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent with API Key
     func testGroupPrivatePublicUserPoolsIAMAPIKeyUnauthenticatedUsers() async {
+        let testId = UUID().uuidString
         await setup(withModels: GroupPrivatePublicUserPoolsAPIKeyModels(),
-              testType: .multiAuth)
+                    testType: .multiAuth,
+                    testId: testId)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.apiKey])
 
         // Query
         await assertQuerySuccess(modelType: GroupPrivatePublicUPIAMAPIPost.self,
@@ -133,7 +149,7 @@ extension AWSDataStoreMultiAuthThreeRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.apiKey])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 }
 
@@ -145,13 +161,17 @@ extension AWSDataStoreMultiAuthThreeRulesTests {
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent
     ///   with Cognito
     func testPrivatePrivatePublicUserPoolsIAMIAMAuthenticatedUsers() async {
+        let testId = UUID().uuidString
         await setup(withModels: PrivatePrivatePublicUserPoolsIAMIAM(),
-              testType: .multiAuth)
+                    testType: .multiAuth,
+                    testId: testId)
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
 
         // Query
         await assertQuerySuccess(modelType: PrivatePrivatePublicUPIAMIAMPost.self,
@@ -165,7 +185,7 @@ extension AWSDataStoreMultiAuthThreeRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     /// Given: an unauthenticated user
@@ -173,12 +193,16 @@ extension AWSDataStoreMultiAuthThreeRulesTests {
     /// Then:
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent with IAM
     func testPrivatePrivatePublicUserPoolsIAMIAMUnauthenticatedUsers() async {
+        let testId = UUID().uuidString
         await setup(withModels: PrivatePrivatePublicUserPoolsIAMIAM(),
-              testType: .multiAuth)
+                    testType: .multiAuth,
+                    testId: testId)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.awsIAM])
 
         // Query
         await assertQuerySuccess(modelType: PrivatePrivatePublicUPIAMIAMPost.self,
@@ -193,7 +217,7 @@ extension AWSDataStoreMultiAuthThreeRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.awsIAM])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 }
 
@@ -205,13 +229,17 @@ extension AWSDataStoreMultiAuthThreeRulesTests {
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent
     ///   with Cognito
     func testPrivatePrivatePublicUserPoolsIAMApiKeyAuthenticatedUsers() async {
+        let testId = UUID().uuidString
         await setup(withModels: PrivatePrivatePublicUserPoolsIAMAPiKey(),
-              testType: .multiAuth)
+                    testType: .multiAuth,
+                    testId: testId)
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
 
         // Query
         await assertQuerySuccess(modelType: PrivatePrivatePublicUPIAMAPIPost.self,
@@ -226,7 +254,7 @@ extension AWSDataStoreMultiAuthThreeRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     /// Given: an unauthenticated user
@@ -236,12 +264,16 @@ extension AWSDataStoreMultiAuthThreeRulesTests {
     /// Note: IAM auth would likely not be used on the client, since it is unlikely that the request would fail with
     ///     User Pool auth but succeed with IAM auth for an authenticated user.
     func testPrivatePrivatePublicUserPoolsIAMApiKeyUnauthenticatedUsers() async {
+        let testId = UUID().uuidString
         await setup(withModels: PrivatePrivatePublicUserPoolsIAMAPiKey(),
-              testType: .multiAuth)
+                    testType: .multiAuth,
+                    testId: testId)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.apiKey])
 
         // Query
         await assertQuerySuccess(modelType: PrivatePrivatePublicUPIAMAPIPost.self,
@@ -256,7 +288,7 @@ extension AWSDataStoreMultiAuthThreeRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.apiKey])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 }
 
@@ -268,13 +300,17 @@ extension AWSDataStoreMultiAuthThreeRulesTests {
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent
     ///   with Cognito
     func testPrivatePublicPublicUserPoolsAPIKeyIAMAuthenticatedUsers() async {
+        let testId = UUID().uuidString
         await setup(withModels: PrivatePublicPublicUserPoolsAPIKeyIAM(),
-              testType: .multiAuth)
+                    testType: .multiAuth,
+                    testId: testId)
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
 
         // Query
         await assertQuerySuccess(modelType: PrivatePublicPublicUPAPIIAMPost.self,
@@ -289,7 +325,7 @@ extension AWSDataStoreMultiAuthThreeRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     /// Given: an unauthenticated user
@@ -299,12 +335,16 @@ extension AWSDataStoreMultiAuthThreeRulesTests {
     /// Note: API key auth would likely not be used on the client, since it is unlikely that the request would fail with
     ///     public IAM auth but succeed with API key auth.
     func testPrivatePublicPublicUserPoolsAPIKeyIAMUnauthenticatedUsers() async {
+        let testId = UUID().uuidString
         await setup(withModels: PrivatePublicPublicUserPoolsAPIKeyIAM(),
-              testType: .multiAuth)
+                    testType: .multiAuth,
+                    testId: testId)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.awsIAM])
 
         // Query
         await assertQuerySuccess(modelType: PrivatePublicPublicUPAPIIAMPost.self,
@@ -319,6 +359,6 @@ extension AWSDataStoreMultiAuthThreeRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.awsIAM])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthTwoRulesTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthTwoRulesTests.swift
@@ -20,7 +20,8 @@ class AWSDataStoreMultiAuthTwoRulesTests: AWSDataStoreAuthBaseTest {
     /// When: DataStore query/mutation operations
     /// Then: DataStore is successfully initialized, are sent with CognitoUserPools auth for authenticated users.
     func testOwnerPrivateUserPoolsIAM() async {
-        await setup(withModels: OwnerPrivateUserPoolsIAMModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: OwnerPrivateUserPoolsIAMModels(), testType: .multiAuth, testId: testId)
         await signIn(user: user1)
 
         let expectations = makeExpectations()
@@ -28,6 +29,7 @@ class AWSDataStoreMultiAuthTwoRulesTests: AWSDataStoreAuthBaseTest {
 
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
         await assertQuerySuccess(modelType: OwnerPrivateUPIAMPost.self,
                            expectations,
                            onFailure: { error in
@@ -40,7 +42,7 @@ class AWSDataStoreMultiAuthTwoRulesTests: AWSDataStoreAuthBaseTest {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     // MARK: - owner/public - User Pools & API Key
@@ -51,13 +53,15 @@ class AWSDataStoreMultiAuthTwoRulesTests: AWSDataStoreAuthBaseTest {
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent with Cognito
     ///   for authenticated users
     func testOwnerPublicUserPoolsAPIKeyAuthenticatedUsers() async {
-        await setup(withModels: OwnerPublicUserPoolsAPIModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: OwnerPublicUserPoolsAPIModels(), testType: .multiAuth, testId: testId)
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
         // Query
         await assertQuerySuccess(modelType: OwnerPublicUPAPIPost.self,
                            expectations,
@@ -71,7 +75,7 @@ class AWSDataStoreMultiAuthTwoRulesTests: AWSDataStoreAuthBaseTest {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     /// Given: an unauthenticated user
@@ -79,12 +83,14 @@ class AWSDataStoreMultiAuthTwoRulesTests: AWSDataStoreAuthBaseTest {
     /// Then:
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent with API key
     func testOwnerPublicUserPoolsAPIKeyUnauthenticatedUsers() async {
-        await setup(withModels: OwnerPublicUserPoolsAPIModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: OwnerPublicUserPoolsAPIModels(), testType: .multiAuth, testId: testId)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.apiKey])
         // Query
         await assertQuerySuccess(modelType: OwnerPublicUPAPIPost.self,
                            expectations,
@@ -98,7 +104,7 @@ class AWSDataStoreMultiAuthTwoRulesTests: AWSDataStoreAuthBaseTest {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.apiKey])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     // MARK: - owner/public - User Pools & IAM
@@ -109,13 +115,15 @@ class AWSDataStoreMultiAuthTwoRulesTests: AWSDataStoreAuthBaseTest {
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent
     ///   with Cognito auth for authenticated users
     func testOwnerPublicUserPoolsIAMAuthenticatedUsers() async {
-        await setup(withModels: OwnerPublicUserPoolsIAMModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: OwnerPublicUserPoolsIAMModels(), testType: .multiAuth, testId: testId)
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
         // Query
         await assertQuerySuccess(modelType: OwnerPublicUPIAMPost.self,
                            expectations,
@@ -128,7 +136,7 @@ class AWSDataStoreMultiAuthTwoRulesTests: AWSDataStoreAuthBaseTest {
                         expectations) { error in
             XCTFail("Error mutation \(error)")
         }
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     /// Given: an unauthenticated user
@@ -136,12 +144,14 @@ class AWSDataStoreMultiAuthTwoRulesTests: AWSDataStoreAuthBaseTest {
     /// Then:
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent with IAM
     func testOwnerPublicUserPoolsIAMUnauthenticatedUsers() async {
-        await setup(withModels: OwnerPublicUserPoolsIAMModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: OwnerPublicUserPoolsIAMModels(), testType: .multiAuth, testId: testId)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.awsIAM])
         // Query
         await assertQuerySuccess(modelType: OwnerPublicUPIAMPost.self,
                            expectations,
@@ -155,7 +165,7 @@ class AWSDataStoreMultiAuthTwoRulesTests: AWSDataStoreAuthBaseTest {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.awsIAM])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     // MARK: - owner/public - OIDC & API KEY
@@ -176,14 +186,24 @@ class AWSDataStoreMultiAuthTwoRulesTests: AWSDataStoreAuthBaseTest {
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent
     ///   with API key for unauthenticated users.
     func testOwnerPublicOIDCAPIUnauthenticatedUsers() async {
-        await setup(withModels: OwnerPublicOIDCAPIModels(),
-              testType: .multiAuth,
-              apiPluginFactory: { AWSAPIPlugin(apiAuthProviderFactory: TestAuthProviderFactory()) })
+        let testId = UUID().uuidString
+        await setup(
+            withModels: OwnerPublicOIDCAPIModels(),
+            testType: .multiAuth,
+            testId: testId,
+            apiPluginFactory: {
+                AWSAPIPlugin(
+                    sessionFactory: DataStoreAuthBaseTestURLSessionFactory(),
+                    apiAuthProviderFactory: TestAuthProviderFactory()
+                )
+            }
+        )
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.apiKey])
         // Query
         await assertQuerySuccess(modelType: OwnerPublicOIDAPIPost.self,
                            expectations,
@@ -197,7 +217,7 @@ class AWSDataStoreMultiAuthTwoRulesTests: AWSDataStoreAuthBaseTest {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.apiKey])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     // MARK: - group/private - UserPools & IAM
@@ -208,13 +228,15 @@ class AWSDataStoreMultiAuthTwoRulesTests: AWSDataStoreAuthBaseTest {
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent
     ///   with Cognito User Pools auth for authenticated users in the “Admins” group.
     func testGroupPrivateUserPoolsIAM() async {
-        await setup(withModels: GroupPrivateUserPoolsIAMModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: GroupPrivateUserPoolsIAMModels(), testType: .multiAuth, testId: testId)
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
         // Query
         await assertQuerySuccess(modelType: GroupPrivateUPIAMPost.self,
                            expectations,
@@ -228,7 +250,7 @@ class AWSDataStoreMultiAuthTwoRulesTests: AWSDataStoreAuthBaseTest {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 }
 
@@ -240,13 +262,15 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent
     ///   with Cognito auth for authenticated users
     func testGroupPublicUserPoolsAPIKeyAuthenticatedUsers() async {
-        await setup(withModels: GroupPublicUserPoolsAPIModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: GroupPublicUserPoolsAPIModels(), testType: .multiAuth, testId: testId)
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
         // Query
         await assertQuerySuccess(modelType: GroupPublicUPAPIPost.self,
                            expectations,
@@ -260,7 +284,7 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     /// Given: an unauthenticated user
@@ -268,12 +292,14 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
     /// Then:
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent with API Key
     func testGroupPublicUserPoolsAPIKeyUnauthenticatedUsers() async {
-        await setup(withModels: GroupPublicUserPoolsAPIModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: GroupPublicUserPoolsAPIModels(), testType: .multiAuth, testId: testId)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.apiKey])
         // Query
         await assertQuerySuccess(modelType: GroupPublicUPAPIPost.self,
                            expectations,
@@ -287,7 +313,7 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.apiKey])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 }
 
@@ -299,13 +325,15 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent
     ///   with Cognito auth for authenticated users
     func testGroupPublicUserPoolsIAMAuthenticatedUsers() async {
-        await setup(withModels: GroupPublicUserPoolsIAMModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: GroupPublicUserPoolsIAMModels(), testType: .multiAuth, testId: testId)
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
         // Query
         await assertQuerySuccess(modelType: GroupPublicUPIAMPost.self,
                            expectations,
@@ -319,7 +347,7 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     /// Given: an unauthenticated user
@@ -327,12 +355,14 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
     /// Then:
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent with IAM
     func testGroupPublicUserPoolsIAMUnauthenticatedUsers() async {
-        await setup(withModels: GroupPublicUserPoolsIAMModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: GroupPublicUserPoolsIAMModels(), testType: .multiAuth, testId: testId)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.awsIAM])
         // Query
         await assertQuerySuccess(modelType: GroupPublicUPIAMPost.self,
                            expectations,
@@ -346,7 +376,7 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.awsIAM])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 }
 
@@ -358,12 +388,14 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent
     ///   with Cognito auth for authenticated users
     func testPrivatePrivateUserPoolsIAMAuthenticatedUsers() async {
-        await setup(withModels: PrivateUserPoolsIAMModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: PrivateUserPoolsIAMModels(), testType: .multiAuth, testId: testId)
         await signIn(user: user1)
 
         let expectations = makeExpectations()
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
         // Query
         await assertQuerySuccess(modelType: PrivatePrivateUPIAMPost.self,
                            expectations,
@@ -377,7 +409,7 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 }
 
@@ -389,13 +421,15 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent with Cognito
     ///   for authenticated users
     func testPrivatePublicUserPoolsAPIKeyAuthenticatedUsers() async {
-        await setup(withModels: PrivatePublicUserPoolsAPIModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: PrivatePublicUserPoolsAPIModels(), testType: .multiAuth, testId: testId)
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
         // Query
         await assertQuerySuccess(modelType: PrivatePublicUPAPIPost.self,
                            expectations,
@@ -409,7 +443,7 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     /// Given: an unauthenticated user
@@ -417,12 +451,14 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
     /// Then:
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent with API key
     func testPrivatePublicUserPoolsAPIKeyUnauthenticatedUsers() async {
-        await setup(withModels: PrivatePublicUserPoolsAPIModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: PrivatePublicUserPoolsAPIModels(), testType: .multiAuth, testId: testId)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.apiKey])
         // Query
         await assertQuerySuccess(modelType: PrivatePublicUPAPIPost.self,
                            expectations,
@@ -436,7 +472,7 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.apiKey])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
 
     }
 }
@@ -449,13 +485,15 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent with Cognito
     ///   for authenticated users
     func testPrivatePublicUserPoolsIAMAuthenticatedUsers() async{
-        await setup(withModels: PrivatePublicUserPoolsIAMModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: PrivatePublicUserPoolsIAMModels(), testType: .multiAuth, testId: testId)
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.amazonCognitoUserPools])
         // Query
         await assertQuerySuccess(modelType: PrivatePublicUPIAMPost.self,
                            expectations,
@@ -469,7 +507,7 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.amazonCognitoUserPools])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 
     /// Given: an unauthenticated user
@@ -477,12 +515,14 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
     /// Then:
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent with IAM
     func testPrivatePublicUserPoolsIAMUnauthenticatedUsers() async {
-        await setup(withModels: PrivatePublicUserPoolsIAMModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: PrivatePublicUserPoolsIAMModels(), testType: .multiAuth, testId: testId)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.awsIAM])
         // Query
         await assertQuerySuccess(modelType: PrivatePublicUPIAMPost.self,
                            expectations,
@@ -496,7 +536,7 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.awsIAM])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
     }
 }
 
@@ -509,13 +549,15 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent with IAM
     ///   for authenticated users
     func testPrivatePublicIAMAPIKeyAuthenticatedUsers() async {
-        await setup(withModels: PrivatePublicIAMAPIModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: PrivatePublicIAMAPIModels(), testType: .multiAuth, testId: testId)
         await signIn(user: user1)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
 
+        let authTypeExpecation = assertUsedAuthTypes(testId: testId, authTypes: [.awsIAM])
         // Query
         await assertQuerySuccess(modelType: PrivatePublicIAMAPIPost.self,
                            expectations,
@@ -529,7 +571,8 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.awsIAM])
+        await fulfillment(of: [authTypeExpecation], timeout: 5)
+
     }
 
     /// Given: an unauthenticated user
@@ -537,12 +580,14 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
     /// Then:
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent with API Key
     func testPrivatePublicIAMAPIKeyUnauthenticatedUsers() async {
-        await setup(withModels: PrivatePublicIAMAPIModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+
+        await setup(withModels: PrivatePublicIAMAPIModels(), testType: .multiAuth, testId: testId)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
-
+        let authTypeExpectations =  assertUsedAuthTypes(testId: testId, authTypes: [.apiKey])
         // Query
         await assertQuerySuccess(modelType: PrivatePublicIAMAPIPost.self,
                            expectations,
@@ -556,7 +601,7 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.apiKey])
+        await fulfillment(of: [authTypeExpectations], timeout: 5)
     }
 
     /// Given: an unauthenticated user
@@ -565,11 +610,15 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
     /// - DataStore is successfully initialized, sync/mutation/subscription network requests are sent with IAM
     ///   for unauthenticated users
     func testPublicPublicAPIKeyIAMUnauthenticatedUsers() async {
-        await setup(withModels: PublicPublicAPIIAMModels(), testType: .multiAuth)
+        let testId = UUID().uuidString
+        await setup(withModels: PublicPublicAPIIAMModels(), testType: .multiAuth, testId: testId)
 
         let expectations = makeExpectations()
 
         await assertDataStoreReady(expectations)
+
+
+        let authTypeExpectation = assertUsedAuthTypes(testId: testId, authTypes: [.awsIAM])
 
         // Query
         await assertQuerySuccess(modelType: PublicPublicIAMAPIPost.self,
@@ -584,7 +633,7 @@ extension AWSDataStoreMultiAuthTwoRulesTests {
             XCTFail("Error mutation \(error)")
         }
 
-        assertUsedAuthTypes([.awsIAM])
+        await fulfillment(of: [authTypeExpectation], timeout: 5)
     }
 
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

We used to use custome interceptor to verify the final request headers for datastore multiAuth test cases. As we've [changed](https://github.com/aws-amplify/amplify-swift/pull/3190) the order of applying custome interceptors, this approach is no longer workable for verifying the final request.

This PR change to use a subclass of `URLProtocol` to monitor the final request and publish the header info to test cases.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
