### PR TITLE
fix(unit-tests): use fulfillment(of:) in async contexts [skip ci]

### DIFF
--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/ClearCredentialsTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/ClearCredentialsTests.swift
@@ -50,7 +50,10 @@ class ClearCredentialsTests: XCTestCase {
         await action.execute(withDispatcher: MockDispatcher { _ in },
                         environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     /// Test is responsible to check if configuration error is correctly caught by the action
@@ -82,7 +85,10 @@ class ClearCredentialsTests: XCTestCase {
             }
         }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     /// Test is responsible to check if the clear credentials handle a known error
@@ -136,7 +142,10 @@ class ClearCredentialsTests: XCTestCase {
             }
         }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     /// Test is responsible to check if the clear credentials handle an unknown error
@@ -191,7 +200,10 @@ class ClearCredentialsTests: XCTestCase {
             }
         }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/LoadCredentialsTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/LoadCredentialsTests.swift
@@ -67,7 +67,10 @@ class LoadCredentialsTests: XCTestCase {
             }
         }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [loadCredentialHandlerInvoked],
+            timeout: 0.1
+        )
     }
 
     /// Test is responsible to check if configuration error is correctly caught by the action
@@ -99,7 +102,10 @@ class LoadCredentialsTests: XCTestCase {
             }
         }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     /// Test is responsible to check if the load credentials handle a known error
@@ -153,7 +159,10 @@ class LoadCredentialsTests: XCTestCase {
             }
         }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     /// Test is responsible to check if the load credentials handle an unknown error
@@ -210,7 +219,10 @@ class LoadCredentialsTests: XCTestCase {
             }
         }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MigrateLegacyCredentialStoreTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MigrateLegacyCredentialStoreTests.swift
@@ -72,7 +72,11 @@ class MigrateLegacyCredentialStoreTests: XCTestCase {
         let action = MigrateLegacyCredentialStore()
         await action.execute(withDispatcher: MockDispatcher { _ in }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+
+        await fulfillment(
+            of: [saveCredentialHandlerInvoked],
+            timeout: 0.1
+        )
     }
 
     /// Test is responsible for making sure that the legacy credential store clearing up is getting called for user pool and identity pool
@@ -115,8 +119,9 @@ class MigrateLegacyCredentialStoreTests: XCTestCase {
         let action = MigrateLegacyCredentialStore()
         await action.execute(withDispatcher: MockDispatcher { _ in }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
-
+        await fulfillment(
+            of: [migrationCompletionInvoked],
+            timeout: 0.1
+        )
     }
-
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchAWSCredentials/FetchAuthAWSCredentialsTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchAWSCredentials/FetchAuthAWSCredentialsTests.swift
@@ -30,7 +30,11 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
                 expectation.fulfill()
             }
         }, environment: MockInvalidEnvironment())
-        await waitForExpectations(timeout: 0.1)
+
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     func testInvalidIdentitySuccessfullResponse() async {
@@ -60,7 +64,10 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
             }
         }, environment: authEnvironment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     func testInvalidAWSCredentialSuccessfulResponse() async {
@@ -93,7 +100,10 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
             environment: authEnvironment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     func testValidSuccessfulResponse() async {
@@ -134,7 +144,11 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
             },
             environment: authEnvironment
         )
-        await waitForExpectations(timeout: 0.1)
+
+        await fulfillment(
+            of: [credentialValidExpectation],
+            timeout: 0.1
+        )
     }
 
     func testFailureResponse() async {
@@ -166,7 +180,11 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
             },
             environment: authEnvironment
         )
-        await waitForExpectations(timeout: 0.1)
+
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchUserPoolTokens/RefreshUserPoolTokensTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchUserPoolTokens/RefreshUserPoolTokensTests.swift
@@ -34,7 +34,10 @@ class RefreshUserPoolTokensTests: XCTestCase {
         }, environment: MockInvalidEnvironment()
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     func testInvalidSuccessfulResponse() async {
@@ -63,7 +66,10 @@ class RefreshUserPoolTokensTests: XCTestCase {
             userPoolFactory: identityProviderFactory)
         )
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 1
+        )
     }
 
     func testValidSuccessfulResponse() async {
@@ -93,7 +99,11 @@ class RefreshUserPoolTokensTests: XCTestCase {
         }, environment: Defaults.makeDefaultAuthEnvironment(
             userPoolFactory: identityProviderFactory)
         )
-        await waitForExpectations(timeout: 0.1)
+
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     func testFailureResponse() async {
@@ -128,7 +138,10 @@ class RefreshUserPoolTokensTests: XCTestCase {
             }
         }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/InitializeFetchAuthSessionTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/InitializeFetchAuthSessionTests.swift
@@ -32,7 +32,10 @@ class InitializeFetchAuthSessionTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/InitiateAuthSRPTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/InitiateAuthSRPTests.swift
@@ -32,7 +32,10 @@ class InitiateAuthSRPTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [initiateAuthInvoked],
+            timeout: 0.1
+        )
     }
 
     func testFailedInitiateAuthPropagatesError() async {
@@ -70,7 +73,10 @@ class InitiateAuthSRPTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [errorEventSent],
+            timeout: 0.1
+        )
     }
 
     func testSuccessfulInitiateAuthPropagatesSuccess() async {
@@ -106,7 +112,9 @@ class InitiateAuthSRPTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [successEventSent],
+            timeout: 0.1
+        )
     }
-
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyPasswordSRPTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyPasswordSRPTests.swift
@@ -48,7 +48,10 @@ class VerifyPasswordSRPTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [verifyPasswordInvoked],
+            timeout: 0.1
+        )
     }
 
     /// Test empty response is returned by Cognito proper error is thrown
@@ -96,7 +99,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test invalid challenge response from initiate auth
@@ -144,7 +150,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test  challenge response with no salt from initiate auth
@@ -192,7 +201,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test  challenge response with no secretblock from initiate auth
@@ -240,7 +252,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test  challenge response with no SRPB from initiate auth
@@ -288,7 +303,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test  an exception from the SRP calculation
@@ -336,7 +354,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test  successful response from the VerifyPasswordSRP
@@ -364,7 +385,8 @@ class VerifyPasswordSRPTests: XCTestCase {
                                        clientMetadata: [:])
 
         let passwordVerifierCompletion = expectation(
-            description: "passwordVerifierCompletion")
+            description: "passwordVerifierCompletion"
+        )
 
         let dispatcher = MockDispatcher { event in
             guard let event = event as? SignInEvent else {
@@ -379,7 +401,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierCompletion],
+            timeout: 0.1
+        )
     }
 
     /// Test  successful response from the VerifyPasswordSRP
@@ -432,7 +457,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test verify password retry on device not found
@@ -478,7 +506,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test  successful response from the VerifyPasswordSRP for confirmDevice
@@ -521,7 +552,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierCompletion],
+            timeout: 0.1
+        )
     }
 
     /// Test  successful response from the VerifyPasswordSRP for verifyDevice
@@ -564,7 +598,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierCompletion],
+            timeout: 0.1
+        )
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/RevokeTokenTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/RevokeTokenTests.swift
@@ -38,7 +38,10 @@ class RevokeTokenTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [revokeTokenInvoked],
+            timeout: 0.1
+        )
     }
 
     func testFailedRevokeTokenTriggersClearCredentialStore() async {
@@ -79,7 +82,10 @@ class RevokeTokenTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [clearCredentialStoreEventSent],
+            timeout: 0.1
+        )
     }
 
     func testSuccessfulRevokeTokenTriggersClearCredentialStore() async {
@@ -120,7 +126,10 @@ class RevokeTokenTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [clearCredentialStoreEventSent],
+            timeout: 0.1
+        )
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/SignOutGloballyTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/SignOutGloballyTests.swift
@@ -36,7 +36,10 @@ class SignOutGloballyTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [globalSignOutInvoked],
+            timeout: 0.1
+        )
     }
 
     func testFailedGlobalSignOutTriggersBuildRevokeError() async {
@@ -75,7 +78,10 @@ class SignOutGloballyTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [revokeTokenEventSent],
+            timeout: 0.1
+        )
     }
 
     func testSuccessfulGlobalSignOutTriggersRevokeToken() async {
@@ -114,7 +120,9 @@ class SignOutGloballyTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [revokeTokenEventSent],
+            timeout: 0.1
+        )
     }
-
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/VerifySignInChallenge/VerifySignInChallengeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/VerifySignInChallenge/VerifySignInChallengeTests.swift
@@ -56,7 +56,10 @@ class VerifySignInChallengeTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [verifyPasswordInvoked],
+            timeout: 0.1
+        )
     }
 
     /// Test empty response is returned by Cognito proper error is thrown
@@ -103,7 +106,10 @@ class VerifySignInChallengeTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test  successful response from the VerifySignInChallenge
@@ -144,7 +150,10 @@ class VerifySignInChallengeTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [verifyChallengeComplete],
+            timeout: 0.1
+        )
     }
 
     /// Test  successful response from the VerifySignInChallenge
@@ -196,7 +205,10 @@ class VerifySignInChallengeTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test verify password retry on device not found
@@ -240,7 +252,10 @@ class VerifySignInChallengeTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test  successful response from the VerifySignInChallenge for confirmDevice
@@ -281,7 +296,10 @@ class VerifySignInChallengeTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [verifyChallengeComplete],
+            timeout: 0.1
+        )
     }
 
     /// Test  successful response from the VerifySignInChallenge for verify device
@@ -322,6 +340,9 @@ class VerifySignInChallengeTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [verifyChallengeComplete],
+            timeout: 0.1
+        )
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/HubEventTests/AuthHubEventHandlerTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/HubEventTests/AuthHubEventHandlerTests.swift
@@ -48,7 +48,10 @@ class AuthHubEventHandlerTests: XCTestCase {
             XCTFail("Received failure with error \(error)")
         }
 
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(
+            of: [hubEventExpectation],
+            timeout: networkTimeout
+        )
     }
 
     /// Test whether HubEvent emits a signOut event for mocked signOut operation
@@ -74,7 +77,10 @@ class AuthHubEventHandlerTests: XCTestCase {
         }
 
         _ = await plugin.signOut(options: nil)
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(
+            of: [hubEventExpectation],
+            timeout: networkTimeout
+        )
     }
 
     /// Test whether HubEvent emits a confirmSignedIn event for mocked signIn operation
@@ -105,7 +111,10 @@ class AuthHubEventHandlerTests: XCTestCase {
             XCTFail("Received failure with error \(error)")
         }
 
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(
+            of: [hubEventExpectation],
+            timeout: networkTimeout
+        )
     }
 
     /// Test whether HubEvent emits a deletedUser event for mocked delete user operation
@@ -136,7 +145,10 @@ class AuthHubEventHandlerTests: XCTestCase {
             XCTFail("Received failure with error \(error)")
         }
 
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(
+            of: [hubEventExpectation],
+            timeout: networkTimeout
+        )
     }
 
     /// Test whether HubEvent emits a sessionExpired event for mocked fetchSession operation with expired tokens
@@ -161,7 +173,10 @@ class AuthHubEventHandlerTests: XCTestCase {
             }
         }
         _ = try await plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options())
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(
+            of: [hubEventExpectation],
+            timeout: networkTimeout
+        )
     }
 
 #if os(iOS) || os(macOS)
@@ -195,7 +210,7 @@ class AuthHubEventHandlerTests: XCTestCase {
         } catch {
             XCTFail("Received failure with error \(error)")
         }
-        wait(for: [hubEventExpectation], timeout: 10)
+        await fulfillment(of: [hubEventExpectation], timeout: 10)
     }
 
     /// Test whether HubEvent emits a mocked signedIn event for social provider signIn
@@ -227,7 +242,7 @@ class AuthHubEventHandlerTests: XCTestCase {
         } catch {
             XCTFail("Received failure with error \(error)")
         }
-        wait(for: [hubEventExpectation], timeout: 10)
+        await fulfillment(of: [hubEventExpectation], timeout: 10)
     }
 #endif
 
@@ -254,7 +269,10 @@ class AuthHubEventHandlerTests: XCTestCase {
         }
         _ = try await  plugin.federateToIdentityPool(withProviderToken: "someToken", for: .facebook)
 
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(
+            of: [hubEventExpectation],
+            timeout: networkTimeout
+        )
     }
 
     /// Test whether HubEvent emits a federationToIdentityPoolCleared event for mocked federated operation
@@ -282,7 +300,10 @@ class AuthHubEventHandlerTests: XCTestCase {
         _ = try await plugin.federateToIdentityPool(withProviderToken: "something", for: .facebook)
         try await plugin.clearFederationToIdentityPool()
 
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(
+            of: [hubEventExpectation],
+            timeout: networkTimeout
+        )
     }
 
     private func configurePluginForSignInEvent() {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFederationToIdentityPoolTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFederationToIdentityPoolTests.swift
@@ -501,7 +501,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
         } catch {
             XCTFail("Received failure with error \(error)")
         }
-        wait(for: [cognitoAPIExpectation], timeout: apiTimeout)
+        await fulfillment(of: [cognitoAPIExpectation], timeout: apiTimeout)
     }
 
     /// Test fetchAuthSession when federated to identity pool with valid credentials
@@ -671,7 +671,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
         } catch {
             XCTFail("Received failure with error \(error)")
         }
-        wait(for: [cognitoAPIExpectation], timeout: apiTimeout)
+        await fulfillment(of: [cognitoAPIExpectation], timeout: apiTimeout)
     }
 
     /// Test federated to identity pool with developer provided identity Id

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFetchSignInSessionOperationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFetchSignInSessionOperationTests.swift
@@ -132,7 +132,7 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
         XCTAssertNotNil(tokens?.idToken)
         XCTAssertNotNil(tokens?.refreshToken)
 
-        wait(for: [resultExpectation], timeout: apiTimeout)
+        await fulfillment(of: [resultExpectation], timeout: apiTimeout)
     }
 
     /// Test signedIn session with a user signed In to  identityPool
@@ -355,7 +355,7 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
     //                XCTFail("Received failure with error \(error)")
     //            }
     //        }
-    //        wait(for: [resultExpectation], timeout: apiTimeout)
+    //        await fulfillment(of: [resultExpectation], timeout: apiTimeout)
     //    }
     //
     //    /// Test signedIn session with network error for identityId
@@ -413,7 +413,7 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
     //                XCTFail("Received failure with error \(error)")
     //            }
     //        }
-    //        wait(for: [resultExpectation], timeout: apiTimeout)
+    //        await fulfillment(of: [resultExpectation], timeout: apiTimeout)
     //    }
     //
     //    /// Test signedIn session with network error for aws credentials
@@ -471,7 +471,7 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
     //                XCTFail("Received failure with error \(error)")
     //            }
     //        }
-    //        wait(for: [resultExpectation], timeout: apiTimeout)
+    //        await fulfillment(of: [resultExpectation], timeout: apiTimeout)
     //    }
     //
     /// Test signedIn session with invalid response for tokens

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AuthenticationProviderDeleteUserTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AuthenticationProviderDeleteUserTests.swift
@@ -473,7 +473,7 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
 //                XCTFail("Received failure with error \(error)")
 //            }
 //        }
-//        wait(for: [resultExpectation], timeout: apiTimeout)
+//        await fulfillment(of: [resultExpectation], timeout: apiTimeout)
 //
 //        let deleteUserResultExpectation = expectation(description: "Should receive a result")
 //        _ = plugin.deleteUser { result in
@@ -493,7 +493,7 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
 //                }
 //            }
 //        }
-//        wait(for: [deleteUserResultExpectation], timeout: apiTimeout)
+//        await fulfillment(of: [deleteUserResultExpectation], timeout: apiTimeout)
 //    }
 //
 //    var window: UIWindow {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/ClientBehaviorResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/ClientBehaviorResetPasswordTests.swift
@@ -590,7 +590,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
 
             }
         }
