### PR TITLE
fix(datastore): Multi auth rule for read subscription

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/Schema/AuthRule.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/AuthRule.swift
@@ -68,3 +68,7 @@ public struct AuthRule {
         self.operations = operations
     }
 }
+
+extension AuthRule: Hashable {
+
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AuthModeStrategyTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AuthModeStrategyTests.swift
@@ -117,10 +117,33 @@ class AuthModeStrategyTests: XCTestCase {
         authMode.authDelegate = delegate
 
         var authTypesIterator = await authMode.authTypesFor(schema: ModelWithCustomStrategy.schema,
-                                                      operation: .create)
+                                                            operation: .create)
         XCTAssertEqual(authTypesIterator.count, 2)
         XCTAssertEqual(authTypesIterator.next(), .function)
         XCTAssertEqual(authTypesIterator.next(), .awsIAM)
+    }
+    
+    // Given: multi-auth strategy and a model schema without auth provider
+    // When: auth types are requested with multiple operation
+    // Then: default values based on the auth strategy should be returned
+    func testMultiAuthShouldReturnDefaultAuthTypesForMultipleOperation() async {
+        let authMode = AWSMultiAuthModeStrategy()
+        var authTypesIterator = await authMode.authTypesFor(schema: ModelNoProvider.schema, operations: [.read, .create])
+        XCTAssertEqual(authTypesIterator.count, 2)
+        XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
+        XCTAssertEqual(authTypesIterator.next(), .apiKey)
+    }
+    
+    // Given: multi-auth strategy and a model schema with auth provider
+    // When: auth types are requested with multiple operation
+    // Then: auth rule for public access should be returned
+    func testMultiAuthReturnDefaultAuthTypesForMultipleOperationWithProvider() async {
+        let authMode = AWSMultiAuthModeStrategy()
+        let delegate = UnauthenticatedUserDelegate()
+        authMode.authDelegate = delegate
+        var authTypesIterator = await authMode.authTypesFor(schema: ModelNoProvider.schema, operations: [.read, .create])
+        XCTAssertEqual(authTypesIterator.count, 1)
+        XCTAssertEqual(authTypesIterator.next(), .apiKey)
     }
 
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -73,7 +73,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
         // onCreate operation
         let onCreateValueListener = onCreateValueListenerHandler(event:)
         let onCreateAuthTypeProvider = await authModeStrategy.authTypesFor(schema: modelSchema,
-                                                                     operation: .create)
+                                                                           operations: [.create, .read])
         self.onCreateValueListener = onCreateValueListener
         self.onCreateOperation = RetryableGraphQLSubscriptionOperation(
             requestFactory: IncomingAsyncSubscriptionEventPublisher.apiRequestFactoryFor(
@@ -94,7 +94,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
         // onUpdate operation
         let onUpdateValueListener = onUpdateValueListenerHandler(event:)
         let onUpdateAuthTypeProvider = await authModeStrategy.authTypesFor(schema: modelSchema,
-                                                                     operation: .update)
+                                                                           operations: [.update, .read])
         self.onUpdateValueListener = onUpdateValueListener
         self.onUpdateOperation = RetryableGraphQLSubscriptionOperation(
             requestFactory: IncomingAsyncSubscriptionEventPublisher.apiRequestFactoryFor(
@@ -115,7 +115,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
         // onDelete operation
         let onDeleteValueListener = onDeleteValueListenerHandler(event:)
         let onDeleteAuthTypeProvider = await authModeStrategy.authTypesFor(schema: modelSchema,
-                                                                     operation: .delete)
+                                                                           operations: [.delete, .read])
         self.onDeleteValueListener = onDeleteValueListener
         self.onDeleteOperation = RetryableGraphQLSubscriptionOperation(
             requestFactory: IncomingAsyncSubscriptionEventPublisher.apiRequestFactoryFor(


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

The issue https://github.com/aws-amplify/amplify-swift/issues/2873 contains lots of details describing the problem.

## Description
<!-- Why is this change required? What problem does it solve? -->
See original PR for more details, this is just a cherry-pick of the `v1` changes applied on `main` https://github.com/aws-amplify/amplify-swift/pull/3029


## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
