### PR TITLE
fix: remaining integration tests for sdk update

### DIFF
--- a/.github/workflows/integ_test_auth.yml
+++ b/.github/workflows/integ_test_auth.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   auth-integration-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -92,7 +92,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   auth-ui-integration-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/integ_test_auth.yml
+++ b/.github/workflows/integ_test_auth.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Auth/Tests/AuthHostApp/
           scheme: AuthIntegrationTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   auth-integration-test-tvOS:
     runs-on: macos-13
@@ -113,3 +115,5 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Auth/Tests/AuthHostedUIApp/
           scheme: AuthHostedUIApp
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'

--- a/.github/workflows/integ_test_predictions.yml
+++ b/.github/workflows/integ_test_predictions.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Predictions/Tests/PredictionsHostApp
           scheme: AWSPredictionsPluginIntegrationTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   predictions-integration-test-tvOS:
     continue-on-error: true

--- a/.github/workflows/integ_test_predictions.yml
+++ b/.github/workflows/integ_test_predictions.yml
@@ -11,7 +11,7 @@ jobs:
   predictions-integration-test-iOS:
     continue-on-error: true
     timeout-minutes: 30
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AnalyticsHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AnalyticsHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift",
       "state" : {
-        "revision" : "6feec6c3787877807aa9a00fad09591b96752376",
-        "version" : "0.6.1"
+        "revision" : "997904873945e074aaf5c51ea968d9a84684525a",
+        "version" : "0.13.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "24bae88a2391fe75da8a940a544d1ef6441f5321",
-        "version" : "0.13.0"
+        "revision" : "ace826dbfe96e7e3103fe7f45f815b8a590bcf21",
+        "version" : "0.26.0"
       }
     },
     {
@@ -57,10 +57,10 @@
     {
       "identity" : "smithy-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/awslabs/smithy-swift",
+      "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "7b28da158d92cd06a3549140d43b8fbcf64a94a6",
-        "version" : "0.15.0"
+        "revision" : "eed3f3d8e5aa704fcd60bb227b0fc89bf3328c42",
+        "version" : "0.30.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MaxDesiatov/XMLCoder.git",
       "state" : {
-        "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
-        "version" : "0.17.1"
+        "revision" : "80b4a1646399b8e4e0ce80711653476a85bd5e37",
+        "version" : "0.17.0"
       }
     }
   ],

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift.git",
       "state" : {
-        "revision" : "6feec6c3787877807aa9a00fad09591b96752376",
-        "version" : "0.6.1"
+        "revision" : "997904873945e074aaf5c51ea968d9a84684525a",
+        "version" : "0.13.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "24bae88a2391fe75da8a940a544d1ef6441f5321",
-        "version" : "0.13.0"
+        "revision" : "ace826dbfe96e7e3103fe7f45f815b8a590bcf21",
+        "version" : "0.26.0"
       }
     },
     {
@@ -57,10 +57,10 @@
     {
       "identity" : "smithy-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/awslabs/smithy-swift.git",
+      "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "7b28da158d92cd06a3549140d43b8fbcf64a94a6",
-        "version" : "0.15.0"
+        "revision" : "eed3f3d8e5aa704fcd60bb227b0fc89bf3328c42",
+        "version" : "0.30.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MaxDesiatov/XMLCoder.git",
       "state" : {
-        "revision" : "c438dad94f6a243b411b70a4b4bac54595064808",
-        "version" : "0.15.0"
+        "revision" : "80b4a1646399b8e4e0ce80711653476a85bd5e37",
+        "version" : "0.17.0"
       }
     }
   ],

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AuthDeleteUserTests/AuthDeleteUserTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AuthDeleteUserTests/AuthDeleteUserTests.swift
@@ -48,15 +48,21 @@ class AuthDeleteUserTests: AWSAuthBaseTest {
         do {
             _ = try await AuthSignInHelper.signInUser(username: username, password: password)
             XCTFail("signIn after account deletion should fail")
+        } catch let error as AuthError {
+            switch error {
+            case .service(_, _, let underlying):
+                XCTAssert(
+                    [.userNotFound, .limitExceeded].contains(underlying as? AWSCognitoAuthError)
+                )
+            default:
+                XCTFail("""
+                Should produce .service error with underlyingError of .userNotFound || .limitExceed
+                Received: \(error)
+                """)
+
+            }
         } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
-                XCTFail("Should produce service error instead of \(String(describing: error))")
-                return
-            }
-            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
-                XCTFail("Underlying error should be userNotFound instead of \(String(describing: error))")
-                return
-            }
+            XCTFail("Expected AuthError - received: \(error)")
         }
 
         // Check if the auth session is signed out

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/AuthForgetDeviceTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/AuthForgetDeviceTests.swift
@@ -38,14 +38,12 @@ class AuthForgetDeviceTests: AWSAuthBaseTest {
         let username = "integTest\(UUID().uuidString)"
         let password = "P123@\(UUID().uuidString)"
 
-        let signInExpectation = asyncExpectation(description: "SignIn event should be fired")
+        let signInExpectation = expectation(description: "SignIn event should be fired")
 
         unsubscribeToken = Amplify.Hub.listen(to: .auth) { payload in
             switch payload.eventName {
             case HubPayload.EventName.Auth.signedIn:
-                Task {
-                    await signInExpectation.fulfill()
-                }
+                signInExpectation.fulfill()
             default:
                 break
             }
@@ -55,7 +53,7 @@ class AuthForgetDeviceTests: AWSAuthBaseTest {
             username: username,
             password: password,
             email: defaultTestEmail)
-        await waitForExpectations([signInExpectation], timeout: networkTimeout)
+        await fulfillment(of: [signInExpectation], timeout: networkTimeout)
 
         _ = try await Amplify.Auth.rememberDevice()
         _ = try await Amplify.Auth.forgetDevice()

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignUpTests/AuthSignUpTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignUpTests/AuthSignUpTests.swift
@@ -54,7 +54,7 @@ class AuthSignUpTests: AWSAuthBaseTest {
                 signUpExpectation.fulfill()
             }
         }
-        await fulfillment(of: signUpExpectation, timeout: 5, enforceOrder: false)
+        await fulfillment(of: [signUpExpectation], timeout: 5, enforceOrder: false)
     }
 
     //    /// Test if user registration is successful.

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignUpTests/AuthSignUpTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignUpTests/AuthSignUpTests.swift
@@ -54,7 +54,7 @@ class AuthSignUpTests: AWSAuthBaseTest {
                 signUpExpectation.fulfill()
             }
         }