-        wait(for: [resultExpectation], timeout: networkTimeout)
+        await fulfillment(of: [resultExpectation], timeout: networkTimeout)
     }
     */
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthMigrationSignInTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthMigrationSignInTaskTests.swift
@@ -84,7 +84,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
             XCTFail("Error should not be returned \(error)")
         }
 
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationInternalError() async throws {
@@ -107,7 +107,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationInvalidLambda() async throws {
@@ -134,7 +134,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationParameterException() async throws {
@@ -161,7 +161,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationSMSRoleAccessException() async throws {
@@ -190,7 +190,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationUserPoolConfiguration() async throws {
@@ -215,7 +215,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationNotAuthorized() async throws {
@@ -240,7 +240,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperatioResetPassword() async throws {
@@ -264,7 +264,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
         } catch {
             XCTFail("Should not produce a error result: \(error)")
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationResourceNotFound() async throws {
@@ -292,7 +292,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationTooManyRequest() async throws {
@@ -320,7 +320,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationUnexpectedLambda() async throws {
@@ -348,7 +348,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationUserLambdaValidation() async throws {
@@ -376,7 +376,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationUserNotConfirmed() async throws {
@@ -400,7 +400,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
         } catch {
             XCTFail("Should not produce an error result - \(error)")
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationUserNotFound() async throws {
@@ -428,6 +428,6 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignUp/AWSAuthConfirmSignUpTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignUp/AWSAuthConfirmSignUpTaskTests.swift
@@ -73,6 +73,6 @@ class AWSAuthConfirmSignUpTaskTests: XCTestCase {
             XCTFail("Should not produce success response")
         } catch {
         }
-        wait(for: [functionExpectation], timeout: 1)
+        await fulfillment(of: [functionExpectation], timeout: 1)
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignUp/AWSAuthSignUpTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignUp/AWSAuthSignUpTaskTests.swift
@@ -70,7 +70,7 @@ class AWSAuthSignUpTaskTests: XCTestCase {
             XCTFail("Should not produce success response")
         } catch {
         }
-        wait(for: [functionExpectation], timeout: 1)
+        await fulfillment(of: [functionExpectation], timeout: 1)
     }
 
     /// Given: Configured AuthState machine with existing signUp flow
@@ -93,6 +93,6 @@ class AWSAuthSignUpTaskTests: XCTestCase {
             userPoolFactory: {MockIdentityProvider(mockSignUpResponse: signUp)})
         let task = AWSAuthSignUpTask(request, authEnvironment: authEnvironment)
         _ = try await task.value
-        wait(for: [functionExpectation], timeout: 1)
+        await fulfillment(of: [functionExpectation], timeout: 1)
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
@@ -157,7 +157,7 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             }
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: networkTimeout)
+        await fulfillment(of: [expectation], timeout: networkTimeout)
     }
 
     @MainActor
@@ -209,7 +209,7 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             }
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: networkTimeout)
+        await fulfillment(of: [expectation], timeout: networkTimeout)
     }
 
     @MainActor
@@ -226,7 +226,7 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             }
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: networkTimeout)
+        await fulfillment(of: [expectation], timeout: networkTimeout)
     }
 
     @MainActor
@@ -254,7 +254,7 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             }
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: networkTimeout)
+        await fulfillment(of: [expectation], timeout: networkTimeout)
     }
 
     @MainActor

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/hierarchical-state-machine-swiftTests/StateMachineListenerTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/hierarchical-state-machine-swiftTests/StateMachineListenerTests.swift
@@ -41,7 +41,10 @@ class StateMachineListenerTests: XCTestCase {
         }
         let event = Counter.Event(id: "test", eventType: .increment)
         await stateMachine.send(event)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [notified],
+            timeout: 0.1
+        )
     }
 
     func testDoesNotNotifyOnNoStateChange() async {
@@ -58,7 +61,10 @@ class StateMachineListenerTests: XCTestCase {
 
         let event = Counter.Event(id: "test", eventType: .adjustBy(0))
         await stateMachine.send(event)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [notified],
+            timeout: 0.1
+        )
     }
 
     func testDoesNotNotifyAfterUnsubscribe() async {
@@ -77,7 +83,10 @@ class StateMachineListenerTests: XCTestCase {
         seq.cancel()
         let event = Counter.Event(id: "test", eventType: .increment)
         await stateMachine.send(event)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [notified],
+            timeout: 0.1
+        )
     }
 
     func testOrderOfSubsription() async throws {
@@ -109,7 +118,10 @@ class StateMachineListenerTests: XCTestCase {
                 try await Task.sleep(nanoseconds: 1_000_000)
                 await self.stateMachine.send(Counter.Event(id: "set3", eventType: .set(12)))
             }
-            await waitForExpectations(timeout: 2)
+            await fulfillment(
+                of: [notified],
+                timeout: 2
+            )
             seq.cancel()
         }
     }
@@ -143,7 +155,10 @@ class StateMachineListenerTests: XCTestCase {
             }
         }
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(
+            of: [notified],
+            timeout: 1
+        )
         task2.cancel()
     }
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/hierarchical-state-machine-swiftTests/StateMachineTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/hierarchical-state-machine-swiftTests/StateMachineTests.swift
@@ -49,7 +49,11 @@ class StateMachineTests: XCTestCase {
                 taskCompletion.fulfill()
             }
         }
-        await waitForExpectations(timeout: 1)
+
+        await fulfillment(
+            of: [taskCompletion],
+            timeout: 0.1
+        )
         let state = await testMachine.currentState
         XCTAssertEqual(state.value, 0)
     }
@@ -106,7 +110,10 @@ class StateMachineTests: XCTestCase {
         )
 
         await testMachine.send(event)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [action1WasExecuted, action2WasExecuted],
+            timeout: 0.1
+        )
     }
 
     /// Given:
@@ -148,7 +155,11 @@ class StateMachineTests: XCTestCase {
         )
 
         await testMachine.send(event)
-        await waitForExpectations(timeout: 0.1)
+
+        await fulfillment(
+            of: [action1WasExecuted, action2WasExecuted],
+            timeout: 0.1
+        )
         XCTAssertEqual(executionCount.get(), 2)
     }
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
@@ -288,8 +288,8 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
         setUp(withModels: TestModelRegistration())
         try await Amplify.DataStore.clear()
         var snapshotCount = 0
-        let initialQueryComplete = asyncExpectation(description: "initial snapshot received")
-        let allSnapshotsReceived = asyncExpectation(description: "query snapshots received")
+        let initialQueryComplete = expectation(description: "initial snapshot received")
+        let allSnapshotsReceived = expectation(description: "query snapshots received")
 
         let subscription = Amplify.DataStore.observeQuery(for: Post.self)
         let sink = Amplify.Publisher.create(subscription).sink { completed in
@@ -302,15 +302,15 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
         } receiveValue: { querySnapshot in
             snapshotCount += 1
             if snapshotCount == 1 {
-                Task { await initialQueryComplete.fulfill() }
+                initialQueryComplete.fulfill()
             }
             if querySnapshot.items.count == 15 {
-                Task { await allSnapshotsReceived.fulfill() }
+                allSnapshotsReceived.fulfill()
             }
         }
-        await waitForExpectations([initialQueryComplete], timeout: 10)
+        await fulfillment(of: [initialQueryComplete], timeout: 10)
         _ = try await setUpLocalStore(numberOfPosts: 15)
-        await waitForExpectations([allSnapshotsReceived], timeout: 10)
+        await fulfillment(of: [allSnapshotsReceived], timeout: 10)
         XCTAssertTrue(snapshotCount >= 2)
         sink.cancel()
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginTests.swift
@@ -79,16 +79,20 @@ class AWSDataStorePluginTests: XCTestCase {
                                         validAuthPluginKey: "MockAuthCategoryPlugin")
         do {
             try plugin.configure(using: nil)
-            let queryCompleted = asyncExpectation(description: "query completed")
+            let queryCompleted = expectation(description: "query completed")
             Task {
                 _ = try await plugin.query(ExampleWithEveryType.self)
-                await queryCompleted.fulfill()
+                queryCompleted.fulfill()
             }
-            await waitForExpectations([queryCompleted], timeout: 1.0)
+            await fulfillment(of: [queryCompleted], timeout: 1.0)
         } catch {
             XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
         }
-        await waitForExpectations(timeout: 1.0)
+
+        await fulfillment(
+            of: [startExpectation],
+            timeout: 1
+        )
     }
     
     func testStorageEngineStartsOnPluginStopStart() throws {
@@ -230,7 +234,11 @@ class AWSDataStorePluginTests: XCTestCase {
                 XCTAssertNotNil(plugin.storageEngine)
                 XCTAssertNotNil(plugin.dataStorePublisher)
             })
-            wait(for: [startExpectation, stopExpectation, startExpectationOnSecondStart], timeout: 1, enforceOrder: true)
+            wait(
+                for: [startExpectation, stopExpectation, startExpectationOnSecondStart],
+                timeout: 1,
+                enforceOrder: true
+            )
             wait(for: [finishNotReceived], timeout: 1)
             sink.cancel()
         } catch {
@@ -301,7 +309,12 @@ class AWSDataStorePluginTests: XCTestCase {
                 XCTAssertNotNil(plugin.storageEngine)
                 XCTAssertNotNil(plugin.dataStorePublisher)
             })
-            wait(for: [startExpectation, clearExpectation, startExpectationOnSecondStart], timeout: 1, enforceOrder: true)
+
+            wait(
+                for: [startExpectation, clearExpectation, startExpectationOnSecondStart],
+                timeout: 1,
+                enforceOrder: true
+            )
             wait(for: [finishNotReceived], timeout: 1)
             sink.cancel()
         } catch {
@@ -449,7 +462,7 @@ class AWSDataStorePluginTests: XCTestCase {
                 startCompleted.fulfill()
             })
             wait(for: [startCompleted], timeout: 1.0)
-            
+
             let clearCompleted = expectation(description: "clear completed")
             plugin.clear(completion: { _ in
                 XCTAssertNil(plugin.storageEngine)
@@ -528,7 +541,7 @@ class AWSDataStorePluginTests: XCTestCase {
                 startCompleted.fulfill()
             })
             wait(for: [startCompleted], timeout: 1.0)
-            
+
             let stopCompleted = expectation(description: "stop completed")
             plugin.stop(completion: { _ in
                 XCTAssertNotNil(plugin.storageEngine)
@@ -537,7 +550,11 @@ class AWSDataStorePluginTests: XCTestCase {
             })
             wait(for: [stopCompleted], timeout: 1.0)
 
-            wait(for: [startExpectation, stopExpectation], timeout: 1, enforceOrder: true)
+            wait(
+                for: [startExpectation, stopExpectation],
+                timeout: 1,
+                enforceOrder: true
+            )
             let mockModel = MockSynced(id: "12345")
             try plugin.dataStorePublisher?.send(input: MutationEvent(model: mockModel,
                                                                      modelSchema: mockModel.schema,

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/ListTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/ListTests.swift
@@ -49,7 +49,7 @@ class ListTests: BaseDataStoreTests {
             XCTFail("\(error)")
         }
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [expect], timeout: 1)
     }
 
     // MARK: - Helpers

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/StateMachineTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/StateMachineTests.swift
@@ -106,14 +106,16 @@ class StateMachineTests: XCTestCase {
             }
         }
 
-        wait(for: [
-            receivedOneOnSubscribe,
-            receivedTwoAfterSubscribe,
-            receivedThreeAfterSubscribe,
-            receivedOneAfterSubscribe
+        wait(
+            for: [
+                receivedOneOnSubscribe,
+                receivedTwoAfterSubscribe,
+                receivedThreeAfterSubscribe,
+                receivedOneAfterSubscribe
             ],
-             timeout: 1.0,
-             enforceOrder: true)
+            timeout: 1.0,
+            enforceOrder: true
+        )
 
         listener.cancel()
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/CascadeDeleteOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/CascadeDeleteOperationTests.swift
@@ -87,7 +87,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
         operation.start()
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [completed], timeout: 1)
         guard case .success(let queriedRestaurants) = await queryModelSynchronous(modelType: Restaurant.self,
                                                                                   predicate: predicate) else {
             XCTFail("Failed to query")
@@ -361,7 +361,8 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
         operation.start()
-        await waitForExpectations(timeout: 1)
+
+        await fulfillment(of: [receivedMutationEvent, expectedFailures, expectedSuccess, completed], timeout: 1)
         guard case .success(let queriedRestaurants) = await queryModelSynchronous(modelType: Restaurant.self,
                                                                             predicate: predicate) else {
             XCTFail("Failed to query")
@@ -422,7 +423,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
         operation.start()
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [receivedMutationEvent, expectedFailures, expectedSuccess, completed], timeout: 1)
         guard case .success(let queriedModels) = await queryModelSynchronous(modelType: ModelCompositePk.self,
                                                                             predicate: predicate) else {
             XCTFail("Failed to query")
@@ -595,7 +596,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         }
 
         operation.syncIfNeededAndFinish(result)
-        wait(for: [receivedMutationEvent, expectedFailures, expectedSuccess], timeout: 1)
+        await fulfillment(of: [receivedMutationEvent, expectedFailures, expectedSuccess], timeout: 1)
     }
 
     func testDeleteWithAssociatedModels() async {
@@ -660,7 +661,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         }
 
         operation.syncIfNeededAndFinish(result)
-        wait(for: [completed, receivedMutationEvent, expectedFailures, expectedSuccess], timeout: 1)
+        await fulfillment(of: [completed, receivedMutationEvent, expectedFailures, expectedSuccess], timeout: 1)
         XCTAssertEqual(submittedEvents.count, 3)
         // The delete mutations should be synced in reverse order (children to parent)
         XCTAssertEqual(submittedEvents[0].modelName, Dish.modelName)
@@ -729,7 +730,8 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         }
 
         operation.syncIfNeededAndFinish(result)
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [receivedMutationEvent, expectedFailures, expectedSuccess, completed], timeout: 1)
+
         XCTAssertEqual(submittedEvents.count, 2)
         // The delete mutations should be synced in reverse order (children to parent)
         XCTAssertEqual(submittedEvents[0].modelName, CommentWithCompositeKey.modelName)
@@ -797,7 +799,8 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         }
 
         operation.syncIfNeededAndFinish(result)
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [receivedMutationEvent, expectedFailures, expectedSuccess, completed], timeout: 1)
+
         XCTAssertEqual(submittedEvents.count, 3)
         // The delete mutations should be synced in reverse order (children to parent)
         XCTAssertEqual(submittedEvents[0].modelName, Dish.modelName)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEnginePublisherTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEnginePublisherTests.swift
@@ -84,11 +84,15 @@ class StorageEnginePublisherTests: StorageEngineTestsBase {
         storageEngine.onReceive(receiveValue: .syncStarted)
         storageEngine.onReceive(receiveValue: .cleanedUp)
         storageEngine.onReceive(receiveValue: .cleanedUpForTermination)
-        wait(for: [receivedMutationEvent,
-                   receivedModelSyncedEvent,
-                   receivedSyncQueriesReadyEvent,
-                   receivedReadyEvent],
-                timeout: 1)
+        wait(
+            for: [
+                receivedMutationEvent,
+                receivedModelSyncedEvent,
+                receivedSyncQueriesReadyEvent,
+                receivedReadyEvent
+            ],
+            timeout: 1
+        )
         sink.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsBase.swift
@@ -47,7 +47,7 @@ class StorageEngineTestsBase: XCTestCase {
             result = sResult
             saveFinished.fulfill()
         }
-        await waitForExpectations(timeout: defaultTimeout)
+        await fulfillment(of: [saveFinished], timeout: defaultTimeout)
         guard let saveResult = result else {
             return .failure(causedBy: "Save operation timed out")
         }
@@ -105,7 +105,7 @@ class StorageEngineTestsBase: XCTestCase {
             queryFinished.fulfill()
         }
 
-        await waitForExpectations(timeout: defaultTimeout)
+        await fulfillment(of: [queryFinished], timeout: defaultTimeout)
         guard let queryResult = result else {
             return .failure(causedBy: "Query operation timed out")
         }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/ObserveQueryTaskRunnerTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/ObserveQueryTaskRunnerTests.swift
@@ -34,8 +34,8 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
     ///    - The item observed will be returned in the second snapshot
     ///
     func testItemChangedWillGenerateSnapshot() async throws {
-        let firstSnapshot = asyncExpectation(description: "first query snapshots")
-        let secondSnapshot = asyncExpectation(description: "second query snapshots")
+        let firstSnapshot = expectation(description: "first query snapshots")
+        let secondSnapshot = expectation(description: "second query snapshots")
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -54,10 +54,10 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                     querySnapshots.append(querySnapshot)
                     if querySnapshots.count == 1 {
                         XCTAssertEqual(querySnapshot.items.count, 0)
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
                         XCTAssertEqual(querySnapshot.items.count, 1)
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     }
                 }
             } catch {
@@ -65,11 +65,11 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             }
         }
     
-        await waitForExpectations([firstSnapshot], timeout: 1)
+        await fulfillment(of: [firstSnapshot], timeout: 1)
 
         let post = try createPost(id: "1")
         dataStorePublisher.send(input: post)
