### PR TITLE
fix(api): sprinkle in some uuids to prevent parallel run clashes [skip ci]

### DIFF
--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/xcshareddata/xcschemes/AWSAPIPluginFunctionalTests.xcscheme
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/xcshareddata/xcschemes/AWSAPIPluginFunctionalTests.xcscheme
@@ -8,7 +8,7 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">
@@ -62,15 +62,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "21698A7A28899804004BD994"
-            BuildableName = "AWSAPIPluginFunctionalTests.xctest"
-            BlueprintName = "AWSAPIPluginFunctionalTests"
-            ReferencedContainer = "container:APIHostApp.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/Base/TestConfigHelper.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/Base/TestConfigHelper.swift
@@ -36,3 +36,9 @@ class TestConfigHelper {
         return try Data(contentsOf: url)
     }
 }
+
+extension String {
+    var withUUID: String {
+        "\(self)-\(UUID().uuidString)"
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario1APISwiftTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario1APISwiftTests.swift
@@ -16,7 +16,7 @@ import Amplify
 extension GraphQLConnectionScenario1Tests {
     
     func createTeamAPISwift() async throws -> APISwift.CreateTeam1Mutation.Data.CreateTeam1? {
-        let input = APISwift.CreateTeam1Input(name: "name")
+        let input = APISwift.CreateTeam1Input(name: "name".withUUID)
         let mutation = APISwift.CreateTeam1Mutation(input: input)
         let request = GraphQLRequest<APISwift.CreateTeam1Mutation.Data>(
             document: APISwift.CreateTeam1Mutation.operationString,

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario1Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario1Tests.swift
@@ -55,7 +55,7 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
     }
     
     func testCreateAndGetProject() async throws {
-        guard let team = try await createTeam(name: "name"),
+        guard let team = try await createTeam(name: "name".withUUID),
               let project = try await createProject(team: team) else {
             XCTFail("Could not create team and a project")
             return
@@ -76,12 +76,12 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
     }
     
     func testUpdateProjectWithAnotherTeam() async throws {
-        guard let team = try await createTeam(name: "name"),
+        guard let team = try await createTeam(name: "name".withUUID),
               var project = try await createProject(team: team) else {
             XCTFail("Could not create a Team")
             return
         }
-        let anotherTeam = Team1(name: "name")
+        let anotherTeam = Team1(name: "name".withUUID)
         guard case .success(let createdAnotherTeam) = try await Amplify.API.mutate(request: .create(anotherTeam)) else {
             XCTFail("Failed to create another team")
             return
@@ -96,7 +96,7 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
     }
     
     func testDeleteAndGetProject() async throws {
-        guard let team = try await createTeam(name: "name"),
+        guard let team = try await createTeam(name: "name".withUUID),
               let project = try await createProject(team: team) else {
             XCTFail("Could not create team and a project")
             return
@@ -124,7 +124,7 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
     // The filter we are passing into is the ProjectTeamID, but the API doesn't have the field ProjectTeamID
     //    so we are disabling it
     func testListProjectsByTeamID() async throws {
-        guard let team = try await createTeam(name: "name"),
+        guard let team = try await createTeam(name: "name".withUUID),
               let project = try await createProject(team: team) else {
             XCTFail("Could not create team and a project")
             return
@@ -143,7 +143,7 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
     func testPaginatedListProjects() async throws {
         let testCompleted = asyncExpectation(description: "test completed")
         Task {
-            guard let team = try await createTeam(name: "name"),
+            guard let team = try await createTeam(name: "name".withUUID),
                   let projecta = try await createProject(team: team),
                   let projectb = try await createProject(team: team) else {
                 XCTFail("Could not create team and two projects")

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario2Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario2Tests.swift
@@ -60,7 +60,7 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
     // 1. `teamID` and `team`
     // 2. With random `teamID` and `team`
     func testCreateAndGetProject() async throws {
-        guard let team = try await createTeam2(name: "name"),
+        guard let team = try await createTeam2(name: "name".withUUID),
               let project2a = try await createProject2(teamID: team.id, team: team),
               let project2b = try await createProject2(teamID: team.id, team: team) else {
             XCTFail("Could not create team and a project")
@@ -93,7 +93,7 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
     }
 
     func testUpdateProjectWithAnotherTeam() async throws {
-        guard let team = try await createTeam2(name: "name"),
+        guard let team = try await createTeam2(name: "name".withUUID),
               var project2 = try await createProject2(teamID: team.id, team: team) else {
             XCTFail("Could not create team and a project")
             return
@@ -115,7 +115,7 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
     }
     
     func testDeleteAndGetProject() async throws {
-        guard let team = try await createTeam2(name: "name"),
+        guard let team = try await createTeam2(name: "name".withUUID),
               let project2 = try await createProject2(teamID: team.id, team: team) else {
             XCTFail("Could not create team and a project")
             return
@@ -141,7 +141,7 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
     }
 
     func testListProjectsByTeamID() async throws {
-        guard let team = try await createTeam2(name: "name"),
+        guard let team = try await createTeam2(name: "name".withUUID),
               try await createProject2(teamID: team.id, team: team) != nil else {
             XCTFail("Could not create team and two projects")
             return
@@ -159,7 +159,7 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
     // Create two projects for the same team, then list the projects by teamID, and expect two projects
     // after exhausting the paginated list via `hasNextPage` and `getNextPage`
     func testPaginatedListProjectsByTeamID() async throws {
-        guard let team = try await createTeam2(name: "name"),
+        guard let team = try await createTeam2(name: "name".withUUID),
               try await createProject2(teamID: team.id, team: team) != nil,
               try await createProject2(teamID: team.id, team: team) != nil else {
             XCTFail("Could not create team and two projects")

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+List.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+List.swift
@@ -35,9 +35,10 @@ import XCTest
 extension GraphQLConnectionScenario3Tests {
 
     func testGetPostThenIterateComments() async throws {
-        guard let post = try await createPost(title: "title"),
-             try await createComment(postID: post.id, content: "content") != nil,
-             try await createComment(postID: post.id, content: "content") != nil else {
+        let commentContent = "content".withUUID
+        guard let post = try await createPost(title: "title".withUUID),
+             try await createComment(postID: post.id, content: commentContent) != nil,
+             try await createComment(postID: post.id, content: commentContent) != nil else {
             XCTFail("Could not create post and two comments")
             return
         }
@@ -73,9 +74,11 @@ extension GraphQLConnectionScenario3Tests {
     }
 
     func testGetPostThenFetchComments() async throws {
-        guard let post = try await createPost(title: "title"),
-              try await createComment(postID: post.id, content: "content") != nil,
-              try await createComment(postID: post.id, content: "content") != nil else {
+        let commentContent = "content".withUUID
+
+        guard let post = try await createPost(title: "title".withUUID),
+              try await createComment(postID: post.id, content: commentContent) != nil,
+              try await createComment(postID: post.id, content: commentContent) != nil else {
             XCTFail("Could not create post and two comments")
             return
         }
@@ -110,7 +113,7 @@ extension GraphQLConnectionScenario3Tests {
 
     // Create a post and list the posts
     func testListPost() async throws {
-        guard try await createPost(title: "title") != nil else {
+        guard try await createPost(title: "title".withUUID) != nil else {
             XCTFail("Failed to ensure at least one Post to be retrieved on the listQuery")
             return
         }
@@ -155,11 +158,11 @@ extension GraphQLConnectionScenario3Tests {
     // Create a post and a comment with that post
     // list the comments by postId
     func testListCommentsByPostID() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard try await createComment(postID: post.id, content: "content") != nil else {
+        guard try await createComment(postID: post.id, content: "content".withUUID) != nil else {
             XCTFail("Could not create comment")
             return
         }
@@ -187,15 +190,16 @@ extension GraphQLConnectionScenario3Tests {
     /// - Then:
     ///    - the in-memory Array is a populated with exactly two comments.
     func testPaginatedListCommentsByPostID() async throws {
-        guard let post = try await createPost(title: "title") else {
+        let commentContent = "content".withUUID
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard try await createComment(postID: post.id, content: "content") != nil else {
+        guard try await createComment(postID: post.id, content: commentContent) != nil else {
             XCTFail("Could not create comment")
             return
         }
-        guard try await createComment(postID: post.id, content: "content") != nil else {
+        guard try await createComment(postID: post.id, content: commentContent) != nil else {
             XCTFail("Could not create comment")
             return
         }
@@ -232,7 +236,7 @@ extension GraphQLConnectionScenario3Tests {
     ///    - A validation error is returned
     func testPaginatedListFetchValidationError() async throws {
         let uuid1 = UUID().uuidString
-        guard try await createPost(id: uuid1, title: "title") != nil else {
+        guard try await createPost(id: uuid1, title: "title".withUUID) != nil else {
             XCTFail("Failed to create post")
             return
         }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests.swift
@@ -57,7 +57,7 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
     }
 
     func testQuerySinglePost() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Failed to set up test")
             return
         }
@@ -77,7 +77,7 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
     // Create a post and a comment for the post
     // Retrieve the comment and ensure that the comment is associated with the correct post
     func testCreatAndGetComment() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
@@ -105,7 +105,8 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
     // Update the existing comment to point to the other post
     // Expect that the queried comment is associated with the other post
     func testUpdateComment() async throws {
-        guard let post = try await createPost(title: "title") else {
+        let postTitle = "title".withUUID
+        guard let post = try await createPost(title: postTitle) else {
             XCTFail("Could not create post")
             return
         }
@@ -113,7 +114,7 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
             XCTFail("Could not create comment")
             return
         }
-        guard let anotherPost = try await createPost(title: "title") else {
+        guard let anotherPost = try await createPost(title: postTitle) else {
             XCTFail("Could not create post")
             return
         }
@@ -130,7 +131,7 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
     func testUpdateExistingPost() async throws {
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
-        let title = testMethodName + "Title"
+        let title = testMethodName + "Title".withUUID
         guard var post = try await createPost(id: uuid, title: title) else {
             XCTFail("Failed to ensure at least one Post to be retrieved on the listQuery")
             return
@@ -149,7 +150,7 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
     func testDeleteExistingPost() async throws {
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
-        let title = testMethodName + "Title"
+        let title = testMethodName + "Title".withUUID
         guard let post = try await createPost(id: uuid, title: title) else {
             XCTFail("Could not create post")
             return
@@ -174,7 +175,7 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
     // Delete the comment and then query for the comment
     // Expected query should return `nil` comment
     func testDeleteAndGetComment() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario4Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario4Tests.swift
@@ -57,11 +57,11 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
     }
 
     func testCreateCommentAndGetCommentWithPost() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard let comment = try await createComment(content: "content", post: post) else {
+        guard let comment = try await createComment(content: "content".withUUID, post: post) else {
             XCTFail("Could not create comment")
             return
         }
@@ -81,16 +81,18 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
     }
 
     func testGetPostThenFetchComments() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard try await createComment(content: "content", post: post) != nil else {
+
+        let commentContent = "comment".withUUID
+        guard try await createComment(content: commentContent, post: post) != nil else {
             XCTFail("Could not create comment")
             return
         }
 
-        guard try await createComment(content: "content", post: post) != nil else {
+        guard try await createComment(content: commentContent, post: post) != nil else {
             XCTFail("Could not create comment")
             return
         }
@@ -134,15 +136,16 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
     }
 
     func testUpdateComment() async throws {
-        guard let post = try await createPost(title: "title") else {
+        let postTitle = "title".withUUID
+        guard let post = try await createPost(title: postTitle) else {
             XCTFail("Could not create post")
             return
         }
-        guard var comment = try await createComment(content: "content", post: post) else {
+        guard var comment = try await createComment(content: "content".withUUID, post: post) else {
             XCTFail("Could not create comment")
             return
         }
-        guard let anotherPost = try await createPost(title: "title") else {
+        guard let anotherPost = try await createPost(title: postTitle) else {
             XCTFail("Could not create post")
             return
         }
@@ -157,11 +160,11 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
     }
 
     func testDeleteAndGetComment() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard let comment = try await createComment(content: "content", post: post) else {
+        guard let comment = try await createComment(content: "content".withUUID, post: post) else {
             XCTFail("Could not create comment")
             return
         }
@@ -186,11 +189,11 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
     }
 
     func testListCommentsByPostID() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard try await createComment(content: "content", post: post) != nil else {
+        guard try await createComment(content: "content".withUUID, post: post) != nil else {
             XCTFail("Could not create comment")
             return
         }
@@ -205,9 +208,10 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
     }
 
     func testPaginatedListCommentsByPostID() async throws {
-        guard let post = try await createPost(title: "title"),
-              try await createComment(content: "content", post: post) != nil,
-              try await createComment(content: "content", post: post) != nil else {
+        let commentContent = "content".withUUID
+        guard let post = try await createPost(title: "title".withUUID),
+              try await createComment(content: commentContent, post: post) != nil,
+              try await createComment(content: commentContent, post: post) != nil else {
             XCTFail("Could not create post and two comments")
             return
         }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario5Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario5Tests.swift
@@ -69,11 +69,11 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
     }
 
     func testListPostEditorByPost() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard let user = try await createUser(username: "username") else {
+        guard let user = try await createUser(username: "username".withUUID) else {
             XCTFail("Could not create user")
             return
         }
@@ -92,11 +92,11 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
     }
 
     func testListPostEditorByUser() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard let user = try await createUser(username: "username") else {
+        guard let user = try await createUser(username: "username".withUUID) else {
             XCTFail("Could not create user")
             return
         }
@@ -118,11 +118,11 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
     // Get the post and fetch the PostEditors for that post
     // The Posteditor contains the user which is connected the post
     func testGetPostThenFetchPostEditorsToRetrieveUser() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard let user = try await createUser(username: "username") else {
+        guard let user = try await createUser(username: "username".withUUID) else {
             XCTFail("Could not create user")
             return
         }
@@ -177,11 +177,12 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
     // Get the user and fetch the PostEditors for that user
     // The PostEditors should contain the two posts `post1` and `post2`
     func testGetUserThenFetchPostEditorsToRetrievePosts() async throws {
-        guard let post1 = try await createPost(title: "title") else {
+        let postTitle = "title".withUUID
+        guard let post1 = try await createPost(title: postTitle) else {
             XCTFail("Could not create post")
             return
         }
-        guard let post2 = try await createPost(title: "title") else {
+        guard let post2 = try await createPost(title: postTitle) else {
             XCTFail("Could not create post")
             return
         }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario6Tests.swift
@@ -64,11 +64,12 @@ class GraphQLConnectionScenario6Tests: XCTestCase {
     }
 
     func testGetBlogThenFetchPostsThenFetchComments() async throws {
-        guard let blog = try await createBlog(name: "name"),
-              let post1 = try await createPost(title: "title", blog: blog),
+        let commentContent = "content".withUUID
+        guard let blog = try await createBlog(name: "name".withUUID),
+              let post1 = try await createPost(title: "title".withUUID, blog: blog),
               try await createPost(title: "title", blog: blog) != nil,
-              let comment1post1 = try await createComment(post: post1, content: "content"),
-              let comment2post1 = try await createComment(post: post1, content: "content") else {
+              let comment1post1 = try await createComment(post: post1, content: commentContent),
+              let comment2post1 = try await createComment(post: post1, content: commentContent) else {
             XCTFail("Could not create blog, posts, and comments")
             return
         }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLScalarTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLScalarTests.swift
@@ -41,7 +41,7 @@ class GraphQLScalarTests: GraphQLTestBase {
     }
 
     func testScalarContainer() async throws {
-        let container = ScalarContainer(myString: "myString",
+        let container = ScalarContainer(myString: "myString".withUUID,
                                         myInt: 1,
                                         myDouble: 1.0,
                                         myBool: true,
@@ -114,9 +114,9 @@ class GraphQLScalarTests: GraphQLTestBase {
 
     func testListStringContainer() async throws {
         let container = ListStringContainer(
-            test: "test",
+            test: "test".withUUID,
             nullableString: nil,
-            stringList: ["value1"],
+            stringList: ["value1".withUUID],
             stringNullableList: [],
             nullableStringList: [],
             nullableStringNullableList: nil)
@@ -150,9 +150,9 @@ class GraphQLScalarTests: GraphQLTestBase {
 
     func testListContainerWithNil() async throws {
         let container = ListStringContainer(
-            test: "test",
+            test: "test".withUUID,
             nullableString: nil,
-            stringList: ["value1"],
+            stringList: ["value1".withUUID],
             stringNullableList: nil,
             nullableStringList: [nil],
             nullableStringNullableList: nil)

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLUserPoolTests/Base/AsyncExpectation.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLUserPoolTests/Base/AsyncExpectation.swift
@@ -110,7 +110,7 @@ extension XCTestCase {
     /// Use this method to create ``AsyncExpectation`` instances that can be
     /// fulfilled when asynchronous tasks in your tests complete.
     ///
-    /// To fulfill an expectation that was created with `asyncExpectation(description:)`,
+    /// To fulfill an expectation that was created with `expectation(description:)`,
     /// call the expectation's `fulfill()` method when the asynchronous task in your
     /// test has completed.
     ///
@@ -118,10 +118,10 @@ extension XCTestCase {
     ///   - description: A string to display in the test log for this expectation, to help diagnose failures.
     ///   - isInverted: Indicates that the expectation is not intended to happen.
     ///   - expectedFulfillmentCount: The number of times fulfill() must be called before the expectation is completely fulfilled. (default = 1)
-    public func asyncExpectation(description: String,
+    public func expectation(description: String,
                                  isInverted: Bool = false,
                                  expectedFulfillmentCount: Int = 1) -> AsyncExpectation {
-        AsyncExpectation(description: description,
+        expectation(description: description,
                          isInverted: isInverted,
                          expectedFulfillmentCount: expectedFulfillmentCount)
     }
@@ -148,7 +148,7 @@ public enum AsyncTesting {
     public static func expectation(description: String,
                                    isInverted: Bool = false,
                                    expectedFulfillmentCount: Int = 1) -> AsyncExpectation {
-        AsyncExpectation(description: description,
+        expectation(description: description,
                          isInverted: isInverted,
                          expectedFulfillmentCount: expectedFulfillmentCount)
     }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
n/a

## Description
<!-- Why is this change required? What problem does it solve? -->
When the API (GraphQL) integration test suite runs in parallel, predicate based queries can result in failing assertions.
This happens today when running test suites on the various supported platforms concurrently in CI.
This can also happen when tests are automatically running in the release process and have been manually kicked off on a different branch for testing.

- Appends UUIDs to various string values in models that are / can be queried for in tests.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
