### PR TITLE
fix(predictions): use readData on textToSpeech bytestream

### DIFF
--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Polly.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Polly.swift
@@ -24,7 +24,7 @@ extension AWSPredictionsService: AWSPollyServiceBehavior {
 
         do {
             let synthesizedSpeechResult = try await awsPolly.synthesizeSpeech(input: input)
-            guard let speech = synthesizedSpeechResult.audioStream
+            guard let speech = try await synthesizedSpeechResult.audioStream?.readData()
             else {
                 throw PredictionsError.service(
                     .init(
@@ -34,16 +34,7 @@ extension AWSPredictionsService: AWSPollyServiceBehavior {
                 )
             }
 
-            switch speech {
-            case .data(let data?):
-                let textToSpeechResult = Predictions.Convert.TextToSpeech.Result(
-                    audioData: data
-                )
-                return textToSpeechResult
-                // TODO: figure out what to throw here
-            default: throw PredictionsError.unknown("Missing respose", "", nil)
-            }
-
+            return .init(audioData: speech)
         } catch let error as PredictionsErrorConvertible {
             throw error.predictionsError
         } catch {

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/PredictionsHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/PredictionsHostApp.xcodeproj/project.pbxproj
@@ -18,9 +18,6 @@
 		6875F90F2A3CCCB7001C9AAF /* InterpretBasicIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9054235A291425630000D108 /* InterpretBasicIntegrationTests.swift */; };
 		6875F9102A3CCCB7001C9AAF /* AWSPredictionsPluginTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90542359291425630000D108 /* AWSPredictionsPluginTestBase.swift */; };
 		6875F9112A3CCCB7001C9AAF /* ConvertBasicIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90542358291425630000D108 /* ConvertBasicIntegrationTests.swift */; };
-		6875F9142A3CCCB7001C9AAF /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = 6875F9092A3CCCB7001C9AAF /* Amplify */; };
-		6875F9152A3CCCB7001C9AAF /* AWSPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 6875F90B2A3CCCB7001C9AAF /* AWSPredictionsPlugin */; };
-		6875F9162A3CCCB7001C9AAF /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 6875F90A2A3CCCB7001C9AAF /* AWSCognitoAuthPlugin */; };
 		6875F9182A3CCCB7001C9AAF /* testImageText.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 9054235E291425630000D108 /* testImageText.jpg */; };
 		6875F9192A3CCCB7001C9AAF /* testImageCeleb.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 90542363291425630000D108 /* testImageCeleb.jpg */; };
 		6875F91A2A3CCCB7001C9AAF /* testImageTextWithTables.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 90542360291425630000D108 /* testImageTextWithTables.jpg */; };
@@ -38,10 +35,6 @@
 		9028304E2914042800897087 /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 9028304D2914042800897087 /* AWSCognitoAuthPlugin */; };
 		902830502914042800897087 /* AWSPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 9028304F2914042800897087 /* AWSPredictionsPlugin */; };
 		902830522914042800897087 /* CoreMLPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 902830512914042800897087 /* CoreMLPredictionsPlugin */; };
-		904D63AD291439890057D06F /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = 904D63AC291439890057D06F /* Amplify */; };
-		904D63AF291439890057D06F /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 904D63AE291439890057D06F /* AWSCognitoAuthPlugin */; };
-		904D63B1291439890057D06F /* AWSPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 904D63B0291439890057D06F /* AWSPredictionsPlugin */; };
-		904D63B3291439890057D06F /* CoreMLPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 904D63B2291439890057D06F /* CoreMLPredictionsPlugin */; };
 		905423522914254B0000D108 /* audio.wav in Resources */ = {isa = PBXBuildFile; fileRef = 9054234E2914254B0000D108 /* audio.wav */; };
 		905423532914254B0000D108 /* people.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 9054234F2914254B0000D108 /* people.jpg */; };
 		905423542914254B0000D108 /* CoreMLPredictionsPluginIntegrationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905423502914254B0000D108 /* CoreMLPredictionsPluginIntegrationTest.swift */; };