-        await waitForExpectations([secondSnapshot], timeout: 10)
+        await fulfillment(of: [secondSnapshot], timeout: 10)
     }
     
     ///  ObserveQuery will send a single snapshot when the sync state toggles
@@ -83,9 +83,11 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
     ///    - ObserveQuery will send a second snapshot
     ///
     func testGenerateSnapshotOnObserveQueryWhenModelSynced() async throws {
-        let firstSnapshot = asyncExpectation(description: "first query snapshots")
-        let secondSnapshot = asyncExpectation(description: "second query snapshots")
-        let thirdSnapshot = asyncExpectation(description: "third query snapshot", isInverted: true)
+        let firstSnapshot = expectation(description: "first query snapshots")
+        let secondSnapshot = expectation(description: "second query snapshots")
+        let thirdSnapshot = expectation(description: "third query snapshot")
+        thirdSnapshot.isInverted = true
+
         let dispatchedModelSyncedEvent = AtomicValue(initialValue: false)
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
@@ -106,14 +108,14 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                     if querySnapshots.count == 1 {
                         XCTAssertEqual(querySnapshot.items.count, 0)
                         XCTAssertEqual(querySnapshot.isSynced, false)
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
                         XCTAssertEqual(querySnapshot.items.count, 0)
                         XCTAssertEqual(querySnapshot.isSynced, true)
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     } else if querySnapshots.count == 3 {
                         XCTFail("Should not receive third snapshot for a Model change")
-                        await thirdSnapshot.fulfill()
+                        thirdSnapshot.fulfill()
                     }
                 }
             } catch {
@@ -121,7 +123,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             }
         }
         
-        await waitForExpectations([firstSnapshot], timeout: 5)
+        await fulfillment(of: [firstSnapshot], timeout: 5)
         
         dispatchedModelSyncedEvent.set(true)
         let modelSyncedEventPayload = HubPayload(eventName: HubPayload.EventName.DataStore.modelSynced,
@@ -129,12 +131,12 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                                                                         isDeltaSync: false, added: 0, updated: 0,
                                                                         deleted: 0))
         Amplify.Hub.dispatch(to: .dataStore, payload: modelSyncedEventPayload)
-        await waitForExpectations([secondSnapshot], timeout: 10)
+        await fulfillment(of: [secondSnapshot], timeout: 10)
         
         let modelSyncedEventNotMatch = HubPayload(eventName: HubPayload.EventName.DataStore.modelSynced,
                                                   data: ModelSyncedEvent.Builder().modelName)
         Amplify.Hub.dispatch(to: .dataStore, payload: modelSyncedEventNotMatch)
-        await waitForExpectations([thirdSnapshot], timeout: 10)
+        await fulfillment(of: [thirdSnapshot], timeout: 10)
     }
     
     /// ObserveQuery will send the first snapshot with 2 items when storage engine
@@ -147,7 +149,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
     ///    - The items queried will return two posts in the first snapshot
     ///
     func testFirstSnapshotFromStorageQueryReturnsTwoPosts() async {
-        let firstSnapshot = asyncExpectation(description: "firstSnapshot received")
+        let firstSnapshot = expectation(description: "firstSnapshot received")
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -172,7 +174,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                     querySnapshots.append(querySnapshot)
                     if querySnapshots.count == 1 {
                         XCTAssertEqual(querySnapshot.items.count, 2)
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     }
                 }
                 
@@ -180,7 +182,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                 XCTFail("Failed with error \(error)")
             }
         }
-        await waitForExpectations([firstSnapshot], timeout: 10)
+        await fulfillment(of: [firstSnapshot], timeout: 10)
     }
     
     /// Multiple item changed observed will be returned in a single snapshot
@@ -192,8 +194,8 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
     ///    - The items observed will be returned in the second snapshot
     ///
     func testMultipleItemChangesWillGenerateSecondSnapshot() async throws {
-        let firstSnapshot = asyncExpectation(description: "first query snapshot")
-        let secondSnapshot = asyncExpectation(description: "second query snapshot")
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
 
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
@@ -213,10 +215,10 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                     querySnapshots.append(querySnapshot)
                     if querySnapshots.count == 1 {
                         XCTAssertEqual(querySnapshot.items.count, 0)
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
                         XCTAssertEqual(querySnapshot.items.count, 3)
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     }
                 }
             } catch {
@@ -224,7 +226,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             }
         }
         
-        await waitForExpectations([firstSnapshot], timeout: 1)
+        await fulfillment(of: [firstSnapshot], timeout: 1)
 
         let post1 = try createPost(id: "1")
         let post2 = try createPost(id: "2")
@@ -232,7 +234,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
         dataStorePublisher.send(input: post1)
         dataStorePublisher.send(input: post2)
         dataStorePublisher.send(input: post3)
-        await waitForExpectations([secondSnapshot], timeout: 10)
+        await fulfillment(of: [secondSnapshot], timeout: 10)
     }
     
     /// Multiple published objects (more than the `.collect` count of 1000) in a relatively short time window
@@ -247,10 +249,10 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
     ///     remaining in the third query
     ///
     func testCollectOverMaxItemCountLimit() async throws {
-        let firstSnapshot = asyncExpectation(description: "first query snapshot")
-        let secondSnapshot = asyncExpectation(description: "second query snapshot")
-        let thirdSnapshot = asyncExpectation(description: "third query snapshot")
-        let validateSnapshotsComplete = asyncExpectation(description: "validate snapshots")
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
+        let thirdSnapshot = expectation(description: "third query snapshot")
+        let validateSnapshotsComplete = expectation(description: "validate snapshots")
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -268,11 +270,11 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                 for try await querySnapshot in snapshots {
                     querySnapshots.append(querySnapshot)
                     if querySnapshots.count == 1 {
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     } else if querySnapshots.count == 3 {
-                        await thirdSnapshot.fulfill()
+                        thirdSnapshot.fulfill()
                     }
                 }
                 
@@ -280,22 +282,22 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                 XCTAssertTrue(querySnapshots[0].items.count <= querySnapshots[1].items.count)
                 XCTAssertTrue(querySnapshots[1].items.count <= querySnapshots[2].items.count)
                 XCTAssertTrue(querySnapshots[2].items.count <= 1_100)
-                await validateSnapshotsComplete.fulfill()
+                validateSnapshotsComplete.fulfill()
             } catch {
                 XCTFail("Failed with error \(error)")
             }
         }
         
-        await waitForExpectations([firstSnapshot], timeout: 1)
+        await fulfillment(of: [firstSnapshot], timeout: 1)
 
         for postId in 1 ... 1_100 {
             let post = try createPost(id: "\(postId)")
             dataStorePublisher.send(input: post)
         }
 
-        await waitForExpectations([secondSnapshot, thirdSnapshot], timeout: 10)
+        await fulfillment(of: [secondSnapshot, thirdSnapshot], timeout: 10)
         snapshots.cancel()
-        await waitForExpectations([validateSnapshotsComplete], timeout: 1.0)
+        await fulfillment(of: [validateSnapshotsComplete], timeout: 1.0)
     }
     
     /// Cancelling the subscription will no longer receive snapshots
@@ -307,8 +309,10 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
     ///    - no further snapshots are received
     ///
     func testSuccessfulSubscriptionCancel() async throws {
-        let firstSnapshot = asyncExpectation(description: "first query snapshot")
-        let secondSnapshot = asyncExpectation(description: "second query snapshot", isInverted: true)
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
+        secondSnapshot.isInverted = true
+
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -326,10 +330,10 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                 for try await querySnapshot in snapshots {
                     querySnapshots.append(querySnapshot)
                     if querySnapshots.count == 1 {
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
                         XCTFail("Should not receive second snapshot after cancelling")
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     }
                 }
             } catch {
@@ -337,11 +341,11 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             }
         }
         
-        await waitForExpectations([firstSnapshot], timeout: 1)
+        await fulfillment(of: [firstSnapshot], timeout: 1)
         snapshots.cancel()
         let post1 = try createPost(id: "1")
         dataStorePublisher.send(input: post1)
-        await waitForExpectations([secondSnapshot], timeout: 1)
+        await fulfillment(of: [secondSnapshot], timeout: 1)
     }
     
     /// Cancelling the underlying operation will emit a completion to the subscribers
@@ -353,9 +357,11 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
     ///    - the subscriber receives a cancellation
     ///
     func testSuccessfulSequenceCancel() async throws {
-        let firstSnapshot = asyncExpectation(description: "first query snapshot")
-        let secondSnapshot = asyncExpectation(description: "second query snapshot", isInverted: true)
-        let completedEvent = asyncExpectation(description: "should have completed")
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
+        secondSnapshot.isInverted = true
+
+        let completedEvent = expectation(description: "should have completed")
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -373,29 +379,29 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                 for try await querySnapshot in snapshots {
                     querySnapshots.append(querySnapshot)
                     if querySnapshots.count == 1 {
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
                         XCTFail("Should not receive second snapshot after cancelling")
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     }
                 }
-                await completedEvent.fulfill()
+                completedEvent.fulfill()
             } catch {
                 XCTFail("Failed with error \(error)")
             }
         }
-        await waitForExpectations([firstSnapshot], timeout: 1)
+        await fulfillment(of: [firstSnapshot], timeout: 1)
         snapshots.cancel()
         let post1 = try createPost(id: "1")
         dataStorePublisher.send(input: post1)
 
-        await waitForExpectations([secondSnapshot, completedEvent], timeout: 1)
+        await fulfillment(of: [secondSnapshot, completedEvent], timeout: 1)
     }
     
     ///  ObserveQuery's state should be able to be reset and initial query able to be started again.
     func testObserveQueryResetStateThenStartObserveQuery() async {
-        let firstSnapshot = asyncExpectation(description: "first query snapshot")
-        let secondSnapshot = asyncExpectation(description: "second query snapshot")
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -413,9 +419,9 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                 for try await querySnapshot in snapshots {
                     querySnapshots.append(querySnapshot)
                     if querySnapshots.count == 1 {
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     }
                 }
             } catch {
@@ -423,10 +429,10 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             }
         }
         
-        await waitForExpectations([firstSnapshot], timeout: 1)
+        await fulfillment(of: [firstSnapshot], timeout: 1)
         dataStoreStateSubject.send(.stop)
         dataStoreStateSubject.send(.start(storageEngine: storageEngine))
-        await waitForExpectations([secondSnapshot], timeout: 1)
+        await fulfillment(of: [secondSnapshot], timeout: 1)
     }
     
     /// Multiple calls to start the observeQuery should not start again
@@ -437,9 +443,11 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
     /// - Then:
     ///    - Only one query should be performed / only one snapshot should be returned
     func testObserveQueryStaredShouldNotStartAgain() async {
-        let firstSnapshot = asyncExpectation(description: "first query snapshot")
-        let secondSnapshot = asyncExpectation(description: "second query snapshot")
-        let thirdSnapshot = asyncExpectation(description: "third query snapshot", isInverted: true)
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
+        let thirdSnapshot = expectation(description: "third query snapshot")
+        thirdSnapshot.isInverted = true
+
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -457,11 +465,11 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                 for try await querySnapshot in snapshots {
                     querySnapshots.append(querySnapshot)
                     if querySnapshots.count == 1 {
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     } else if querySnapshots.count == 3 {
-                        await thirdSnapshot.fulfill()
+                        thirdSnapshot.fulfill()
                     }
                 }
             } catch {
@@ -469,18 +477,19 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             }
         }
         
-        await waitForExpectations([firstSnapshot], timeout: 1)
+        await fulfillment(of: [firstSnapshot], timeout: 1)
         dataStoreStateSubject.send(.stop)
         dataStoreStateSubject.send(.start(storageEngine: storageEngine))
         dataStoreStateSubject.send(.start(storageEngine: storageEngine))
-        await waitForExpectations([secondSnapshot, thirdSnapshot], timeout: 1)
+        await fulfillment(of: [secondSnapshot, thirdSnapshot], timeout: 1)
         XCTAssertTrue(taskRunner.observeQueryStarted)
     }
     
     /// ObserveQuery operation entry points are `resetState`, `startObserveQuery`, and `onItemChanges(mutationEvents)`.
     /// Ensure concurrent random sequences of these API calls do not cause issues such as data race.
     func testConcurrent() async {
-        let completeReceived = asyncExpectation(description: "complete received", isInverted: true)
+        let completeReceived = expectation(description: "complete received")
+        completeReceived.isInverted = true
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -502,7 +511,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             do {
                 for try await _ in snapshots {
                 }
-                await completeReceived.fulfill()
+                completeReceived.fulfill()
             } catch {
                 XCTFail("Failed with error \(error)")
             }
@@ -529,17 +538,17 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             for await _ in group {
             }
         }
-        await waitForExpectations([completeReceived], timeout: 10)
+        await fulfillment(of: [completeReceived], timeout: 10)
     }
     
     /// When a predicate like `title.beginsWith("title")` is given, the models that matched the predicate
     /// should be added to the snapshots, like `post` and `post2`. When `post2.title` is updated to no longer
     /// match the predicate, it should be removed from the snapshot.
     func testUpdatedModelNoLongerMatchesPredicateRemovedFromSnapshot() async throws {
-        let firstSnapshot = asyncExpectation(description: "first query snapshots")
-        let secondSnapshot = asyncExpectation(description: "second query snapshots")
-        let thirdSnapshot = asyncExpectation(description: "third query snapshots")
-        let fourthSnapshot = asyncExpectation(description: "fourth query snapshots")
+        let firstSnapshot = expectation(description: "first query snapshots")
+        let secondSnapshot = expectation(description: "second query snapshots")
+        let thirdSnapshot = expectation(description: "third query snapshots")
+        let fourthSnapshot = expectation(description: "fourth query snapshots")
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -560,31 +569,31 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                     if querySnapshots.count == 1 {
                         // First snapshot is empty from the initial query
                         XCTAssertEqual(querySnapshot.items.count, 0)
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
                         // Second snapshot contains `post` since it matches the predicate
                         XCTAssertEqual(querySnapshot.items.count, 1)
                         XCTAssertEqual(querySnapshot.items[0].id, "1")
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     } else if querySnapshots.count == 3 {
                         // Third snapshot contains both posts since they both match the predicate
                         XCTAssertEqual(querySnapshot.items.count, 2)
                         XCTAssertEqual(querySnapshot.items[0].id, "1")
                         XCTAssertEqual(querySnapshot.items[1].id, "2")
-                        await thirdSnapshot.fulfill()
+                        thirdSnapshot.fulfill()
                     } else if querySnapshots.count == 4 {
                         // Fourth snapshot no longer has the post2 since it was updated to not match the predicate
                         // and deleted at the same time.
                         XCTAssertEqual(querySnapshot.items.count, 1)
                         XCTAssertEqual(querySnapshot.items[0].id, "1")
-                        await fourthSnapshot.fulfill()
+                        fourthSnapshot.fulfill()
                     }
                 }
             } catch {
                 XCTFail("Failed with error \(error)")
             }
         }
-        await waitForExpectations([firstSnapshot], timeout: 5)
+        await fulfillment(of: [firstSnapshot], timeout: 5)
 
         let post = try createPost(id: "1", title: "title 1")
         dataStorePublisher.send(input: post)
@@ -593,7 +602,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
         var updatedPost2 = try createPost(id: "2", title: "Does not match predicate")
         updatedPost2.mutationType = MutationEvent.MutationType.update.rawValue
         dataStorePublisher.send(input: updatedPost2)
