### PR TITLE
chore(integration-tests): use macos-13 and xcode 14.3 - increase timeouts [skip ci]

### DIFF
--- a/.github/workflows/integ_test_analytics.yml
+++ b/.github/workflows/integ_test_analytics.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   analytics-integration-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Analytics/Tests/AnalyticsHostApp
           scheme: AWSPinpointAnalyticsPluginIntegrationTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   analytics-integration-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_api.yml
+++ b/.github/workflows/integ_test_api.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   prepare-for-test:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/integ_test_api_functional.yml
+++ b/.github/workflows/integ_test_api_functional.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   api-functional-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginFunctionalTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   api-functional-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_api_graphql_auth_directive.yml
+++ b/.github/workflows/integ_test_api_graphql_auth_directive.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   api-graphql-auth-directive-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginGraphQLAuthDirectiveTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-auth-directive-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_api_graphql_iam.yml
+++ b/.github/workflows/integ_test_api_graphql_iam.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   api-graphql-iam-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginGraphQLIAMTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-iam-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_api_graphql_lambda_auth.yml
+++ b/.github/workflows/integ_test_api_graphql_lambda_auth.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   api-graphql-lambda-auth-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginGraphQLLambdaAuthTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-lambda-auth-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_api_graphql_lazy_load.yml
+++ b/.github/workflows/integ_test_api_graphql_lazy_load.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   api-lazy-load-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginLazyLoadTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   api-lazy-load-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_api_graphql_user_pool.yml
+++ b/.github/workflows/integ_test_api_graphql_user_pool.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   api-graphql-user-pool-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginGraphQLUserPoolTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-user-pool-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_api_rest_iam.yml
+++ b/.github/workflows/integ_test_api_rest_iam.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   api-rest-iam-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginRESTIAMTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   api-rest-iam-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_api_rest_user_pool.yml
+++ b/.github/workflows/integ_test_api_rest_user_pool.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   api-rest-user-pool-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginRESTUserPoolTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   api-rest-user-pool-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_auth.yml
+++ b/.github/workflows/integ_test_auth.yml
@@ -92,7 +92,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   auth-ui-integration-test-iOS:
-    runs-on: macos-13
+    runs-on: macos-12
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -115,5 +115,3 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Auth/Tests/AuthHostedUIApp/
           scheme: AuthHostedUIApp
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
-          xcode_path: '/Applications/Xcode_14.3.app'

--- a/.github/workflows/integ_test_datastore_auth_cognito.yml
+++ b/.github/workflows/integ_test_datastore_auth_cognito.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   datastore-integration-auth-cognito-test-iOS:
     timeout-minutes: 30
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -33,6 +33,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginAuthCognitoTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-cognito-test-tvOS:
     timeout-minutes: 30

--- a/.github/workflows/integ_test_geo.yml
+++ b/.github/workflows/integ_test_geo.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   geo-integration-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Geo/Tests/GeoHostApp/
           scheme: AWSLocationGeoPluginIntegrationTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   geo-integration-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_logging.yml
+++ b/.github/workflows/integ_test_logging.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   logging-integration-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginHostApp
           scheme: AWSCloudWatchLoggingPluginIntegrationTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   logging-integration-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_push_notifications.yml
+++ b/.github/workflows/integ_test_push_notifications.yml
@@ -9,8 +9,8 @@ permissions:
 
 jobs:
   push-notification-integration-test-iOS:
-    runs-on: macos-12
-    timeout-minutes: 20
+    runs-on: macos-13
+    timeout-minutes: 45
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -45,10 +45,12 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp
           scheme: PushNotificationHostApp
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   push-notification-integration-test-tvOS:
     runs-on: macos-13
-    timeout-minutes: 20
+    timeout-minutes: 30
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -89,7 +91,7 @@ jobs:
 
   push-notification-integration-test-watchOS:
     runs-on: macos-13
-    timeout-minutes: 20
+    timeout-minutes: 30
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
n/a 

## Description
<!-- Why is this change required? What problem does it solve? -->
- Moves from macos-12 / Xcode 14.2 --> Use macos-13 / Xcode 14.3 in remaining integration tests.
- Increases some timeouts that occasionally get hit in integration test suites.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