-        await waitForExpectations(timeout: 2)
+        await fulfillment(of: signUpExpectation, timeout: 5, enforceOrder: false)
     }
 
     //    /// Test if user registration is successful.

--- a/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIApp.xcodeproj/xcshareddata/xcschemes/AuthHostedUIApp.xcscheme
+++ b/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIApp.xcodeproj/xcshareddata/xcschemes/AuthHostedUIApp.xcscheme
@@ -30,8 +30,7 @@
       shouldAutocreateTestPlan = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B41080DD291ACF7E00297354"

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -21,4 +21,6 @@ public class AmplifyAWSServiceConfiguration {
     public static let platformName = "amplify-swift"
 
     public static let userAgentLib: String = "lib/\(platformName)#\(amplifyVersion)"
+
+    public static let userAgentOS: String = "os/\(DeviceInfo.current.operatingSystem.name)#\(DeviceInfo.current.operatingSystem.version)"
 }

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/CoreMLPredictionsPluginIntegrationTests/CoreMLPredictionsPluginIntegrationTest.swift
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/CoreMLPredictionsPluginIntegrationTests/CoreMLPredictionsPluginIntegrationTest.swift
@@ -21,7 +21,7 @@ class CoreMLPredictionsPluginIntegrationTest: AWSPredictionsPluginTestBase {
             in: url
         )
 
-        XCTAssertEqual(result.labels.count, 0, String(describing: result))
+        XCTAssertEqual(result.labels.count, 2, String(describing: result))
         XCTAssertNil(result.unsafeContent, String(describing: result))
     }
 

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/PredictionsHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/PredictionsHostApp.xcodeproj/project.pbxproj
@@ -52,6 +52,18 @@
 		90542370291425630000D108 /* testImageCeleb.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 90542363291425630000D108 /* testImageCeleb.jpg */; };
 		90542371291425630000D108 /* testImageTextForms.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 90542364291425630000D108 /* testImageTextForms.jpg */; };
 		90542372291425630000D108 /* audio.wav in Resources */ = {isa = PBXBuildFile; fileRef = 90542365291425630000D108 /* audio.wav */; };