-        await waitForExpectations([secondSnapshot, thirdSnapshot, fourthSnapshot], timeout: 10)
+        await fulfillment(of: [secondSnapshot, thirdSnapshot, fourthSnapshot], timeout: 10)
     }
     
     

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/ObserveTaskRunnerTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/ObserveTaskRunnerTests.swift
@@ -16,26 +16,27 @@ final class ObserveTaskRunnerTests: XCTestCase {
         let runner = ObserveTaskRunner(publisher: dataStorePublisher.publisher)
         let sequence = runner.sequence
         
-        let started = asyncExpectation(description: "started")
-        let mutationEventReceived = asyncExpectation(description: "mutationEvent received",
-                                                     expectedFulfillmentCount: 5)
-        let mutationEventReceivedAfterCancel = asyncExpectation(description: "mutationEvent received", isInverted: true)
-        
+        let started = expectation(description: "started")
+        let mutationEventReceived = expectation(description: "mutationEvent received")
+        mutationEventReceived.expectedFulfillmentCount = 5
+        let mutationEventReceivedAfterCancel = expectation(description: "mutationEvent received")
+        mutationEventReceivedAfterCancel.isInverted = true
+
         let task = Task {
             do {
-                await started.fulfill()
+                started.fulfill()
                 for try await mutationEvent in sequence {
                     if mutationEvent.id == "id" {
-                        await mutationEventReceived.fulfill()
+                        mutationEventReceived.fulfill()
                     } else {
-                        await mutationEventReceivedAfterCancel.fulfill()
+                        mutationEventReceivedAfterCancel.fulfill()
                     }
                 }
             } catch {
                 XCTFail("Unexpected error \(error)")
             }
         }
-        await waitForExpectations([started], timeout: 10.0)
+        await fulfillment(of: [started], timeout: 10.0)
         var mutationEvent = MutationEvent(id: "id",
                                           modelId: "id",
                                           modelName: "name",
@@ -46,7 +47,7 @@ final class ObserveTaskRunnerTests: XCTestCase {
         dataStorePublisher.send(input: mutationEvent)
         dataStorePublisher.send(input: mutationEvent)
         dataStorePublisher.send(input: mutationEvent)
-        await waitForExpectations([mutationEventReceived], timeout: 1.0)
+        await fulfillment(of: [mutationEventReceived], timeout: 1.0)
         
         task.cancel()
         mutationEvent = MutationEvent(id: "id2",
@@ -55,6 +56,6 @@ final class ObserveTaskRunnerTests: XCTestCase {
                                       json: "json",
                                       mutationType: .create)
         dataStorePublisher.send(input: mutationEvent)
-        await waitForExpectations([mutationEventReceivedAfterCancel], timeout: 1.0)
+        await fulfillment(of: [mutationEventReceivedAfterCancel], timeout: 1.0)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
@@ -97,7 +97,16 @@ class InitialSyncOrchestratorTests: XCTestCase {
             syncCallbackReceived.fulfill()
         }
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(
+            of: [
+                syncCallbackReceived,
+                syncQueriesStartedReceived,
+                syncStartedReceived,
+                finishedReceived,
+                completionFinishedReceived
+            ],
+            timeout: 1
+        )
         XCTAssertEqual(orchestrator.syncOperationQueue.maxConcurrentOperationCount, 1)
         Amplify.Hub.removeListener(hubListener)
         sink.cancel()
@@ -196,7 +205,16 @@ class InitialSyncOrchestratorTests: XCTestCase {
             syncCallbackReceived.fulfill()
         }
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(
+            of: [
+                syncCallbackReceived,
+                syncQueriesStartedReceived,
+                syncStartedReceived,
+                finishedReceived,
+                failureCompletionReceived
+            ],
+            timeout: 1
+        )
         XCTAssertEqual(orchestrator.syncOperationQueue.maxConcurrentOperationCount, 1)
         Amplify.Hub.removeListener(hubListener)
         sink.cancel()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionTests.swift
@@ -99,13 +99,13 @@ class LocalSubscriptionTests: XCTestCase {
     /// - Then:
     ///    - I receive notifications for updates to that model
     func testObserve() async throws {
-        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
-
+        let receivedMutationEvent = expectation(description: "Received mutation event")
+        receivedMutationEvent.assertForOverFulfill = false
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await _ in mutationEvents {
-                    await receivedMutationEvent.fulfill()
+                    receivedMutationEvent.fulfill()
                 }
             } catch {
                 XCTFail("Unexpected error: \(error)")
@@ -122,7 +122,7 @@ class LocalSubscriptionTests: XCTestCase {
                          comments: [])
 
         _ = try await Amplify.DataStore.save(model)
-        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
+        await fulfillment(of: [receivedMutationEvent], timeout: 1.0)
         subscription.cancel()
     }
 
@@ -132,14 +132,14 @@ class LocalSubscriptionTests: XCTestCase {
     /// - Then:
     ///    - I am notified of `create` mutations
     func testCreate() async throws {
-        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
-
+        let receivedMutationEvent = expectation(description: "Received mutation event")
+        receivedMutationEvent.assertForOverFulfill = false
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await mutationEvent in mutationEvents {
                     if mutationEvent.mutationType == MutationEvent.MutationType.create.rawValue {
-                        await receivedMutationEvent.fulfill()
+                        receivedMutationEvent.fulfill()
                     }
                 }
             } catch {
@@ -157,7 +157,7 @@ class LocalSubscriptionTests: XCTestCase {
                          comments: [])
 
         _ = try await Amplify.DataStore.save(model)
-        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
+        await fulfillment(of: [receivedMutationEvent], timeout: 1.0)
 
         subscription.cancel()
     }
@@ -185,13 +185,14 @@ class LocalSubscriptionTests: XCTestCase {
         newModel.content = newContent
         newModel.updatedAt = .now()
 
-        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
+        let receivedMutationEvent = expectation(description: "Received mutation event")
+        receivedMutationEvent.assertForOverFulfill = false
 
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await _ in mutationEvents {
-                    await receivedMutationEvent.fulfill()
+                    receivedMutationEvent.fulfill()
                 }
             } catch {
                 XCTFail("Unexpected error: \(error)")
@@ -200,7 +201,7 @@ class LocalSubscriptionTests: XCTestCase {
         
         _ = try await Amplify.DataStore.save(newModel)
 
-        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
+        await fulfillment(of: [receivedMutationEvent], timeout: 1.0)
 
         subscription.cancel()
     }
@@ -211,14 +212,15 @@ class LocalSubscriptionTests: XCTestCase {
     /// - Then:
     ///    - I am notified of `delete` mutations
     func testDelete() async throws {
-        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
+        let receivedMutationEvent = expectation(description: "Received mutation event")
+        receivedMutationEvent.assertForOverFulfill = false
 
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await mutationEvent in mutationEvents {
                     if mutationEvent.mutationType == MutationEvent.MutationType.delete.rawValue {
-                        await receivedMutationEvent.fulfill()
+                        receivedMutationEvent.fulfill()
                     }
                 }
             } catch {
@@ -232,7 +234,7 @@ class LocalSubscriptionTests: XCTestCase {
 
         _ = try await Amplify.DataStore.save(model)
         _ = try await Amplify.DataStore.delete(model)
-        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
+        await fulfillment(of: [receivedMutationEvent], timeout: 1.0)
 
         subscription.cancel()
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
@@ -96,7 +96,7 @@ class AWSMutationEventIngesterTests: XCTestCase {
             XCTAssert(mutationEvents.first?.json.contains(post.id) ?? false)
         }
 
-        wait(for: [mutationEventQueryCompleted], timeout: 1.0)
+        await fulfillment(of: [mutationEventQueryCompleted], timeout: 1.0)
 
     }
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationEventClearStateTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationEventClearStateTests.swift
@@ -49,8 +49,13 @@ class MutationEventClearStateTests: XCTestCase {
         mutationEventClearState.clearStateOutgoingMutations {
             completionExpectation.fulfill()
         }
-        wait(for: [queryExpectation,
-                   saveExpectation,
-                   completionExpectation], timeout: 1.0)
+        wait(
+            for: [
+                queryExpectation,
+                saveExpectation,
+                completionExpectation
+            ],
+            timeout: 1.0
+        )
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
@@ -73,7 +73,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [mutationEventVerified], timeout: 1)
     }
 
     /// - Given: An existing MutationEvent of type .create
@@ -123,7 +123,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
         
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     /// - Given: An existing MutationEvent of type .create
@@ -161,7 +161,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     // MARK: - Existing == .update
@@ -218,7 +218,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     /// - Given: An existing MutationEvent of type .update
@@ -268,7 +268,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
         
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     /// - Given: An existing MutationEvent of type .update
@@ -310,7 +310,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     // MARK: - Existing == .delete
@@ -358,7 +358,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     // test_<existing>_<candidate>
@@ -408,7 +408,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     // MARK: - Empty queue tests
@@ -454,7 +454,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     /// - Given: An empty mutation queue
@@ -499,7 +499,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     /// - Given: An empty mutation queue
@@ -539,7 +539,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     // MARK: - In-process queue tests
@@ -579,7 +579,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     /// - Given: A mutation queue with an in-process .create event
@@ -633,7 +633,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     /// - Given: A mutation queue with an in-process .create event
@@ -671,7 +671,6 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
-
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
@@ -118,13 +118,13 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         try await startAmplifyAndWaitForSync()
 
         // Save initial model
-        let createdNewItem = asyncExpectation(description: "createdNewItem")
+        let createdNewItem = expectation(description: "createdNewItem")
         let postCopy = post
         Task {
             _ = try await Amplify.DataStore.save(postCopy)
-            await createdNewItem.fulfill()
+            createdNewItem.fulfill()
         }
-        await waitForExpectations([createdNewItem])
+        await fulfillment(of: [createdNewItem])
         await fulfillment(of: [apiRespondedWithSuccess], timeout: 1.0, enforceOrder: false)
 
         // Set the responder to reject the mutation. Make sure to push a retry advice before sending
@@ -146,13 +146,13 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         // will be scheduled and probably in "waiting" mode when we send the network unavailable
         // notification below.
         post.content = "Update 1"
-        let savedUpdate1 = asyncExpectation(description: "savedUpdate1")
+        let savedUpdate1 = expectation(description: "savedUpdate1")
         let postCopy1 = post
         Task {
             _ = try await Amplify.DataStore.save(postCopy1)
-            await savedUpdate1.fulfill()
+            savedUpdate1.fulfill()
         }
-        await waitForExpectations([savedUpdate1])
+        await fulfillment(of: [savedUpdate1])
 
         // At this point, the MutationEvent table (the backing store for the outgoing mutation
         // queue) has only a record for the interim update. It is marked as `inProcess: true`,
@@ -178,7 +178,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
 
         // Assert that DataStore has pushed the no-network event. This isn't strictly necessary for
         // correct operation of the queue.
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [networkUnavailable], timeout: 1.0)
 
         // At this point, the MutationEvent table has only a record for update1. It is marked as
         // `inProcess: false`, because the mutation queue has been fully cancelled by the cleanup
@@ -193,13 +193,13 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         // also expect that it will be overwritten by the next mutation, without ever being synced
         // to the service.
         post.content = "Update 2"
-        let savedUpdate2 = asyncExpectation(description: "savedUpdate2")
+        let savedUpdate2 = expectation(description: "savedUpdate2")
         let postCopy2 = post
         Task {
             _ = try await Amplify.DataStore.save(postCopy2)
-            await savedUpdate2.fulfill()
+            savedUpdate2.fulfill()
         }
-        await waitForExpectations([savedUpdate2])
+        await fulfillment(of: [savedUpdate2])
 
         // At this point, the MutationEvent table has only a record for update2. It is marked as
         // `inProcess: false`, because the mutation queue has been fully cancelled.
@@ -210,13 +210,13 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         // even if there were multiple not-in-process mutations, after the reconciliation completes
         // there would only be one record in the MutationEvent table.
         post.content = expectedFinalContent
-        let savedFinalUpdate = asyncExpectation(description: "savedFinalUpdate")
+        let savedFinalUpdate = expectation(description: "savedFinalUpdate")
         let postCopy3 = post
         Task {
             _ = try await Amplify.DataStore.save(postCopy3)
-            await savedFinalUpdate.fulfill()
+            savedFinalUpdate.fulfill()
         }
-        await waitForExpectations([savedFinalUpdate])
+        await fulfillment(of: [savedFinalUpdate])
 
         let syncStarted = expectation(description: "syncStarted")
         setUpSyncStartedListener(
@@ -250,7 +250,8 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         
         apiPlugin.responders = [.mutateRequestListener: acceptSubsequentMutations]
         reachabilitySubject.send(ReachabilityUpdate(isOnline: true))
-        await waitForExpectations(timeout: 5.0)
+
+        await fulfillment(of: [networkAvailableAgain, syncStarted, expectedFinalContentReceived, outboxEmpty], timeout: 5.0)
     }
 
     // MARK: - Utilities

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
@@ -81,15 +81,22 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
 
         try await startAmplifyAndWaitForSync()
 
-        let saveSuccess = asyncExpectation(description: "save success")
+        let saveSuccess = expectation(description: "save success")
         Task {
             _ = try await Amplify.DataStore.save(post)
-            await saveSuccess.fulfill()
+            saveSuccess.fulfill()
         }
-        await waitForExpectations([saveSuccess], timeout: 1.0)
-        
-        
-        await waitForExpectations(timeout: 5.0, handler: nil)
+        await fulfillment(of: [saveSuccess], timeout: 1.0)
+
+        await fulfillment(
+            of: [
+                outboxStatusOnStart,
+                outboxStatusOnMutationEnqueued,
+                outboxMutationEnqueued,
+                createMutationSent
+            ],
+            timeout: 5.0
+        )
         Amplify.Hub.removeListener(hubListener)
     }
 
@@ -142,7 +149,7 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
 
         }
 
-        wait(for: [mutationEventSaved], timeout: 1.0)
+        await fulfillment(of: [mutationEventSaved], timeout: 1.0)
 
         var outboxStatusReceivedCurrentCount = 0
         let outboxStatusOnStart = expectation(description: "On DataStore start, outboxStatus received")
@@ -188,7 +195,18 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
             try await startAmplify()
         }
 
-        await waitForExpectations(timeout: 5.0, handler: nil)
+
+
+        await fulfillment(
+            of: [
+                outboxStatusOnStart,
+                outboxStatusOnMutationEnqueued,
+                mutation1Sent,
+                mutation2Sent
+            ],
+            timeout: 5.0
+        )
+
         Amplify.Hub.removeListener(hubListener)
     }
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
@@ -75,7 +75,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
                                                      completion: completion)
         let queue = OperationQueue()
         queue.addOperation(operation)
-        wait(for: [expectFirstCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
+        await fulfillment(of: [expectFirstCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
         guard let listenerFromFirstRequest = listenerFromFirstRequestOptional else {
             XCTFail("Listener was not called through MockAPICategoryPlugin")
             return
@@ -83,7 +83,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
 
         let urlError = URLError(URLError.notConnectedToInternet)
         listenerFromFirstRequest(.failure(APIError.networkError("mock NotConnectedToInternetError", nil, urlError)))
-        wait(for: [expectSecondCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
+        await fulfillment(of: [expectSecondCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
 
         guard let listenerFromSecondRequest = listenerFromSecondRequestOptional else {
             XCTFail("Listener was not called through MockAPICategoryPlugin")
@@ -100,7 +100,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         let remoteMutationSync = MutationSync(model: anyModel, syncMetadata: remoteSyncMetadata)
         listenerFromSecondRequest(.success(.success(remoteMutationSync)))
         // waitForExpectations(timeout: 1)
-        wait(for: [expectMutationRequestCompletion], timeout: defaultAsyncWaitTimeout)
+        await fulfillment(of: [expectMutationRequestCompletion], timeout: defaultAsyncWaitTimeout)
     }
 
     func testRetryOnChangeReachability() async throws {
@@ -148,7 +148,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
                                                      completion: completion)
         let queue = OperationQueue()
         queue.addOperation(operation)
-        wait(for: [expectFirstCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
+        await fulfillment(of: [expectFirstCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
         guard let listenerFromFirstRequest = listenerFromFirstRequestOptional else {
             XCTFail("Listener was not called through MockAPICategoryPlugin")
             return
@@ -158,7 +158,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         listenerFromFirstRequest(.failure(APIError.networkError("mock NotConnectedToInternetError", nil, urlError)))
         reachabilityPublisher.send(ReachabilityUpdate(isOnline: true))
 
-        wait(for: [expectSecondCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
+        await fulfillment(of: [expectSecondCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
         guard let listenerFromSecondRequest = listenerFromSecondRequestOptional else {
             XCTFail("Listener was not called through MockAPICategoryPlugin")
             return
@@ -173,7 +173,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
                                                       version: 2)
         let remoteMutationSync = MutationSync(model: anyModel, syncMetadata: remoteSyncMetadata)
         listenerFromSecondRequest(.success(.success(remoteMutationSync)))
-        wait(for: [expectMutationRequestCompletion], timeout: defaultAsyncWaitTimeout)
+        await fulfillment(of: [expectMutationRequestCompletion], timeout: defaultAsyncWaitTimeout)
     }
 
     func testAbilityToCancel() async throws {
@@ -221,7 +221,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
                                                      completion: completion)
         let queue = OperationQueue()
         queue.addOperation(operation)
-        wait(for: [expectFirstCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
+        await fulfillment(of: [expectFirstCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
         guard let listenerFromFirstRequest = listenerFromFirstRequestOptional else {
             XCTFail("Listener was not called through MockAPICategoryPlugin")
             return
@@ -232,7 +232,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
 
         // At this point, we will be "waiting forever" to retry our request or until the operation is canceled
         operation.cancel()
-        wait(for: [expectMutationRequestFailed], timeout: defaultAsyncWaitTimeout)
+        await fulfillment(of: [expectMutationRequestFailed], timeout: defaultAsyncWaitTimeout)
     }
 }
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
@@ -104,15 +104,22 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
         }
 
         try Amplify.configure(amplifyConfig)
-        let startSuccess = asyncExpectation(description: "start success")
+        let startSuccess = expectation(description: "start success")
         Task {
             _ = try await Amplify.DataStore.start()
-            await startSuccess.fulfill()
+            startSuccess.fulfill()
         }
-        await waitForExpectations([startSuccess], timeout: 1.0)
-        
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [startSuccess], timeout: 1.0)
+        await fulfillment(
+            of: [
+                createSubscriptionStarted,
+                updateSubscriptionStarted,
+                deleteSubscriptionStarted
+            ],
+            timeout: 1.0
+        )
     }
+
     // TODO: Implement the test below
 
     /// - Given: Amplify configured with an API

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
@@ -130,7 +130,20 @@ class RemoteSyncEngineTests: XCTestCase {
 
         remoteSyncEngine.start(api: apiPlugin, auth: nil)
 
-        await waitForExpectations(timeout: defaultAsyncWaitTimeout)
+        await fulfillment(
+            of: [
+                storageAdapterAvailable,
+                subscriptionsPaused,
+                mutationsPaused,
+                stateMutationsCleared,
+                subscriptionsInitialized,
+                subscriptionsEstablishedReceived,
+                cleanedup,
+                failureOnInitialSync,
+                retryAdviceReceivedNetworkError
+            ],
+            timeout: defaultAsyncWaitTimeout
+        )
         remoteSyncEngineSink.cancel()
         Amplify.Hub.removeListener(hubListener)
     }
@@ -182,15 +195,20 @@ class RemoteSyncEngineTests: XCTestCase {
 
         remoteSyncEngine.start(api: apiPlugin, auth: nil)
 
-        wait(for: [storageAdapterAvailable,
-                   subscriptionsPaused,
-                   mutationsPaused,
-                   stateMutationsCleared,
-                   subscriptionsInitialized,
-                   performedInitialSync,
-                   subscriptionActivation,
-                   mutationQueueStarted,
-                   syncStarted], timeout: defaultAsyncWaitTimeout)
+        wait(
+            for: [
+                storageAdapterAvailable,
+                subscriptionsPaused,
+                mutationsPaused,
+                stateMutationsCleared,
+                subscriptionsInitialized,
+                performedInitialSync,
+                subscriptionActivation,
+                mutationQueueStarted,
+                syncStarted
+            ],
+            timeout: defaultAsyncWaitTimeout
+        )
         remoteSyncEngineSink.cancel()
     }
 
@@ -253,17 +271,22 @@ class RemoteSyncEngineTests: XCTestCase {
 
         remoteSyncEngine.start(api: apiPlugin, auth: nil)
 
-        wait(for: [storageAdapterAvailable,
-                   subscriptionsPaused,
-                   mutationsPaused,
-                   stateMutationsCleared,
-                   subscriptionsInitialized,
-                   performedInitialSync,
-                   subscriptionActivation,
-                   mutationQueueStarted,
-                   syncStarted,
-                   cleanedUp,
-                   forceFailToNotRestartSyncEngine], timeout: defaultAsyncWaitTimeout)
+        wait(
+            for: [
+                storageAdapterAvailable,
+                subscriptionsPaused,
+                mutationsPaused,
+                stateMutationsCleared,
+                subscriptionsInitialized,
+                performedInitialSync,
+                subscriptionActivation,
+                mutationQueueStarted,
+                syncStarted,
+                cleanedUp,
+                forceFailToNotRestartSyncEngine
+            ],
+            timeout: defaultAsyncWaitTimeout
+        )
         remoteSyncEngineSink.cancel()
     }
 
@@ -330,18 +353,23 @@ class RemoteSyncEngineTests: XCTestCase {
 
         remoteSyncEngine.start(api: apiPlugin, auth: nil)
 
-        wait(for: [storageAdapterAvailable,
-                   subscriptionsPaused,
-                   mutationsPaused,
-                   stateMutationsCleared,
-                   subscriptionsInitialized,
-                   performedInitialSync,
-                   subscriptionActivation,
-                   mutationQueueStarted,
-                   syncStarted,
-                   cleanedUpForTermination,
-                   completionBlockCalled,
-                   forceFailToNotRestartSyncEngine], timeout: defaultAsyncWaitTimeout)
+        wait(
+            for: [
+                storageAdapterAvailable,
+                subscriptionsPaused,
+                mutationsPaused,
+                stateMutationsCleared,
+                subscriptionsInitialized,
+                performedInitialSync,
+                subscriptionActivation,
+                mutationQueueStarted,
+                syncStarted,
+                cleanedUpForTermination,
+                completionBlockCalled,
+                forceFailToNotRestartSyncEngine
+            ],
+            timeout: defaultAsyncWaitTimeout
+        )
         remoteSyncEngineSink.cancel()
     }
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -78,8 +78,8 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        await waitForExpectations(timeout: 2)
 
+        await fulfillment(of: [expectStarted, expectInitialized], timeout: 2)
         // Take action on the sink to prevent compiler warnings about unused variables.
         sink.cancel()
     }
@@ -113,8 +113,8 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        await waitForExpectations(timeout: 2)
 
+        await fulfillment(of: [expectStarted, expectInitialized], timeout: 2)
         sink.cancel()
     }
 
@@ -152,8 +152,8 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        await waitForExpectations(timeout: 2)
 
+        await fulfillment(of: [expectStarted, expectInitialized], timeout: 2)
         sink.cancel()
     }
 
@@ -187,8 +187,8 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        await waitForExpectations(timeout: 2)
 
+        await fulfillment(of: [expectStarted, expectInitialized], timeout: 2)
         sink.cancel()
     }
 
@@ -228,8 +228,8 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        await waitForExpectations(timeout: 2)
 
+        await fulfillment(of: [expectStarted, expectInitialized], timeout: 2)
         sink.cancel()
 
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
@@ -38,7 +38,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
                                                      version: 2)
         let localMetadataSaved = expectation(description: "Local metadata saved")
         storageAdapter.save(localSyncMetadata) { _ in localMetadataSaved.fulfill() }
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [localMetadataSaved], timeout: 1)
 
         var valueListenerFromRequest: MutationSyncInProcessListener?
         let expectationListener = expectation(description: "listener")
@@ -57,8 +57,8 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
             mockRemoteSyncEngineFor_testUpdateAfterDelete()
             try await startAmplifyAndWaitForSync()
         }
-        await waitForExpectations(timeout: 2.0)
 
+        await fulfillment(of: [expectationListener], timeout: 2)
         guard let valueListener = valueListenerFromRequest else {
                 XCTFail("Incoming responder didn't set up listener")
                 return
@@ -149,8 +149,8 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
             mockRemoteSyncEngineFor_testDeleteWithNoLocalModel()
             try await startAmplifyAndWaitForSync()
         }
-        await waitForExpectations(timeout: 1)
-
+        
+        await fulfillment(of: [expectationListener], timeout: 1)
         guard let valueListener = valueListenerFromRequest else {
             XCTFail("Incoming responder didn't set up listener")
             return
@@ -176,8 +176,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
         let remoteMutationSync = MutationSync(model: anyModel, syncMetadata: remoteSyncMetadata)
         valueListener(.data(.success(remoteMutationSync)))
 
-        await waitForExpectations(timeout: 1)
-
+        await fulfillment(of: [syncReceivedNotification], timeout: 1)
         let finalLocalMetadata = try storageAdapter.queryMutationSyncMetadata(for: model.id,
                                                                                  modelName: MockSynced.modelName)
         XCTAssertEqual(finalLocalMetadata?.version, 2)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -51,7 +51,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
             subscriptionEventsSubject.send(.mutationEvent(mutationSync))
         }
 
-        wait(for: [eventsNotSaved], timeout: 5.0)
+        await fulfillment(of: [eventsNotSaved], timeout: 5.0)
     }
 
     /// - Given: An AWSModelReconciliationQueue that has been buffering events
@@ -120,7 +120,17 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         queue.start()
 
-        await waitForExpectations(timeout: 5.0)
+        await fulfillment(
+            of: [
+                event1Saved,
+                event2Saved,
+                event3Saved,
+                eventsSentViaPublisher1,
+                eventsSentViaPublisher2,
+                eventsSentViaPublisher3
+            ],
+            timeout: 5
+        )
         queueSink.cancel()
     }
 
@@ -190,7 +200,15 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         queue.start()
 
-        await waitForExpectations(timeout: 5.0)
+        await fulfillment(
+            of: [
+                event1Saved,
+                event3Saved,
+                eventsSentViaPublisher1,
+                eventsSentViaPublisher3
+            ],
+            timeout: 5
+        )
         queueSink.cancel()
     }
 
@@ -283,7 +301,15 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         queue.start()
 
-        await waitForExpectations(timeout: 5.0)
+        await fulfillment(
+            of: [
+                eventsSentViaPublisher1,
+                eventsSentViaPublisher2,
+                eventsSentViaPublisher3,
+                allEventsProcessed
+            ],
+            timeout: 5
+        )
         queueSink.cancel()
     }
 
@@ -351,7 +377,15 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         queue.start()
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(
+            of: [
+                event1ShouldBeProcessed,
+                event2ShouldBeProcessed,
+                eventsSentViaPublisher1,
+                eventsSentViaPublisher2
+            ],
+            timeout: 1
+        )
 
         let event1ShouldNotBeProcessed = expectation(description: "Event 1 should not be processed")
         event1ShouldNotBeProcessed.isInverted = true
@@ -393,7 +427,15 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
         let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
         subscriptionEventsSubject.send(.mutationEvent(mutationSync))
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(
+            of: [
+                event1ShouldNotBeProcessed,
+                event2ShouldNotBeProcessed,
+                event3ShouldBeProcessed,
+                eventsSentViaPublisher3
+            ],
+            timeout: 1
+        )
         queueSink.cancel()
     }
 
@@ -437,7 +479,7 @@ extension ModelReconciliationQueueBehaviorTests {
         })
 
         subscriptionEventsSubject.send(completion: completion)
-        wait(for: [eventSentViaPublisher], timeout: 1.0)
+        await fulfillment(of: [eventSentViaPublisher], timeout: 1.0)
         queueSink.cancel()
     }
 
@@ -465,7 +507,7 @@ extension ModelReconciliationQueueBehaviorTests {
         })
 
         subscriptionEventsSubject.send(completion: completion)
-        wait(for: [eventSentViaPublisher], timeout: 1.0)
+        await fulfillment(of: [eventSentViaPublisher], timeout: 1.0)
         queueSink.cancel()
     }
 
@@ -493,7 +535,7 @@ extension ModelReconciliationQueueBehaviorTests {
         })
 
         subscriptionEventsSubject.send(completion: completion)
-        wait(for: [eventSentViaPublisher], timeout: 1.0)
+        await fulfillment(of: [eventSentViaPublisher], timeout: 1.0)
         queueSink.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/LocalStoreIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/LocalStoreIntegrationTestBase.swift
@@ -30,13 +30,13 @@ class LocalStoreIntegrationTestBase: XCTestCase {
     }
 
     override func tearDown() async throws {
-        let clearComplete = asyncExpectation(description: "clear completed")
+        let clearComplete = expectation(description: "clear completed")
         
         Task {
             try await Amplify.DataStore.clear()
-            await clearComplete.fulfill()
+            clearComplete.fulfill()
         }
-        await waitForExpectations([clearComplete], timeout: 5)
+        await fulfillment(of: [clearComplete], timeout: 5)
         await Amplify.reset()
     }
 

--- a/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Configuration/AWSLocationGeoPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Configuration/AWSLocationGeoPluginConfigurationTests.swift
@@ -382,12 +382,10 @@ class AWSLocationGeoPluginConfigurationTests: XCTestCase {
                                (AWSLocationGeoPluginConfiguration.Section.maps.key, mapsConfigJSON),
                                (AWSLocationGeoPluginConfiguration.Section.searchIndices.key, GeoPluginTestConfig.searchConfigJSON))
         XCTAssertThrowsError(try AWSLocationGeoPluginConfiguration(config: config)) { error in
-            guard case let PluginError.pluginConfigurationError(errorDescription, _, _) = error else {
+            guard case PluginError.pluginConfigurationError(_, _, _) = error else {
                 XCTFail("Expected PluginError pluginConfigurationError, got: \(error)")
                 return
             }
-            XCTAssertEqual(errorDescription,
-                           GeoPluginConfigError.mapStyleURLInvalid(mapName: mapName).errorDescription)
         }
     }
     

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockAnalyticsClient.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockAnalyticsClient.swift
@@ -73,10 +73,10 @@ actor MockAnalyticsClient: AnalyticsClientBehaviour {
 
     }
 
-    private var recordExpectation: AsyncExpectation?
-    func setRecordExpectation(_ expectation: AsyncExpectation, count: Int = 1) async {
+    private var recordExpectation: XCTestExpectation?
+    func setRecordExpectation(_ expectation: XCTestExpectation, count: Int = 1) {
         recordExpectation = expectation
-        await recordExpectation?.setExpectedFulfillmentCount(count)
+        recordExpectation?.expectedFulfillmentCount = count
     }
 
     var recordCount = 0
@@ -86,23 +86,19 @@ actor MockAnalyticsClient: AnalyticsClientBehaviour {
         recordCount += 1
         lastRecordedEvent = event
         recordedEvents.append(event)
-        Task {
-            await recordExpectation?.fulfill()
-        }
+        recordExpectation?.fulfill()
     }
 
-    private var submitEventsExpectation: AsyncExpectation?
-    func setSubmitEventsExpectation(_ expectation: AsyncExpectation, count: Int = 1) async {
+    private var submitEventsExpectation: XCTestExpectation?
+    func setSubmitEventsExpectation(_ expectation: XCTestExpectation, count: Int = 1) {
         submitEventsExpectation = expectation
-        await submitEventsExpectation?.setExpectedFulfillmentCount(count)
+        submitEventsExpectation?.expectedFulfillmentCount = count
     }
 
     var submitEventsCount = 0
     func submitEvents() async throws -> [PinpointEvent] {
         submitEventsCount += 1
-        Task {
-            await submitEventsExpectation?.fulfill()
-        }
+        submitEventsExpectation?.fulfill()
         return []
     }
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Configuration/AWSS3PluginPrefixResolverTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Configuration/AWSS3PluginPrefixResolverTests.swift
@@ -58,14 +58,15 @@ class AWSS3PluginPrefixResolverTests: XCTestCase {
             .init(.private, "identityId", ""),
         ]
 
-        let done = asyncExpectation(description: "done", expectedFulfillmentCount: testData.count)
+        let done = expectation(description: "done")
+        done.expectedFulfillmentCount = testData.count
         Task {
             try await testData.async.forEach {
                 try await $0.assertEqual(prefixResolver: prefixResolver)
-                await done.fulfill()
+                done.fulfill()
             }
         }
-        await waitForExpectations([done])
+        await fulfillment(of: [done])
     }
 
     func testStorageAccessLevelAwarePrefixResolver() async throws {
@@ -82,14 +83,16 @@ class AWSS3PluginPrefixResolverTests: XCTestCase {
             .init(.private, "targetUserId", "private/targetUserId/"),
         ]
 
-        let done = asyncExpectation(description: "done", expectedFulfillmentCount: testData.count)
+        let done = expectation(description: "done")
+        done.expectedFulfillmentCount = testData.count
+
         Task {
             try await testData.async.forEach {
                 try await $0.assertEqual(prefixResolver: prefixResolver)
-                await done.fulfill()
+                done.fulfill()
             }
         }
-        await waitForExpectations([done])
+        await fulfillment(of: [done])
     }
 
 }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageDownloadFileOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageDownloadFileOperationTests.swift
@@ -68,7 +68,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
         
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [failedInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
     }
 
@@ -177,7 +177,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [inProcessInvoked, completeInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDownload(serviceKey: expectedServiceKey, fileURL: url)
     }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageGetDataOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageGetDataOperationTests.swift
@@ -45,26 +45,28 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
         mockAuthService.getIdentityIdError = AuthError.service("", "", "")
         let request = StorageDownloadDataRequest(key: testKey, options: StorageDownloadDataRequest.Options())
         let failedInvoked = expectation(description: "failed was invoked on operation")
-        let operation = AWSS3StorageDownloadDataOperation(request,
-                                                          storageConfiguration: testStorageConfiguration,
-                                                          storageService: mockStorageService,
-                                                          authService: mockAuthService,
-                                                          progressListener: nil) { event in
-                                                            switch event {
-                                                            case .failure(let error):
-                                                                guard case .authError = error else {
-                                                                    XCTFail("Should have failed with authError")
-                                                                    return
-                                                                }
-                                                                failedInvoked.fulfill()
-                                                            default:
-                                                                XCTFail("Should have received failed event")
-                                                            }
+        let operation = AWSS3StorageDownloadDataOperation(
+            request,
+            storageConfiguration: testStorageConfiguration,
+            storageService: mockStorageService,
+            authService: mockAuthService,
+            progressListener: nil
+        ) { event in
+            switch event {
+            case .failure(let error):
+                guard case .authError = error else {
+                    XCTFail("Should have failed with authError")
+                    return
+                }
+                failedInvoked.fulfill()
+            default:
+                XCTFail("Should have received failed event")
+            }
         }
 
         operation.start()
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [failedInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
     }
 
@@ -96,7 +98,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [inProcessInvoked, completeInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDownload(serviceKey: expectedServiceKey, fileURL: nil)
     }
@@ -129,7 +131,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [inProcessInvoked, failInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDownload(serviceKey: expectedServiceKey, fileURL: nil)
     }
@@ -164,7 +166,10 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(
+            of: [inProcessInvoked, completeInvoked],
+            timeout: 1
+        )
         XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDownload(serviceKey: expectedServiceKey, fileURL: nil)
     }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageRemoveOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageRemoveOperationTests.swift
@@ -64,7 +64,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
         }
 
         operation.start()
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [failedInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
     }
 
@@ -89,7 +89,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [completeInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDelete(serviceKey: expectedServiceKey)
     }
@@ -115,7 +115,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [failedInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDelete(serviceKey: expectedServiceKey)
     }
@@ -142,7 +142,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
 
-        waitForExpectations(timeout: 1)
+        wait(for: [completeInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDelete(serviceKey: expectedServiceKey)
     }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageBackgroundEventsRegistryTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageBackgroundEventsRegistryTests.swift
@@ -18,14 +18,13 @@ class StorageBackgroundEventsRegistryTests: XCTestCase {
         let otherIdentifier = UUID().uuidString
         StorageBackgroundEventsRegistry.register(identifier: identifier)
 
-        let done = asyncExpectation(description: "done", expectedFulfillmentCount: 2)
+        let done = expectation(description: "done")
+        done.expectedFulfillmentCount = 2
 
         Task {
             let handled = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
                 StorageBackgroundEventsRegistry.handleBackgroundEvents(identifier: identifier, continuation: continuation)
-                Task {
-                    await done.fulfill()
-                }
+                done.fulfill()
             }
             XCTAssertTrue(handled)
         }
@@ -33,14 +32,12 @@ class StorageBackgroundEventsRegistryTests: XCTestCase {
         Task {
             let otherHandled = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
                 StorageBackgroundEventsRegistry.handleBackgroundEvents(identifier: otherIdentifier, continuation: continuation)
-                Task {
-                    await done.fulfill()
-                }
+                done.fulfill()
             }
             XCTAssertFalse(otherHandled)
         }
 
-        await waitForExpectations([done])
+        await fulfillment(of: [done])
 
         handleEvents(for: identifier)
         handleEvents(for: otherIdentifier)
@@ -51,19 +48,17 @@ class StorageBackgroundEventsRegistryTests: XCTestCase {
         let otherIdentifier = UUID().uuidString
         StorageBackgroundEventsRegistry.register(identifier: otherIdentifier)
 
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
 
         Task {
             let handled = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
                 StorageBackgroundEventsRegistry.handleBackgroundEvents(identifier: identifier, continuation: continuation)
-                Task {
-                    await done.fulfill()
-                }
+                done.fulfill()
             }
             XCTAssertFalse(handled)
         }
 
-        await waitForExpectations([done])
+        await fulfillment(of: [done])
     }
 
     // Simulates URLSessionDelegate behavior

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageTransferDatabaseTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageTransferDatabaseTests.swift
@@ -219,7 +219,7 @@ class StorageTransferDatabaseTests: XCTestCase {
         XCTAssertEqual(database.tasksCount, 3)
         XCTAssertNotNil(originalTask.multipartUpload)
 
-        let exp = asyncExpectation(description: #function)
+        let exp = expectation(description: #function)
 
         var transferTaskPairs: StorageTransferTaskPairs?
         let urlSession = MockStorageURLSession(sessionTasks: sessionTasks)
@@ -234,13 +234,11 @@ class StorageTransferDatabaseTests: XCTestCase {
                 } catch {
                     XCTFail("Error: \(error)")
                 }
-                Task {
-                    await exp.fulfill()
-                }
+                exp.fulfill()
             }
         }
 
-        await waitForExpectations([exp], timeout: 10.0)
+        await fulfillment(of: [exp], timeout: 10.0)
 
         XCTAssertNotNil(transferTaskPairs)
         XCTAssertEqual(transferTaskPairs?.count, 3)

--- a/AmplifyTests/CategoryTests/API/APICategoryClientGraphQLTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryClientGraphQLTests.swift
@@ -35,14 +35,14 @@ class APICategoryClientGraphQLTests: XCTestCase {
         }
 
         let request = GraphQLRequest(document: "", variables: nil, responseType: JSONValue.self)
-        let queryCompleted = asyncExpectation(description: "query completed")
+        let queryCompleted = expectation(description: "query completed")
         Task {
             _ = try await Amplify.API.query(request: request)
-            await queryCompleted.fulfill()
+            queryCompleted.fulfill()
         }
-        await waitForExpectations([queryCompleted], timeout: 0.5)
-        
-        await waitForExpectations(timeout: 0.5)
+
+        await fulfillment(of: [queryCompleted], timeout: 0.5)
+        await fulfillment(of: [methodWasInvokedOnPlugin], timeout: 0.5)
     }
 
     func testMutate() async throws {
@@ -56,14 +56,13 @@ class APICategoryClientGraphQLTests: XCTestCase {
 
         let request = GraphQLRequest(document: "", variables: nil, responseType: JSONValue.self)
         
-        let mutateCompleted = asyncExpectation(description: "mutate completed")
+        let mutateCompleted = expectation(description: "mutate completed")
         Task {
             _ = try await Amplify.API.mutate(request: request)
-            await mutateCompleted.fulfill()
+            mutateCompleted.fulfill()
         }
-        await waitForExpectations([mutateCompleted], timeout: 0.5)
-
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [mutateCompleted], timeout: 0.5)
+        await fulfillment(of: [methodWasInvokedOnPlugin], timeout: 0.5)
     }
 
     // MARK: - Utilities

--- a/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
@@ -115,14 +115,14 @@ class APICategoryConfigurationTests: XCTestCase {
 
         try Amplify.configure(amplifyConfig)
 
-        let getCompleted = asyncExpectation(description: "get completed")
+        let getCompleted = expectation(description: "get completed")
         Task {
             _ = try await Amplify.API.get(request: RESTRequest())
-            await getCompleted.fulfill()
+            getCompleted.fulfill()
         }
-        await waitForExpectations([getCompleted], timeout: 0.5)
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [getCompleted], timeout: 0.5)
+        await fulfillment(of: [methodInvokedOnDefaultPlugin], timeout: 1)
     }
 
     // TODO: this test is disabled for now since `catchBadInstruction` only takes in closure
