### PR TITLE
fix: resolve compiler errors in AWSPluginsCore after sdk update

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -13,7 +13,7 @@ public class AWSAuthService: AWSAuthServiceBehavior {
 
     public init() {}
 
-    public func getCredentialsProvider() -> CredentialsProvider {
+    public func getCredentialsProvider() -> CredentialsProviding {
         return AmplifyAWSCredentialsProvider()
     }
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -11,7 +11,7 @@ import AWSClientRuntime
 
 public protocol AWSAuthServiceBehavior: AnyObject {
 
-    func getCredentialsProvider() -> CredentialsProvider
+    func getCredentialsProvider() -> CredentialsProviding
 
     func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError>
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AmplifyAWSCredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AmplifyAWSCredentialsProvider.swift
@@ -10,7 +10,7 @@ import AWSClientRuntime
 import AwsCommonRuntimeKit
 import Foundation
 
-public class AmplifyAWSCredentialsProvider: AWSClientRuntime.CredentialsProvider {
+public class AmplifyAWSCredentialsProvider: AWSClientRuntime.CredentialsProviding {
 
     public func getCredentials() async throws -> AWSClientRuntime.AWSCredentials {
         let authSession = try await Amplify.Auth.fetchAuthSession()

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AmplifyAWSSignatureV4Signer.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/AmplifyAWSSignatureV4Signer.swift
@@ -13,7 +13,7 @@ import AwsCommonRuntimeKit
 
 public protocol AWSSignatureV4Signer {
     func sigV4SignedRequest(requestBuilder: SdkHttpRequestBuilder,
-                            credentialsProvider: AWSClientRuntime.CredentialsProvider,
+                            credentialsProvider: AWSClientRuntime.CredentialsProviding,
                             signingName: Swift.String,
                             signingRegion: Swift.String,
                             date: ClientRuntime.Date) async throws -> SdkHttpRequest?
@@ -24,7 +24,7 @@ public class AmplifyAWSSignatureV4Signer: AWSSignatureV4Signer {
     }
 
     public func sigV4SignedRequest(requestBuilder: SdkHttpRequestBuilder,
-                                   credentialsProvider: AWSClientRuntime.CredentialsProvider,
+                                   credentialsProvider: AWSClientRuntime.CredentialsProviding,
                                    signingName: Swift.String,
                                    signingRegion: Swift.String,
                                    date: ClientRuntime.Date) async throws -> SdkHttpRequest? {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/IAMCredentialProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/Provider/IAMCredentialProvider.swift
@@ -10,7 +10,7 @@ import Amplify
 import AWSClientRuntime
 
 public protocol IAMCredentialsProvider {
-    func getCredentialsProvider() -> CredentialsProvider
+    func getCredentialsProvider() -> CredentialsProviding
 }
 
 public struct BasicIAMCredentialsProvider: IAMCredentialsProvider {
@@ -20,7 +20,7 @@ public struct BasicIAMCredentialsProvider: IAMCredentialsProvider {
         self.authService = authService
     }
 
-    public func getCredentialsProvider() -> CredentialsProvider {
+    public func getCredentialsProvider() -> CredentialsProviding {
         return authService.getCredentialsProvider()
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -9,6 +9,54 @@ import Foundation
 import AWSClientRuntime
 import Amplify
 
+// TODO: FrameworkMetadata Replacement
+private let tokenNoHashCharacterSet = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!$%'*+-.^_`|~")
+private let tokenCharacterSet = tokenNoHashCharacterSet.union(Set("#"))
+private let substituteCharacter = Character("-")
+
+extension String {
+
+    var userAgentToken: String {
+        String(map { tokenCharacterSet.contains($0) ? $0 : substituteCharacter })
+    }
+
+    var userAgentTokenNoHash: String {
+        String(map { tokenNoHashCharacterSet.contains($0) ? $0 : substituteCharacter })
+    }
+}
+
+
+public struct FrameworkMetadata {
+    let name: String
+    let version: String
+    let extras: [String: String]
+
+    var sanitizedName: String {
+        name.userAgentToken
+    }
+    var sanitizedVersion: String {
+        version.userAgentToken
+    }
+
+    public init(name: String, version: String, extras: [String: String] = [String: String]()) {
+        self.name = name
+        self.version = version
+        self.extras = extras
+    }
+ }
+
+extension FrameworkMetadata: CustomStringConvertible {
+    public var description: String {
+        let extrasMetaData = !extras.isEmpty
+            ? extras.map {
+                " md/\($0.key.userAgentToken)/\($0.value.userAgentToken)"
+            }.joined()
+            : ""
+        return "lib/\(sanitizedName)/\(sanitizedVersion)\(extrasMetaData)"
+    }
+}
+// MARK: - End TODO: FrameworkMetadata Replacement
+
 /// Convenience class that is used by Amplify to include metadata such as values for a "User-Agent" during
 /// server interactions.
 ///

--- a/AmplifyPlugins/Core/AWSPluginsCore/Utils/CustomHttpClientEngine/ClientRuntimeFoundationBridge.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Utils/CustomHttpClientEngine/ClientRuntimeFoundationBridge.swift
@@ -9,7 +9,7 @@ import Foundation
 import ClientRuntime
 
 extension Foundation.URLRequest {
-    init(sdkRequest: ClientRuntime.SdkHttpRequest) throws {
+    init(sdkRequest: ClientRuntime.SdkHttpRequest) async throws {
         guard let url = sdkRequest.endpoint.url else {
             throw FoundationClientEngineError.invalidRequestURL(sdkRequest: sdkRequest)
         }
@@ -22,11 +22,7 @@ extension Foundation.URLRequest {
             }
         }
 
-        switch sdkRequest.body {
-        case .data(let data): httpBody = data
-        case .stream(let stream): httpBody = stream.toBytes().getData()
-        case .none: break
-        }
+        httpBody = try await sdkRequest.body.readData()
     }
 }
 
@@ -49,7 +45,9 @@ extension ClientRuntime.HttpResponse {
 
     convenience init(httpURLResponse: HTTPURLResponse, data: Data) throws {
         let headers = Self.headers(from: httpURLResponse.allHeaderFields)
-        let body = HttpBody.stream(ByteStream.from(data: data))
+        // TODO: double check if this works as expected
+        // Previously this needed to be `HttpBody.stream()`
+        let body = HttpBody.data(data)
 
         guard let statusCode = HttpStatusCode(rawValue: httpURLResponse.statusCode) else {
             // This shouldn't happen, but `HttpStatusCode` only exposes a failable

--- a/AmplifyPlugins/Core/AWSPluginsCore/Utils/CustomHttpClientEngine/FoundationClientEngine.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Utils/CustomHttpClientEngine/FoundationClientEngine.swift
@@ -12,7 +12,7 @@ import Amplify
 @_spi(FoundationClientEngine)
 public struct FoundationClientEngine: HttpClientEngine {
     public func execute(request: ClientRuntime.SdkHttpRequest) async throws -> ClientRuntime.HttpResponse {
-        let urlRequest = try URLRequest(sdkRequest: request)
+        let urlRequest = try await URLRequest(sdkRequest: request)
 
         let (data, response) = try await URLSession.shared.data(for: urlRequest)
         guard let httpURLResponse = response as? HTTPURLResponse else {

--- a/AmplifyPlugins/Core/AWSPluginsCore/Utils/CustomHttpClientEngine/UserAgentSuffixAppender.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Utils/CustomHttpClientEngine/UserAgentSuffixAppender.swift
@@ -25,13 +25,10 @@ extension UserAgentSuffixAppender: HttpClientEngine {
         guard let target = target  else {
             throw ClientError.unknownError("HttpClientEngine is not set")
         }
-        var headers = request.headers
-        let currentUserAgent = headers.value(for: userAgentHeader) ?? ""
-        headers.update(
-            name: userAgentHeader,
-            value: "\(currentUserAgent) \(suffix)"
-        )
-        request.headers = headers
+
+        let currentUserAgent = request.headers.value(for: userAgentHeader) ?? ""
+        request.withHeader(name: userAgentHeader, value: "\(currentUserAgent) \(suffix)")
+
         return try await target.execute(request: request)
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Utils/UserAgentSuffixAppenderTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Utils/UserAgentSuffixAppenderTests.swift
@@ -31,7 +31,7 @@ class UserAgentSuffixAppenderTests: XCTestCase {
     /// Then: The user agent suffix is appended
     func testExecute_withExistingUserAgentHeader_shouldAppendSuffix() async throws {
         let request = createRequest()
-        request.headers.add(name: userAgentKey, value: "existingUserAgent")
+        request.withHeader(name: userAgentKey, value: "existingUserAgent")
 
         _ = try await appender.execute(request: request)
         XCTAssertEqual(httpClientEngine.executeCount, 1)
@@ -72,8 +72,7 @@ class UserAgentSuffixAppenderTests: XCTestCase {
     private func createRequest() -> SdkHttpRequest {
         return SdkHttpRequest(
             method: .get,
-            endpoint: .init(host: "customHost"),
-            headers: .init()
+            endpoint: .init(host: "customHost")
         )
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -28,7 +28,7 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
         interactions.append(#function)
     }
 
-    public func getCredentialsProvider() -> CredentialsProvider {
+    public func getCredentialsProvider() -> CredentialsProviding {
         interactions.append(#function)
         let cognitoCredentialsProvider = MyCustomCredentialsProvider()
         return cognitoCredentialsProvider
@@ -61,7 +61,7 @@ public class MockAWSAuthService: AWSAuthServiceBehavior {
     }
 }
 
-struct MyCustomCredentialsProvider: CredentialsProvider {
+struct MyCustomCredentialsProvider: CredentialsProviding {
     func getCredentials() async throws -> AWSClientRuntime.AWSCredentials {
         AWSCredentials(
             accessKey: "AKIDEXAMPLE",

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSSignatureV4Signer.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSSignatureV4Signer.swift
@@ -12,7 +12,7 @@ import Foundation
 
 class MockAWSSignatureV4Signer: AWSSignatureV4Signer {
     func sigV4SignedRequest(requestBuilder: SdkHttpRequestBuilder,
-                            credentialsProvider: CredentialsProvider,
+                            credentialsProvider: CredentialsProviding,
                             signingName: String,
                             signingRegion: String,
                             date: Date) throws -> SdkHttpRequest? {

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift",
       "state" : {
-        "revision" : "6feec6c3787877807aa9a00fad09591b96752376",
-        "version" : "0.6.1"
+        "revision" : "997904873945e074aaf5c51ea968d9a84684525a",
+        "version" : "0.13.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "24bae88a2391fe75da8a940a544d1ef6441f5321",
-        "version" : "0.13.0"
+        "revision" : "ace826dbfe96e7e3103fe7f45f815b8a590bcf21",
+        "version" : "0.26.0"
       }
     },
     {
@@ -57,10 +57,10 @@
     {
       "identity" : "smithy-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/awslabs/smithy-swift",
+      "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "7b28da158d92cd06a3549140d43b8fbcf64a94a6",
-        "version" : "0.15.0"
+        "revision" : "eed3f3d8e5aa704fcd60bb227b0fc89bf3328c42",
+        "version" : "0.30.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MaxDesiatov/XMLCoder.git",
       "state" : {
-        "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
-        "version" : "0.17.1"
+        "revision" : "80b4a1646399b8e4e0ce80711653476a85bd5e37",
+        "version" : "0.17.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let platforms: [SupportedPlatform] = [
     .watchOS(.v9)
 ]
 let dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/awslabs/aws-sdk-swift.git", exact: "0.13.0"),
+    .package(url: "https://github.com/awslabs/aws-sdk-swift.git", exact: "0.26.0"),
     .package(url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git", from: "3.0.0"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", exact: "0.13.2"),
     .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.1.0"),


### PR DESCRIPTION
## Swift SDK Update 0.26.0

Makes necessary changes to get AWSPluginsCore to compile.

## Debt Introduced
- Added new `FrameworkMetadata` type that needs to be removed in a subsequent PR


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