@@ -132,9 +125,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6875F9142A3CCCB7001C9AAF /* Amplify in Frameworks */,
-				6875F9152A3CCCB7001C9AAF /* AWSPredictionsPlugin in Frameworks */,
-				6875F9162A3CCCB7001C9AAF /* AWSCognitoAuthPlugin in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -160,10 +150,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				904D63B3291439890057D06F /* CoreMLPredictionsPlugin in Frameworks */,
-				904D63AD291439890057D06F /* Amplify in Frameworks */,
-				904D63B1291439890057D06F /* AWSPredictionsPlugin in Frameworks */,
-				904D63AF291439890057D06F /* AWSCognitoAuthPlugin in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -326,9 +312,6 @@
 			);
 			name = AWSPredictionsPluginIntegrationTestsWatch;
 			packageProductDependencies = (
-				6875F9092A3CCCB7001C9AAF /* Amplify */,
-				6875F90A2A3CCCB7001C9AAF /* AWSCognitoAuthPlugin */,
-				6875F90B2A3CCCB7001C9AAF /* AWSPredictionsPlugin */,
 			);
 			productName = AWSPredictionsPluginIntegrationTests;
 			productReference = 6875F9242A3CCCB7001C9AAF /* AWSPredictionsPluginIntegrationTestsWatch.xctest */;
@@ -391,10 +374,6 @@
 			);
 			name = AWSPredictionsPluginIntegrationTests;
 			packageProductDependencies = (
-				904D63AC291439890057D06F /* Amplify */,
-				904D63AE291439890057D06F /* AWSCognitoAuthPlugin */,
-				904D63B0291439890057D06F /* AWSPredictionsPlugin */,
-				904D63B2291439890057D06F /* CoreMLPredictionsPlugin */,
 			);
 			productName = AWSPredictionsPluginIntegrationTests;
 			productReference = 903555F829141355004B83C2 /* AWSPredictionsPluginIntegrationTests.xctest */;
@@ -882,6 +861,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.coffee.PredictionsHostApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
@@ -916,6 +896,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.coffee.PredictionsHostApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
@@ -943,6 +924,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.coffee.CoreMLPredictionsPluginIntegrationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
@@ -973,6 +955,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.coffee.CoreMLPredictionsPluginIntegrationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator";
@@ -1119,18 +1102,6 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = AWSPredictionsPlugin;
 		};
-		6875F9092A3CCCB7001C9AAF /* Amplify */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Amplify;
-		};
-		6875F90A2A3CCCB7001C9AAF /* AWSCognitoAuthPlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AWSCognitoAuthPlugin;
-		};
-		6875F90B2A3CCCB7001C9AAF /* AWSPredictionsPlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AWSPredictionsPlugin;
-		};
 		9028304B2914042800897087 /* Amplify */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Amplify;
@@ -1144,22 +1115,6 @@
 			productName = AWSPredictionsPlugin;
 		};
 		902830512914042800897087 /* CoreMLPredictionsPlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = CoreMLPredictionsPlugin;
-		};
-		904D63AC291439890057D06F /* Amplify */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Amplify;
-		};
-		904D63AE291439890057D06F /* AWSCognitoAuthPlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AWSCognitoAuthPlugin;
-		};
-		904D63B0291439890057D06F /* AWSPredictionsPlugin */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AWSPredictionsPlugin;
-		};
-		904D63B2291439890057D06F /* CoreMLPredictionsPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = CoreMLPredictionsPlugin;
 		};


### PR DESCRIPTION
## Swift SDK Update 0.26.0
- Uses provided `readData()` method on `ByteStream` in Polly response for `textToSpeech`
- Removes linked libraries from test targets causing problems with Xcode 15.
- Resolves open item in base branch:
> There's a new error branch in AWSPredictionsService+Polly that now throws an .unknown error. Take another look at it to see if there's a more appropriate error than can be thrown there. Added in https://github.com/aws-amplify/amplify-swift/pull/3257

## Debt Introduced
none

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.