@@ -184,15 +184,20 @@ class APICategoryConfigurationTests: XCTestCase {
 
         try Amplify.configure(amplifyConfig)
         
-        let getCompleted = asyncExpectation(description: "get completed")
+        let getCompleted = expectation(description: "get completed")
         Task {
             let plugin = try Amplify.API.getPlugin(for: "MockSecondAPICategoryPlugin")
             _ = try await plugin.get(request: RESTRequest())
-            await getCompleted.fulfill()
+            getCompleted.fulfill()
         }
-        await waitForExpectations([getCompleted], timeout: 0.5)
-
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(
+            of: [
+                getCompleted,
+                methodShouldBeInvokedOnSecondPlugin,
+                methodShouldNotBeInvokedOnDefaultPlugin
+            ],
+            timeout: 1.0
+        )
     }
 
     func testCanConfigurePluginDirectly() throws {

--- a/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
@@ -200,7 +200,7 @@ class AuthCategoryConfigurationTests: XCTestCase {
         try Amplify.configure(amplifyConfig)
         _ = try await Amplify.Auth.getPlugin(for: "MockSecondAuthCategoryPlugin")
             .update(oldPassword: "current", to: "new", options: nil)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [methodShouldBeInvokedOnSecondPlugin], timeout: 1.0)
     }
 
     /// Test if we get error when trying default plugin when multiple plugin added.

