### PR TITLE
Revert "fix(datastore): call errorHandler in Sync operation when failure"

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -130,13 +130,10 @@ final class InitialSyncOperation: AsynchronousOperation {
             switch result {
             case .failure(let apiError):
                 if self.isAuthSignedOutError(apiError: apiError) {
-                    self.log.error("Sync for \(self.modelSchema.name) failed due to signed out error \(apiError.errorDescription)")
+                    self.dataStoreConfiguration.errorHandler(DataStoreError.api(apiError))
                 }
-                
                 // TODO: Retry query on error
-                let error = DataStoreError.api(apiError)
-                self.dataStoreConfiguration.errorHandler(error)
-                self.finish(result: .failure(error))
+                self.finish(result: .failure(DataStoreError.api(apiError)))
             case .success(let graphQLResult):
                 self.handleQueryResults(lastSyncTime: lastSyncTime, graphQLResult: graphQLResult)
             }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
This reverts https://github.com/aws-amplify/amplify-swift/pull/3231, to merge it back in as a squash and merge

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