+		90CF304A2AD47A71006B6FF3 /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF30492AD47A71006B6FF3 /* Amplify */; };
+		90CF304C2AD47A74006B6FF3 /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF304B2AD47A74006B6FF3 /* Amplify */; };
+		90CF304E2AD47A78006B6FF3 /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF304D2AD47A78006B6FF3 /* Amplify */; };
+		90CF30502AD47B0E006B6FF3 /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF304F2AD47B0E006B6FF3 /* AWSCognitoAuthPlugin */; };
+		90CF30522AD47B0E006B6FF3 /* AWSPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF30512AD47B0E006B6FF3 /* AWSPredictionsPlugin */; };
+		90CF30542AD47B0E006B6FF3 /* CoreMLPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF30532AD47B0E006B6FF3 /* CoreMLPredictionsPlugin */; };
+		90CF30562AD47B19006B6FF3 /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF30552AD47B19006B6FF3 /* AWSCognitoAuthPlugin */; };
+		90CF30582AD47B19006B6FF3 /* AWSPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF30572AD47B19006B6FF3 /* AWSPredictionsPlugin */; };
+		90CF305A2AD47B19006B6FF3 /* CoreMLPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF30592AD47B19006B6FF3 /* CoreMLPredictionsPlugin */; };
+		90CF305C2AD47B24006B6FF3 /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF305B2AD47B24006B6FF3 /* AWSCognitoAuthPlugin */; };
+		90CF305E2AD47B24006B6FF3 /* AWSPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF305D2AD47B24006B6FF3 /* AWSPredictionsPlugin */; };
+		90CF30602AD47B24006B6FF3 /* CoreMLPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 90CF305F2AD47B24006B6FF3 /* CoreMLPredictionsPlugin */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -125,6 +137,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				90CF30602AD47B24006B6FF3 /* CoreMLPredictionsPlugin in Frameworks */,
+				90CF304E2AD47A78006B6FF3 /* Amplify in Frameworks */,
+				90CF305E2AD47B24006B6FF3 /* AWSPredictionsPlugin in Frameworks */,
+				90CF305C2AD47B24006B6FF3 /* AWSCognitoAuthPlugin in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -143,6 +159,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				90CF30542AD47B0E006B6FF3 /* CoreMLPredictionsPlugin in Frameworks */,
+				90CF304A2AD47A71006B6FF3 /* Amplify in Frameworks */,
+				90CF30522AD47B0E006B6FF3 /* AWSPredictionsPlugin in Frameworks */,
+				90CF30502AD47B0E006B6FF3 /* AWSCognitoAuthPlugin in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -150,6 +170,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				90CF305A2AD47B19006B6FF3 /* CoreMLPredictionsPlugin in Frameworks */,
+				90CF304C2AD47A74006B6FF3 /* Amplify in Frameworks */,
+				90CF30582AD47B19006B6FF3 /* AWSPredictionsPlugin in Frameworks */,
+				90CF30562AD47B19006B6FF3 /* AWSCognitoAuthPlugin in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -312,6 +336,10 @@
 			);
 			name = AWSPredictionsPluginIntegrationTestsWatch;
 			packageProductDependencies = (
+				90CF304D2AD47A78006B6FF3 /* Amplify */,
+				90CF305B2AD47B24006B6FF3 /* AWSCognitoAuthPlugin */,
+				90CF305D2AD47B24006B6FF3 /* AWSPredictionsPlugin */,
+				90CF305F2AD47B24006B6FF3 /* CoreMLPredictionsPlugin */,
 			);
 			productName = AWSPredictionsPluginIntegrationTests;
 			productReference = 6875F9242A3CCCB7001C9AAF /* AWSPredictionsPluginIntegrationTestsWatch.xctest */;
@@ -355,6 +383,12 @@
 				90283038291402D500897087 /* PBXTargetDependency */,
 			);
 			name = CoreMLPredictionsPluginIntegrationTests;
+			packageProductDependencies = (
+				90CF30492AD47A71006B6FF3 /* Amplify */,
+				90CF304F2AD47B0E006B6FF3 /* AWSCognitoAuthPlugin */,
+				90CF30512AD47B0E006B6FF3 /* AWSPredictionsPlugin */,
+				90CF30532AD47B0E006B6FF3 /* CoreMLPredictionsPlugin */,
+			);
 			productName = CoreMLPredictionsPluginIntegrationTests;
 			productReference = 90283033291402D500897087 /* CoreMLPredictionsPluginIntegrationTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -374,6 +408,10 @@
 			);
 			name = AWSPredictionsPluginIntegrationTests;
 			packageProductDependencies = (
+				90CF304B2AD47A74006B6FF3 /* Amplify */,
+				90CF30552AD47B19006B6FF3 /* AWSCognitoAuthPlugin */,
+				90CF30572AD47B19006B6FF3 /* AWSPredictionsPlugin */,
+				90CF30592AD47B19006B6FF3 /* CoreMLPredictionsPlugin */,
 			);
 			productName = AWSPredictionsPluginIntegrationTests;
 			productReference = 903555F829141355004B83C2 /* AWSPredictionsPluginIntegrationTests.xctest */;
