### PR TITLE
fix(analytics): add missing headers prop

### DIFF
--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Support/Utils/PinpointRequestsRegistry.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Support/Utils/PinpointRequestsRegistry.swift
@@ -66,6 +66,7 @@ private struct CustomPinpointHttpClientEngine: HttpClientEngine {
             return try await httpClientEngine.execute(request: request)
         }
 
+        let headers = request.headers
         let currentUserAgent = headers.value(for: userAgentHeader) ?? ""
         request.withHeader(
             name: userAgentHeader,


### PR DESCRIPTION
## Swift SDK Update 0.26.0
- Adds back in a local property unintentionally removed in https://github.com/aws-amplify/amplify-swift/pull/3264

## Debt Introduced
none


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.