### PR TITLE
feat(datastore): Add `isLoaded` public property in List+Model

### DIFF
--- a/Amplify/Categories/DataStore/Model/Lazy/List+Model.swift
+++ b/Amplify/Categories/DataStore/Model/Lazy/List+Model.swift
@@ -19,13 +19,13 @@ public class List<ModelType: Model>: Collection, Codable, ExpressibleByArrayLite
     public typealias Element = ModelType
 
     /// Represents the data state of the `List`.
-    enum LoadedState {
+    public enum LoadedState {
         case notLoaded
         case loaded([Element])
     }
 
     /// The current state of lazily loaded list
-    var loadedState: LoadedState
+    public internal(set) var loadedState: LoadedState
 
     /// The provider for fulfilling list behaviors
     let listProvider: AnyModelListProvider<Element>

--- a/Amplify/Categories/DataStore/Model/Lazy/List+Model.swift
+++ b/Amplify/Categories/DataStore/Model/Lazy/List+Model.swift
@@ -19,13 +19,22 @@ public class List<ModelType: Model>: Collection, Codable, ExpressibleByArrayLite
     public typealias Element = ModelType
 
     /// Represents the data state of the `List`.
-    public enum LoadedState {
+    enum LoadedState {
         case notLoaded
         case loaded([Element])
     }
 
     /// The current state of lazily loaded list
-    public internal(set) var loadedState: LoadedState
+    var loadedState: LoadedState
+    
+    /// Boolean property to check if list is loaded
+    public var isLoaded: Bool {
+        if case .loaded = loadedState {
+            return true
+        }
+        
+        return false
+    }
 
     /// The provider for fulfilling list behaviors
     let listProvider: AnyModelListProvider<Element>
@@ -60,6 +69,7 @@ public class List<ModelType: Model>: Collection, Codable, ExpressibleByArrayLite
             }
         }
     }
+
 
     // MARK: - Initializers
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/ListTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/ListTests.swift
@@ -25,15 +25,9 @@ class ListTests: BaseDataStoreTests {
         let postId = preparePostDataForTest()
 
         func checkComments(_ comments: List<Comment>) async throws {
-            guard case .notLoaded = comments.loadedState else {
-                XCTFail("Should not be loaded")
-                return
-            }
+            XCTAssertFalse(comments.isLoaded)
             try await comments.fetch()
-            guard case .loaded = comments.loadedState else {
-                XCTFail("Should be loaded")
-                return
-            }
+            XCTAssertTrue(comments.isLoaded)
             XCTAssertEqual(comments.count, 2)
             expect.fulfill()
         }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/ListTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/ListTests.swift
@@ -8,9 +8,9 @@
 import Combine
 import XCTest
 
-@testable import Amplify
-@testable import AmplifyTestCommon
-@testable import AWSDataStorePlugin
+import Amplify
+import AmplifyTestCommon
+import AWSDataStorePlugin
 
 class ListTests: BaseDataStoreTests {
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/3286

## Description
<!-- Why is this change required? What problem does it solve? -->
This public API change adds a `isLoaded` property in the `List+Model` public to help customers check if the list is loaded before calling `fetch()` to avoid network calls.

## General Checklist
<!-- Check or cross out if not relevant -->
- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
~~- [ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style
~~- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~~
~~- [ ] If breaking change, documentation/changelog update with migration instructions~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
