### PR TITLE
chore: Fixing retries in unit tests workflow

### DIFF
--- a/.github/workflows/run_xcodebuild_test_platforms.yml
+++ b/.github/workflows/run_xcodebuild_test_platforms.yml
@@ -98,7 +98,8 @@ jobs:
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: true
-          test_without_building: true
+          # Only test without building when this exact SHA was cached or we did not restore the build from main.
+          test_without_building: ${{ steps.restore-build.outputs.cache-hit || !steps.restore-main-build.outputs.cache-hit }}
           other_flags: ${{ inputs.other_flags }}
       - name: Save the SHA build cache for re-runs
         if: failure() && steps.retry-tests.outcome=='failure'
@@ -201,7 +202,8 @@ jobs:
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: true
-          test_without_building: true
+          # Only test without building when this exact SHA was cached or we did not restore the build from main.
+          test_without_building: ${{ steps.restore-build.outputs.cache-hit || !steps.restore-main-build.outputs.cache-hit }}
           other_flags: ${{ inputs.other_flags }}
       - name: Save the SHA build cache for re-runs
         if: failure() && steps.retry-tests.outcome=='failure'
@@ -295,7 +297,8 @@ jobs:
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: true
-          test_without_building: true
+          # Only test without building when this exact SHA was cached or we did not restore the build from main.
+          test_without_building: ${{ steps.restore-build.outputs.cache-hit || !steps.restore-main-build.outputs.cache-hit }}
           other_flags: ${{ inputs.other_flags }}
       - name: Save the SHA build cache for re-runs
         if: failure() && steps.retry-tests.outcome=='failure'
@@ -389,7 +392,8 @@ jobs:
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: true
-          test_without_building: true
+          # Only test without building when this exact SHA was cached or we did not restore the build from main.
+          test_without_building: ${{ steps.restore-build.outputs.cache-hit || !steps.restore-main-build.outputs.cache-hit }}
           other_flags: ${{ inputs.other_flags }}
       - name: Save the SHA build cache for re-runs
         if: failure() && steps.retry-tests.outcome=='failure'


### PR DESCRIPTION
## Description
Only setting `test-without-building` to `true` if there was a cache for the exact SHA that's being tested, **or** if there wasn't a main build cached.

Otherwise the retry would end up using an old successful build and result in a success, even if the actual tests in the current commit are not passing.

## General Checklist

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
