### PR TITLE
fix(storage-test): use identity comparison operators not XCTest methods

### DIFF
--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Configuration/S3ClientConfigurationProxyTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Configuration/S3ClientConfigurationProxyTests.swift
@@ -35,7 +35,7 @@ final class S3ClientConfigurationAccelerateTestCase: XCTestCase {
         let baseConfiguration = try await configuration(accelerate: baseAccelerate)
 
         let nilAccelerate = try baseConfiguration.withAccelerate(nil)
-        XCTAssertIdentical(baseConfiguration, nilAccelerate)
+        XCTAssert(baseConfiguration === nilAccelerate)
     }
 
     /// Given: A client configuration.
@@ -46,7 +46,7 @@ final class S3ClientConfigurationAccelerateTestCase: XCTestCase {
         let baseConfiguration = try await configuration(accelerate: baseAccelerate)
 
         let equalAccelerate = try baseConfiguration.withAccelerate(baseAccelerate)
-        XCTAssertIdentical(baseConfiguration, equalAccelerate)
+        XCTAssert(baseConfiguration === equalAccelerate)
     }
 
     /// Given: A client configuration.
@@ -57,7 +57,7 @@ final class S3ClientConfigurationAccelerateTestCase: XCTestCase {
         let baseConfiguration = try await configuration(accelerate: baseAccelerate)
 
         let nonEqualAccelerate = try baseConfiguration.withAccelerate(!baseAccelerate)
-        XCTAssertNotIdentical(baseConfiguration, nonEqualAccelerate)
+        XCTAssert(baseConfiguration !== nonEqualAccelerate)
     }
 
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Configuration/S3ClientConfigurationProxyTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Configuration/S3ClientConfigurationProxyTests.swift
@@ -19,9 +19,7 @@ final class S3ClientConfigurationAccelerateTestCase: XCTestCase {
     /// When: An override is set through `withAccelerate(_:)`
     /// Then: The base configuration is not mutated.
     func testPropertyOverrides() async throws {
-        let baseConfiguration = try await S3Client.S3ClientConfiguration()
-        baseConfiguration.serviceSpecific.accelerate = true
-
+        let baseConfiguration = try await configuration(accelerate: true)
         let sut = try baseConfiguration.withAccelerate(false)
         XCTAssertEqual(sut.serviceSpecific.accelerate, false)
         XCTAssertEqual(baseConfiguration.serviceSpecific.accelerate, true)
@@ -74,7 +72,7 @@ final class S3ClientConfigurationAccelerateTestCase: XCTestCase {
             credentialsProvider: nil,
             endpoint: UUID().uuidString,
             serviceSpecific: serviceSpecific,
-            region: nil,
+            region: "us-east-1",
             regionResolver: nil,
             signingRegion: UUID().uuidString,
             useDualStack: .random(),


### PR DESCRIPTION
## Swift SDK Update 0.26.0
- Adds region to client configuration used in tests.
- Configuration copy semantics test case now use identity operator checks instead of built in XCTest methods.

## Debt Introduced
none

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.