### PR TITLE
fix: skip network monitoring for watchOS

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
@@ -15,12 +15,12 @@ import Foundation
 public struct ConflictResolutionDecorator: ModelBasedGraphQLDocumentDecorator {
 
     private let version: Int?
-    private let lastSync: Int?
+    private let lastSync: Int64?
     private let graphQLType: GraphQLOperationType
     private var primaryKeysOnly: Bool
     
     public init(version: Int? = nil,
-                lastSync: Int? = nil,
+                lastSync: Int64? = nil,
                 graphQLType: GraphQLOperationType,
                 primaryKeysOnly: Bool = true) {
         self.version = version

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -49,7 +49,7 @@ protocol ModelSyncGraphQLRequestFactory {
                           where predicate: QueryPredicate?,
                           limit: Int?,
                           nextToken: String?,
-                          lastSync: Int?,
+                          lastSync: Int64?,
                           authType: AWSAuthorizationType?) -> GraphQLRequest<SyncQueryResult>
 
 }
@@ -110,7 +110,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                  where predicate: QueryPredicate? = nil,
                                  limit: Int? = nil,
                                  nextToken: String? = nil,
-                                 lastSync: Int? = nil,
+                                 lastSync: Int64? = nil,
                                  authType: AWSAuthorizationType? = nil) -> GraphQLRequest<SyncQueryResult> {
         syncQuery(modelSchema: modelType.schema,
                          where: predicate,
@@ -215,7 +215,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                  where predicate: QueryPredicate? = nil,
                                  limit: Int? = nil,
                                  nextToken: String? = nil,
-                                 lastSync: Int? = nil,
+                                 lastSync: Int64? = nil,
                                  authType: AWSAuthorizationType? = nil) -> GraphQLRequest<SyncQueryResult> {
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelSchema,
                                                                operationType: .query,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/GraphQLDocumentInputValue.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/GraphQLDocumentInputValue.swift
@@ -37,6 +37,16 @@ extension Int: GraphQLDocumentValueRepresentable {
     }
 }
 
+extension Int64: GraphQLDocumentValueRepresentable {
+    public var graphQLDocumentValue: String {
+        return "\(self)"
+    }
+
+    public var graphQLInlineValue: String {
+        return "\(self)"
+    }
+}
+
 extension String: GraphQLDocumentValueRepresentable {
     public var graphQLDocumentValue: String {
         return self

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata.swift
@@ -12,10 +12,10 @@ public struct ModelSyncMetadata: Model {
     public let id: String
 
     /// The timestamp (in Unix seconds) at which the last sync was started, as reported by the service
-    public var lastSync: Int?
+    public var lastSync: Int64?
 
     public init(id: String,
-                lastSync: Int?) {
+                lastSync: Int64?) {
         self.id = id
         self.lastSync = lastSync
     }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSync.swift
@@ -87,7 +87,7 @@ public struct MutationSync<ModelType: Model>: Decodable {
         self.syncMetadata = MutationSyncMetadata(modelId: modelIdentifier,
                                                  modelName: resolvedModelName,
                                                  deleted: deleted,
-                                                 lastChangedAt: Int(lastChangedAt),
+                                                 lastChangedAt: Int64(lastChangedAt),
                                                  version: Int(version))
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata.swift
@@ -14,7 +14,7 @@ public struct MutationSyncMetadata: Model {
 
     public let id: MutationSyncIdentifier
     public var deleted: Bool
-    public var lastChangedAt: Int
+    public var lastChangedAt: Int64
     public var version: Int
 
     static let deliminator = "|"
@@ -30,14 +30,14 @@ public struct MutationSyncMetadata: Model {
         The format of the `id` has changed to support unique ids across mutiple model types.
         Use init(modelId:modelName:deleted:lastChangedAt) to pass in the `modelName`.
     """)
-    public init(id: MutationSyncIdentifier, deleted: Bool, lastChangedAt: Int, version: Int) {
+    public init(id: MutationSyncIdentifier, deleted: Bool, lastChangedAt: Int64, version: Int) {
         self.id = id
         self.deleted = deleted
         self.lastChangedAt = lastChangedAt
         self.version = version
     }
 
-    public init(modelId: ModelId, modelName: String, deleted: Bool, lastChangedAt: Int, version: Int) {
+    public init(modelId: ModelId, modelName: String, deleted: Bool, lastChangedAt: Int64, version: Int) {
         self.id = Self.identifier(modelName: modelName, modelId: modelId)
         self.deleted = deleted
         self.lastChangedAt = lastChangedAt

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/PaginatedList.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/PaginatedList.swift
@@ -11,5 +11,5 @@ import Foundation
 public struct PaginatedList<ModelType: Model>: Decodable {
     public let items: [MutationSync<ModelType>]
     public let nextToken: String?
-    public let startedAt: Int?
+    public let startedAt: Int64?
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Events/OutboxMutationEvent.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Events/OutboxMutationEvent.swift
@@ -36,7 +36,7 @@ public struct OutboxMutationEvent {
     public struct OutboxMutationEventElement {
         public let model: Model
         public var version: Int?
-        public var lastChangedAt: Int?
+        public var lastChangedAt: Int64?
         public var deleted: Bool?
     }
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -67,7 +67,7 @@ final class InitialSyncOperation: AsynchronousOperation {
         }
     }
 
-    private func getLastSyncTime() -> Int? {
+    private func getLastSyncTime() -> Int64? {
         guard !isCancelled else {
             finish(result: .successfulVoid)
             return nil
@@ -109,7 +109,7 @@ final class InitialSyncOperation: AsynchronousOperation {
         }
     }
 
-    private func query(lastSyncTime: Int?, nextToken: String? = nil) async {
+    private func query(lastSyncTime: Int64?, nextToken: String? = nil) async {
         guard !isCancelled else {
             finish(result: .successfulVoid)
             return
@@ -160,7 +160,7 @@ final class InitialSyncOperation: AsynchronousOperation {
 
     /// Disposes of the query results: Stops if error, reconciles results if success, and kick off a new query if there
     /// is a next token
-    private func handleQueryResults(lastSyncTime: Int?,
+    private func handleQueryResults(lastSyncTime: Int64?,
                                     graphQLResult: Result<SyncQueryResult, GraphQLResponseError<SyncQueryResult>>) {
         guard !isCancelled else {
             finish(result: .successfulVoid)
@@ -198,7 +198,7 @@ final class InitialSyncOperation: AsynchronousOperation {
         }
     }
 
-    private func updateModelSyncMetadata(lastSyncTime: Int?) {
+    private func updateModelSyncMetadata(lastSyncTime: Int64?) {
         guard !isCancelled else {
             finish(result: .successfulVoid)
             return

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -146,10 +146,11 @@ final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueu
                 }
             }
         case .disconnected(modelName: let modelName, reason: .operationDisabled),
-             .disconnected(modelName: let modelName, reason: .unauthorized):
+             .disconnected(modelName: let modelName, reason: .unauthorized),
+             .disconnected(modelName: let modelName, reason: .operationNotAllowed):
             connectionStatusSerialQueue.async {
                 self.log.verbose("[InitializeSubscription.4] subscription disconnected [\(modelName)] reason: [\(receiveValue)]")
-                // A disconnected subscription due to operation disabled or unauthorized will still contribute
+                // A disconnected subscription due to operation disabled, notAllowed or unauthorized will still contribute
                 // to the overall state of the reconciliation queue system on sending the `.initialized` event
                 // since subscriptions may be disabled and have to reconcile locally sourced mutation evemts.
                 self.reconciliationQueueConnectionStatus[modelName] = true

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ModelReconciliationQueue.swift
@@ -12,6 +12,7 @@ import Combine
 enum ModelConnectionDisconnectedReason {
     case unauthorized
     case operationDisabled
+    case operationNotAllowed
 }
 
 enum ModelReconciliationQueueEvent {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "location" : "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
       "state" : {
         "branch" : "fix-watchos",
-        "revision" : "ed49c3bfb89fa14ee54fc181a7a5634bd9ecc0f3"
+        "revision" : "6a6fcd12888a5e3aef262127cfec00c07383959f"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
+        "revision" : "a902f1823a7ff3c9ab2fba0f992396b948eda307",
+        "version" : "1.0.5"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
       "state" : {
-        "revision" : "c7ec93dcbbcd8abc90c74203937f207a7fcaa611",
-        "version" : "3.1.1"
+        "branch" : "fix-watchos",
+        "revision" : "ed49c3bfb89fa14ee54fc181a7a5634bd9ecc0f3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let platforms: [SupportedPlatform] = [
 ]
 let dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/awslabs/aws-sdk-swift.git", exact: "0.13.0"),
-    .package(url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git", from: "3.0.0"),
+    .package(url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git", branch: "fix-watchos"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", exact: "0.13.2"),
     .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.1.0"),
     .package(url: "https://github.com/aws-amplify/amplify-swift-utils-notifications.git", from: "1.1.0")


### PR DESCRIPTION
## Issue \#
https://github.com/aws-amplify/amplify-swift/issues/3220

## Description
<!-- Why is this change required? What problem does it solve? -->
Uses the changes from https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/139. See this for more details.

## Testing
We need to run this app on a physical device to fully verify that the issue is fixed. However, running on a simulator, we can check that there are no logs around network monitoring.

The logs around networking monitoring looks like this:
```
[RealtimeConnectionProvider] Status: inProgress. Connectivity status: unsatisfied
```

Running the app on a simulator and then calling `DataStore.start()` shows that there are no "Connectivity" related logs

https://github.com/lawmicha/watchOSTestApp/blob/main/logs/start.logs

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
