### PR TITLE
fix(internal-pinpoint-tests): update tests for new sdk version

### DIFF
--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockEndpointClient.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockEndpointClient.swift
@@ -13,7 +13,7 @@ import Foundation
 actor MockEndpointClient: EndpointClientBehaviour {
     let pinpointClient: PinpointClientProtocol = MockPinpointClient()
 
-    class MockCredentialsProvider: CredentialsProvider {
+    class MockCredentialsProvider: CredentialsProviding {
         func getCredentials() async throws -> AWSCredentials {
             return AWSCredentials(accessKey: "", secret: "", expirationTimeout: Date().addingTimeInterval(1000))
         }

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockPinpointClient.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockPinpointClient.swift
@@ -9,6 +9,18 @@ import AWSPinpoint
 import Foundation
 
 class MockPinpointClient: PinpointClientProtocol {
+    func getJourneyRunExecutionActivityMetrics(input: GetJourneyRunExecutionActivityMetricsInput) async throws -> GetJourneyRunExecutionActivityMetricsOutputResponse {
+        fatalError("Not supported")
+    }
+
+    func getJourneyRunExecutionMetrics(input: GetJourneyRunExecutionMetricsInput) async throws -> GetJourneyRunExecutionMetricsOutputResponse {
+        fatalError("Not supported")
+    }
+
+    func getJourneyRuns(input: GetJourneyRunsInput) async throws -> GetJourneyRunsOutputResponse {
+        fatalError("Not supported")
+    }
+
     func createApp(input: CreateAppInput) async throws -> CreateAppOutputResponse {
         fatalError("Not supported")
     }

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/PinpointRequestsRegistryTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/PinpointRequestsRegistryTests.swift
@@ -72,48 +72,20 @@ class PinpointRequestsRegistryTests: XCTestCase {
 
     private func createSdkRequest(for api: PinpointRequestsRegistry.API?) throws -> SdkHttpRequest {
         let apiPath = api?.rawValue ?? "otherApi"
-        let endpoint = try Endpoint(urlString: "https://host:42/path/\(apiPath)/suffix")
-        let headers = [
-            "User-Agent": "mocked_user_agent"
-        ]
-        return SdkHttpRequest(method: .put,
-                              endpoint: endpoint,
-                              headers: .init(headers))
+        let endpoint = try Endpoint(
+            urlString: "https://host:42/path/\(apiPath)/suffix",
+            headers: .init(["User-Agent": "mocked_user_agent"])
+        )
+        return SdkHttpRequest(
+            method: .put,
+            endpoint: endpoint
+        )
     }
 }
 
 private extension HttpClientEngine {
     var typeString: String {
         String(describing: type(of: self))
-    }
-}
-
-private class MockSDKRuntimeConfiguration: SDKRuntimeConfiguration {
-    var encoder: ClientRuntime.RequestEncoder?
-    var decoder: ClientRuntime.ResponseDecoder?
-    var httpClientConfiguration: ClientRuntime.HttpClientConfiguration
-    var idempotencyTokenGenerator: ClientRuntime.IdempotencyTokenGenerator
-    var clientLogMode: ClientRuntime.ClientLogMode
-    var partitionID: String?
-    
-    let logger: LogAgent
-    let retryer: SDKRetryer
-    var endpoint: String? = nil
-    private let mockedHttpClientEngine : HttpClientEngine
-
-    init(httpClientEngine: HttpClientEngine) throws {
-        let defaultSDKRuntimeConfig = try DefaultSDKRuntimeConfiguration("MockSDKRuntimeConfiguration")
-        httpClientConfiguration = defaultSDKRuntimeConfig.httpClientConfiguration
-        idempotencyTokenGenerator = defaultSDKRuntimeConfig.idempotencyTokenGenerator
-        clientLogMode = defaultSDKRuntimeConfig.clientLogMode
-        
-        logger = MockLogAgent()
-        retryer = try SDKRetryer(options: RetryOptions(jitterMode: .default))
-        mockedHttpClientEngine = httpClientEngine
-    }
-
-    var httpClientEngine: HttpClientEngine {
-        mockedHttpClientEngine
     }
 }
 


### PR DESCRIPTION
## Swift SDK Update 0.26.0
Minor changes to InternalAWSPinpointUnitTests target to account for new Swift SDK types / methods.

## Debt Introduced
none

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
