### PR TITLE
fix(cloudwatch-logging): clientruntime type name changes for sdk update

### DIFF
--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingCategoryClient.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingCategoryClient.swift
@@ -26,7 +26,7 @@ final class AWSCloudWatchLoggingCategoryClient {
     private let lock = NSLock()
     private let logGroupName: String
     private let region: String
-    private let credentialsProvider: CredentialsProvider
+    private let credentialsProvider: CredentialsProviding
     private let authentication: AuthCategoryUserBehavior
     private var loggersByKey: [LoggerKey: AWSCloudWatchLoggingSessionController] = [:]
     private let localStoreMaxSizeInMB: Int
@@ -38,7 +38,7 @@ final class AWSCloudWatchLoggingCategoryClient {
     
     init(
         enable: Bool,
-        credentialsProvider: CredentialsProvider,
+        credentialsProvider: CredentialsProviding,
         authentication: AuthCategoryUserBehavior,
         loggingConstraintsResolver: AWSCloudWatchLoggingConstraintsResolver,
         logGroupName: String,

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
@@ -25,7 +25,7 @@ final class AWSCloudWatchLoggingSessionController {
     private let logGroupName: String
     private let region: String
     private let localStoreMaxSizeInMB: Int
-    private let credentialsProvider: CredentialsProvider
+    private let credentialsProvider: CredentialsProviding
     private let authentication: AuthCategoryUserBehavior
     private let category: String
     private var session: AWSCloudWatchLoggingSession?
@@ -59,7 +59,7 @@ final class AWSCloudWatchLoggingSessionController {
     }
 
     /// - Tag: CloudWatchLogSessionController.init
-    init(credentialsProvider: CredentialsProvider,
+    init(credentialsProvider: CredentialsProviding,
          authentication: AuthCategoryUserBehavior,
          logFilter: AWSCloudWatchLoggingFilterBehavior,
          category: String,
@@ -103,10 +103,10 @@ final class AWSCloudWatchLoggingSessionController {
 
     private func createConsumer() throws -> LogBatchConsumer? {
         if self.client == nil {
+            // TODO: FrameworkMetadata Replacement
             let configuration = try CloudWatchLogsClient.CloudWatchLogsClientConfiguration(
-                credentialsProvider: credentialsProvider,
-                frameworkMetadata: AmplifyAWSServiceConfiguration.frameworkMetaData(),
-                region: region
+                region: region,
+                credentialsProvider: credentialsProvider
             )
 
             #if os(iOS) || os(macOS) // no-op

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Configuration/DefaultRemoteLoggingConstraintsProvider.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Configuration/DefaultRemoteLoggingConstraintsProvider.swift
@@ -14,7 +14,7 @@ import ClientRuntime
 public class DefaultRemoteLoggingConstraintsProvider: RemoteLoggingConstraintsProvider {    
     public let refreshIntervalInSeconds: Int
     private let endpoint: URL
-    private let credentialProvider: CredentialsProvider?
+    private let credentialProvider: CredentialsProviding?
     private let region: String
     private let loggingConstraintsLocalStore: LoggingConstraintsLocalStore = UserDefaults.standard
     
@@ -31,7 +31,7 @@ public class DefaultRemoteLoggingConstraintsProvider: RemoteLoggingConstraintsPr
     public init(
          endpoint: URL,
          region: String,
-         credentialProvider: CredentialsProvider? = nil,
+         credentialProvider: CredentialsProviding? = nil,
          refreshIntervalInSeconds: Int = 1200
     ) {
         self.endpoint = endpoint
@@ -79,7 +79,9 @@ public class DefaultRemoteLoggingConstraintsProvider: RemoteLoggingConstraintsPr
         let httpMethod = (request.httpMethod?.uppercased())
             .flatMap(HttpMethodType.init(rawValue:)) ?? .get
 
-        let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .map { ClientRuntime.URLQueryItem(name: $0.name, value: $0.value) } ?? []
 
         let requestBuilder = SdkHttpRequestBuilder()
             .withHost(host)

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/MockCloudWatchLogsClient.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/MockCloudWatchLogsClient.swift
@@ -224,5 +224,15 @@ class MockCloudWatchLogsClient: CloudWatchLogsClientProtocol {
         throw MockError.unimplemented
     }
     
-    
+    func deleteAccountPolicy(input: AWSCloudWatchLogs.DeleteAccountPolicyInput) async throws -> AWSCloudWatchLogs.DeleteAccountPolicyOutputResponse {
+        throw MockError.unimplemented
+    }
+
+    func describeAccountPolicies(input: AWSCloudWatchLogs.DescribeAccountPoliciesInput) async throws -> AWSCloudWatchLogs.DescribeAccountPoliciesOutputResponse {
+        throw MockError.unimplemented
+    }
+
+    func putAccountPolicy(input: AWSCloudWatchLogs.PutAccountPolicyInput) async throws -> AWSCloudWatchLogs.PutAccountPolicyOutputResponse {
+        throw MockError.unimplemented
+    }
 }


### PR DESCRIPTION
## Swift SDK Update 0.26.0
- `CredentialsProvider` --> `CredentialsProviding`
- Using `ClientRuntime.URLQueryItem` as needed.
- Adds a few new APIs to `MockCloudWatchLogsClient`

## Debt Introduced
- Removed `FrameworkMetadata` from client configuration. Need to tackle this with user-agent / client engine proxy PR. Tracking on base PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
