### PR TITLE
fix(analytics): add explicit return cause 5.7

### DIFF
--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Extensions/CommonRunTimeError+isConnectivityError.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Extensions/CommonRunTimeError+isConnectivityError.swift
@@ -35,7 +35,9 @@ extension CommonRunTimeError {
     public var isConnectivityError: Bool {
         switch self {
         case .crtError(let error):
-            Self.connectivityErrorCodes.contains(UInt32(error.code))
+            return Self.connectivityErrorCodes.contains(
+                UInt32(error.code)
+            )
         }
     }
 }


### PR DESCRIPTION
## Swift SDK Update 0.26.0
Add explicit return in InternalAWSPinpoint to compile < 5.9
[Analytics integration tests are also now passing](https://github.com/aws-amplify/amplify-swift/actions/runs/6394386068/job/17355658106)

## Debt Introduced
none

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
