### PR TITLE
feat(datastore): support multi owner auth rules

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelMultipleOwnerAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelMultipleOwnerAuthRuleTests.swift
@@ -71,31 +71,7 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
     override func tearDown() {
         ModelRegistry.reset()
     }
-    // This is a test case to demostrate if we attempt to use a model with multiple auth rules
-    // with a read operation, we effectively create a subscription without decorating it with auth.
-    // We should delete this use case when the AppSync service supports this use case.
-    func testUnsupportedModelMultipleOwner_CreateMutation() {
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelType: ModelMultipleOwner.self,
-                                                               operationType: .mutation)
-        documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
-        documentBuilder.add(decorator: AuthRuleDecorator(.mutation))
-        let document = documentBuilder.build()
-        let expectedQueryDocument = """
-        mutation CreateModelMultipleOwner {
-          createModelMultipleOwner {
-            id
-            content
-            editors
-            __typename
-          }
-        }
-        """
-        XCTAssertEqual(document.name, "createModelMultipleOwner")
-        XCTAssertEqual(document.stringValue, expectedQueryDocument)
-        XCTAssertTrue(document.variables.isEmpty)
-    }
-
-/*
+    
     // Ensure that the `owner` field is added to the model fields
     func testModelMultipleOwner_CreateMutation() {
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: ModelMultipleOwner.schema,
@@ -219,7 +195,7 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
                                                                operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .sync))
         documentBuilder.add(decorator: PaginationDecorator())
-        documentBuilder.add(decorator: ConflictResolutionDecorator())
+        documentBuilder.add(decorator: ConflictResolutionDecorator(graphQLType: .query))
         documentBuilder.add(decorator: AuthRuleDecorator(.query))
         let document = documentBuilder.build()
         let expectedQueryDocument = """
@@ -243,7 +219,7 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
         XCTAssertEqual(document.name, "syncModelMultipleOwners")
         XCTAssertEqual(document.stringValue, expectedQueryDocument)
     }
-
+    
     // Only the 'owner' inherently has `.create` operation, requiring the subscription operation to contain the input
     func testModelMultipleOwner_OnCreateSubscription() {
         let claims = ["username": "user1",
@@ -254,8 +230,8 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onCreate, claims)))
         let document = documentBuilder.build()
         let expectedQueryDocument = """
-        subscription OnCreateModelMultipleOwner($editors: String!, $owner: String!) {
-          onCreateModelMultipleOwner(editors: $editors, owner: $owner) {
+        subscription OnCreateModelMultipleOwner($owner: String!) {
+          onCreateModelMultipleOwner(owner: $owner) {
             id
             content
             editors
@@ -283,8 +259,8 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onUpdate, claims)))
         let document = documentBuilder.build()
         let expectedQueryDocument = """
-        subscription OnUpdateModelMultipleOwner($editors: String!, $owner: String!) {
-          onUpdateModelMultipleOwner(editors: $editors, owner: $owner) {
+        subscription OnUpdateModelMultipleOwner($owner: String!) {
+          onUpdateModelMultipleOwner(owner: $owner) {
             id
             content
             editors
@@ -300,7 +276,6 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
             return
         }
         XCTAssertEqual(variables["owner"] as? String, "user1")
-        XCTAssertEqual(variables["editors"] as? String, "user1")
     }
 
     // Only the 'owner' inherently has `.delete` operation, requiring the subscription operation to contain the input
@@ -313,8 +288,8 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
         documentBuilder.add(decorator: AuthRuleDecorator(.subscription(.onDelete, claims)))
         let document = documentBuilder.build()
         let expectedQueryDocument = """
-        subscription OnDeleteModelMultipleOwner($editors: String!, $owner: String!) {
-          onDeleteModelMultipleOwner(editors: $editors, owner: $owner) {
+        subscription OnDeleteModelMultipleOwner($owner: String!) {
+          onDeleteModelMultipleOwner(owner: $owner) {
             id
             content
             editors
@@ -331,5 +306,5 @@ class ModelMultipleOwnerAuthRuleTests: XCTestCase {
         }
         XCTAssertEqual(variables["owner"] as? String, "user1")
     }
-*/
+
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/Models/TodoCognitoMultiOwner+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/Models/TodoCognitoMultiOwner+Schema.swift
@@ -1,0 +1,57 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+extension TodoCognitoMultiOwner {
+  // MARK: - CodingKeys 
+   public enum CodingKeys: String, ModelKey {
+    case id
+    case title
+    case content
+    case owner
+    case editors
+    case createdAt
+    case updatedAt
+  }
+  
+  public static let keys = CodingKeys.self
+  //  MARK: - ModelSchema 
+  
+  public static let schema = defineSchema { model in
+    let todoCognitoMultiOwner = TodoCognitoMultiOwner.keys
+    
+    model.authRules = [
+      rule(allow: .owner, ownerField: "owner", identityClaim: "cognito:username", provider: .userPools, operations: [.create, .update, .delete, .read]),
+      rule(allow: .owner, ownerField: "editors", identityClaim: "cognito:username", provider: .userPools, operations: [.update, .read])
+    ]
+    
+    model.listPluralName = "TodoCognitoMultiOwners"
+    model.syncPluralName = "TodoCognitoMultiOwners"
+    
+    model.attributes(
+      .primaryKey(fields: [todoCognitoMultiOwner.id])
+    )
+    
+    model.fields(
+      .field(todoCognitoMultiOwner.id, is: .required, ofType: .string),
+      .field(todoCognitoMultiOwner.title, is: .required, ofType: .string),
+      .field(todoCognitoMultiOwner.content, is: .optional, ofType: .string),
+      .field(todoCognitoMultiOwner.owner, is: .optional, ofType: .string),
+      .field(todoCognitoMultiOwner.editors, is: .optional, ofType: .embeddedCollection(of: String.self)),
+      .field(todoCognitoMultiOwner.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
+      .field(todoCognitoMultiOwner.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
+    )
+    }
+}
+
+extension TodoCognitoMultiOwner: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/Models/TodoCognitoMultiOwner.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/Models/TodoCognitoMultiOwner.swift
@@ -1,0 +1,49 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// swiftlint:disable all
+import Amplify
+import Foundation
+
+public struct TodoCognitoMultiOwner: Model {
+  public let id: String
+  public var title: String
+  public var content: String?
+  public var owner: String?
+  public var editors: [String?]?
+  public var createdAt: Temporal.DateTime?
+  public var updatedAt: Temporal.DateTime?
+  
+  public init(id: String = UUID().uuidString,
+      title: String,
+      content: String? = nil,
+      owner: String? = nil,
+      editors: [String?]? = nil) {
+    self.init(id: id,
+      title: title,
+      content: content,
+      owner: owner,
+      editors: editors,
+      createdAt: nil,
+      updatedAt: nil)
+  }
+  internal init(id: String = UUID().uuidString,
+      title: String,
+      content: String? = nil,
+      owner: String? = nil,
+      editors: [String?]? = nil,
+      createdAt: Temporal.DateTime? = nil,
+      updatedAt: Temporal.DateTime? = nil) {
+      self.id = id
+      self.title = title
+      self.content = content
+      self.owner = owner
+      self.editors = editors
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+  }
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/Models/TodoCognitoPrivate+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/Models/TodoCognitoPrivate+Schema.swift
@@ -17,24 +17,34 @@ extension TodoCognitoPrivate {
     case createdAt
     case updatedAt
   }
-
+  
   public static let keys = CodingKeys.self
   //  MARK: - ModelSchema
-
+  
   public static let schema = defineSchema { model in
     let todoCognitoPrivate = TodoCognitoPrivate.keys
-
+    
     model.authRules = [
-        rule(allow: .private, provider: .userPools, operations: [.create, .update, .delete, .read])
+      rule(allow: .private, operations: [.create, .update, .delete, .read])
     ]
-
-    model.pluralName = "TodoCognitoPrivates"
-
+    
+    model.listPluralName = "TodoCognitoPrivates"
+    model.syncPluralName = "TodoCognitoPrivates"
+    
+    model.attributes(
+      .primaryKey(fields: [todoCognitoPrivate.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(todoCognitoPrivate.id, is: .required, ofType: .string),
       .field(todoCognitoPrivate.title, is: .required, ofType: .string),
       .field(todoCognitoPrivate.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(todoCognitoPrivate.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+
+extension TodoCognitoPrivate: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/Models/TodoCustomOwnerExplicit+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/Models/TodoCustomOwnerExplicit+Schema.swift
@@ -18,25 +18,35 @@ extension TodoCustomOwnerExplicit {
     case createdAt
     case updatedAt
   }
-
+  
   public static let keys = CodingKeys.self
   //  MARK: - ModelSchema
-
+  
   public static let schema = defineSchema { model in
     let todoCustomOwnerExplicit = TodoCustomOwnerExplicit.keys
-
+    
     model.authRules = [
       rule(allow: .owner, ownerField: "dominus", identityClaim: "cognito:username", provider: .userPools, operations: [.create, .update, .delete, .read])
     ]
-
-    model.pluralName = "TodoCustomOwnerExplicits"
-
+    
+    model.listPluralName = "TodoCustomOwnerExplicits"
+    model.syncPluralName = "TodoCustomOwnerExplicits"
+    
+    model.attributes(
+      .primaryKey(fields: [todoCustomOwnerExplicit.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(todoCustomOwnerExplicit.id, is: .required, ofType: .string),
       .field(todoCustomOwnerExplicit.title, is: .required, ofType: .string),
       .field(todoCustomOwnerExplicit.dominus, is: .optional, ofType: .string),
       .field(todoCustomOwnerExplicit.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(todoCustomOwnerExplicit.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+
+extension TodoCustomOwnerExplicit: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/Models/TodoCustomOwnerImplicit+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/Models/TodoCustomOwnerImplicit+Schema.swift
@@ -17,24 +17,34 @@ extension TodoCustomOwnerImplicit {
     case createdAt
     case updatedAt
   }
-
+  
   public static let keys = CodingKeys.self
   //  MARK: - ModelSchema
-
+  
   public static let schema = defineSchema { model in
     let todoCustomOwnerImplicit = TodoCustomOwnerImplicit.keys
-
+    
     model.authRules = [
       rule(allow: .owner, ownerField: "dominus", identityClaim: "cognito:username", provider: .userPools, operations: [.create, .update, .delete, .read])
     ]
-
-    model.pluralName = "TodoCustomOwnerImplicits"
-
+    
+    model.listPluralName = "TodoCustomOwnerImplicits"
+    model.syncPluralName = "TodoCustomOwnerImplicits"
+    
+    model.attributes(
+      .primaryKey(fields: [todoCustomOwnerImplicit.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(todoCustomOwnerImplicit.id, is: .required, ofType: .string),
       .field(todoCustomOwnerImplicit.title, is: .required, ofType: .string),
       .field(todoCustomOwnerImplicit.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(todoCustomOwnerImplicit.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+
+extension TodoCustomOwnerImplicit: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/Models/TodoExplicitOwnerField+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/Models/TodoExplicitOwnerField+Schema.swift
@@ -18,25 +18,35 @@ extension TodoExplicitOwnerField {
     case createdAt
     case updatedAt
   }
-
+  
   public static let keys = CodingKeys.self
   //  MARK: - ModelSchema
-
+  
   public static let schema = defineSchema { model in
     let todoExplicitOwnerField = TodoExplicitOwnerField.keys
-
+    
     model.authRules = [
       rule(allow: .owner, ownerField: "owner", identityClaim: "cognito:username", provider: .userPools, operations: [.read, .create, .update, .delete])
     ]
-
-    model.pluralName = "TodoExplicitOwnerFields"
-
+    
+    model.listPluralName = "TodoExplicitOwnerFields"
+    model.syncPluralName = "TodoExplicitOwnerFields"
+    
+    model.attributes(
+      .primaryKey(fields: [todoExplicitOwnerField.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(todoExplicitOwnerField.id, is: .required, ofType: .string),
       .field(todoExplicitOwnerField.content, is: .required, ofType: .string),
       .field(todoExplicitOwnerField.owner, is: .optional, ofType: .string),
       .field(todoExplicitOwnerField.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(todoExplicitOwnerField.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+
+extension TodoExplicitOwnerField: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/Models/TodoImplicitOwnerField+Schema.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/Models/TodoImplicitOwnerField+Schema.swift
@@ -17,24 +17,34 @@ extension TodoImplicitOwnerField {
     case createdAt
     case updatedAt
   }
-
+  
   public static let keys = CodingKeys.self
   //  MARK: - ModelSchema
-
+  
   public static let schema = defineSchema { model in
     let todoImplicitOwnerField = TodoImplicitOwnerField.keys
-
+    
     model.authRules = [
       rule(allow: .owner, ownerField: "owner", identityClaim: "cognito:username", provider: .userPools, operations: [.create, .update, .delete, .read])
     ]
-
-    model.pluralName = "TodoImplicitOwnerFields"
-
+    
+    model.listPluralName = "TodoImplicitOwnerFields"
+    model.syncPluralName = "TodoImplicitOwnerFields"
+    
+    model.attributes(
+      .primaryKey(fields: [todoImplicitOwnerField.id])
+    )
+    
     model.fields(
-      .id(),
+      .field(todoImplicitOwnerField.id, is: .required, ofType: .string),
       .field(todoImplicitOwnerField.content, is: .required, ofType: .string),
       .field(todoImplicitOwnerField.createdAt, is: .optional, isReadOnly: true, ofType: .dateTime),
       .field(todoImplicitOwnerField.updatedAt, is: .optional, isReadOnly: true, ofType: .dateTime)
     )
     }
+}
+
+extension TodoImplicitOwnerField: ModelIdentifiable {
+  public typealias IdentifierFormat = ModelIdentifierFormat.Default
+  public typealias IdentifierProtocol = DefaultModelIdentifier<Self>
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/README.md
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/README.md
@@ -9,27 +9,22 @@ This configuration is used to run the tests in `AWSDataStoreCategoryPluginAuthIn
 
 2. Make sure the correct CLI version is used for this test. 
 
-- `amplify --v` should be at least 8.5.2
-- cli.json "transformerversion": 2
-- cli.json "useexperimentalpipelinedtransformer": true
-- cli.json "usesubusernamefordefaultidentityclaim": true
+- `amplify --v` should be at least 12.4.0
+- cli.json "generatemodelsforlazyloadandcustomselectionset": true
 
 3. `amplify add api`
 
 ```perl
-? Select from one of the below mentioned services: GraphQL
-  Authorization modes: Amazon Cognito User Pool (default) 
-  Conflict detection (required for DataStore): Enabled 
-  Conflict resolution strategy: Auto Merge
-? Choose a schema template: Blank Schema  
-? Do you want to edit the schema now? `Yes`
+? Select from one of the below mentioned services: `GraphQL`
+? Here is the GraphQL API that we will create. Select a setting to edit or continue `Authorization mode`
+? Choose the default authorization type for the API `Amazon Cognito User Pool`
+? Configure additional auth types? `No`
+? Enable conflict detection? `Yes`
+? Select the default resolution strategy `Auto Merge`
+? Choose a schema template: `Blank Schema`
 ```
 
 Copy the content of the schema from `AWSDataStoreCategoryPluginAuthIntegrationTests/DefaultAuthCognito/singleauth-cognito-schema.graphql` into the newly created `schema.graphql` file
-
-3. `amplify update api`
-? Please select from one of the below mentioned services: `GraphQL`
-? Select from the options below `Enable DataStore for entire API`
 
 4. `amplify push`
 ```perl
@@ -42,42 +37,30 @@ Copy the content of the schema from `AWSDataStoreCategoryPluginAuthIntegrationTe
 cp amplifyconfiguration.json ~/.aws-amplify/amplify-ios/testconfiguration/AWSDataStoreCategoryPluginAuthIntegrationTests-amplifyconfiguration.json
 ```
 
-6. Create `AWSDataStoreCategoryPluginAuthIntegrationTests-credentials.json` inside the same folder with a json object containing `user1`, and `password`, used to create the cognito user in the userpool. In step 2, the cognito userpool is configured to allow users to sign up with their email as the username.
-
-```json
-{
-    "user1": "<USER EMAIL>",
-    "passwordUser1": "<PASSWORD>",
-    "user2": "<USER2 EMAIL>",
-    "passwordUser2": "<PASSWORD>"
-}
+6. Creating users through AWS CLI, run the following commands
 
 ```
-
-### Creating users through AWS Console
-
-7. `amplify console auth`
-```perl
-? Which console `User Pool`
-```
-
-8. Click on `Users and groups`, Sign up the two new users with the email and a temporary password. 
-
-9. Click on App clients, and keep note of the app client web's `App client id`. This can be used the AWS AppSync console Queries.
-
-10. `amplify console api`
-Click on Queries tab, and click on Log in. This will prompt you to enter the app client id, username, and temporary password. After logging in successfully, it will ask you to enter a new password. Make sure those are the same as the one specified in the credentials json file from step 5. Do this for both users.
-
-
-### Creating users through AWS CLI
-
-7. Run the following commands
-
-```
-aws cognito-idp admin-create-user --user-pool-id [POOL_ID] --username [USER EMAIL]
-aws cognito-idp admin-set-user-password --user-pool-id [POOL_ID] --username [USER EMAIL] --password [PASSWORD] --permanent
+aws cognito-idp admin-create-user --user-pool-id [POOL_ID] --username [USERNAME]
+aws cognito-idp admin-set-user-password --user-pool-id [POOL_ID] --username [USERNAME] --password [PASSWORD] --permanent
 ```
 
 The `[POOL_ID]` can be found in `amplifyconfiguration.json` under `auth.plugin.awsCognitoAuthPlugin.CognitoUserPool.Default.PoolId`
+
+7. Create `AWSDataStoreCategoryPluginAuthIntegrationTests-credentials.json` inside the same folder, containing a json object of the user information from the users in the cognito user in the userpool.
+
+```
+touch ~/.aws-amplify/amplify-ios/testconfiguration/AWSDataStoreCategoryPluginAuthIntegrationTests-credentials.json
+```
+
+```json
+{
+    "user1": "<USERNAME>",
+    "passwordUser1": "<PASSWORD>",
+    "user2": "<USERNAME>",
+    "passwordUser2": "<PASSWORD>"
+}
+```
+
+8. Optionally, re-run `amplify codegen models` if you want to replace the existing model files under the Models directory in this project with the latest codegen output. You generally don't have to do this unless adding and testing new functionality.
 
 Now you can run the AWSDataStoreCategoryPluginAuthIntegrationTests

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/singleauth-cognito-schema.graphql
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/singleauth-cognito-schema.graphql
@@ -34,3 +34,14 @@ type TodoCognitoPrivate @model @auth(rules: [{ allow: private }]) {
   id: ID!
   title: String!
 }
+
+type TodoCognitoMultiOwner @model
+    @auth(rules: [
+        { allow: owner },
+        { allow: owner, ownerField: "editors", operations: [update, read]} ]) {
+  id: ID!
+  title: String!
+  content: String
+  owner: String
+  editors: [String]
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		210445632AB4F6C900420AF9 /* TodoCognitoMultiOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210445612AB4F6C900420AF9 /* TodoCognitoMultiOwner.swift */; };
+		210445642AB4F6C900420AF9 /* TodoCognitoMultiOwner+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210445622AB4F6C900420AF9 /* TodoCognitoMultiOwner+Schema.swift */; };
 		210D5D4A2982EF6B00D748FE /* AWSDataStoreLazyLoadPostCommentWithCompositeKeySnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210D5D492982EF6B00D748FE /* AWSDataStoreLazyLoadPostCommentWithCompositeKeySnapshotTests.swift */; };
 		210D5D4C2982F0A300D748FE /* AWSDataStoreLazyLoadPostComment4SnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210D5D4B2982F0A300D748FE /* AWSDataStoreLazyLoadPostComment4SnapshotTests.swift */; };
 		210D5D4E2982F1E700D748FE /* AWSDataStoreLazyLoadPostComment7SnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210D5D4D2982F1E700D748FE /* AWSDataStoreLazyLoadPostComment7SnapshotTests.swift */; };
@@ -1537,6 +1539,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		210445612AB4F6C900420AF9 /* TodoCognitoMultiOwner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodoCognitoMultiOwner.swift; sourceTree = "<group>"; };
+		210445622AB4F6C900420AF9 /* TodoCognitoMultiOwner+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TodoCognitoMultiOwner+Schema.swift"; sourceTree = "<group>"; };
 		210D5D492982EF6B00D748FE /* AWSDataStoreLazyLoadPostCommentWithCompositeKeySnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadPostCommentWithCompositeKeySnapshotTests.swift; sourceTree = "<group>"; };
 		210D5D4B2982F0A300D748FE /* AWSDataStoreLazyLoadPostComment4SnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadPostComment4SnapshotTests.swift; sourceTree = "<group>"; };
 		210D5D4D2982F1E700D748FE /* AWSDataStoreLazyLoadPostComment7SnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadPostComment7SnapshotTests.swift; sourceTree = "<group>"; };
@@ -2994,6 +2998,8 @@
 		21BBFA94289BFE4E00B32A39 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				210445612AB4F6C900420AF9 /* TodoCognitoMultiOwner.swift */,
+				210445622AB4F6C900420AF9 /* TodoCognitoMultiOwner+Schema.swift */,
 				21BBFA96289BFE4E00B32A39 /* TodoCognitoPrivate.swift */,
 				21BBFA97289BFE4E00B32A39 /* TodoCognitoPrivate+Schema.swift */,
 				21BBFA9E289BFE4E00B32A39 /* TodoCustomOwnerExplicit.swift */,
@@ -4956,8 +4962,10 @@
 				213DBBFF28A577B200B30280 /* AWSDataStoreCategoryPluginAuthIntegrationTests+Support.swift in Sources */,
 				213DBC0728A577C900B30280 /* TodoCustomOwnerImplicit+Schema.swift in Sources */,
 				213DBC5928A57FFE00B30280 /* TestConfigHelper.swift in Sources */,
+				210445642AB4F6C900420AF9 /* TodoCognitoMultiOwner+Schema.swift in Sources */,
 				213DBC0328A577C300B30280 /* TodoExplicitOwnerField.swift in Sources */,
 				213DBC0928A577C900B30280 /* TodoExplicitOwnerField+Schema.swift in Sources */,
+				210445632AB4F6C900420AF9 /* TodoCognitoMultiOwner.swift in Sources */,
 				681DFE9028E746FD0000C36A /* AsyncExpectation.swift in Sources */,
 				681DFE8F28E746FD0000C36A /* XCTestCase+AsyncTesting.swift in Sources */,
 				213DBC0128A577BC00B30280 /* TodoCognitoPrivate.swift in Sources */,


### PR DESCRIPTION
## Issue \#
Taking this PR forward: https://github.com/aws-amplify/amplify-swift/pull/1606

## Description
<!-- Why is this change required? What problem does it solve? -->
This PR enables the use case of having multiple "owner" auth rules on a single model type. 

Instead of using the hand written swift types in the Integration test from #1606, it makes more sense to update the schema file for that test suite. In `singleauth-cogniot-schema.graphql`, I added the use case:
```
type TodoCognitoMultiOwner @model
    @auth(rules: [
        { allow: owner },
        { allow: owner, ownerField: "editors", operations: [update, read]} ]) {
  id: ID!
  title: String!
  content: String
  owner: String
  editors: [String]
}

```

- [ ] The Github Actions backend will have to be updated as well.

I believe the use cases are
1. Signed in Cognito User Pool user, "user1", can perform all operations on models created by them.
2. "user2" can subscribe to onCreate, onUpdate, onDelete subscriptions and read all models which they are an editor of
3. "user2" can perform updates to data that they are an editor of, since they have the "update" operation. 

Think of "user1" as the admin user creating the Todo with "user2" assigned in the editors field, so "user2" can read, receive changes to the data, and perform updates to the Todo.

In the following examples, I've provisioned the backend using the steps from here https://github.com/aws-amplify/amplify-swift/pull/3223/files#diff-5d3a18e8865a6311b2ab88fa95415c905d81544fae2d44ba19295f0bfbd7fb17 so it is enabled for DataStore.

1. "michael" and "michael2" are my users..

"michael2" establishes subscription to this data:
```
subscription MySubscription {
  onCreateTodoCognitoMultiOwner(owner: "michael2") {
    _deleted
    _lastChangedAt
    _version
    content
    createdAt
    editors
    id
    owner
    title
    updatedAt
  }
}

```

"michael" creates the data
```
mutation MyMutation {
  createTodoCognitoMultiOwner(input: {editors: "michael2", owner: "michael", title: "titleByUser1"}) {
    _deleted
    _lastChangedAt
    _version
    content
    createdAt
    editors
    owner
    id
    title
    updatedAt
  }
}

```

"michael2" receives the data:
```
{
  "data": {
    "onCreateTodoCognitoMultiOwner": {
      "_deleted": null,
      "_lastChangedAt": 1695048189453,
      "_version": 1,
      "content": null,
      "createdAt": "2023-09-18T14:43:09.430Z",
      "editors": [
        "michael2"
      ],
      "id": "b7d763d3-9e64-456a-8631-6c39364efcdb",
      "owner": "michael",
      "title": "titleByUser1",
      "updatedAt": "2023-09-18T14:43:09.430Z"
    }
  }
}
```

"michael2" establiesh onUpdate:
```
subscription MySubscription {
  onUpdateTodoCognitoMultiOwner(owner: "michael2") {
    _deleted
    _lastChangedAt
    _version
    content
    createdAt
    editors
    id
    owner
    title
    updatedAt
  }
}

```

"michael2" tries to update the data:
```
mutation MyMutation {
  updateTodoCognitoMultiOwner(input: {title: "titleUpdatedByUser2", id: "b7d763d3-9e64-456a-8631-6c39364efcdb", _version: 1}) {
    _deleted
    _lastChangedAt
    _version
    content
    createdAt
    editors
    id
    owner
    title
    updatedAt
  }
}
```

"michael2" receives the update mutation
```
{
  "data": {
    "onUpdateTodoCognitoMultiOwner": {
      "_deleted": null,
      "_lastChangedAt": 1695048302918,
      "_version": 2,
      "content": null,
      "createdAt": "2023-09-18T14:43:09.430Z",
      "editors": [
        "michael2"
      ],
      "id": "b7d763d3-9e64-456a-8631-6c39364efcdb",
      "owner": "michael",
      "title": "titleUpdatedByUser2",
      "updatedAt": "2023-09-18T14:44:54.896Z"
    }
  }
}
```

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
