### PR TITLE
test: add TodoCognitoMultiOwner to watchOS target for DataStore test

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
@@ -265,6 +265,8 @@
 		21977DBF289C171A005B49D6 /* TestConfigHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21977DBE289C1719005B49D6 /* TestConfigHelper.swift */; };
 		219B518528E3A4B00080EDCC /* DataStoreConnectionOptionalAssociations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BBFA00289BFE3400B32A39 /* DataStoreConnectionOptionalAssociations.swift */; };
 		219B518628E3A7150080EDCC /* DataStoreHubEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BBF9EE289BFE3400B32A39 /* DataStoreHubEvent.swift */; };
+		21AA64B72AC5D78B001C6D3B /* TodoCognitoMultiOwner+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210445622AB4F6C900420AF9 /* TodoCognitoMultiOwner+Schema.swift */; };
+		21AA64B82AC5D791001C6D3B /* TodoCognitoMultiOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210445612AB4F6C900420AF9 /* TodoCognitoMultiOwner.swift */; };
 		21AB5C2A297AE56D00CCA482 /* AWSDataStoreLazyLoadPostTagSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C29297AE56D00CCA482 /* AWSDataStoreLazyLoadPostTagSnapshotTests.swift */; };
 		21AB5C5529819BF100CCA482 /* Nested.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C4829819BF000CCA482 /* Nested.swift */; };
 		21AB5C5629819BF100CCA482 /* NestedTypeTestModel+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C4929819BF000CCA482 /* NestedTypeTestModel+Schema.swift */; };
@@ -6094,8 +6096,10 @@
 			files = (
 				68826E692A43A1DB005E85A7 /* TodoCustomOwnerExplicit+Schema.swift in Sources */,
 				6812A9D32A44989E00570222 /* AmplifyURLSession.swift in Sources */,
+				21AA64B72AC5D78B001C6D3B /* TodoCognitoMultiOwner+Schema.swift in Sources */,
 				68826E6A2A43A1DB005E85A7 /* AWSDataStoreCategoryPluginAuthIntegrationTests+Support.swift in Sources */,
 				68826E6B2A43A1DB005E85A7 /* TodoCustomOwnerImplicit+Schema.swift in Sources */,
+				21AA64B82AC5D791001C6D3B /* TodoCognitoMultiOwner.swift in Sources */,
 				68826E6C2A43A1DB005E85A7 /* TestConfigHelper.swift in Sources */,
 				68826E6D2A43A1DB005E85A7 /* TodoExplicitOwnerField.swift in Sources */,
 				68826E6E2A43A1DB005E85A7 /* TodoExplicitOwnerField+Schema.swift in Sources */,


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
Related PR with test issue https://github.com/aws-amplify/amplify-swift/pull/3223

## Description
<!-- Why is this change required? What problem does it solve? -->
Test is missing file added to watchOS target (https://github.com/aws-amplify/amplify-swift/actions/runs/6340116424/job/17222695667#logs)
```
❌  /Users/runner/work/amplify-swift/amplify-swift/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthOwnerIntegrationTests.swift:225:47: cannot find 'TodoCognitoMultiOwner' in scope

            ModelRegistry.register(modelType: TodoCognitoMultiOwner.self)
                   ^~~~~~~~~~~~~~~~~~~~~
```

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