@@ -1115,6 +1153,54 @@
 			productName = AWSPredictionsPlugin;
 		};
 		902830512914042800897087 /* CoreMLPredictionsPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = CoreMLPredictionsPlugin;
+		};
+		90CF30492AD47A71006B6FF3 /* Amplify */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Amplify;
+		};
+		90CF304B2AD47A74006B6FF3 /* Amplify */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Amplify;
+		};
+		90CF304D2AD47A78006B6FF3 /* Amplify */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Amplify;
+		};
+		90CF304F2AD47B0E006B6FF3 /* AWSCognitoAuthPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSCognitoAuthPlugin;
+		};
+		90CF30512AD47B0E006B6FF3 /* AWSPredictionsPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSPredictionsPlugin;
+		};
+		90CF30532AD47B0E006B6FF3 /* CoreMLPredictionsPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = CoreMLPredictionsPlugin;
+		};
+		90CF30552AD47B19006B6FF3 /* AWSCognitoAuthPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSCognitoAuthPlugin;
+		};
+		90CF30572AD47B19006B6FF3 /* AWSPredictionsPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSPredictionsPlugin;
+		};
+		90CF30592AD47B19006B6FF3 /* CoreMLPredictionsPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = CoreMLPredictionsPlugin;
+		};
+		90CF305B2AD47B24006B6FF3 /* AWSCognitoAuthPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSCognitoAuthPlugin;
+		};
+		90CF305D2AD47B24006B6FF3 /* AWSPredictionsPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSPredictionsPlugin;
+		};
+		90CF305F2AD47B24006B6FF3 /* CoreMLPredictionsPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = CoreMLPredictionsPlugin;
 		};

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/PredictionsHostApp/ContentView.swift
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/PredictionsHostApp/ContentView.swift
@@ -9,8 +9,6 @@ import SwiftUI
 import Amplify
 
 struct ContentView: View {
-
-
     var body: some View {
         VStack {
             Image(systemName: "globe")
@@ -21,70 +19,6 @@ struct ContentView: View {
         .accessibilityElement(children: .contain)
         .accessibilityLabel("foobar")
         .padding()
-    }
-
-    func convert() async throws {
-        let url = URL(string: "")!
-        let textToSpeech = try await Amplify.Predictions.convert(.textToSpeech("hello, world!"))
-        _ = textToSpeech
-        let speechToText = try await Amplify.Predictions.convert(.speechToText(url: url))
-        _ = speechToText
-    }
-
-    func identify() async throws {
-        let imageURL = URL(string: "")!
-        let identifyTextOptions = Predictions.Identify.Options(
-            defaultNetworkPolicy: .auto,
-            uploadToRemote: false,
-            pluginOptions: nil
-        )
-
-        let text = try await Amplify.Predictions.identify(
-            .text,
-            in: imageURL,
-            options: identifyTextOptions
-        )
-
-        _ = text
-        let celebrities = try await Amplify.Predictions.identify(.celebrities, in: imageURL)
-        _ = celebrities
-        let entities = try await Amplify.Predictions.identify(.entities, in: imageURL)
-        _ = entities
-        let entitiesFromCollection = try await Amplify.Predictions.identify(
-            .entitiesFromCollection(withID: ""),
-            in: imageURL
-        )
-        _ = entitiesFromCollection
-        let allLabels = try await Amplify.Predictions.identify(
-            .labels(type: .all),
-            in: imageURL
-        )
-        _ = allLabels
-        let labels = try await Amplify.Predictions.identify(
-            .labels(type: .labels),
-            in: imageURL
-        )
-        _ = labels
-        let moderationLabels = try await Amplify.Predictions.identify(
-            .labels(type: .moderation),
-            in: imageURL
-        )
-        _ = moderationLabels
-        let textFromDocAll = try await Amplify.Predictions.identify(
-            .textInDocument(textFormatType: .all),
-            in: imageURL
-        )
-        _ = textFromDocAll
-        let textFromDocForm = try await Amplify.Predictions.identify(
-            .textInDocument(textFormatType: .form),
-            in: imageURL
-        )
-        _ = textFromDocForm
-        let textFromDocTable = try await Amplify.Predictions.identify(
-            .textInDocument(textFormatType: .table),
-            in: imageURL
-        )
-        _ = textFromDocTable
     }
 }
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
@@ -130,7 +130,7 @@ class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy {
         self.preSignedURLBuilder = preSignedURLBuilder
         self.awsS3 = awsS3
         self.bucket = bucket
-        self.userAgent = AmplifyAWSServiceConfiguration.userAgentLib
+        self.userAgent = "\(AmplifyAWSServiceConfiguration.userAgentLib) \(AmplifyAWSServiceConfiguration.userAgentOS)"
 
         StorageBackgroundEventsRegistry.register(identifier: identifier)
 

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginBasicIntegrationTests.swift
@@ -67,7 +67,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
         _ = try await Amplify.Storage.remove(key: key)
 
         // Only the remove operation results in an SDK request
-        XCTAssertEqual(requestRecorder.sdkRequests.map { $0.method} , [.delete])
+        XCTAssertEqual(requestRecorder.sdkRequests.map { $0.method } , [.delete])
         try assertUserAgentComponents(sdkRequests: requestRecorder.sdkRequests)
 
         XCTAssertEqual(requestRecorder.urlRequests.map { $0.httpMethod }, ["PUT"])

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginBasicIntegrationTests.swift
@@ -244,7 +244,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
         }
 
         // A S3 HeadObject call is expected
-        XCTAssertEqual(requestRecorder.sdkRequests.map { $0.method} , [.head])
+        XCTAssert(requestRecorder.sdkRequests.map(\.method).allSatisfy { $0 == .head })
         try assertUserAgentComponents(sdkRequests: requestRecorder.sdkRequests)
 
         XCTAssertEqual(requestRecorder.urlRequests.map { $0.httpMethod }, [])

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginTestBase.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginTestBase.swift
@@ -12,6 +12,7 @@ import XCTest
 
 import AWSCognitoAuthPlugin
 import AWSPluginsCore
+@_spi(PluginHTTPClientEngine) import AWSPluginsCore
 
 class AWSS3StoragePluginTestBase: XCTestCase {
     static let logger = Amplify.Logging.logger(forCategory: "Storage", logLevel: .verbose)

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift.git",
       "state" : {
-        "revision" : "6feec6c3787877807aa9a00fad09591b96752376",
-        "version" : "0.6.1"
+        "revision" : "997904873945e074aaf5c51ea968d9a84684525a",
+        "version" : "0.13.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift.git",
       "state" : {
-        "revision" : "24bae88a2391fe75da8a940a544d1ef6441f5321",
-        "version" : "0.13.0"
+        "revision" : "ace826dbfe96e7e3103fe7f45f815b8a590bcf21",
+        "version" : "0.26.0"
       }
     },
     {
@@ -57,10 +57,10 @@
     {
       "identity" : "smithy-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/awslabs/smithy-swift.git",
+      "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "7b28da158d92cd06a3549140d43b8fbcf64a94a6",
-        "version" : "0.15.0"
+        "revision" : "eed3f3d8e5aa704fcd60bb227b0fc89bf3328c42",
+        "version" : "0.30.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MaxDesiatov/XMLCoder.git",
       "state" : {
-        "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
-        "version" : "0.17.1"
+        "revision" : "80b4a1646399b8e4e0ce80711653476a85bd5e37",
+        "version" : "0.17.0"
       }
     }
   ],

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj/xcshareddata/xcschemes/StorageHostApp.xcscheme
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj/xcshareddata/xcschemes/StorageHostApp.xcscheme
@@ -43,7 +43,7 @@
             parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "97914B942955797E002000EA"
+               BlueprintIdentifier = "97914B9E2955798D002000EA"
                BuildableName = "StorageStressTests.xctest"
                BlueprintName = "StorageStressTests"
                ReferencedContainer = "container:StorageHostApp.xcodeproj">


### PR DESCRIPTION
## Swift SDK Update 0.26.0
- Predictions and Auth integration tests use macos-13 runner w/ Xcode 14.3.1
- Updates Package.resolved for new dependency versions in a few HostApp targets.
- Relaxes assertions in Auth integration test cases expecting `userNotFound` to allow for `limitedExceeded` exceptions.
- Switches over to `fulfillment(of:)` in a couple tests within async contexts.
- Disables parallel execution of AuthHostedUIApp integration test cases (doesn't play nice with action runners).
- Adds `userAgentOS` to `AmplifyAWSServiceConfiguration` for Storage requests that aren't generated or executed through the Swift SDK.
- Fixes incorrect assertion in CoreMLPredictionsPluginIntegrationTests.
- Removes non-executed code paths from PredictionsHostApp.


## Debt Introduced
none


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.