### PR TITLE
fix(datastore): call errorHandler in Sync operation when failure

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -130,10 +130,13 @@ final class InitialSyncOperation: AsynchronousOperation {
             switch result {
             case .failure(let apiError):
                 if self.isAuthSignedOutError(apiError: apiError) {
-                    self.dataStoreConfiguration.errorHandler(DataStoreError.api(apiError))
+                    self.log.error("Sync for \(self.modelSchema.name) failed due to signed out error \(apiError.errorDescription)")
                 }
+                
                 // TODO: Retry query on error
-                self.finish(result: .failure(DataStoreError.api(apiError)))
+                let error = DataStoreError.api(apiError)
+                self.dataStoreConfiguration.errorHandler(error)
+                self.finish(result: .failure(error))
             case .success(let graphQLResult):
                 self.handleQueryResults(lastSyncTime: lastSyncTime, graphQLResult: graphQLResult)
             }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/3028

## Description
<!-- Why is this change required? What problem does it solve? -->
DataStore's sync operation performs paginated sync query operations for each model, in the order of the model graph. Whenever the network request fails, we should provide that information to the `errorHandler` for visibility. Before this change, it was calling the `errorHandler` only on auth signed out errors. 

Similar to the discussion we had in https://github.com/aws-amplify/amplify-swift/pull/2532#discussion_r1014284029 / https://github.com/aws-amplify/amplify-swift/issues/3232, this PR only focuses on passing the error back to the developer. We have not improved the error handling experience by mapping it to a well defined "SyncError" type.

If we did, it would be the equivalent of the `ProcessName.sync` in JS.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