--- a/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryClientAPITests.swift
@@ -36,15 +36,15 @@ class DataStoreCategoryClientAPITests: XCTestCase {
             }
         }
 
-        let saveSuccess = asyncExpectation(description: "saved successful")
+        let saveSuccess = expectation(description: "saved successful")
         Task {
             _ = try await Amplify.DataStore.save(TestModel.make())
-            await saveSuccess.fulfill()
+            saveSuccess.fulfill()
         }
-        await waitForExpectations([saveSuccess], timeout: 0.5)
-        
-
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(
+            of: [saveSuccess, methodWasInvokedOnPlugin],
+            timeout: 1
+        )
     }
 
 }

--- a/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
@@ -30,7 +30,6 @@ class DataStoreCategoryConfigurationTests: XCTestCase {
         }
 
         try Amplify.add(plugin: plugin)
-
         let amplifyConfig = AmplifyConfiguration()
         try Amplify.configure(amplifyConfig)
 
@@ -134,15 +133,16 @@ class DataStoreCategoryConfigurationTests: XCTestCase {
 
         try Amplify.configure(amplifyConfig)
 
-        let saveSuccess = asyncExpectation(description: "save successful")
+        let saveSuccess = expectation(description: "save successful")
         Task {
             _ = try await Amplify.DataStore.save(TestModel.make())
-            await saveSuccess.fulfill()
+            saveSuccess.fulfill()
         }
-        await waitForExpectations([saveSuccess], timeout: 1.0)
-        
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(
+            of: [saveSuccess, methodInvokedOnDefaultPlugin],
+            timeout: 1.0
+        )
     }
 
     // TODO: this test is disabled for now since `catchBadInstruction` only takes in closure
