### PR TITLE
fix(analytics): user-agent patch

### DIFF
--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Support/Utils/PinpointRequestsRegistry.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Support/Utils/PinpointRequestsRegistry.swift
@@ -66,15 +66,11 @@ private struct CustomPinpointHttpClientEngine: HttpClientEngine {
             return try await httpClientEngine.execute(request: request)
         }
 
-        var headers = request.headers
         let currentUserAgent = headers.value(for: userAgentHeader) ?? ""
-        headers.update(name: userAgentHeader,
-                       value: "\(currentUserAgent)\(userAgentSuffix)")
-        for header in headers.headers {
-            for value in header.value {
-                request.withHeader(name: header.name, value: value)
-            }
-        }
+        request.withHeader(
+            name: userAgentHeader,
+            value: "\(currentUserAgent)\(userAgentSuffix)"
+        )
 
         await PinpointRequestsRegistry.shared.unregisterSources(for: pinpointApi)
         return try await httpClientEngine.execute(request: request)


### PR DESCRIPTION
## Swift SDK Update 0.26.0
Partially addresses https://github.com/aws-amplify/amplify-swift/pull/3261#discussion_r1343119222 

## Debt Introduced
- This likely duplicates the user-agent. Needs to address this with the user-agent overhaul in a subsequent PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
