### PR TITLE
fix(storage): add metadata support to uploads

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+AsyncClientBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+AsyncClientBehavior.swift
@@ -35,6 +35,7 @@ extension AWSS3StoragePlugin {
         let result = try await storageService.getPreSignedURL(
             serviceKey: serviceKey,
             signingOperation: .getObject,
+            metadata: nil,
             accelerate: accelerate,
             expires: options.expires)
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3PreSignedURLBuilderAdapter.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3PreSignedURLBuilderAdapter.swift
@@ -34,6 +34,7 @@ class AWSS3PreSignedURLBuilderAdapter: AWSS3PreSignedURLBuilderBehavior {
     /// - Returns: Pre-Signed URL
     func getPreSignedURL(key: String,
                          signingOperation: AWSS3SigningOperation,
+                         metadata: [String: String]? = nil,
                          accelerate: Bool? = nil,
                          expires: Int64? = nil) async throws -> URL {
         let expiresDate = Date(timeIntervalSinceNow: Double(expires ?? defaultExpiration))
@@ -47,7 +48,7 @@ class AWSS3PreSignedURLBuilderAdapter: AWSS3PreSignedURLBuilderBehavior {
                 config: config,
                 expiration: expiration)
         case .putObject:
-            let input = PutObjectInput(bucket: bucket, key: key)
+            let input = PutObjectInput(bucket: bucket, key: key, metadata: metadata)
             preSignedUrl = try await input.presignURL(
                 config: config,
                 expiration: expiration)

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3PreSignedURLBuilderBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3PreSignedURLBuilderBehavior.swift
@@ -41,6 +41,7 @@ protocol AWSS3PreSignedURLBuilderBehavior {
     /// - Tag: AWSS3PreSignedURLBuilderBehavior.getPreSignedURL
     func getPreSignedURL(key: String,
                          signingOperation: AWSS3SigningOperation,
+                         metadata: [String: String]?,
                          accelerate: Bool?,
                          expires: Int64?) async throws -> URL
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+DownloadBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+DownloadBehavior.swift
@@ -30,6 +30,7 @@ extension AWSS3StorageService {
             do {
                 let preSignedURL = try await preSignedURLBuilder.getPreSignedURL(key: serviceKey,
                                                                                  signingOperation: .getObject,
+                                                                                 metadata: nil,
                                                                                  accelerate: accelerate,
                                                                                  expires: nil)
                 startDownload(preSignedURL: preSignedURL, transferTask: transferTask)

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+GetPreSignedURLBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+GetPreSignedURLBehavior.swift
@@ -14,11 +14,13 @@ extension AWSS3StorageService {
 
     func getPreSignedURL(serviceKey: String,
                          signingOperation: AWSS3SigningOperation,
+                         metadata: [String: String]?,
                          accelerate: Bool?,
                          expires: Int) async throws -> URL {
         return try await preSignedURLBuilder.getPreSignedURL(
             key: serviceKey,
             signingOperation: signingOperation,
+            metadata: metadata,
             accelerate: nil,
             expires: Int64(expires)
         )

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+MultiPartUploadBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+MultiPartUploadBehavior.swift
@@ -32,7 +32,8 @@ extension AWSS3StorageService {
         let client = DefaultStorageMultipartUploadClient(serviceProxy: self,
                                                          bucket: bucket,
                                                          key: serviceKey,
-                                                         uploadFile: uploadFile)
+                                                         uploadFile: uploadFile,
+                                                         metadata: metadata)
         let multipartUploadSession = StorageMultipartUploadSession(client: client,
                                                                    bucket: bucket,
                                                                    key: serviceKey,

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+UploadBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+UploadBehavior.swift
@@ -36,6 +36,7 @@ extension AWSS3StorageService {
             do {
                 let preSignedURL = try await preSignedURLBuilder.getPreSignedURL(key: serviceKey,
                                                                                  signingOperation: .putObject,
+                                                                                 metadata: metadata,
                                                                                  accelerate: accelerate,
                                                                                  expires: nil)
                 startUpload(preSignedURL: preSignedURL,

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageServiceBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageServiceBehavior.swift
@@ -44,6 +44,7 @@ protocol AWSS3StorageServiceBehavior {
 
     func getPreSignedURL(serviceKey: String,
                          signingOperation: AWSS3SigningOperation,
+                         metadata: [String: String]?,
                          accelerate: Bool?,
                          expires: Int) async throws -> URL
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
@@ -42,14 +42,17 @@ class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
     let contentType: String?
     let requestHeaders: RequestHeaders?
     weak var session: StorageMultipartUploadSession?
-
+    let metadata: [String: String]?
+    
     init(serviceProxy: StorageServiceProxy,
          fileSystem: FileSystem = .default,
          bucket: String,
          key: String,
          uploadFile: UploadFile,
          contentType: String? = nil,
-         requestHeaders: RequestHeaders? = nil) {
+         requestHeaders: RequestHeaders? = nil,
+         metadata: [String: String]? = nil
+    ) {
         self.serviceProxy = serviceProxy
         self.fileSystem = fileSystem
         self.bucket = bucket
@@ -57,6 +60,7 @@ class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
         self.uploadFile = uploadFile
         self.contentType = contentType
         self.requestHeaders = requestHeaders
+        self.metadata = metadata
     }
 
     func integrate(session: StorageMultipartUploadSession) {
@@ -135,7 +139,7 @@ class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
                     let preSignedURL = try await serviceProxy.preSignedURLBuilder.getPreSignedURL(
                         key: self.key,
                         signingOperation: operation,
-                        metadata: nil,
+                        metadata: self.metadata,
                         accelerate: nil,
                         expires: nil
                     )

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
@@ -135,6 +135,7 @@ class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
                     let preSignedURL = try await serviceProxy.preSignedURLBuilder.getPreSignedURL(
                         key: self.key,
                         signingOperation: operation,
+                        metadata: nil,
                         accelerate: nil,
                         expires: nil
                     )

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginGetPresignedUrlTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginGetPresignedUrlTests.swift
@@ -65,7 +65,7 @@ final class AWSS3StoragePluginGetPresignedUrlTests: XCTestCase {
         ])
         let expectedServiceKey = "public/" + testKey
         XCTAssertEqual(storageService.interactions, [
-            "getPreSignedURL(serviceKey:signingOperation:accelerate:expires:) \(expectedServiceKey) getObject 18000"
+            "getPreSignedURL(serviceKey:signingOperation:metadata:accelerate:expires:) \(expectedServiceKey) getObject nil 18000"
         ])
     }
     
@@ -120,7 +120,7 @@ final class AWSS3StoragePluginGetPresignedUrlTests: XCTestCase {
 
         let expectedServiceKey = StorageAccessLevel.protected.rawValue + "/" + testIdentityId + "/" + testKey
         XCTAssertEqual(storageService.interactions, [
-            "getPreSignedURL(serviceKey:signingOperation:accelerate:expires:) \(expectedServiceKey) getObject \(expectedExpires)"
+            "getPreSignedURL(serviceKey:signingOperation:metadata:accelerate:expires:) \(expectedServiceKey) getObject nil \(expectedExpires)"
         ])
     }
 
@@ -152,7 +152,7 @@ final class AWSS3StoragePluginGetPresignedUrlTests: XCTestCase {
 
         let expectedServiceKey = StorageAccessLevel.protected.rawValue + "/" + testIdentityId + "/" + testKey
         XCTAssertEqual(storageService.interactions, [
-            "getPreSignedURL(serviceKey:signingOperation:accelerate:expires:) \(expectedServiceKey) getObject \(expectedExpires)"
+            "getPreSignedURL(serviceKey:signingOperation:metadata:accelerate:expires:) \(expectedServiceKey) getObject nil \(expectedExpires)"
         ])
     }
 
@@ -173,7 +173,7 @@ final class AWSS3StoragePluginGetPresignedUrlTests: XCTestCase {
         let expectedExpires = 18000
         let expectedServiceKey = StorageAccessLevel.protected.rawValue + "/" + testIdentityId + "/" + testKey
         XCTAssertEqual(storageService.interactions, [
-            "getPreSignedURL(serviceKey:signingOperation:accelerate:expires:) \(expectedServiceKey) getObject \(expectedExpires)"
+            "getPreSignedURL(serviceKey:signingOperation:metadata:accelerate:expires:) \(expectedServiceKey) getObject nil \(expectedExpires)"
         ])
     }
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockAWSS3PreSignedURLBuilder.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockAWSS3PreSignedURLBuilder.swift
@@ -22,9 +22,15 @@ extension MockAWSS3PreSignedURLBuilder: AWSS3PreSignedURLBuilderBehavior {
     func getPreSignedURL(
         key: String,
         signingOperation: AWSS3SigningOperation,
+        metadata: [String : String]?,
         accelerate: Bool?,
         expires: Int64?) async throws -> URL {
-            interactions.append("\(#function) \(key) \(signingOperation) \(String(describing: expires))")
+            if let metadata = metadata {
+                interactions.append("\(#function) \(key) \(signingOperation) \(metadata) \(String(describing: expires))")
+            } else {
+                interactions.append("\(#function) \(key) \(signingOperation) \(String(describing: expires))")
+            }
+            
             return try await getPreSignedURLHandler(key, signingOperation, expires)
         }
 }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockAWSS3PreSignedURLBuilder.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockAWSS3PreSignedURLBuilder.swift
@@ -25,12 +25,7 @@ extension MockAWSS3PreSignedURLBuilder: AWSS3PreSignedURLBuilderBehavior {
         metadata: [String : String]?,
         accelerate: Bool?,
         expires: Int64?) async throws -> URL {
-            if let metadata = metadata {
-                interactions.append("\(#function) \(key) \(signingOperation) \(metadata) \(String(describing: expires))")
-            } else {
-                interactions.append("\(#function) \(key) \(signingOperation) \(String(describing: expires))")
-            }
-            
+            interactions.append("\(#function) \(key) \(signingOperation) \(String(describing: metadata)) \(String(describing: expires))")
             return try await getPreSignedURLHandler(key, signingOperation, expires)
         }
 }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockAWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockAWSS3StorageService.swift
@@ -80,9 +80,10 @@ public class MockAWSS3StorageService: AWSS3StorageServiceBehavior {
     public func getPreSignedURL(
         serviceKey: String,
         signingOperation: AWSS3SigningOperation,
+        metadata: [String: String]?,
         accelerate: Bool?,
         expires: Int) async throws -> URL {
-            interactions.append("\(#function) \(serviceKey) \(signingOperation) \(expires)")
+            interactions.append("\(#function) \(serviceKey) \(signingOperation) \(String(describing: metadata)) \(expires)")
             return try await getPreSignedURLHandler(serviceKey, signingOperation, expires)
         }
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceGetPreSignedURLBehaviorTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceGetPreSignedURLBehaviorTests.swift
@@ -68,11 +68,12 @@ class AWSS3StorageServiceGetPreSignedURLBehaviorTests: XCTestCase {
     func testForGetObject() async throws {
         let url = try await systemUnderTest.getPreSignedURL(serviceKey: serviceKey,
                                                             signingOperation: .getObject,
+                                                            metadata: nil,
                                                             accelerate: nil,
                                                             expires: expires)
         XCTAssertEqual(url, presignedURL)
         XCTAssertEqual(builder.interactions, [
-            "getPreSignedURL(key:signingOperation:accelerate:expires:) \(serviceKey ?? "") \(AWSS3SigningOperation.getObject) \(String(describing: expires))"
+            "getPreSignedURL(key:signingOperation:metadata:accelerate:expires:) \(serviceKey ?? "") \(AWSS3SigningOperation.getObject) \(String(describing: expires))"
         ])
     }
     
@@ -82,11 +83,28 @@ class AWSS3StorageServiceGetPreSignedURLBehaviorTests: XCTestCase {
     func testForPutObject() async throws {
         let url = try await systemUnderTest.getPreSignedURL(serviceKey: serviceKey,
                                                             signingOperation: .putObject,
+                                                            metadata: nil,
                                                             accelerate: nil,
                                                             expires: expires)
         XCTAssertEqual(url, presignedURL)
         XCTAssertEqual(builder.interactions, [
-            "getPreSignedURL(key:signingOperation:accelerate:expires:) \(serviceKey ?? "") \(AWSS3SigningOperation.putObject) \(String(describing: expires))"
+            "getPreSignedURL(key:signingOperation:metadata:accelerate:expires:) \(serviceKey ?? "") \(AWSS3SigningOperation.putObject) \(String(describing: expires))"
+        ])
+    }
+    
+    /// - Given: A storage service configured to use a AWSS3PreSignedURLBuilder
+    /// - When: A presigned URL is requested for a **AWSS3SigningOperation.putObject** operation with metadata
+    /// - Then: A valid URL is returned
+    func testForPutObjectWithMetadata() async throws {
+        let metadata = ["test": "value"]
+        let url = try await systemUnderTest.getPreSignedURL(serviceKey: serviceKey,
+                                                            signingOperation: .putObject,
+                                                            metadata: metadata,
+                                                            accelerate: nil,
+                                                            expires: expires)
+        XCTAssertEqual(url, presignedURL)
+        XCTAssertEqual(builder.interactions, [
+            "getPreSignedURL(key:signingOperation:metadata:accelerate:expires:) \(serviceKey ?? "") \(AWSS3SigningOperation.putObject) \(metadata) \(String(describing: expires))"
         ])
     }
     
@@ -97,11 +115,12 @@ class AWSS3StorageServiceGetPreSignedURLBehaviorTests: XCTestCase {
         let operation = AWSS3SigningOperation.uploadPart(partNumber: 0, uploadId: UUID().uuidString)
         let url = try await systemUnderTest.getPreSignedURL(serviceKey: serviceKey,
                                                             signingOperation: operation,
+                                                            metadata: nil,
                                                             accelerate: nil,
                                                             expires: expires)
         XCTAssertEqual(url, presignedURL)
         XCTAssertEqual(builder.interactions, [
-            "getPreSignedURL(key:signingOperation:accelerate:expires:) \(serviceKey ?? "") \(operation) \(String(describing: expires))"
+            "getPreSignedURL(key:signingOperation:metadata:accelerate:expires:) \(serviceKey ?? "") \(operation) \(String(describing: expires))"
         ])
     }
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceGetPreSignedURLBehaviorTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceGetPreSignedURLBehaviorTests.swift
@@ -73,7 +73,7 @@ class AWSS3StorageServiceGetPreSignedURLBehaviorTests: XCTestCase {
                                                             expires: expires)
         XCTAssertEqual(url, presignedURL)
         XCTAssertEqual(builder.interactions, [
-            "getPreSignedURL(key:signingOperation:metadata:accelerate:expires:) \(serviceKey ?? "") \(AWSS3SigningOperation.getObject) \(String(describing: expires))"
+            "getPreSignedURL(key:signingOperation:metadata:accelerate:expires:) \(serviceKey ?? "") \(AWSS3SigningOperation.getObject) nil \(String(describing: expires))"
         ])
     }
     
@@ -88,7 +88,7 @@ class AWSS3StorageServiceGetPreSignedURLBehaviorTests: XCTestCase {
                                                             expires: expires)
         XCTAssertEqual(url, presignedURL)
         XCTAssertEqual(builder.interactions, [
-            "getPreSignedURL(key:signingOperation:metadata:accelerate:expires:) \(serviceKey ?? "") \(AWSS3SigningOperation.putObject) \(String(describing: expires))"
+            "getPreSignedURL(key:signingOperation:metadata:accelerate:expires:) \(serviceKey ?? "") \(AWSS3SigningOperation.putObject) nil \(String(describing: expires))"
         ])
     }
     
@@ -96,7 +96,7 @@ class AWSS3StorageServiceGetPreSignedURLBehaviorTests: XCTestCase {
     /// - When: A presigned URL is requested for a **AWSS3SigningOperation.putObject** operation with metadata
     /// - Then: A valid URL is returned
     func testForPutObjectWithMetadata() async throws {
-        let metadata = ["test": "value"]
+        let metadata: [String: String]? = ["test": "value"]
         let url = try await systemUnderTest.getPreSignedURL(serviceKey: serviceKey,
                                                             signingOperation: .putObject,
                                                             metadata: metadata,
@@ -104,7 +104,7 @@ class AWSS3StorageServiceGetPreSignedURLBehaviorTests: XCTestCase {
                                                             expires: expires)
         XCTAssertEqual(url, presignedURL)
         XCTAssertEqual(builder.interactions, [
-            "getPreSignedURL(key:signingOperation:metadata:accelerate:expires:) \(serviceKey ?? "") \(AWSS3SigningOperation.putObject) \(metadata) \(String(describing: expires))"
+            "getPreSignedURL(key:signingOperation:metadata:accelerate:expires:) \(serviceKey ?? "") \(AWSS3SigningOperation.putObject) \(String(describing: metadata)) \(String(describing: expires))"
         ])
     }
     
@@ -120,7 +120,7 @@ class AWSS3StorageServiceGetPreSignedURLBehaviorTests: XCTestCase {
                                                             expires: expires)
         XCTAssertEqual(url, presignedURL)
         XCTAssertEqual(builder.interactions, [
-            "getPreSignedURL(key:signingOperation:metadata:accelerate:expires:) \(serviceKey ?? "") \(operation) \(String(describing: expires))"
+            "getPreSignedURL(key:signingOperation:metadata:accelerate:expires:) \(serviceKey ?? "") \(operation) nil \(String(describing: expires))"
         ])
     }
 


### PR DESCRIPTION
## Issue \#
https://github.com/aws-amplify/amplify-swift/issues/2744
## Description
* Include metadata in s3 uploads

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
