### PR TITLE
chore: Sending repo name instead of URL in release notification [skip ci]

### DIFF
--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
           VERSION: ${{github.event.release.html_url}}
-          REPO_URL: ${{github.event.repository.html_url}}
+          REPO_NAME: ${{github.event.repository.name}}
           ACTION_NAME: ${{github.event.action}}
         shell: bash
-        run: echo $VERSION | xargs -I {} curl -s POST "$WEBHOOK_URL" -H "Content-Type:application/json" --data '{"action":"'$ACTION_NAME'", "repo":"'$REPO_URL'", "version":"{}"}'
+        run: echo $VERSION | xargs -I {} curl -s POST "$WEBHOOK_URL" -H "Content-Type:application/json" --data '{"action":"'$ACTION_NAME'", "repo":"'$REPO_NAME'", "version":"{}"}'


### PR DESCRIPTION
## Description
Sending `github.event.repository.name` instead of `github.event.repository.html_url` to the Slack webhook, since the release url already includes a link.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
