### PR TITLE
chore: Tweaking notification workflows

### DIFF
--- a/.github/workflows/notify_issue_comment.yml
+++ b/.github/workflows/notify_issue_comment.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Exclude comments in PRs and comments made from maintainers
-    if: ${{ !github.event.issue.pull_request && !contains(fromJSON('["CONTRIBUTOR", "MEMBER", "OWNER"]'), github.event.comment.author_association) }}
+    if: ${{ !github.event.issue.pull_request && !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association) }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/notify_issue_comment.yml
+++ b/.github/workflows/notify_issue_comment.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: Notify Comments on Pending/Closing Soon Issues
+name: Notify Comments on Issues
 
 # Controls when the workflow will run
 on:
@@ -18,7 +18,8 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    if: ${{ !github.event.issue.pull_request && !contains(fromJSON('["palpatim", "jcjimenez", "5d", "lawmicha", "harsh62", "thisisabhash", "royjit", "atierian", "ukhan-amazon", "ruisebas", "phantumcode"]'), github.event.comment.user.login) }}
+    # Exclude comments in PRs and comments made from maintainers
+    if: ${{ !github.event.issue.pull_request && !contains(fromJSON('["CONTRIBUTOR", "MEMBER", "OWNER"]'), github.event.comment.author_association) }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -27,7 +28,7 @@ jobs:
         env:
           WEBHOOK_URL: ${{ secrets.SLACK_COMMENT_WEBHOOK_URL }}
           COMMENT: ${{toJson(github.event.comment.body)}}
-          USER: ${{github.event.issue.user.login}}
+          USER: ${{github.event.comment.user.login}}
           COMMENT_URL: ${{github.event.comment.html_url}}
         shell: bash
         run: echo $COMMENT | sed "s/\\\n/. /g; s/\\\r//g; s/[^a-zA-Z0-9 &().,:]//g" | xargs -I {} curl -s POST "$WEBHOOK_URL" -H "Content-Type:application/json" --data '{"comment":"{}", "commentUrl":"'$COMMENT_URL'", "user":"'$USER'"}'

--- a/.github/workflows/notify_new_issue.yml
+++ b/.github/workflows/notify_new_issue.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Exclude issues opened by maintainers
-    if: ${{ !contains(fromJSON('["CONTRIBUTOR", "MEMBER", "OWNER"]'), github.event.issue.author_association) }}
+    if: ${{ !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.issue.author_association) }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/notify_new_issue.yml
+++ b/.github/workflows/notify_new_issue.yml
@@ -18,6 +18,9 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    # Exclude issues opened by maintainers
+    if: ${{ !contains(fromJSON('["CONTRIBUTOR", "MEMBER", "OWNER"]'), github.event.issue.author_association) }}
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Runs a single command using the runners shell

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -4,9 +4,9 @@ name: Notify Amplify iOS Release
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on release created (draft) or released (stable) events but only for the main branch
+  # Triggers the workflow on released events
   release:
-    types: [created, released]
+    types: [released]
 
 # Limit the GITHUB_TOKEN permissions
 permissions: {}


### PR DESCRIPTION
## Description
Updating the notifications workflows to:
- Filter by `author_association` instead of hardcoding aliases, for both comments and issues
- Notify the comment author instead of the issue author
- Remove notifications for draft releases, they are just spammy

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
