### PR TITLE
fix(integration-tests): increase timeout of hostedui ui tests [skip ci]

### DIFF
--- a/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIAppUITests/Screen/AuthenticatedScreen.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIAppUITests/Screen/AuthenticatedScreen.swift
@@ -31,7 +31,7 @@ struct AuthenticatedScreen: Screen {
 
     func dismissSignOutAlert() -> Self {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        XCTAssertTrue(springboard.buttons["Continue"].waitForExistence(timeout: 5))
+        XCTAssertTrue(springboard.buttons["Continue"].waitForExistence(timeout: 60))
         springboard.buttons["Continue"].tap()
         return self
     }

--- a/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIAppUITests/Screen/SignInScreen.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIAppUITests/Screen/SignInScreen.swift
@@ -40,13 +40,13 @@ struct SignInScreen: Screen {
 
     func dismissSignInAlert() -> Self {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        XCTAssertTrue(springboard.buttons["Continue"].waitForExistence(timeout: 5))
+        XCTAssertTrue(springboard.buttons["Continue"].waitForExistence(timeout: 60))
         springboard.buttons["Continue"].tap()
         return self
     }
 
     func signIn(username: String, password: String) -> Self {
-        _ = app.webViews.textFields["Username"].waitForExistence(timeout: 5)
+        _ = app.webViews.textFields["Username"].waitForExistence(timeout: 60)
         app.webViews.textFields["Username"].tap()
         app.webViews.textFields["Username"].typeText(username)
 
@@ -59,7 +59,7 @@ struct SignInScreen: Screen {
 
     func testSignInSucceeded() -> Self {
         let successText = app.staticTexts[Identifiers.successLabel]
-        XCTAssertTrue(successText.waitForExistence(timeout: 5), "SignIn operation failed")
+        XCTAssertTrue(successText.waitForExistence(timeout: 60), "SignIn operation failed")
         return self
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIAppUITests/Screen/SignUpScreen.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIAppUITests/Screen/SignUpScreen.swift
@@ -38,7 +38,7 @@ struct SignUpScreen: Screen {
 
     func testSignUpSucceeded() -> Self {
         let successText = app.staticTexts[Identifiers.successLabel]
-        XCTAssertTrue(successText.waitForExistence(timeout: 5), "Signup operation failed")
+        XCTAssertTrue(successText.waitForExistence(timeout: 60), "Signup operation failed")
         return self
     }
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
n/a

## Description
<!-- Why is this change required? What problem does it solve? -->
The (lack of) speed in our current CI runner results in timeouts in HostedUI integration tests.
- increases timeout for affected UI tests.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