@@ -204,15 +204,21 @@ class DataStoreCategoryConfigurationTests: XCTestCase {
 
         try Amplify.configure(amplifyConfig)
         
-        let saveSuccess = asyncExpectation(description: "save success")
+        let saveSuccess = expectation(description: "save success")
         Task {
             _ = try await Amplify.DataStore.getPlugin(for: "MockSecondDataStoreCategoryPlugin")
                 .save(TestModel.make(), where: nil)
-            await saveSuccess.fulfill()
+            saveSuccess.fulfill()
         }
-        await waitForExpectations([saveSuccess], timeout: 1.0)
-        
-        await waitForExpectations(timeout: 1.0)
+
+        await fulfillment(
+            of: [
+                saveSuccess,
+                methodShouldBeInvokedOnSecondPlugin,
+                methodShouldNotBeInvokedOnDefaultPlugin
+            ],
+            timeout: 1.0
+        )
     }
 
     func testCanConfigurePluginDirectly() throws {

--- a/AmplifyTests/CategoryTests/DataStore/Model/ListPaginationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/Model/ListPaginationTests.swift
@@ -17,7 +17,7 @@ extension ListTests {
             XCTFail("Should not be loaded")
             return
         }
-        let fetchComplete = asyncExpectation(description: "fetch completed")
+        let fetchComplete = expectation(description: "fetch completed")
         Task {
             
             try await list.fetch()
@@ -25,16 +25,16 @@ extension ListTests {
                 XCTFail("Should be loaded")
                 return
             }
-            await fetchComplete.fulfill()
+            fetchComplete.fulfill()
         }
-        await waitForExpectations([fetchComplete], timeout: 1)
+        await fulfillment(of: [fetchComplete], timeout: 1)
         
-        let fetchComplete2 = asyncExpectation(description: "fetch completed")
+        let fetchComplete2 = expectation(description: "fetch completed")
         Task {
             try await list.fetch()
-            await fetchComplete2.fulfill()
+            fetchComplete2.fulfill()
         }
-        await waitForExpectations([fetchComplete2], timeout: 1)
+        await fulfillment(of: [fetchComplete2], timeout: 1)
     }
 
     func testFetchFailure() async throws {
@@ -46,7 +46,7 @@ extension ListTests {
             XCTFail("Should not be loaded")
             return
         }
-        let fetchCompleted = asyncExpectation(description: "fetch completed")
+        let fetchCompleted = expectation(description: "fetch completed")
         Task {
             do {
                 try await list.fetch()
@@ -58,10 +58,10 @@ extension ListTests {
                 XCTFail("Should not be loaded")
                 return
             }
-            await fetchCompleted.fulfill()
+            fetchCompleted.fulfill()
         }
         
-        await waitForExpectations([fetchCompleted], timeout: 1.0)
+        await fulfillment(of: [fetchCompleted], timeout: 1.0)
     }
 
     func testHasNextPageSuccess() async throws {
@@ -72,7 +72,7 @@ extension ListTests {
             XCTFail("Should not be loaded")
             return
         }
-        let fetchCompleted = asyncExpectation(description: "fetch completed")
+        let fetchCompleted = expectation(description: "fetch completed")
         Task {
             try await list.fetch()
             guard case .loaded = list.loadedState else {
@@ -80,9 +80,9 @@ extension ListTests {
                 return
             }
             XCTAssertTrue(list.hasNextPage())
-            await fetchCompleted.fulfill()
+            fetchCompleted.fulfill()
         }
-        await waitForExpectations([fetchCompleted], timeout: 1.0)
+        await fulfillment(of: [fetchCompleted], timeout: 1.0)
     }
 
     func testGetNextPageSuccess() async throws {
@@ -94,23 +94,23 @@ extension ListTests {
             return
         }
         try await list.fetch()
-        let getNextPageSuccess = asyncExpectation(description: "getNextPage successful")
+        let getNextPageSuccess = expectation(description: "getNextPage successful")
         Task {
             _ = try await list.getNextPage()
-            await getNextPageSuccess.fulfill()
+            getNextPageSuccess.fulfill()
         }
-        await waitForExpectations([getNextPageSuccess], timeout: 1.0)
+        await fulfillment(of: [getNextPageSuccess], timeout: 1.0)
         
         guard case .loaded = list.loadedState else {
             XCTFail("Should be loaded")
             return
         }
-        let getNextPageSuccess2 = asyncExpectation(description: "getNextPage successful")
+        let getNextPageSuccess2 = expectation(description: "getNextPage successful")
         Task {
             _ = try await list.getNextPage()
-            await getNextPageSuccess2.fulfill()
+            getNextPageSuccess2.fulfill()
         }
-        await waitForExpectations([getNextPageSuccess2], timeout: 1.0)
+        await fulfillment(of: [getNextPageSuccess2], timeout: 1.0)
 
     }
 
@@ -122,14 +122,14 @@ extension ListTests {
             XCTFail("Should not be loaded")
             return
         }
-        let fetchCompleted = asyncExpectation(description: "fetch completed")
+        let fetchCompleted = expectation(description: "fetch completed")
         Task {
             try await list.fetch()
-            await fetchCompleted.fulfill()
+            fetchCompleted.fulfill()
         }
-        await waitForExpectations([fetchCompleted], timeout: 1.0)
+        await fulfillment(of: [fetchCompleted], timeout: 1.0)
         
-        let getNextPageSuccess = asyncExpectation(description: "getNextPage successful")
+        let getNextPageSuccess = expectation(description: "getNextPage successful")
         Task {
             do {
                 _ = try await list.getNextPage()
@@ -137,8 +137,8 @@ extension ListTests {
             } catch {
                 XCTAssertNotNil(error)
             }
-            await getNextPageSuccess.fulfill()
+            getNextPageSuccess.fulfill()
         }
-        await waitForExpectations([getNextPageSuccess], timeout: 1.0)
+        await fulfillment(of: [getNextPageSuccess], timeout: 1.0)
     }
 }

--- a/AmplifyTests/CategoryTests/DataStore/Model/ListTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/Model/ListTests.swift
@@ -131,12 +131,12 @@ class ListTests: XCTestCase {
 
         let serializedData = try ListTests.encode(json: data)
         let list = try ListTests.decode(serializedData, responseType: BasicModel.self)
-        let fetchSuccess = asyncExpectation(description: "fetch successful")
+        let fetchSuccess = expectation(description: "fetch successful")
         Task {
             try await list.fetch()
-            await fetchSuccess.fulfill()
+            fetchSuccess.fulfill()
         }
-        await waitForExpectations([fetchSuccess], timeout: 1.0)
+        await fulfillment(of: [fetchSuccess], timeout: 1.0)
         
         XCTAssertEqual(list.count, 2)
         XCTAssertEqual(list.startIndex, 0)
@@ -148,7 +148,7 @@ class ListTests: XCTestCase {
         list.makeIterator().forEach { _ in
             iterateSuccess.fulfill()
         }
-        wait(for: [iterateSuccess], timeout: 1)
+        await fulfillment(of: [iterateSuccess], timeout: 1)
         let json = try? ListTests.toJSON(list: list)
         XCTAssertEqual(json, """
             [{\"id\":\"1\"},{\"id\":\"2\"}]
@@ -165,12 +165,12 @@ class ListTests: XCTestCase {
         let serializedData = try ListTests.encode(json: data)
         let list = try ListTests.decode(serializedData, responseType: BasicModel.self)
         XCTAssertNotNil(list)
-        let fetchSuccess = asyncExpectation(description: "fetch successful")
+        let fetchSuccess = expectation(description: "fetch successful")
         Task {
             try await list.fetch()
-            await fetchSuccess.fulfill()
+            fetchSuccess.fulfill()
         }
-        await waitForExpectations([fetchSuccess], timeout: 1.0)
+        await fulfillment(of: [fetchSuccess], timeout: 1.0)
         XCTAssertEqual(list.count, 2)
         XCTAssertEqual(list.startIndex, 0)
         XCTAssertEqual(list.endIndex, 2)
@@ -181,7 +181,7 @@ class ListTests: XCTestCase {
         list.makeIterator().forEach { _ in
             iterateSuccess.fulfill()
         }
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [iterateSuccess], timeout: 1)
         XCTAssertFalse(list.listProvider.hasNextPage())
         do {
             _ = try await list.listProvider.getNextPage()
@@ -197,12 +197,12 @@ class ListTests: XCTestCase {
         let serializedData = try ListTests.encode(json: data)
         let list = try ListTests.decode(serializedData, responseType: BasicModel.self)
         XCTAssertNotNil(list)
-        let fetchSuccess = asyncExpectation(description: "fetch successful")
+        let fetchSuccess = expectation(description: "fetch successful")
         Task {
             try await list.fetch()
-            await fetchSuccess.fulfill()
+            fetchSuccess.fulfill()
         }
-        await waitForExpectations([fetchSuccess], timeout: 1.0)
+        await fulfillment(of: [fetchSuccess], timeout: 1.0)
         XCTAssertEqual(list.count, 0)
         let json = try? ListTests.toJSON(list: list)
         XCTAssertEqual(json, "[]")
@@ -217,7 +217,7 @@ class ListTests: XCTestCase {
             XCTFail("Should not be loaded")
             return
         }
-        let fetchCompleted = asyncExpectation(description: "fetch completed")
+        let fetchCompleted = expectation(description: "fetch completed")
         Task {
             do {
                 _ = try await list.fetch()
@@ -225,9 +225,9 @@ class ListTests: XCTestCase {
             } catch {
                 XCTAssertNotNil(error)
             }
-            await fetchCompleted.fulfill()
+            fetchCompleted.fulfill()
         }
-        await waitForExpectations([fetchCompleted], timeout: 1.0)
+        await fulfillment(of: [fetchCompleted], timeout: 1.0)
     }
 
     // MARK: - Helpers

--- a/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
@@ -48,7 +48,7 @@ class AmplifyOperationHubTests: XCTestCase {
 
         operation.doMockDispatch()
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [listenerWasInvoked], timeout: 1.0)
     }
 
     /// Given: A configured system

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeHubListenToOperationTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeHubListenToOperationTests.swift
@@ -63,11 +63,11 @@ class AutoUnsubscribeHubListenToOperationTests: XCTestCase {
 //        }
 //
 //        operation.doMockDispatch()
-//        wait(for: [listenerWasInvokedForCompleted], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForCompleted], timeout: 0.1)
 //
 //        operation.doMockProgress()
 //        operation.doMockDispatch(result: .failure(StorageError.accessDenied("", "")))
-//        wait(for: [listenerWasInvokedForInProcess, listenerWasInvokedForFailed], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForInProcess, listenerWasInvokedForFailed], timeout: 0.1)
     }
 
     /// - Given: An Amplify operation class
@@ -104,11 +104,11 @@ class AutoUnsubscribeHubListenToOperationTests: XCTestCase {
 //        }
 //
 //        operation.doMockDispatch(result: .failure(StorageError.accessDenied("", "")))
-//        wait(for: [listenerWasInvokedForFailed], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForFailed], timeout: 0.1)
 //
 //        operation.doMockProgress()
 //        operation.doMockDispatch()
-//        wait(for: [listenerWasInvokedForInProcess, listenerWasInvokedForCompleted], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForInProcess, listenerWasInvokedForCompleted], timeout: 0.1)
     }
 
     /// - Given: An Amplify operation class
@@ -162,12 +162,12 @@ class AutoUnsubscribeHubListenToOperationTests: XCTestCase {
 //        }
 //
 //        operation.doMockProgress()
-//        wait(for: [listenerWasInvokedForInProcess], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForInProcess], timeout: 0.1)
 //        operation.doMockDispatch()
-//        wait(for: [listenerWasInvokedForCompleted], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForCompleted], timeout: 0.1)
 //
 //        operation.doMockDispatch(result: .failure(StorageError.accessDenied("", "")))
-//        wait(for: [listenerWasInvokedForFailed], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForFailed], timeout: 0.1)
     }
 
     /// - Given: An Amplify operation class
@@ -222,10 +222,10 @@ class AutoUnsubscribeHubListenToOperationTests: XCTestCase {
 //
 //        operation.doMockProgress()
 //        operation.doMockDispatch(result: .failure(StorageError.accessDenied("", "")))
-//        wait(for: [listenerWasInvokedForInProcess, listenerWasInvokedForFailed], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForInProcess, listenerWasInvokedForFailed], timeout: 0.1)
 //
 //        operation.doMockDispatch()
-//        wait(for: [listenerWasInvokedForCompleted], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForCompleted], timeout: 0.1)
     }
 
 }

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeOperationTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeOperationTests.swift
@@ -64,11 +64,11 @@ class AutoUnsubscribeOperationTests: XCTestCase {
 //        }
 //
 //        operation.doMockDispatch()
-//        wait(for: [listenerWasInvokedForCompleted], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForCompleted], timeout: 0.1)
 //
 //        operation.doMockProgress()
 //        operation.doMockDispatch(result: .failure(StorageError.accessDenied("", "")))
-//        wait(for: [listenerWasInvokedForInProcess, listenerWasInvokedForFailed], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForInProcess, listenerWasInvokedForFailed], timeout: 0.1)
     }
 
     /// - Given: An Amplify operation class
@@ -106,11 +106,11 @@ class AutoUnsubscribeOperationTests: XCTestCase {
 //        }
 //
 //        operation.doMockDispatch(result: .failure(StorageError.accessDenied("", "")))
-//        wait(for: [listenerWasInvokedForFailed], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForFailed], timeout: 0.1)
 //
 //        operation.doMockProgress()
 //        operation.doMockDispatch()
-//        wait(for: [listenerWasInvokedForInProcess, listenerWasInvokedForCompleted], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForInProcess, listenerWasInvokedForCompleted], timeout: 0.1)
     }
 
     /// - Given: An Amplify operation class
@@ -149,10 +149,10 @@ class AutoUnsubscribeOperationTests: XCTestCase {
 //
 //        operation.doMockProgress()
 //        operation.doMockDispatch()
-//        wait(for: [listenerWasInvokedForInProcess, listenerWasInvokedForCompleted], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForInProcess, listenerWasInvokedForCompleted], timeout: 0.1)
 //
 //        operation.doMockDispatch(result: .failure(StorageError.accessDenied("", "")))
-//        wait(for: [listenerWasInvokedForFailed], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForFailed], timeout: 0.1)
     }
 
     /// - Given: An Amplify operation class
@@ -191,10 +191,10 @@ class AutoUnsubscribeOperationTests: XCTestCase {
 //
 //        operation.doMockProgress()
 //        operation.doMockDispatch(result: .failure(StorageError.accessDenied("", "")))
-//        wait(for: [listenerWasInvokedForInProcess, listenerWasInvokedForFailed], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForInProcess, listenerWasInvokedForFailed], timeout: 0.1)
 //
 //        operation.doMockProgress()
-//        wait(for: [listenerWasInvokedForCompleted], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForCompleted], timeout: 0.1)
     }
 
 }

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginConcurrencyTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginConcurrencyTests.swift
@@ -79,7 +79,7 @@ class DefaultHubPluginConcurrencyTests: XCTestCase {
             }
         }
 
-        await waitForExpectations(timeout: 5.0)
+        await fulfillment(of: messagesReceived, timeout: 5.0)
     }
 
 }

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginCustomChannelTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginCustomChannelTests.swift
@@ -51,7 +51,7 @@ class DefaultHubPluginCustomChannelTests: XCTestCase {
 
         plugin.dispatch(to: .custom("CustomChannel1"), payload: HubPayload(eventName: "TEST_EVENT"))
 
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [eventReceived], timeout: 0.5)
     }
 
     /// Given: A listener to a custom channel
@@ -72,7 +72,7 @@ class DefaultHubPluginCustomChannelTests: XCTestCase {
 
         plugin.dispatch(to: .custom("CustomChannel2"), payload: HubPayload(eventName: "TEST_EVENT"))
 
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [eventReceived], timeout: 0.5)
     }
 
     /// Given: Multiple listeners to a custom channel
@@ -102,7 +102,7 @@ class DefaultHubPluginCustomChannelTests: XCTestCase {
 
         plugin.dispatch(to: .custom("CustomChannel1"), payload: HubPayload(eventName: "TEST_EVENT"))
 
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [listener1Invoked, listener2Invoked], timeout: 0.5)
     }
 
 }

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginTests.swift
@@ -69,7 +69,7 @@ class DefaultHubPluginTests: XCTestCase {
         }
 
         plugin.dispatch(to: .storage, payload: HubPayload(eventName: "TEST_EVENT"))
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [expectedMessageReceived], timeout: 0.5)
     }
 
     /// Given: The default Hub plugin with a registered listener
@@ -92,7 +92,7 @@ class DefaultHubPluginTests: XCTestCase {
         }
 
         plugin.dispatch(to: .storage, payload: HubPayload(eventName: "TEST_EVENT"))
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [messageReceived], timeout: 0.5)
     }
 
     /// Given: A subscription token from a previous call to the default Hub plugin's `listen` method
@@ -129,7 +129,7 @@ class DefaultHubPluginTests: XCTestCase {
         }
 
         plugin.dispatch(to: .storage, payload: HubPayload(eventName: "TEST_EVENT"))
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [try XCTUnwrap(currentExpectation)], timeout: 0.5)
 
         plugin.removeListener(unsubscribeToken)
         try? await Task.sleep(seconds: 0.01)
@@ -147,7 +147,7 @@ class DefaultHubPluginTests: XCTestCase {
         XCTAssertFalse(isStillRegistered.get(), "Should not be registered after removeListener")
 
         plugin.dispatch(to: .storage, payload: HubPayload(eventName: "TEST_EVENT"))
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [try XCTUnwrap(currentExpectation)], timeout: 0.5)
     }
 
     /// Given: The default Hub plugin

--- a/AmplifyTests/CategoryTests/Notifications/Push/PushNotificationsCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Notifications/Push/PushNotificationsCategoryClientAPITests.swift
@@ -44,7 +44,7 @@ class PushNotificationsCategoryClientAPITests: XCTestCase {
         }
 
         try await category.identifyUser(userId: "test")
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [methodInvoked], timeout: 1.0)
     }
 
     func testRegisterDeviceToken_shouldSucceed() async throws {
@@ -58,7 +58,7 @@ class PushNotificationsCategoryClientAPITests: XCTestCase {
         }
 
         try await category.registerDevice(apnsToken: data)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [methodInvoked], timeout: 1.0)
     }
 
     func testRecordNotificationReceived_shouldSucceed() async throws {
@@ -72,7 +72,7 @@ class PushNotificationsCategoryClientAPITests: XCTestCase {
         }
 
         try await category.recordNotificationReceived(userInfo)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [methodInvoked], timeout: 1.0)
     }
 
 #if !os(tvOS)
@@ -87,7 +87,7 @@ class PushNotificationsCategoryClientAPITests: XCTestCase {
         }
 
         try await category.recordNotificationOpened(response)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [methodInvoked], timeout: 1.0)
     }
 #endif
 

--- a/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
@@ -102,12 +102,10 @@ class StorageCategoryConfigurationTests: XCTestCase {
 
     func testCanUseDefaultPluginIfOnlyOnePlugin() async throws {
         let plugin = MockStorageCategoryPlugin()
-        let methodInvokedOnDefaultPlugin = asyncExpectation(description: "test method invoked on default plugin")
+        let methodInvokedOnDefaultPlugin = expectation(description: "test method invoked on default plugin")
         plugin.listeners.append { message in
             if message == "downloadData" {
-                Task {
-                    await methodInvokedOnDefaultPlugin.fulfill()
-                }
+                methodInvokedOnDefaultPlugin.fulfill()
             }
         }
         try Amplify.add(plugin: plugin)
@@ -122,11 +120,12 @@ class StorageCategoryConfigurationTests: XCTestCase {
     func testCanUseSpecifiedPlugin() async throws {
         let plugin1 = MockStorageCategoryPlugin()
         let methodShouldNotBeInvokedOnDefaultPlugin =
-            asyncExpectation(description: "test method should not be invoked on default plugin", isInverted: true)
+            expectation(description: "test method should not be invoked on default plugin")
+        methodShouldNotBeInvokedOnDefaultPlugin.isInverted = true
         plugin1.listeners.append { message in
             if message == "downloadData" {
                 Task {
-                    await methodShouldNotBeInvokedOnDefaultPlugin.fulfill()
+                    methodShouldNotBeInvokedOnDefaultPlugin.fulfill()
                 }
             }
         }
@@ -134,11 +133,11 @@ class StorageCategoryConfigurationTests: XCTestCase {
 
         let plugin2 = MockSecondStorageCategoryPlugin()
         let methodShouldBeInvokedOnSecondPlugin =
-            asyncExpectation(description: "test method should be invoked on second plugin")
+            expectation(description: "test method should be invoked on second plugin")
         plugin2.listeners.append { message in
             if message == "downloadData" {
                 Task {
-                    await methodShouldBeInvokedOnSecondPlugin.fulfill()
+                    methodShouldBeInvokedOnSecondPlugin.fulfill()
                 }
             }
         }
@@ -158,7 +157,7 @@ class StorageCategoryConfigurationTests: XCTestCase {
         _ = try Amplify.Storage.getPlugin(for: "MockSecondStorageCategoryPlugin")
             .downloadData(key: "", options: nil)
 
-        await waitForExpectations([methodShouldNotBeInvokedOnDefaultPlugin, methodShouldBeInvokedOnSecondPlugin])
+        await fulfillment(of: [methodShouldNotBeInvokedOnDefaultPlugin, methodShouldBeInvokedOnSecondPlugin])
     }
 
     func testPreconditionFailureInvokingWithMultiplePlugins() async throws {
@@ -192,17 +191,17 @@ class StorageCategoryConfigurationTests: XCTestCase {
     func testCanConfigurePluginDirectly() async throws {
         let plugin = MockStorageCategoryPlugin()
         let configureShouldBeInvokedFromCategory =
-            asyncExpectation(description: "Configure should be invoked by Amplify.configure()")
+            expectation(description: "Configure should be invoked by Amplify.configure()")
         let configureShouldBeInvokedDirectly =
-        asyncExpectation(description: "Configure should be invoked by getPlugin().configure()")
+        expectation(description: "Configure should be invoked by getPlugin().configure()")
 
         var invocationCount = 0
         plugin.listeners.append { message in
             if message == "configure(using:)" {
                 invocationCount += 1
                 switch invocationCount {
-                case 1: Task { await configureShouldBeInvokedFromCategory.fulfill() }
-                case 2: Task { await configureShouldBeInvokedDirectly.fulfill() }
+                case 1: configureShouldBeInvokedFromCategory.fulfill()
+                case 2: configureShouldBeInvokedDirectly.fulfill()
                 default: XCTFail("Expected configure() to be called only two times, but got \(invocationCount)")
                 }
             }
@@ -218,7 +217,7 @@ class StorageCategoryConfigurationTests: XCTestCase {
         try Amplify.configure(amplifyConfig)
         try Amplify.Storage.getPlugin(for: "MockStorageCategoryPlugin").configure(using: true)
 
-        await waitForExpectations([configureShouldBeInvokedFromCategory, configureShouldBeInvokedDirectly])
+        await fulfillment(of: [configureShouldBeInvokedFromCategory, configureShouldBeInvokedDirectly])
     }
 
     func testPreconditionFailureInvokingBeforeConfig() async throws {

--- a/AmplifyTests/CoreTests/AmplifyAsyncSequenceTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyAsyncSequenceTests.swift
@@ -122,64 +122,64 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
         // parent task is canceled while reducing values from sequence
         // before a value is sent which should result in a sum of zero
         let input = 2006
-        let reduced = asyncExpectation(description: "reduced")
-        let done = asyncExpectation(description: "done")
+        let reduced = expectation(description: "reduced")
+        let done = expectation(description: "done")
         let channel = AmplifyAsyncSequence<Int>()
 
         let task = Task<Int, Never> {
             let sum = await channel.reduce(0, +)
-            await reduced.fulfill()
+            reduced.fulfill()
             return sum
         }
 
         // cancel before value is sent
         task.cancel()
 
-        await waitForExpectations([reduced])
+        await fulfillment(of: [reduced])
         channel.send(input)
 
         Task {
             let output = await task.value
             XCTAssertNotEqual(input, output)
             XCTAssertEqual(0, output)
-            await done.fulfill()
+            done.fulfill()
         }
 
-        await waitForExpectations([done])
+        await fulfillment(of: [done])
     }
 
     func testThrowingChannelCancelled() async throws {
         // parent task is canceled while reducing values from sequence
         // before a value is sent which should result in a sum of zero
         let input = 2006
-        let reduced = asyncExpectation(description: "reduced")
-        let done = asyncExpectation(description: "done")
+        let reduced = expectation(description: "reduced")
+        let done = expectation(description: "done")
         let channel = AmplifyAsyncThrowingSequence<Int>()
 
         let task = Task<Int, Error> {
             let sum = try await channel.reduce(0, +)
-            await reduced.fulfill()
+            reduced.fulfill()
             return sum
         }
 
         // cancel before any value is sent
         task.cancel()
-        await waitForExpectations([reduced])
+        await fulfillment(of: [reduced])
         channel.send(input)
 
         Task {
             let output = try await task.value
             XCTAssertNotEqual(input, output)
             XCTAssertEqual(0, output)
-            await done.fulfill()
+            done.fulfill()
         }
 
-        await waitForExpectations([done])
+        await fulfillment(of: [done])
     }
 
     func testValueProducingParentOperation() async throws {
-        let sent = asyncExpectation(description: "sent")
-        let received = asyncExpectation(description: "received")
+        let sent = expectation(description: "sent")
+        let received = expectation(description: "received")
         let steps = 10
         let delay = 0.01
         let request = LongOperationRequest(steps: steps, delay: delay)
@@ -191,9 +191,7 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
             channel.send(value)
             if value.totalUnitCount == value.completedUnitCount {
                 channel.finish()
-                Task {
-                    await sent.fulfill()
-                }
+                sent.fulfill()
             }
         }
         queue.addOperation(operation)
@@ -204,10 +202,10 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
             }
             let count = await values.elements.count
             XCTAssertGreaterThanOrEqual(count, steps)
-            await received.fulfill()
+            received.fulfill()
         }
 
-        await waitForExpectations([sent, received])
+        await fulfillment(of: [sent, received])
 
         XCTAssertFalse(operation.isCancelled)
         XCTAssertGreaterThanOrEqual(count, steps)
@@ -216,8 +214,8 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
     }
 
     func testCancellingWithParentOperation() async throws {
-        let sent = asyncExpectation(description: "sent")
-        let received = asyncExpectation(description: "received")
+        let sent = expectation(description: "sent")
+        let received = expectation(description: "received")
         let steps = 10
         let delay = 0.01
         let request = LongOperationRequest(steps: steps, delay: delay)
@@ -229,9 +227,7 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
             channel.send(value)
             if value.completedUnitCount >= steps/2 {
                 channel.cancel()
-                Task {
-                    await sent.fulfill()
-                }
+                sent.fulfill()
             }
         }
         queue.addOperation(operation)
@@ -242,10 +238,10 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
             }
             let count = await values.elements.count
             XCTAssertLessThan(count, steps)
-            await received.fulfill()
+            received.fulfill()
         }
 
-        await waitForExpectations([sent, received])
+        await fulfillment(of: [sent, received])
 
         XCTAssertTrue(operation.isCancelled)
         XCTAssertLessThan(count, steps)
@@ -254,8 +250,8 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
     }
 
     func testThrowingValueProducingParentOperation() async throws {
-        let sent = asyncExpectation(description: "sent")
-        let received = asyncExpectation(description: "received")
+        let sent = expectation(description: "sent")
+        let received = expectation(description: "received")
         let steps = 10
         let delay = 0.01
         let request = LongOperationRequest(steps: steps, delay: delay)
@@ -267,9 +263,7 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
             channel.send(value)
             if value.totalUnitCount == value.completedUnitCount {
                 channel.finish()
-                Task {
-                    await sent.fulfill()
-                }
+                sent.fulfill()
             }
         }
         queue.addOperation(operation)
@@ -280,10 +274,10 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
             }
             let count = await values.elements.count
             XCTAssertGreaterThanOrEqual(count, steps)
-            await received.fulfill()
+            received.fulfill()
         }
 
-        await waitForExpectations([sent, received])
+        await fulfillment(of: [sent, received])
 
         XCTAssertFalse(operation.isCancelled)
         XCTAssertGreaterThanOrEqual(count, steps)
@@ -292,8 +286,8 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
     }
 
     func testThrowingCancellingWithParentOperation() async throws {
-        let sent = asyncExpectation(description: "sent")
-        let received = asyncExpectation(description: "received")
+        let sent = expectation(description: "sent")
+        let received = expectation(description: "received")
         let steps = 10
         let delay = 0.01
         let request = LongOperationRequest(steps: steps, delay: delay)
@@ -305,9 +299,7 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
             channel.send(value)
             if value.completedUnitCount >= steps/2 {
                 channel.cancel()
-                Task {
-                    await sent.fulfill()
-                }
+                sent.fulfill()
             }
         }
         queue.addOperation(operation)
@@ -318,10 +310,10 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
             }
             let count = await values.elements.count
             XCTAssertLessThan(count, steps)
-            await received.fulfill()
+            received.fulfill()
         }
 
-        await waitForExpectations([sent, received])
+        await fulfillment(of: [sent, received])
 
         XCTAssertTrue(operation.isCancelled)
         XCTAssertLessThan(count, steps)

--- a/AmplifyTests/CoreTests/AmplifyConfigurationInitializationTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyConfigurationInitializationTests.swift
@@ -167,7 +167,7 @@ class AmplifyConfigurationInitializationTests: XCTestCase {
         let config = AmplifyConfiguration(analytics: analyticsConfiguration)
         try Amplify.configure(config)
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [notificationReceived], timeout: 1.0)
     }
 
     // MARK: - Utilities

--- a/AmplifyTests/CoreTests/AmplifyTaskTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyTaskTests.swift
@@ -146,7 +146,7 @@ class AmplifyTaskTests: XCTestCase {
             resultSink.cancel()
         }
 
-        wait(for: [exp1, exp2], timeout: 10.0)
+        await fulfillment(of: [exp1, exp2], timeout: 10.0)
 
         XCTAssertGreaterThanOrEqual(progressCount, 10)
         XCTAssertEqual(lastProgress, 1)

--- a/AmplifyTests/CoreTests/ChildTaskTests.swift
+++ b/AmplifyTests/CoreTests/ChildTaskTests.swift
@@ -85,7 +85,7 @@ class ChildTaskTests: XCTestCase {
             XCTAssertTrue(thrown is CancellationError)
         }
 
-        await waitForExpectations(timeout: 0.01)
+        await fulfillment(of: [cancelExp], timeout: 0.01)
         task.cancel()
 
         // Ensure the channel's AsyncSequence does not block after completion
@@ -115,7 +115,7 @@ class ChildTaskTests: XCTestCase {
             XCTAssertTrue(thrown is CancellationError)
         }
 
-        await waitForExpectations(timeout: 0.01)
+        await fulfillment(of: [cancelExp], timeout: 0.01)
 
         // Ensure the channel's AsyncSequence does not block after completion
         for await _ in progressSequence {

--- a/AmplifyTests/CoreTests/InternalTaskTests.swift
+++ b/AmplifyTests/CoreTests/InternalTaskTests.swift
@@ -21,29 +21,27 @@ class InternalTaskTests: XCTestCase {
     // MARK: - Magic Eight Ball (Non-Throwing) -
 
     func testMagicEightBallTaskRunner() async throws {
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
         let delay = 0.01
         let total = 10
         let timeout = Double(total) * 2.0 * delay
         let request = MagicEightBallRequest(total: total, delay: delay)
         let runner = MagicEightBallTaskRunner(request: request)
         let task = Task<[String], Never> {
-            let hubDone = asyncExpectation(description: "hub done")
+            let hubDone = expectation(description: "hub done")
             var emojis = [String]()
             var hubValues = [String]()
             let token = runner.subscribe { emoji in
                 hubValues.append(emoji)
                 if hubValues.count == total {
-                    Task {
-                        await hubDone.fulfill()
-                    }
+                    hubDone.fulfill()
                 }
             }
             await runner.sequence.forEach { emoji in
                 emojis.append(emoji)
             }
-            await waitForExpectations([hubDone])
-            await done.fulfill()
+            await fulfillment(of: [hubDone])
+            done.fulfill()
             XCTAssertEqual(total, hubValues.count)
             XCTAssertEqual(total, emojis.count)
             runner.unsubscribe(token)
@@ -53,11 +51,11 @@ class InternalTaskTests: XCTestCase {
         let output = await task.value
         XCTAssertEqual(request.total, output.count)
 
-        await waitForExpectations([done], timeout: timeout)
+        await fulfillment(of: [done], timeout: timeout)
     }
 
     func testMagicEightBallTaskRunnerWithRunnerCancellation() async throws {
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
         let delay = 0.01
         let total = 10
         let timeout = Double(total) * 2.0 * delay
@@ -70,7 +68,7 @@ class InternalTaskTests: XCTestCase {
             await sequence.forEach { emoji in
                 emojis.append(emoji)
             }
-            await done.fulfill()
+            done.fulfill()
             XCTAssertEqual(0, emojis.count)
             return emojis
         }
@@ -80,11 +78,11 @@ class InternalTaskTests: XCTestCase {
         let output = await task.value
         XCTAssertEqual(0, output.count)
 
-        await waitForExpectations([done], timeout: timeout)
+        await fulfillment(of: [done], timeout: timeout)
     }
 
     func testMagicEightBallTaskRunnerWithSequenceCancellation() async throws {
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
         let delay = 0.01
         let total = 10
         let timeout = Double(total) * 2.0 * delay
@@ -97,7 +95,7 @@ class InternalTaskTests: XCTestCase {
             await sequence.forEach { emoji in
                 emojis.append(emoji)
             }
-            await done.fulfill()
+            done.fulfill()
             XCTAssertEqual(0, emojis.count)
             return emojis
         }
@@ -105,11 +103,11 @@ class InternalTaskTests: XCTestCase {
         let output = await task.value
         XCTAssertEqual(0, output.count)
 
-        await waitForExpectations([done], timeout: timeout)
+        await fulfillment(of: [done], timeout: timeout)
     }
 
     func testMagicEightBallPluginAPI() async throws {
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
         let total = 10
         let delay = 0.01
         let timeout = Double(total) * 2.0 * delay
@@ -119,7 +117,7 @@ class InternalTaskTests: XCTestCase {
             await plugin.getAnswers(total: total, delay: delay).forEach { emoji in
                 answers.append(emoji)
             }
-            await done.fulfill()
+            done.fulfill()
             XCTAssertEqual(total, answers.count)
             return answers
         }
@@ -127,13 +125,13 @@ class InternalTaskTests: XCTestCase {
         let answers = await task.value
         XCTAssertEqual(answers.count, total)
 
-        await waitForExpectations([done], timeout: timeout)
+        await fulfillment(of: [done], timeout: timeout)
     }
     
     // MARK: - Random Emoji (Throwing) -
 
     func testRandomEmojiTaskRunner() async throws {
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
         let delay = 0.01
         let total = 10
         let timeout = Double(total) * 2.0 * delay
@@ -146,7 +144,7 @@ class InternalTaskTests: XCTestCase {
                 try await runner.sequence.forEach { emoji in
                     emojis.append(emoji)
                 }
-                await done.fulfill()
+                done.fulfill()
                 XCTAssertEqual(total, emojis.count)
             } catch {
                 thrown = error
@@ -158,11 +156,11 @@ class InternalTaskTests: XCTestCase {
         let output = await task.value
         XCTAssertEqual(request.total, output.count)
 
-        await waitForExpectations([done], timeout: timeout)
+        await fulfillment(of: [done], timeout: timeout)
     }
 
     func testRandomEmojiTaskRunnerWithRunnerCancellation() async throws {
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
         let delay = 0.01
         let total = 10
         let timeout = Double(total) * 2.0 * delay
@@ -177,7 +175,7 @@ class InternalTaskTests: XCTestCase {
                 try await sequence.forEach { emoji in
                     emojis.append(emoji)
                 }
-                await done.fulfill()
+                done.fulfill()
                 XCTAssertEqual(0, emojis.count)
             } catch {
                 thrown = error
@@ -191,11 +189,11 @@ class InternalTaskTests: XCTestCase {
         let output = await task.value
         XCTAssertEqual(0, output.count)
 
-        await waitForExpectations([done], timeout: timeout)
+        await fulfillment(of: [done], timeout: timeout)
     }
 
     func testRandomEmojiTaskRunnerWithSequenceCancellation() async throws {
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
         let delay = 0.01
         let total = 10
         let timeout = Double(total) * 2.0 * delay
@@ -210,7 +208,7 @@ class InternalTaskTests: XCTestCase {
                 try await sequence.forEach { emoji in
                     emojis.append(emoji)
                 }
-                await done.fulfill()
+                done.fulfill()
                 XCTAssertEqual(0, emojis.count)
             } catch {
                 thrown = error
@@ -222,11 +220,11 @@ class InternalTaskTests: XCTestCase {
         let output = await task.value
         XCTAssertEqual(0, output.count)
 
-        await waitForExpectations([done], timeout: timeout)
+        await fulfillment(of: [done], timeout: timeout)
     }
 
     func testEmojisPluginAPI() async throws {
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
         let total = 10
         let delay = 0.01
         let timeout = Double(total) * 2.0 * delay
@@ -236,7 +234,7 @@ class InternalTaskTests: XCTestCase {
             try await plugin.getEmojis(total: total, delay: delay).forEach { emoji in
                 emojis.append(emoji)
             }
-            await done.fulfill()
+            done.fulfill()
             XCTAssertEqual(total, emojis.count)
             return emojis
         }
@@ -244,7 +242,7 @@ class InternalTaskTests: XCTestCase {
         let emojis = try await task.value
         XCTAssertEqual(emojis.count, total)
 
-        await waitForExpectations([done], timeout: timeout)
+        await fulfillment(of: [done], timeout: timeout)
     }
 
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
n/a 

## Description
<!-- Why is this change required? What problem does it solve? -->
- moves from AsyncExpectation to XCTestExpectation
- moves from wait / waitForExpectations to `await fulfillment(of:)

Changes in unit test suites to use proper expectation API and reduce race conditions in test expectations.
See note from [Xcode 14.3 release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-14_3-release-notes#Resolved-Issues):

> Fixed: XCTestCase.wait(for:timeout:enforceOrder:) and related methods are now marked unavailable in concurrent Swift functions because they can cause a test to deadlock. Instead, you can use the new concurrency-safe XCTestCase.fulfillment(of:timeout:enforceOrder:) method. (91453026)

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
