### PR TITLE
test: use fulfillment(of:) and address intermittent integration test failures

### DIFF
--- a/.github/workflows/integ_test_analytics.yml
+++ b/.github/workflows/integ_test_analytics.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   analytics-integration-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Analytics/Tests/AnalyticsHostApp
           scheme: AWSPinpointAnalyticsPluginIntegrationTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   analytics-integration-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_api.yml
+++ b/.github/workflows/integ_test_api.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   prepare-for-test:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/integ_test_api_functional.yml
+++ b/.github/workflows/integ_test_api_functional.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   api-functional-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginFunctionalTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   api-functional-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_api_graphql_auth_directive.yml
+++ b/.github/workflows/integ_test_api_graphql_auth_directive.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   api-graphql-auth-directive-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginGraphQLAuthDirectiveTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-auth-directive-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_api_graphql_iam.yml
+++ b/.github/workflows/integ_test_api_graphql_iam.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   api-graphql-iam-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginGraphQLIAMTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-iam-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_api_graphql_lambda_auth.yml
+++ b/.github/workflows/integ_test_api_graphql_lambda_auth.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   api-graphql-lambda-auth-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginGraphQLLambdaAuthTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-lambda-auth-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_api_graphql_lazy_load.yml
+++ b/.github/workflows/integ_test_api_graphql_lazy_load.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   api-lazy-load-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginLazyLoadTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   api-lazy-load-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_api_graphql_user_pool.yml
+++ b/.github/workflows/integ_test_api_graphql_user_pool.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   api-graphql-user-pool-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginGraphQLUserPoolTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-user-pool-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_api_rest_iam.yml
+++ b/.github/workflows/integ_test_api_rest_iam.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   api-rest-iam-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginRESTIAMTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   api-rest-iam-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_api_rest_user_pool.yml
+++ b/.github/workflows/integ_test_api_rest_user_pool.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   api-rest-user-pool-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginRESTUserPoolTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   api-rest-user-pool-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_auth.yml
+++ b/.github/workflows/integ_test_auth.yml
@@ -92,7 +92,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   auth-ui-integration-test-iOS:
-    runs-on: macos-13
+    runs-on: macos-12
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -115,5 +115,3 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Auth/Tests/AuthHostedUIApp/
           scheme: AuthHostedUIApp
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
-          xcode_path: '/Applications/Xcode_14.3.app'

--- a/.github/workflows/integ_test_datastore_auth_cognito.yml
+++ b/.github/workflows/integ_test_datastore_auth_cognito.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   datastore-integration-auth-cognito-test-iOS:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -37,7 +37,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-cognito-test-tvOS:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -66,7 +66,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-cognito-test-watchOS:
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_datastore_auth_cognito.yml
+++ b/.github/workflows/integ_test_datastore_auth_cognito.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   datastore-integration-auth-cognito-test-iOS:
     timeout-minutes: 30
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -33,6 +33,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginAuthCognitoTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-cognito-test-tvOS:
     timeout-minutes: 30

--- a/.github/workflows/integ_test_datastore_auth_iam.yml
+++ b/.github/workflows/integ_test_datastore_auth_iam.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   datastore-integration-auth-iam-test-iOS:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -37,7 +37,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-iam-test-tvOS:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -66,7 +66,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-iam-test-watchOS:
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_datastore_base.yml
+++ b/.github/workflows/integ_test_datastore_base.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   datastore-integration-test-base-iOS:
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -37,7 +37,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-test-base-tvOS:
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -66,7 +66,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-test-base-watchOS:
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_datastore_cpk.yml
+++ b/.github/workflows/integ_test_datastore_cpk.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   datastore-integration-cpk-test-iOS:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -37,7 +37,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-cpk-test-tvOS:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -66,7 +66,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-cpk-test-watchOS:
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_datastore_lazy_load.yml
+++ b/.github/workflows/integ_test_datastore_lazy_load.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   datastore-integration-lazy-load-test-iOS:
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -37,7 +37,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-lazy-load-test-tvOS:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -66,7 +66,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-lazy-load-test-watchOS:
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_datastore_multi_auth.yml
+++ b/.github/workflows/integ_test_datastore_multi_auth.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   datastore-integration-multi-auth-test-iOS:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -37,7 +37,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-multi-auth-test-tvOS:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -66,7 +66,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-multi-auth-test-watchOS:
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   datastore-integration-v2-test-iOS:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -37,7 +37,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-v2-test-tvOS:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -66,7 +66,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-v2-test-watchOS:
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_geo.yml
+++ b/.github/workflows/integ_test_geo.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   geo-integration-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Geo/Tests/GeoHostApp/
           scheme: AWSLocationGeoPluginIntegrationTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   geo-integration-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_logging.yml
+++ b/.github/workflows/integ_test_logging.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   logging-integration-test-iOS:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -32,6 +32,8 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginHostApp
           scheme: AWSCloudWatchLoggingPluginIntegrationTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   logging-integration-test-tvOS:
     runs-on: macos-13

--- a/.github/workflows/integ_test_push_notifications.yml
+++ b/.github/workflows/integ_test_push_notifications.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp
           scheme: PushNotificationHostApp
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   push-notification-integration-test-tvOS:

--- a/.github/workflows/integ_test_push_notifications.yml
+++ b/.github/workflows/integ_test_push_notifications.yml
@@ -9,8 +9,8 @@ permissions:
 
 jobs:
   push-notification-integration-test-iOS:
-    runs-on: macos-12
-    timeout-minutes: 20
+    runs-on: macos-13
+    timeout-minutes: 45
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -45,10 +45,12 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp
           scheme: PushNotificationHostApp
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   push-notification-integration-test-tvOS:
     runs-on: macos-13
-    timeout-minutes: 20
+    timeout-minutes: 30
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -89,7 +91,7 @@ jobs:
 
   push-notification-integration-test-watchOS:
     runs-on: macos-13
-    timeout-minutes: 20
+    timeout-minutes: 30
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/xcshareddata/xcschemes/AWSAPIPluginFunctionalTests.xcscheme
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/xcshareddata/xcschemes/AWSAPIPluginFunctionalTests.xcscheme
@@ -8,7 +8,7 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">
@@ -62,15 +62,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "21698A7A28899804004BD994"
-            BuildableName = "AWSAPIPluginFunctionalTests.xctest"
-            BlueprintName = "AWSAPIPluginFunctionalTests"
-            ReferencedContainer = "container:APIHostApp.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/AnyModelIntegrationTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/AnyModelIntegrationTests.swift
@@ -61,7 +61,7 @@ class AnyModelIntegrationTests: XCTestCase {
             }
         }
 
-        wait(for: [callbackInvoked], timeout: networkTimeout)
+        await fulfillment(of: [callbackInvoked], timeout: networkTimeout)
 
         guard let response = responseFromOperation else {
             XCTAssertNotNil(responseFromOperation)
@@ -106,7 +106,7 @@ class AnyModelIntegrationTests: XCTestCase {
             createCallbackInvoked.fulfill()
         }
 
-        wait(for: [createCallbackInvoked], timeout: networkTimeout)
+        await fulfillment(of: [createCallbackInvoked], timeout: networkTimeout)
 
         let newContent = "Updated post content as of \(Date())"
 
@@ -128,7 +128,7 @@ class AnyModelIntegrationTests: XCTestCase {
             }
         }
 
-        wait(for: [updateCallbackInvoked], timeout: networkTimeout)
+        await fulfillment(of: [updateCallbackInvoked], timeout: networkTimeout)
 
         guard let response = responseFromOperation else {
             XCTAssertNotNil(responseFromOperation)
@@ -171,7 +171,7 @@ class AnyModelIntegrationTests: XCTestCase {
             createCallbackInvoked.fulfill()
         }
 
-        wait(for: [createCallbackInvoked], timeout: networkTimeout)
+        await fulfillment(of: [createCallbackInvoked], timeout: networkTimeout)
 
         let deleteCallbackInvoked = expectation(description: "Delete callback invoked")
         var responseFromOperation: GraphQLResponse<AnyModel>?
@@ -187,7 +187,7 @@ class AnyModelIntegrationTests: XCTestCase {
             }
         }
 
-        wait(for: [deleteCallbackInvoked], timeout: networkTimeout)
+        await fulfillment(of: [deleteCallbackInvoked], timeout: networkTimeout)
 
         guard let response = responseFromOperation else {
             XCTAssertNotNil(responseFromOperation)

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/Base/TestConfigHelper.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/Base/TestConfigHelper.swift
@@ -36,3 +36,9 @@ class TestConfigHelper {
         return try Data(contentsOf: url)
     }
 }
+
+extension String {
+    var withUUID: String {
+        "\(self)-\(UUID().uuidString)"
+    }
+}

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario1APISwiftTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario1APISwiftTests.swift
@@ -16,7 +16,7 @@ import Amplify
 extension GraphQLConnectionScenario1Tests {
     
     func createTeamAPISwift() async throws -> APISwift.CreateTeam1Mutation.Data.CreateTeam1? {
-        let input = APISwift.CreateTeam1Input(name: "name")
+        let input = APISwift.CreateTeam1Input(name: "name".withUUID)
         let mutation = APISwift.CreateTeam1Mutation(input: input)
         let request = GraphQLRequest<APISwift.CreateTeam1Mutation.Data>(
             document: APISwift.CreateTeam1Mutation.operationString,

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario1Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario1Tests.swift
@@ -55,7 +55,7 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
     }
     
     func testCreateAndGetProject() async throws {
-        guard let team = try await createTeam(name: "name"),
+        guard let team = try await createTeam(name: "name".withUUID),
               let project = try await createProject(team: team) else {
             XCTFail("Could not create team and a project")
             return
@@ -76,12 +76,12 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
     }
     
     func testUpdateProjectWithAnotherTeam() async throws {
-        guard let team = try await createTeam(name: "name"),
+        guard let team = try await createTeam(name: "name".withUUID),
               var project = try await createProject(team: team) else {
             XCTFail("Could not create a Team")
             return
         }
-        let anotherTeam = Team1(name: "name")
+        let anotherTeam = Team1(name: "name".withUUID)
         guard case .success(let createdAnotherTeam) = try await Amplify.API.mutate(request: .create(anotherTeam)) else {
             XCTFail("Failed to create another team")
             return
@@ -96,7 +96,7 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
     }
     
     func testDeleteAndGetProject() async throws {
-        guard let team = try await createTeam(name: "name"),
+        guard let team = try await createTeam(name: "name".withUUID),
               let project = try await createProject(team: team) else {
             XCTFail("Could not create team and a project")
             return
@@ -124,7 +124,7 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
     // The filter we are passing into is the ProjectTeamID, but the API doesn't have the field ProjectTeamID
     //    so we are disabling it
     func testListProjectsByTeamID() async throws {
-        guard let team = try await createTeam(name: "name"),
+        guard let team = try await createTeam(name: "name".withUUID),
               let project = try await createProject(team: team) else {
             XCTFail("Could not create team and a project")
             return
@@ -143,7 +143,7 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
     func testPaginatedListProjects() async throws {
         let testCompleted = asyncExpectation(description: "test completed")
         Task {
-            guard let team = try await createTeam(name: "name"),
+            guard let team = try await createTeam(name: "name".withUUID),
                   let projecta = try await createProject(team: team),
                   let projectb = try await createProject(team: team) else {
                 XCTFail("Could not create team and two projects")

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario1Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario1Tests.swift
@@ -141,7 +141,7 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
     }
     
     func testPaginatedListProjects() async throws {
-        let testCompleted = asyncExpectation(description: "test completed")
+        let testCompleted = expectation(description: "test completed")
         Task {
             guard let team = try await createTeam(name: "name".withUUID),
                   let projecta = try await createProject(team: team),
@@ -173,9 +173,9 @@ class GraphQLConnectionScenario1Tests: XCTestCase {
                 resultsArray.append(contentsOf: subsequentResults)
             }
             XCTAssertEqual(resultsArray.count, 2)
-            await testCompleted.fulfill()
+            testCompleted.fulfill()
         }
-        await waitForExpectations([testCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [testCompleted], timeout: TestCommonConstants.networkTimeout)
     }
     
     func createTeam(id: String = UUID().uuidString, name: String) async throws -> Team1? {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario2Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario2Tests.swift
@@ -60,7 +60,7 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
     // 1. `teamID` and `team`
     // 2. With random `teamID` and `team`
     func testCreateAndGetProject() async throws {
-        guard let team = try await createTeam2(name: "name"),
+        guard let team = try await createTeam2(name: "name".withUUID),
               let project2a = try await createProject2(teamID: team.id, team: team),
               let project2b = try await createProject2(teamID: team.id, team: team) else {
             XCTFail("Could not create team and a project")
@@ -93,7 +93,7 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
     }
 
     func testUpdateProjectWithAnotherTeam() async throws {
-        guard let team = try await createTeam2(name: "name"),
+        guard let team = try await createTeam2(name: "name".withUUID),
               var project2 = try await createProject2(teamID: team.id, team: team) else {
             XCTFail("Could not create team and a project")
             return
@@ -115,7 +115,7 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
     }
     
     func testDeleteAndGetProject() async throws {
-        guard let team = try await createTeam2(name: "name"),
+        guard let team = try await createTeam2(name: "name".withUUID),
               let project2 = try await createProject2(teamID: team.id, team: team) else {
             XCTFail("Could not create team and a project")
             return
@@ -141,7 +141,7 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
     }
 
     func testListProjectsByTeamID() async throws {
-        guard let team = try await createTeam2(name: "name"),
+        guard let team = try await createTeam2(name: "name".withUUID),
               try await createProject2(teamID: team.id, team: team) != nil else {
             XCTFail("Could not create team and two projects")
             return
@@ -159,7 +159,7 @@ class GraphQLConnectionScenario2Tests: XCTestCase {
     // Create two projects for the same team, then list the projects by teamID, and expect two projects
     // after exhausting the paginated list via `hasNextPage` and `getNextPage`
     func testPaginatedListProjectsByTeamID() async throws {
-        guard let team = try await createTeam2(name: "name"),
+        guard let team = try await createTeam2(name: "name".withUUID),
               try await createProject2(teamID: team.id, team: team) != nil,
               try await createProject2(teamID: team.id, team: team) != nil else {
             XCTFail("Could not create team and two projects")

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3APISwiftTests+Subscribe.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3APISwiftTests+Subscribe.swift
@@ -40,12 +40,13 @@ extension GraphQLConnectionScenario3Tests {
     }
     
     func testOnCreateSubscriptionAPISwift() async throws {
-        let connectedInvoked = asyncExpectation(description: "Connection established")
-        let progressInvoked = asyncExpectation(description: "progress invoked", expectedFulfillmentCount: 2)
+        let connectedInvoked = expectation(description: "Connection established")
+        let progressInvoked = expectation(description: "progress invoked")
+        progressInvoked.expectedFulfillmentCount = 2
         let uuid = UUID().uuidString
         let uuid2 = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
-        let title = testMethodName + "Title"
+        let title = testMethodName + "Title".withUUID
         let subscription = Amplify.API.subscribe(request: onCreatePost3APISwiftRequest())
         Task {
             do {
@@ -56,7 +57,7 @@ extension GraphQLConnectionScenario3Tests {
                         case .connecting:
                             break
                         case .connected:
-                            await connectedInvoked.fulfill()
+                            connectedInvoked.fulfill()
                         case .disconnected:
                             break
                         }
@@ -64,7 +65,7 @@ extension GraphQLConnectionScenario3Tests {
                         switch result {
                         case .success(let data):
                             if data.onCreatePost3?.id == uuid || data.onCreatePost3?.id == uuid2 {
-                                await progressInvoked.fulfill()
+                                progressInvoked.fulfill()
                             }
                         case .failure(let error):
                             XCTFail("\(error)")
@@ -76,13 +77,13 @@ extension GraphQLConnectionScenario3Tests {
             }
         }
         
-        await waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         guard try await createPost3APISwift(uuid, title) != nil,
               try await createPost3APISwift(uuid2, title) != nil else {
             XCTFail("Failed to create post")
             return
         }
 
-        await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+List.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+List.swift
@@ -35,9 +35,10 @@ import XCTest
 extension GraphQLConnectionScenario3Tests {
 
     func testGetPostThenIterateComments() async throws {
-        guard let post = try await createPost(title: "title"),
-             try await createComment(postID: post.id, content: "content") != nil,
-             try await createComment(postID: post.id, content: "content") != nil else {
+        let commentContent = "content".withUUID
+        guard let post = try await createPost(title: "title".withUUID),
+             try await createComment(postID: post.id, content: commentContent) != nil,
+             try await createComment(postID: post.id, content: commentContent) != nil else {
             XCTFail("Could not create post and two comments")
             return
         }
@@ -73,9 +74,11 @@ extension GraphQLConnectionScenario3Tests {
     }
 
     func testGetPostThenFetchComments() async throws {
-        guard let post = try await createPost(title: "title"),
-              try await createComment(postID: post.id, content: "content") != nil,
-              try await createComment(postID: post.id, content: "content") != nil else {
+        let commentContent = "content".withUUID
+
+        guard let post = try await createPost(title: "title".withUUID),
+              try await createComment(postID: post.id, content: commentContent) != nil,
+              try await createComment(postID: post.id, content: commentContent) != nil else {
             XCTFail("Could not create post and two comments")
             return
         }
@@ -110,7 +113,7 @@ extension GraphQLConnectionScenario3Tests {
 
     // Create a post and list the posts
     func testListPost() async throws {
-        guard try await createPost(title: "title") != nil else {
+        guard try await createPost(title: "title".withUUID) != nil else {
             XCTFail("Failed to ensure at least one Post to be retrieved on the listQuery")
             return
         }
@@ -155,11 +158,11 @@ extension GraphQLConnectionScenario3Tests {
     // Create a post and a comment with that post
     // list the comments by postId
     func testListCommentsByPostID() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard try await createComment(postID: post.id, content: "content") != nil else {
+        guard try await createComment(postID: post.id, content: "content".withUUID) != nil else {
             XCTFail("Could not create comment")
             return
         }
@@ -187,15 +190,16 @@ extension GraphQLConnectionScenario3Tests {
     /// - Then:
     ///    - the in-memory Array is a populated with exactly two comments.
     func testPaginatedListCommentsByPostID() async throws {
-        guard let post = try await createPost(title: "title") else {
+        let commentContent = "content".withUUID
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard try await createComment(postID: post.id, content: "content") != nil else {
+        guard try await createComment(postID: post.id, content: commentContent) != nil else {
             XCTFail("Could not create comment")
             return
         }
-        guard try await createComment(postID: post.id, content: "content") != nil else {
+        guard try await createComment(postID: post.id, content: commentContent) != nil else {
             XCTFail("Could not create comment")
             return
         }
@@ -232,7 +236,7 @@ extension GraphQLConnectionScenario3Tests {
     ///    - A validation error is returned
     func testPaginatedListFetchValidationError() async throws {
         let uuid1 = UUID().uuidString
-        guard try await createPost(id: uuid1, title: "title") != nil else {
+        guard try await createPost(id: uuid1, title: "title".withUUID) != nil else {
             XCTFail("Failed to create post")
             return
         }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+Subscribe.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests+Subscribe.swift
@@ -17,12 +17,13 @@ import XCTest
 extension GraphQLConnectionScenario3Tests {
 
     func testOnCreatePostSubscriptionWithModel() async throws {
-        let connectedInvoked = asyncExpectation(description: "Connection established")
-        let progressInvoked = asyncExpectation(description: "progress invoked", expectedFulfillmentCount: 2)
+        let connectedInvoked = expectation(description: "Connection established")
+        let progressInvoked = expectation(description: "progress invoked")
+        progressInvoked.expectedFulfillmentCount = 2
         let uuid = UUID().uuidString
         let uuid2 = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
-        let title = testMethodName + "Title"
+        let title = testMethodName + "Title".withUUID
         let subscription = Amplify.API.subscribe(request: .subscription(of: Post3.self, type: .onCreate))
         Task {
             do {
@@ -33,7 +34,7 @@ extension GraphQLConnectionScenario3Tests {
                         case .connecting:
                             break
                         case .connected:
-                            await connectedInvoked.fulfill()
+                            connectedInvoked.fulfill()
                         case .disconnected:
                             break
                         }
@@ -41,8 +42,7 @@ extension GraphQLConnectionScenario3Tests {
                         switch result {
                         case .success(let post):
                             if post.id == uuid || post.id == uuid2 {
-                                
-                                await progressInvoked.fulfill()
+                                progressInvoked.fulfill()
                             }
                         case .failure(let error):
                             XCTFail("\(error)")
@@ -54,19 +54,20 @@ extension GraphQLConnectionScenario3Tests {
             }
         }
         
-        await waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         let post = Post3(id: uuid, title: title)
         _ = try await Amplify.API.mutate(request: .create(post))
         let post2 = Post3(id: uuid2, title: title)
         _ = try await Amplify.API.mutate(request: .create(post2))
 
-        await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
     }
     
     func testOnUpdatePostSubscriptionWithModel() async throws {
-        let connectingInvoked = AsyncExpectation(description: "Connection connecting")
-        let connectedInvoked = AsyncExpectation(description: "Connection established")
-        let progressInvoked = AsyncExpectation(description: "progress invoked")
+        let connectingInvoked = expectation(description: "Connection connecting")
+        let connectedInvoked = expectation(description: "Connection established")
+        let progressInvoked = expectation(description: "progress invoked")
+        progressInvoked.assertForOverFulfill = false
 
         let subscription = Amplify.API.subscribe(request: .subscription(of: Post3.self, type: .onUpdate))
         Task {
@@ -76,14 +77,14 @@ extension GraphQLConnectionScenario3Tests {
                     case .connection(let state):
                         switch state {
                         case .connecting:
-                            await connectingInvoked.fulfill()
+                            connectingInvoked.fulfill()
                         case .connected:
-                            await connectedInvoked.fulfill()
+                            connectedInvoked.fulfill()
                         case .disconnected:
                             break
                         }
                     case .data:
-                        await progressInvoked.fulfill()
+                        progressInvoked.fulfill()
                     }
                 }
             } catch {
@@ -91,22 +92,22 @@ extension GraphQLConnectionScenario3Tests {
             }
         }
                                  
-        await waitForExpectations([connectingInvoked, connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [connectingInvoked, connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
-        let title = testMethodName + "Title"
+        let title = testMethodName + "Title".withUUID
         let post = Post3(id: uuid, title: title)
         _ = try await Amplify.API.mutate(request: .create(post))
         _ = try await Amplify.API.mutate(request: .update(post))
 
-        await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
     }
     
     func testOnDeletePostSubscriptionWithModel() async throws {
-        let connectingInvoked = AsyncExpectation(description: "Connection connecting")
-        let connectedInvoked = AsyncExpectation(description: "Connection established")
-        let progressInvoked = AsyncExpectation(description: "progress invoked")
+        let connectingInvoked = expectation(description: "Connection connecting")
+        let connectedInvoked = expectation(description: "Connection established")
+        let progressInvoked = expectation(description: "progress invoked")
         
         let subscription = Amplify.API.subscribe(request: .subscription(of: Post3.self, type: .onDelete))
         Task {
@@ -116,24 +117,24 @@ extension GraphQLConnectionScenario3Tests {
                     case .connection(let state):
                         switch state {
                         case .connecting:
-                            await connectingInvoked.fulfill()
+                            connectingInvoked.fulfill()
                         case .connected:
-                            await connectedInvoked.fulfill()
+                            connectedInvoked.fulfill()
                         case .disconnected:
                             break
                         }
                     case .data:
-                        await progressInvoked.fulfill()
+                        progressInvoked.fulfill()
                     }
                 }
             } catch {
                 XCTFail("Unexpected subscription failure")
             }
         }
-        await waitForExpectations([connectingInvoked, connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [connectingInvoked, connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
-        let title = testMethodName + "Title"
+        let title = testMethodName + "Title".withUUID
 
         guard let post = try await createPost(id: uuid, title: title) else {
             XCTFail("Failed to create post")
@@ -145,13 +146,13 @@ extension GraphQLConnectionScenario3Tests {
             return
         }
 
-        await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testOnCreateCommentSubscriptionWithModel() async throws {
-        let connectingInvoked = AsyncExpectation(description: "Connection connecting")
-        let connectedInvoked = AsyncExpectation(description: "Connection established")
-        let progressInvoked = AsyncExpectation(description: "progress invoked")
+        let connectedInvoked = expectation(description: "Connection established")
+        let progressInvoked = expectation(description: "progress invoked")
+        progressInvoked.assertForOverFulfill = false
         let subscription = Amplify.API.subscribe(request: .subscription(of: Comment3.self, type: .onCreate))
         Task {
             do {
@@ -160,24 +161,24 @@ extension GraphQLConnectionScenario3Tests {
                     case .connection(let state):
                         switch state {
                         case .connecting:
-                            await connectingInvoked.fulfill()
+                            break
                         case .connected:
-                            await connectedInvoked.fulfill()
+                            connectedInvoked.fulfill()
                         case .disconnected:
                             break
                         }
                     case .data:
-                        await progressInvoked.fulfill()
+                        progressInvoked.fulfill()
                     }
                 }
             } catch {
                 XCTFail("Unexpected subscription failure")
             }
         }
-        await waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [connectedInvoked], timeout: 30)
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
-        let title = testMethodName + "Title"
+        let title = testMethodName + "Title".withUUID
 
         guard let createdPost = try await createPost(id: uuid, title: title) else {
             XCTFail("Failed to create post")
@@ -189,6 +190,6 @@ extension GraphQLConnectionScenario3Tests {
             return
         }
 
-        await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [progressInvoked], timeout: 30)
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests.swift
@@ -57,7 +57,7 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
     }
 
     func testQuerySinglePost() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Failed to set up test")
             return
         }
@@ -77,7 +77,7 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
     // Create a post and a comment for the post
     // Retrieve the comment and ensure that the comment is associated with the correct post
     func testCreatAndGetComment() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
@@ -105,7 +105,8 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
     // Update the existing comment to point to the other post
     // Expect that the queried comment is associated with the other post
     func testUpdateComment() async throws {
-        guard let post = try await createPost(title: "title") else {
+        let postTitle = "title".withUUID
+        guard let post = try await createPost(title: postTitle) else {
             XCTFail("Could not create post")
             return
         }
@@ -113,7 +114,7 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
             XCTFail("Could not create comment")
             return
         }
-        guard let anotherPost = try await createPost(title: "title") else {
+        guard let anotherPost = try await createPost(title: postTitle) else {
             XCTFail("Could not create post")
             return
         }
@@ -130,7 +131,7 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
     func testUpdateExistingPost() async throws {
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
-        let title = testMethodName + "Title"
+        let title = testMethodName + "Title".withUUID
         guard var post = try await createPost(id: uuid, title: title) else {
             XCTFail("Failed to ensure at least one Post to be retrieved on the listQuery")
             return
@@ -149,7 +150,7 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
     func testDeleteExistingPost() async throws {
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
-        let title = testMethodName + "Title"
+        let title = testMethodName + "Title".withUUID
         guard let post = try await createPost(id: uuid, title: title) else {
             XCTFail("Could not create post")
             return
@@ -174,7 +175,7 @@ class GraphQLConnectionScenario3Tests: XCTestCase {
     // Delete the comment and then query for the comment
     // Expected query should return `nil` comment
     func testDeleteAndGetComment() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario4Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario4Tests.swift
@@ -120,7 +120,7 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
         case .failure(let response):
             XCTFail("Failed with: \(response)")
         }
-        wait(for: [getPostCompleted, fetchCommentsCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getPostCompleted, fetchCommentsCompleted], timeout: TestCommonConstants.networkTimeout)
         guard var subsequentResults = results else {
             XCTFail("Could not get first results")
             return

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario4Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario4Tests.swift
@@ -57,11 +57,11 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
     }
 
     func testCreateCommentAndGetCommentWithPost() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard let comment = try await createComment(content: "content", post: post) else {
+        guard let comment = try await createComment(content: "content".withUUID, post: post) else {
             XCTFail("Could not create comment")
             return
         }
@@ -81,16 +81,18 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
     }
 
     func testGetPostThenFetchComments() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard try await createComment(content: "content", post: post) != nil else {
+
+        let commentContent = "comment".withUUID
+        guard try await createComment(content: commentContent, post: post) != nil else {
             XCTFail("Could not create comment")
             return
         }
 
-        guard try await createComment(content: "content", post: post) != nil else {
+        guard try await createComment(content: commentContent, post: post) != nil else {
             XCTFail("Could not create comment")
             return
         }
@@ -134,15 +136,16 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
     }
 
     func testUpdateComment() async throws {
-        guard let post = try await createPost(title: "title") else {
+        let postTitle = "title".withUUID
+        guard let post = try await createPost(title: postTitle) else {
             XCTFail("Could not create post")
             return
         }
-        guard var comment = try await createComment(content: "content", post: post) else {
+        guard var comment = try await createComment(content: "content".withUUID, post: post) else {
             XCTFail("Could not create comment")
             return
         }
-        guard let anotherPost = try await createPost(title: "title") else {
+        guard let anotherPost = try await createPost(title: postTitle) else {
             XCTFail("Could not create post")
             return
         }
@@ -157,11 +160,11 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
     }
 
     func testDeleteAndGetComment() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard let comment = try await createComment(content: "content", post: post) else {
+        guard let comment = try await createComment(content: "content".withUUID, post: post) else {
             XCTFail("Could not create comment")
             return
         }
@@ -186,11 +189,11 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
     }
 
     func testListCommentsByPostID() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard try await createComment(content: "content", post: post) != nil else {
+        guard try await createComment(content: "content".withUUID, post: post) != nil else {
             XCTFail("Could not create comment")
             return
         }
@@ -205,9 +208,10 @@ class GraphQLConnectionScenario4Tests: XCTestCase {
     }
 
     func testPaginatedListCommentsByPostID() async throws {
-        guard let post = try await createPost(title: "title"),
-              try await createComment(content: "content", post: post) != nil,
-              try await createComment(content: "content", post: post) != nil else {
+        let commentContent = "content".withUUID
+        guard let post = try await createPost(title: "title".withUUID),
+              try await createComment(content: commentContent, post: post) != nil,
+              try await createComment(content: commentContent, post: post) != nil else {
             XCTFail("Could not create post and two comments")
             return
         }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario5Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario5Tests.swift
@@ -69,11 +69,11 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
     }
 
     func testListPostEditorByPost() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard let user = try await createUser(username: "username") else {
+        guard let user = try await createUser(username: "username".withUUID) else {
             XCTFail("Could not create user")
             return
         }
@@ -92,11 +92,11 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
     }
 
     func testListPostEditorByUser() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard let user = try await createUser(username: "username") else {
+        guard let user = try await createUser(username: "username".withUUID) else {
             XCTFail("Could not create user")
             return
         }
@@ -118,11 +118,11 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
     // Get the post and fetch the PostEditors for that post
     // The Posteditor contains the user which is connected the post
     func testGetPostThenFetchPostEditorsToRetrieveUser() async throws {
-        guard let post = try await createPost(title: "title") else {
+        guard let post = try await createPost(title: "title".withUUID) else {
             XCTFail("Could not create post")
             return
         }
-        guard let user = try await createUser(username: "username") else {
+        guard let user = try await createUser(username: "username".withUUID) else {
             XCTFail("Could not create user")
             return
         }
@@ -177,11 +177,12 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
     // Get the user and fetch the PostEditors for that user
     // The PostEditors should contain the two posts `post1` and `post2`
     func testGetUserThenFetchPostEditorsToRetrievePosts() async throws {
-        guard let post1 = try await createPost(title: "title") else {
+        let postTitle = "title".withUUID
+        guard let post1 = try await createPost(title: postTitle) else {
             XCTFail("Could not create post")
             return
         }
-        guard let post2 = try await createPost(title: "title") else {
+        guard let post2 = try await createPost(title: postTitle) else {
             XCTFail("Could not create post")
             return
         }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario5Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario5Tests.swift
@@ -152,7 +152,7 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
         case .failure(let response):
             XCTFail("Failed with: \(response)")
         }
-        wait(for: [getPostCompleted, fetchPostEditorCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getPostCompleted, fetchPostEditorCompleted], timeout: TestCommonConstants.networkTimeout)
         guard var subsequentResults = results else {
             XCTFail("Could not get first results")
             return
@@ -220,7 +220,7 @@ class GraphQLConnectionScenario5Tests: XCTestCase {
         case .failure(let response):
             XCTFail("Failed with: \(response)")
         }
-        wait(for: [getUserCompleted, fetchPostEditorCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getUserCompleted, fetchPostEditorCompleted], timeout: TestCommonConstants.networkTimeout)
 
         guard var subsequentResults = results else {
             XCTFail("Could not get first results")

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario6Tests.swift
@@ -94,7 +94,7 @@ class GraphQLConnectionScenario6Tests: XCTestCase {
             fetchPostCompleted.fulfill()
         case .failure(let response): XCTFail("Failed with: \(response)")
         }
-        wait(for: [getBlogCompleted, fetchPostCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getBlogCompleted, fetchPostCompleted], timeout: TestCommonConstants.networkTimeout)
 
         let allPosts = try await getAll(list: resultPosts)
         XCTAssertEqual(allPosts.count, 2)
@@ -110,7 +110,7 @@ class GraphQLConnectionScenario6Tests: XCTestCase {
         try await comments.fetch()
         resultComments = comments
         fetchCommentsCompleted.fulfill()
-        wait(for: [fetchCommentsCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [fetchCommentsCompleted], timeout: TestCommonConstants.networkTimeout)
         let allComments = try await getAll(list: resultComments)
         XCTAssertEqual(allComments.count, 2)
         XCTAssertTrue(allComments.contains(where: { (comment) -> Bool in

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario6Tests.swift
@@ -64,11 +64,12 @@ class GraphQLConnectionScenario6Tests: XCTestCase {
     }
 
     func testGetBlogThenFetchPostsThenFetchComments() async throws {
-        guard let blog = try await createBlog(name: "name"),
-              let post1 = try await createPost(title: "title", blog: blog),
+        let commentContent = "content".withUUID
+        guard let blog = try await createBlog(name: "name".withUUID),
+              let post1 = try await createPost(title: "title".withUUID, blog: blog),
               try await createPost(title: "title", blog: blog) != nil,
-              let comment1post1 = try await createComment(post: post1, content: "content"),
-              let comment2post1 = try await createComment(post: post1, content: "content") else {
+              let comment1post1 = try await createComment(post: post1, content: commentContent),
+              let comment2post1 = try await createComment(post: post1, content: commentContent) else {
             XCTFail("Could not create blog, posts, and comments")
             return
         }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
@@ -273,8 +273,9 @@ class GraphQLModelBasedTests: XCTestCase {
     }
     
     func testOnCreatePostSubscriptionWithModel() async throws {
-        let connectedInvoked = AsyncExpectation(description: "Connection established")
-        let progressInvoked = AsyncExpectation(description: "progress invoked", expectedFulfillmentCount: 2)
+        let connectedInvoked = expectation(description: "Connection established")
+        let progressInvoked = expectation(description: "progress invoked")
+        progressInvoked.expectedFulfillmentCount = 2
         let uuid = UUID().uuidString
         let uuid2 = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
@@ -289,7 +290,7 @@ class GraphQLModelBasedTests: XCTestCase {
                         case .connecting:
                             break
                         case .connected:
-                            await connectedInvoked.fulfill()
+                            connectedInvoked.fulfill()
                         case .disconnected:
                             break
                         }
@@ -297,7 +298,7 @@ class GraphQLModelBasedTests: XCTestCase {
                         switch result {
                         case .success(let post):
                             if post.id == uuid || post.id == uuid2 {
-                                await progressInvoked.fulfill()
+                                progressInvoked.fulfill()
                             }
                         case .failure(let error):
                             XCTFail("\(error)")
@@ -309,20 +310,21 @@ class GraphQLModelBasedTests: XCTestCase {
             }
         }
         
-        await waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         
         let post = Post(id: uuid, title: title, content: "content", createdAt: .now())
         _ = try await Amplify.API.mutate(request: .create(post))
         let post2 = Post(id: uuid2, title: title, content: "content", createdAt: .now())
         _ = try await Amplify.API.mutate(request: .create(post2))
-        await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
     }
     
     func testOnUpdatePostSubscriptionWithModel() async throws {
-        let connectingInvoked = AsyncExpectation(description: "Connection connecting")
-        let connectedInvoked = AsyncExpectation(description: "Connection established")
-        let progressInvoked = AsyncExpectation(description: "progress invoked")
-        
+        let connectingInvoked = expectation(description: "Connection connecting")
+        let connectedInvoked = expectation(description: "Connection established")
+        let progressInvoked = expectation(description: "progress invoked")
+        progressInvoked.assertForOverFulfill = false
+
         let subscription = Amplify.API.subscribe(request: .subscription(of: Post.self, type: .onUpdate))
         Task {
             do {
@@ -331,14 +333,14 @@ class GraphQLModelBasedTests: XCTestCase {
                     case .connection(let state):
                         switch state {
                         case .connecting:
-                            await connectingInvoked.fulfill()
+                            connectingInvoked.fulfill()
                         case .connected:
-                            await connectedInvoked.fulfill()
+                            connectedInvoked.fulfill()
                         case .disconnected:
                             break
                         }
                     case .data:
-                        await progressInvoked.fulfill()
+                        progressInvoked.fulfill()
                     }
                 }
             } catch {
@@ -346,7 +348,7 @@ class GraphQLModelBasedTests: XCTestCase {
             }
         }
         
-        await waitForExpectations([connectingInvoked, connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [connectingInvoked, connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
@@ -355,13 +357,13 @@ class GraphQLModelBasedTests: XCTestCase {
         _ = try await Amplify.API.mutate(request: .create(post))
         _ = try await Amplify.API.mutate(request: .update(post))
         
-        await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
     }
     
     func testOnDeletePostSubscriptionWithModel() async throws {
-        let connectingInvoked = AsyncExpectation(description: "Connection connecting")
-        let connectedInvoked = AsyncExpectation(description: "Connection established")
-        let progressInvoked = AsyncExpectation(description: "progress invoked")
+        let connectingInvoked = expectation(description: "Connection connecting")
+        let connectedInvoked = expectation(description: "Connection established")
+        let progressInvoked = expectation(description: "progress invoked")
         
         let subscription = Amplify.API.subscribe(request: .subscription(of: Post.self, type: .onDelete))
         Task {
@@ -371,14 +373,14 @@ class GraphQLModelBasedTests: XCTestCase {
                     case .connection(let state):
                         switch state {
                         case .connecting:
-                            await connectingInvoked.fulfill()
+                            connectingInvoked.fulfill()
                         case .connected:
-                            await connectedInvoked.fulfill()
+                            connectedInvoked.fulfill()
                         case .disconnected:
                             break
                         }
                     case .data:
-                        await progressInvoked.fulfill()
+                        progressInvoked.fulfill()
                     }
                 }
             } catch {
@@ -386,7 +388,7 @@ class GraphQLModelBasedTests: XCTestCase {
             }
         }
         
-        await waitForExpectations([connectingInvoked, connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [connectingInvoked, connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
@@ -395,12 +397,13 @@ class GraphQLModelBasedTests: XCTestCase {
         _ = try await Amplify.API.mutate(request: .create(post))
         _ = try await Amplify.API.mutate(request: .delete(post))
         
-        await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
     }
     
     func testOnCreateCommentSubscriptionWithModel() async throws {
-        let connectedInvoked = AsyncExpectation(description: "Connection established")
-        let progressInvoked = AsyncExpectation(description: "progress invoked", expectedFulfillmentCount: 2)
+        let connectedInvoked = expectation(description: "Connection established")
+        let progressInvoked = expectation(description: "progress invoked")
+        progressInvoked.expectedFulfillmentCount = 2
         let uuid = UUID().uuidString
         let uuid2 = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
@@ -415,7 +418,7 @@ class GraphQLModelBasedTests: XCTestCase {
                         case .connecting:
                             break
                         case .connected:
-                            await connectedInvoked.fulfill()
+                            connectedInvoked.fulfill()
                         case .disconnected:
                             break
                         }
@@ -423,7 +426,7 @@ class GraphQLModelBasedTests: XCTestCase {
                         switch result {
                         case .success(let comment):
                             if comment.id == uuid || comment.id == uuid2 {
-                                await progressInvoked.fulfill()
+                                progressInvoked.fulfill()
                             }
                         case .failure(let error):
                             XCTFail("\(error)")
@@ -435,14 +438,14 @@ class GraphQLModelBasedTests: XCTestCase {
             }
         }
         
-        await waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         let post = Post(id: uuid, title: title, content: "content", createdAt: .now())
         _ = try await Amplify.API.mutate(request: .create(post))
         let comment = Comment(id: uuid, content: "content", createdAt: .now(), post: post)
         _ = try await Amplify.API.mutate(request: .create(comment))
         let comment2 = Comment(id: uuid2, content: "content", createdAt: .now(), post: post)
         _ = try await Amplify.API.mutate(request: .create(comment2))
-        await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
     }
 
     // MARK: Helpers

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLScalarTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLScalarTests.swift
@@ -41,7 +41,7 @@ class GraphQLScalarTests: GraphQLTestBase {
     }
 
     func testScalarContainer() async throws {
-        let container = ScalarContainer(myString: "myString",
+        let container = ScalarContainer(myString: "myString".withUUID,
                                         myInt: 1,
                                         myDouble: 1.0,
                                         myBool: true,
@@ -114,9 +114,9 @@ class GraphQLScalarTests: GraphQLTestBase {
 
     func testListStringContainer() async throws {
         let container = ListStringContainer(
-            test: "test",
+            test: "test".withUUID,
             nullableString: nil,
-            stringList: ["value1"],
+            stringList: ["value1".withUUID],
             stringNullableList: [],
             nullableStringList: [],
             nullableStringNullableList: nil)
@@ -150,9 +150,9 @@ class GraphQLScalarTests: GraphQLTestBase {
 
     func testListContainerWithNil() async throws {
         let container = ListStringContainer(
-            test: "test",
+            test: "test".withUUID,
             nullableString: nil,
-            stringList: ["value1"],
+            stringList: ["value1".withUUID],
             stringNullableList: nil,
             nullableStringList: [nil],
             nullableStringNullableList: nil)

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncBasedTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncBasedTests.swift
@@ -60,7 +60,7 @@ class GraphQLSyncBasedTests: XCTestCase {
                 XCTFail("\(apiError)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
 
         guard let response = responseFromOperation else {
             XCTAssertNotNil(responseFromOperation)
@@ -118,7 +118,7 @@ class GraphQLSyncBasedTests: XCTestCase {
                 XCTFail("\(apiError)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
 
         guard let response = responseFromOperation else {
             XCTAssertNotNil(responseFromOperation)
@@ -190,7 +190,7 @@ class GraphQLSyncBasedTests: XCTestCase {
                 XCTFail("\(apiError)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
 
         guard let response = responseFromOperation else {
             XCTAssertNotNil(responseFromOperation)
@@ -263,7 +263,7 @@ class GraphQLSyncBasedTests: XCTestCase {
                 XCTFail("\(apiError)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
 
         guard let response = responseFromOperation else {
             XCTAssertNotNil(responseFromOperation)
@@ -296,7 +296,7 @@ class GraphQLSyncBasedTests: XCTestCase {
             }
         }
 
-        wait(for: [conditionalFailedError], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [conditionalFailedError], timeout: TestCommonConstants.networkTimeout)
     }
 
     // Given: A newly created post
@@ -327,7 +327,7 @@ class GraphQLSyncBasedTests: XCTestCase {
                 XCTFail("\(apiError)")
             }
         }
-        wait(for: [firstUpdateSuccess], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [firstUpdateSuccess], timeout: TestCommonConstants.networkTimeout)
 
         var responseFromOperation: GraphQLResponse<MutationSync<AnyModel>>?
         let secondUpdateFailed = expectation(
@@ -344,7 +344,7 @@ class GraphQLSyncBasedTests: XCTestCase {
                 XCTFail("\(apiError)")
             }
         }
-        wait(for: [secondUpdateFailed], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [secondUpdateFailed], timeout: TestCommonConstants.networkTimeout)
 
         guard let response = responseFromOperation else {
             XCTAssertNotNil(responseFromOperation)
@@ -392,7 +392,7 @@ class GraphQLSyncBasedTests: XCTestCase {
             }
         }
 
-        wait(for: [conflictUnhandledError], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [conflictUnhandledError], timeout: TestCommonConstants.networkTimeout)
     }
 
     // Given: Two newly created posts
@@ -432,7 +432,7 @@ class GraphQLSyncBasedTests: XCTestCase {
                 print(error)
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
 
         guard let response = responseFromOperation else {
             XCTAssertNotNil(responseFromOperation)
@@ -517,16 +517,16 @@ class GraphQLSyncBasedTests: XCTestCase {
         })
 
         XCTAssertNotNil(operation)
-        wait(for: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
 
         guard createPost(id: uuid, title: title) != nil else {
             XCTFail("Failed to create post")
             return
         }
 
-        wait(for: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
         operation.cancel()
-        wait(for: [disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
         XCTAssertTrue(operation.isFinished)
     }
 
@@ -558,7 +558,7 @@ class GraphQLSyncBasedTests: XCTestCase {
                 print(error)
             }
         })
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncCustomPrimaryKeyTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncCustomPrimaryKeyTests.swift
@@ -122,7 +122,7 @@ class GraphQLSyncCustomPrimaryKeyTests: XCTestCase {
                 print(error)
             }
         })
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
@@ -156,7 +156,7 @@ class GraphQLSyncCustomPrimaryKeyTests: XCTestCase {
                 XCTFail("\(error)")
             }
         }
-        wait(for: [querySuccess], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [querySuccess], timeout: TestCommonConstants.networkTimeout)
         return querySyncResult
     }
 
@@ -184,7 +184,7 @@ class GraphQLSyncCustomPrimaryKeyTests: XCTestCase {
                 XCTFail("\(error)")
             }
         }
-        wait(for: [updateSuccess], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [updateSuccess], timeout: TestCommonConstants.networkTimeout)
         return updateSyncResult
     }
 
@@ -212,7 +212,7 @@ class GraphQLSyncCustomPrimaryKeyTests: XCTestCase {
                 XCTFail("\(error)")
             }
         }
-        wait(for: [deleteSuccess], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteSuccess], timeout: TestCommonConstants.networkTimeout)
         return deleteSyncResult
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLIAMTests/GraphQLWithIAMIntegrationTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLIAMTests/GraphQLWithIAMIntegrationTests.swift
@@ -135,9 +135,10 @@ class GraphQLWithIAMIntegrationTests: XCTestCase {
     }
     
     func onCreateTodoTest() async throws {
-        let connectedInvoked = asyncExpectation(description: "Connection established")
-        let progressInvoked = asyncExpectation(description: "progress invoked", expectedFulfillmentCount: 2)
-        let disconnectedInvoked = asyncExpectation(description: "Connection disconnected")
+        let connectedInvoked = expectation(description: "Connection established")
+        let progressInvoked = expectation(description: "progress invoked")
+        progressInvoked.expectedFulfillmentCount = 2
+        let disconnectedInvoked = expectation(description: "Connection disconnected")
         let subscription = Amplify.API.subscribe(request: .subscription(of: Todo.self, type: .onCreate))
         let uuid = UUID().uuidString
         let uuid2 = UUID().uuidString
@@ -150,15 +151,15 @@ class GraphQLWithIAMIntegrationTests: XCTestCase {
                     case .connecting:
                         break
                     case .connected:
-                        await connectedInvoked.fulfill()
+                        connectedInvoked.fulfill()
                     case .disconnected:
-                        await disconnectedInvoked.fulfill()
+                        disconnectedInvoked.fulfill()
                     }
                 case .data(let result):
                     switch result {
                     case .success(let todo):
                         if todo.id == uuid || todo.id == uuid2 {
-                            await progressInvoked.fulfill()
+                            progressInvoked.fulfill()
                         }
                     case .failure(let error):
                         XCTFail("\(error)")
@@ -167,12 +168,12 @@ class GraphQLWithIAMIntegrationTests: XCTestCase {
             }
         }
         
-        await waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         _ = try await createTodo(id: uuid, name: name)
         _ = try await createTodo(id: uuid2, name: name)
-        await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
         subscription.cancel()
-        await waitForExpectations([disconnectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [disconnectedInvoked], timeout: TestCommonConstants.networkTimeout)
     }
 
     // MARK: - Helpers

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLUserPoolTests/Base/AsyncExpectation.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLUserPoolTests/Base/AsyncExpectation.swift
@@ -110,7 +110,7 @@ extension XCTestCase {
     /// Use this method to create ``AsyncExpectation`` instances that can be
     /// fulfilled when asynchronous tasks in your tests complete.
     ///
-    /// To fulfill an expectation that was created with `asyncExpectation(description:)`,
+    /// To fulfill an expectation that was created with `expectation(description:)`,
     /// call the expectation's `fulfill()` method when the asynchronous task in your
     /// test has completed.
     ///
@@ -118,10 +118,10 @@ extension XCTestCase {
     ///   - description: A string to display in the test log for this expectation, to help diagnose failures.
     ///   - isInverted: Indicates that the expectation is not intended to happen.
     ///   - expectedFulfillmentCount: The number of times fulfill() must be called before the expectation is completely fulfilled. (default = 1)
-    public func asyncExpectation(description: String,
+    public func expectation(description: String,
                                  isInverted: Bool = false,
                                  expectedFulfillmentCount: Int = 1) -> AsyncExpectation {
-        AsyncExpectation(description: description,
+        expectation(description: description,
                          isInverted: isInverted,
                          expectedFulfillmentCount: expectedFulfillmentCount)
     }
@@ -148,7 +148,7 @@ public enum AsyncTesting {
     public static func expectation(description: String,
                                    isInverted: Bool = false,
                                    expectedFulfillmentCount: Int = 1) -> AsyncExpectation {
-        AsyncExpectation(description: description,
+        expectation(description: description,
                          isInverted: isInverted,
                          expectedFulfillmentCount: expectedFulfillmentCount)
     }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLUserPoolTests/GraphQLWithUserPoolIntegrationTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLUserPoolTests/GraphQLWithUserPoolIntegrationTests.swift
@@ -356,9 +356,10 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
     /// The user is not signed in so establishing the subscription will fail with an unauthorized error.
     func testOnCreateSubscriptionUnauthorized() async throws {
         Amplify.Logging.logLevel = .verbose
-        let connectingInvoked = asyncExpectation(description: "Connecting invoked")
-        let connectedInvoked = asyncExpectation(description: "Connection established", isInverted: true)
-        let completedInvoked = asyncExpectation(description: "Completed invoked")
+        let connectingInvoked = expectation(description: "Connecting invoked")
+        let connectedInvoked = expectation(description: "Connection established")
+        connectedInvoked.isInverted = true
+        let completedInvoked = expectation(description: "Completed invoked")
         let request = GraphQLRequest(document: OnCreateTodoSubscription.document,
                                      variables: nil,
                                      responseType: OnCreateTodoSubscription.Data.self)
@@ -371,9 +372,9 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
                     case .connection(let state):
                         switch state {
                         case .connecting:
-                            await connectingInvoked.fulfill()
+                            connectingInvoked.fulfill()
                         case .connected:
-                            await connectedInvoked.fulfill()
+                            connectedInvoked.fulfill()
                         case .disconnected:
                             break
                         }
@@ -383,11 +384,11 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
                 }
             } catch {
                 if let apiError = error as? APIError, apiError.isUnauthorized() {
-                    await completedInvoked.fulfill()
+                    completedInvoked.fulfill()
                 }
             }
         }
-        await waitForExpectations([connectingInvoked, connectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [connectingInvoked, connectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
     }
 
     /// Given: A successful subscription is created for CreateTodo's
@@ -395,10 +396,11 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
     /// Then: The subscription handler is called and Todo object is returned
     func testOnCreateTodoSubscription() async throws {
         try await createAuthenticatedUser()
-        let connectedInvoked = asyncExpectation(description: "Connection established")
-        let disconnectedInvoked = asyncExpectation(description: "Connection disconnected")
-        let completedInvoked = asyncExpectation(description: "Completed invoked")
-        let progressInvoked = asyncExpectation(description: "progress invoked", expectedFulfillmentCount: 2)
+        let connectedInvoked = expectation(description: "Connection established")
+        let disconnectedInvoked = expectation(description: "Connection disconnected")
+        let completedInvoked = expectation(description: "Completed invoked")
+        let progressInvoked = expectation(description: "progress invoked")
+        progressInvoked.expectedFulfillmentCount = 2
         let request = GraphQLRequest(document: OnCreateTodoSubscription.document,
                                      variables: nil,
                                      responseType: OnCreateTodoSubscription.Data.self)
@@ -411,18 +413,18 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
                     case .connecting:
                         break
                     case .connected:
-                        await connectedInvoked.fulfill()
+                        connectedInvoked.fulfill()
                     case .disconnected:
-                        await disconnectedInvoked.fulfill()
+                        disconnectedInvoked.fulfill()
                     }
                 case .data:
-                    Task { await progressInvoked.fulfill() }
+                    progressInvoked.fulfill()
                 }
             }
             
-            await completedInvoked.fulfill()
+            completedInvoked.fulfill()
         }
-        await waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let name = testMethodName + "Name"
@@ -439,9 +441,9 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
             return
         }
 
-        await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
         subscriptions.cancel()
-        await waitForExpectations([disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
     }
 
     /// Given: A subscription is created for UpdateTodo's
@@ -449,10 +451,12 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
     /// Then: The subscription handler is called and Todo object is returned
     func testOnUpdateTodoSubscription() async throws {
         try await createAuthenticatedUser()
-        let connectedInvoked = asyncExpectation(description: "Connection established")
-        let disconnectedInvoked = asyncExpectation(description: "Connection disconnected")
-        let completedInvoked = asyncExpectation(description: "Completed invoked")
-        let progressInvoked = asyncExpectation(description: "progress invoked", expectedFulfillmentCount: 2)
+        let connectedInvoked = expectation(description: "Connection established")
+        let disconnectedInvoked = expectation(description: "Connection disconnected")
+        let completedInvoked = expectation(description: "Completed invoked")
+        let progressInvoked = expectation(description: "progress invoked")
+        progressInvoked.expectedFulfillmentCount = 2
+
         let request = GraphQLRequest(document: OnUpdateTodoSubscription.document,
                                      variables: nil,
                                      responseType: OnUpdateTodoSubscription.Data.self)
@@ -465,17 +469,17 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
                     case .connecting:
                         break
                     case .connected:
-                        Task { await connectedInvoked.fulfill() }
+                        connectedInvoked.fulfill()
                     case .disconnected:
-                        Task { await disconnectedInvoked.fulfill() }
+                        disconnectedInvoked.fulfill()
                     }
                 case .data:
-                    Task { await progressInvoked.fulfill() }
+                    progressInvoked.fulfill()
                 }
             }
-            await completedInvoked.fulfill()
+            completedInvoked.fulfill()
         }
-        await waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let name = testMethodName + "Name"
@@ -496,9 +500,9 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
             return
         }
 
-        await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
         subscriptions.cancel()
-        await waitForExpectations([disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
     }
 
     /// Given: A subscription is created for DeleteTodo
@@ -506,10 +510,10 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
     /// Then: The subscription handler is called and Todo object is returned
     func testOnDeleteTodoSubscription() async throws {
         try await createAuthenticatedUser()
-        let connectedInvoked = asyncExpectation(description: "Connection established")
-        let disconnectedInvoked = asyncExpectation(description: "Connection disconnected")
-        let completedInvoked = asyncExpectation(description: "Completed invoked")
-        let progressInvoked = asyncExpectation(description: "progress invoked")
+        let connectedInvoked = expectation(description: "Connection established")
+        let disconnectedInvoked = expectation(description: "Connection disconnected")
+        let completedInvoked = expectation(description: "Completed invoked")
+        let progressInvoked = expectation(description: "progress invoked")
         let request = GraphQLRequest(document: OnDeleteTodoSubscription.document,
                                      variables: nil,
                                      responseType: OnDeleteTodoSubscription.Data.self)
@@ -522,17 +526,17 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
                     case .connecting:
                         break
                     case .connected:
-                        Task { await connectedInvoked.fulfill() }
+                        connectedInvoked.fulfill()
                     case .disconnected:
-                        Task { await disconnectedInvoked.fulfill() }
+                        disconnectedInvoked.fulfill()
                     }
                 case .data:
-                    Task { await progressInvoked.fulfill() }
+                    progressInvoked.fulfill()
                 }
             }
-            await completedInvoked.fulfill()
+            completedInvoked.fulfill()
         }
-        await waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         let uuid = UUID().uuidString
         let testMethodName = String("\(#function)".dropLast(2))
         let name = testMethodName + "Name"
@@ -548,10 +552,10 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
             return
         }
 
-        await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
         
         subscriptions.cancel()
-        await waitForExpectations([disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [disconnectedInvoked, completedInvoked], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testCreateMultipleSubscriptions() async throws {
@@ -648,7 +652,7 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
     }
 
     func createTodoSubscription() async -> AmplifyAsyncThrowingSequence<GraphQLSubscriptionEvent<OnCreateTodoSubscription.Data>> {
-        let connectedInvoked = asyncExpectation(description: "Connection established")
+        let connectedInvoked = expectation(description: "Connection established")
         let request = GraphQLRequest(document: OnCreateTodoSubscription.document,
                                      variables: nil,
                                      responseType: OnCreateTodoSubscription.Data.self)
@@ -659,7 +663,7 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
                 case .connection(let state):
                     switch state {
                     case .connected:
-                        await connectedInvoked.fulfill()
+                        connectedInvoked.fulfill()
                     default:
                         break
                     }
@@ -668,7 +672,7 @@ class GraphQLWithUserPoolIntegrationTests: XCTestCase {
                 }
             }
         }
-        await waitForExpectations([connectedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [connectedInvoked], timeout: TestCommonConstants.networkTimeout)
         return subscriptions
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/GraphQLLazyLoadBaseTest.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/GraphQLLazyLoadBaseTest.swift
@@ -191,15 +191,15 @@ class GraphQLLazyLoadBaseTest: XCTestCase {
         of modelType: M.Type,
         type: GraphQLSubscriptionType,
         verifyChange: @escaping (M) async throws -> Bool
-    ) async throws -> (AsyncExpectation, AmplifyAsyncThrowingSequence<GraphQLSubscriptionEvent<M>>) {
-        let connected = asyncExpectation(description: "Subscription connected")
-        let eventReceived = asyncExpectation(description: "\(type.rawValue) received")
+    ) async throws -> (XCTestExpectation, AmplifyAsyncThrowingSequence<GraphQLSubscriptionEvent<M>>) {
+        let connected = expectation(description: "Subscription connected")
+        let eventReceived = expectation(description: "\(type.rawValue) received")
         let subscription = Amplify.API.subscribe(request: .subscription(of: modelType, type: type))
 
         Task {
             for try await subscriptionEvent in subscription {
                 if subscriptionEvent.isConnected() {
-                    await connected.fulfill()
+                    connected.fulfill()
                 }
 
                 if let error = subscriptionEvent.extractError() {
@@ -209,12 +209,12 @@ class GraphQLLazyLoadBaseTest: XCTestCase {
                 if let data = subscriptionEvent.extractData(),
                    try await verifyChange(data)
                 {
-                    await eventReceived.fulfill()
+                    eventReceived.fulfill()
                 }
             }
         }
 
-        await waitForExpectations([connected], timeout: 10)
+        await fulfillment(of: [connected], timeout: 10)
         return (eventReceived, subscription)
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL1/GraphQLLazyLoadPostComment4V2Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL1/GraphQLLazyLoadPostComment4V2Tests.swift
@@ -301,8 +301,8 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
         await setup(withModels: PostComment4V2Models())
         let post = Post(title: "title")
         try await mutate(.create(post))
-        let connected = asyncExpectation(description: "subscription connected")
-        let onCreatedComment = asyncExpectation(description: "onCreatedComment received")
+        let connected = expectation(description: "subscription connected")
+        let onCreatedComment = expectation(description: "onCreatedComment received")
         let subscription = Amplify.API.subscribe(request: .subscription(of: Comment.self, type: .onCreate))
         Task {
             do {
@@ -311,14 +311,14 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
                     case .connection(let subscriptionConnectionState):
                         log.verbose("Subscription connect state is \(subscriptionConnectionState)")
                         if case .connected = subscriptionConnectionState {
-                            await connected.fulfill()
+                            connected.fulfill()
                         }
                     case .data(let result):
                         switch result {
                         case .success(let createdComment):
                             log.verbose("Successfully got createdComment from subscription: \(createdComment)")
                             assertLazyReference(createdComment._post, state: .notLoaded(identifiers: [.init(name: "id", value: post.id)]))
-                            await onCreatedComment.fulfill()
+                            onCreatedComment.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")
                         }
@@ -329,10 +329,10 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
             }
         }
         
-        await waitForExpectations([connected], timeout: 10)
+        await fulfillment(of: [connected], timeout: 10)
         let comment = Comment(content: "content", post: post)
         try await mutate(.create(comment))
-        await waitForExpectations([onCreatedComment], timeout: 10)
+        await fulfillment(of: [onCreatedComment], timeout: 10)
         subscription.cancel()
     }
     
@@ -342,8 +342,8 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
         await setup(withModels: PostComment4V2Models())
         let post = Post(title: "title")
         try await mutate(.create(post))
-        let connected = asyncExpectation(description: "subscription connected")
-        let onCreatedComment = asyncExpectation(description: "onCreatedComment received")
+        let connected = expectation(description: "subscription connected")
+        let onCreatedComment = expectation(description: "onCreatedComment received")
         let subscriptionIncludes = Amplify.API.subscribe(request: .subscription(of: Comment.self,
                                                                                 type: .onCreate,
                                                                                 includes: { comment in [comment.post]}))
@@ -354,14 +354,14 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
                     case .connection(let subscriptionConnectionState):
                         log.verbose("Subscription connect state is \(subscriptionConnectionState)")
                         if case .connected = subscriptionConnectionState {
-                            await connected.fulfill()
+                            connected.fulfill()
                         }
                     case .data(let result):
                         switch result {
                         case .success(let createdComment):
                             log.verbose("Successfully got createdComment from subscription: \(createdComment)")
                             assertLazyReference(createdComment._post, state: .loaded(model: post))
-                            await onCreatedComment.fulfill()
+                            onCreatedComment.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")
                         }
@@ -372,10 +372,10 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
             }
         }
         
-        await waitForExpectations([connected], timeout: 20)
+        await fulfillment(of: [connected], timeout: 20)
         let comment = Comment(content: "content", post: post)
         try await mutate(.create(comment, includes: { comment in [comment.post] }))
-        await waitForExpectations([onCreatedComment], timeout: 20)
+        await fulfillment(of: [onCreatedComment], timeout: 20)
         subscriptionIncludes.cancel()
     }
     
@@ -383,8 +383,8 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
         await setup(withModels: PostComment4V2Models())
         let post = Post(title: "title")
         
-        let connected = asyncExpectation(description: "subscription connected")
-        let onCreatedPost = asyncExpectation(description: "onCreatedPost received")
+        let connected = expectation(description: "subscription connected")
+        let onCreatedPost = expectation(description: "onCreatedPost received")
         let subscription = Amplify.API.subscribe(request: .subscription(of: Post.self, type: .onCreate))
         Task {
             do {
@@ -393,14 +393,14 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
                     case .connection(let subscriptionConnectionState):
                         log.verbose("Subscription connect state is \(subscriptionConnectionState)")
                         if case .connected = subscriptionConnectionState {
-                            await connected.fulfill()
+                            connected.fulfill()
                         }
                     case .data(let result):
                         switch result {
                         case .success(let createdPost):
                             log.verbose("Successfully got createdPost from subscription: \(createdPost)")
                             assertList(createdPost.comments!, state: .isNotLoaded(associatedIdentifiers: [post.id], associatedFields: ["post"]))
-                            await onCreatedPost.fulfill()
+                            onCreatedPost.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")
                         }
@@ -411,9 +411,9 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
             }
         }
         
-        await waitForExpectations([connected], timeout: 10)
+        await fulfillment(of: [connected], timeout: 10)
         try await mutate(.create(post))
-        await waitForExpectations([onCreatedPost], timeout: 10)
+        await fulfillment(of: [onCreatedPost], timeout: 10)
         subscription.cancel()
     }
     
@@ -421,8 +421,8 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
         await setup(withModels: PostComment4V2Models())
         let post = Post(title: "title")
         
-        let connected = asyncExpectation(description: "subscription connected")
-        let onCreatedPost = asyncExpectation(description: "onCreatedPost received")
+        let connected = expectation(description: "subscription connected")
+        let onCreatedPost = expectation(description: "onCreatedPost received")
         let subscriptionIncludes = Amplify.API.subscribe(request: .subscription(of: Post.self,
                                                                                 type: .onCreate,
                                                                                 includes: { post in [post.comments]}))
@@ -433,14 +433,14 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
                     case .connection(let subscriptionConnectionState):
                         log.verbose("Subscription connect state is \(subscriptionConnectionState)")
                         if case .connected = subscriptionConnectionState {
-                            await connected.fulfill()
+                            connected.fulfill()
                         }
                     case .data(let result):
                         switch result {
                         case .success(let createdPost):
                             log.verbose("Successfully got createdPost from subscription: \(createdPost)")
                             assertList(createdPost.comments!, state: .isLoaded(count: 0))
-                            await onCreatedPost.fulfill()
+                            onCreatedPost.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")
                         }
@@ -451,9 +451,9 @@ final class GraphQLLazyLoadPostComment4V2Tests: GraphQLLazyLoadBaseTest {
             }
         }
         
-        await waitForExpectations([connected], timeout: 10)
+        await fulfillment(of: [connected], timeout: 10)
         try await mutate(.create(post, includes: { post in [post.comments]}))
-        await waitForExpectations([onCreatedPost], timeout: 10)
+        await fulfillment(of: [onCreatedPost], timeout: 10)
         subscriptionIncludes.cancel()
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/DefaultPK/GraphQLLazyLoadDefaultPKTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/DefaultPK/GraphQLLazyLoadDefaultPKTests.swift
@@ -118,7 +118,7 @@ final class GraphQLLazyLoadDefaultPKTests: GraphQLLazyLoadBaseTest {
         }
 
         try await mutate(.create(child))
-        await waitForExpectations([onCreate], timeout: 10)
+        await fulfillment(of: [onCreate], timeout: 10)
         subscription.cancel()
     }
 
@@ -146,7 +146,7 @@ final class GraphQLLazyLoadDefaultPKTests: GraphQLLazyLoadBaseTest {
 
         try await mutate(.create(child))
         try await mutate(.create(parent))
-        await waitForExpectations([onCreate], timeout: 10)
+        await fulfillment(of: [onCreate], timeout: 10)
         subscription.cancel()
     }
 
@@ -171,7 +171,7 @@ final class GraphQLLazyLoadDefaultPKTests: GraphQLLazyLoadBaseTest {
         var updatingChild = child
         updatingChild.content = UUID().uuidString
         try await mutate(.update(updatingChild))
-        await waitForExpectations([onUpdate], timeout: 10)
+        await fulfillment(of: [onUpdate], timeout: 10)
         subscription.cancel()
     }
 
@@ -208,7 +208,7 @@ final class GraphQLLazyLoadDefaultPKTests: GraphQLLazyLoadBaseTest {
         var updatingParent = parent
         updatingParent.content = UUID().uuidString
         try await mutate(.update(updatingParent))
-        await waitForExpectations([onUpdate], timeout: 10)
+        await fulfillment(of: [onUpdate], timeout: 10)
         subscription.cancel()
     }
 
@@ -230,7 +230,7 @@ final class GraphQLLazyLoadDefaultPKTests: GraphQLLazyLoadBaseTest {
 
         try await mutate(.create(child))
         try await mutate(.delete(child))
-        await waitForExpectations([onDelete], timeout: 10)
+        await fulfillment(of: [onDelete], timeout: 10)
         subscription.cancel()
     }
 
@@ -261,7 +261,7 @@ final class GraphQLLazyLoadDefaultPKTests: GraphQLLazyLoadBaseTest {
         try await mutate(.create(child))
         try await mutate(.create(parent))
         try await mutate(.delete(parent))
-        await waitForExpectations([onDelete], timeout: 10)
+        await fulfillment(of: [onDelete], timeout: 10)
         subscription.cancel()
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/HasOneParentChild/GraphQLLazyLoadHasOneTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL12/HasOneParentChild/GraphQLLazyLoadHasOneTests.swift
@@ -113,7 +113,7 @@ final class GraphQLLazyLoadHasOneTests: GraphQLLazyLoadBaseTest {
             newChild.identifier == child.identifier
         }
         try await mutate(.create(child))
-        await waitForExpectations([onCreate], timeout: 10)
+        await fulfillment(of: [onCreate], timeout: 10)
         subscription.cancel()
     }
 
@@ -139,7 +139,7 @@ final class GraphQLLazyLoadHasOneTests: GraphQLLazyLoadBaseTest {
 
         try await mutate(.create(child))
         try await mutate(.create(parent))
-        await waitForExpectations([onCreate], timeout: 10)
+        await fulfillment(of: [onCreate], timeout: 10)
         subscription.cancel()
     }
 
@@ -163,7 +163,7 @@ final class GraphQLLazyLoadHasOneTests: GraphQLLazyLoadBaseTest {
         var updatingChild = child
         updatingChild.content = UUID().uuidString
         try await mutate(.update(updatingChild))
-        await waitForExpectations([onUpdate], timeout: 10)
+        await fulfillment(of: [onUpdate], timeout: 10)
         subscription.cancel()
     }
 
@@ -197,7 +197,7 @@ final class GraphQLLazyLoadHasOneTests: GraphQLLazyLoadBaseTest {
         updatingParent.hasOneParentChildId = anotherChild.id
         try await mutate(.create(anotherChild))
         try await mutate(.update(updatingParent))
-        await waitForExpectations([onUpdate], timeout: 10)
+        await fulfillment(of: [onUpdate], timeout: 10)
         subscription.cancel()
     }
 
@@ -219,7 +219,7 @@ final class GraphQLLazyLoadHasOneTests: GraphQLLazyLoadBaseTest {
 
         try await mutate(.create(child))
         try await mutate(.delete(child))
-        await waitForExpectations([onDelete], timeout: 10)
+        await fulfillment(of: [onDelete], timeout: 10)
         subscription.cancel()
     }
 
@@ -248,7 +248,7 @@ final class GraphQLLazyLoadHasOneTests: GraphQLLazyLoadBaseTest {
         try await mutate(.create(child))
         try await mutate(.create(parent))
         try await mutate(.delete(parent))
-        await waitForExpectations([onDelete], timeout: 10)
+        await fulfillment(of: [onDelete], timeout: 10)
         subscription.cancel()
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL3/GraphQLLazyLoadPostCommentWithCompositeKeyTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL3/GraphQLLazyLoadPostCommentWithCompositeKeyTests.swift
@@ -273,8 +273,8 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
         await setup(withModels: PostCommentWithCompositeKeyModels())
         let post = Post(title: "title")
         try await mutate(.create(post))
-        let connected = asyncExpectation(description: "subscription connected")
-        let onCreatedComment = asyncExpectation(description: "onCreatedComment received")
+        let connected = expectation(description: "subscription connected")
+        let onCreatedComment = expectation(description: "onCreatedComment received")
         let subscription = Amplify.API.subscribe(request: .subscription(of: Comment.self, type: .onCreate))
         Task {
             do {
@@ -283,7 +283,7 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
                     case .connection(let subscriptionConnectionState):
                         log.verbose("Subscription connect state is \(subscriptionConnectionState)")
                         if case .connected = subscriptionConnectionState {
-                            await connected.fulfill()
+                            connected.fulfill()
                         }
                     case .data(let result):
                         switch result {
@@ -291,7 +291,7 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
                             log.verbose("Successfully got createdComment from subscription: \(createdComment)")
                             assertLazyReference(createdComment._post, state: .notLoaded(identifiers: [.init(name: "id", value: post.id),
                                                                                                   .init(name: "title", value: post.title)]))
-                            await onCreatedComment.fulfill()
+                            onCreatedComment.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")
                         }
@@ -302,10 +302,10 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
             }
         }
         
-        await waitForExpectations([connected], timeout: 10)
+        await fulfillment(of: [connected], timeout: 10)
         let comment = Comment(content: "content", post: post)
         try await mutate(.create(comment))
-        await waitForExpectations([onCreatedComment], timeout: 10)
+        await fulfillment(of: [onCreatedComment], timeout: 10)
         subscription.cancel()
     }
     
@@ -315,8 +315,8 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
         await setup(withModels: PostCommentWithCompositeKeyModels())
         let post = Post(title: "title")
         try await mutate(.create(post))
-        let connected = asyncExpectation(description: "subscription connected")
-        let onCreatedComment = asyncExpectation(description: "onCreatedComment received")
+        let connected = expectation(description: "subscription connected")
+        let onCreatedComment = expectation(description: "onCreatedComment received")
         let subscriptionIncludes = Amplify.API.subscribe(request: .subscription(of: Comment.self,
                                                                                 type: .onCreate,
                                                                                 includes: { comment in [comment.post]}))
@@ -327,14 +327,14 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
                     case .connection(let subscriptionConnectionState):
                         log.verbose("Subscription connect state is \(subscriptionConnectionState)")
                         if case .connected = subscriptionConnectionState {
-                            await connected.fulfill()
+                            connected.fulfill()
                         }
                     case .data(let result):
                         switch result {
                         case .success(let createdComment):
                             log.verbose("Successfully got createdComment from subscription: \(createdComment)")
                             assertLazyReference(createdComment._post, state: .loaded(model: post))
-                            await onCreatedComment.fulfill()
+                            onCreatedComment.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")
                         }
@@ -345,10 +345,10 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
             }
         }
         
-        await waitForExpectations([connected], timeout: 20)
+        await fulfillment(of: [connected], timeout: 20)
         let comment = Comment(content: "content", post: post)
         try await mutate(.create(comment, includes: { comment in [comment.post] }))
-        await waitForExpectations([onCreatedComment], timeout: 20)
+        await fulfillment(of: [onCreatedComment], timeout: 20)
         subscriptionIncludes.cancel()
     }
     
@@ -356,8 +356,8 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
         await setup(withModels: PostCommentWithCompositeKeyModels())
         let post = Post(title: "title")
         
-        let connected = asyncExpectation(description: "subscription connected")
-        let onCreatedPost = asyncExpectation(description: "onCreatedPost received")
+        let connected = expectation(description: "subscription connected")
+        let onCreatedPost = expectation(description: "onCreatedPost received")
         let subscription = Amplify.API.subscribe(request: .subscription(of: Post.self, type: .onCreate))
         Task {
             do {
@@ -366,14 +366,14 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
                     case .connection(let subscriptionConnectionState):
                         log.verbose("Subscription connect state is \(subscriptionConnectionState)")
                         if case .connected = subscriptionConnectionState {
-                            await connected.fulfill()
+                            connected.fulfill()
                         }
                     case .data(let result):
                         switch result {
                         case .success(let createdPost):
                             log.verbose("Successfully got createdPost from subscription: \(createdPost)")
                             assertList(createdPost.comments!, state: .isNotLoaded(associatedIdentifiers: [post.id, post.title], associatedFields: ["post"]))
-                            await onCreatedPost.fulfill()
+                            onCreatedPost.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")
                         }
@@ -384,9 +384,9 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
             }
         }
         
-        await waitForExpectations([connected], timeout: 10)
+        await fulfillment(of: [connected], timeout: 10)
         try await mutate(.create(post))
-        await waitForExpectations([onCreatedPost], timeout: 10)
+        await fulfillment(of: [onCreatedPost], timeout: 10)
         subscription.cancel()
     }
     
@@ -394,8 +394,8 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
         await setup(withModels: PostCommentWithCompositeKeyModels())
         let post = Post(title: "title")
         
-        let connected = asyncExpectation(description: "subscription connected")
-        let onCreatedPost = asyncExpectation(description: "onCreatedPost received")
+        let connected = expectation(description: "subscription connected")
+        let onCreatedPost = expectation(description: "onCreatedPost received")
         let subscriptionIncludes = Amplify.API.subscribe(request: .subscription(of: Post.self,
                                                                                 type: .onCreate,
                                                                                 includes: { post in [post.comments]}))
@@ -406,14 +406,14 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
                     case .connection(let subscriptionConnectionState):
                         log.verbose("Subscription connect state is \(subscriptionConnectionState)")
                         if case .connected = subscriptionConnectionState {
-                            await connected.fulfill()
+                            connected.fulfill()
                         }
                     case .data(let result):
                         switch result {
                         case .success(let createdPost):
                             log.verbose("Successfully got createdPost from subscription: \(createdPost)")
                             assertList(createdPost.comments!, state: .isLoaded(count: 0))
-                            await onCreatedPost.fulfill()
+                            onCreatedPost.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")
                         }
@@ -424,9 +424,9 @@ final class GraphQLLazyLoadPostCommentWithCompositeKeyTests: GraphQLLazyLoadBase
             }
         }
         
-        await waitForExpectations([connected], timeout: 10)
+        await fulfillment(of: [connected], timeout: 10)
         try await mutate(.create(post, includes: { post in [post.comments]}))
-        await waitForExpectations([onCreatedPost], timeout: 10)
+        await fulfillment(of: [onCreatedPost], timeout: 10)
         subscriptionIncludes.cancel()
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL7/GraphQLLazyLoadPostComment4Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL7/GraphQLLazyLoadPostComment4Tests.swift
@@ -171,8 +171,8 @@ final class GraphQLLazyLoadPostComment4Tests: GraphQLLazyLoadBaseTest {
         await setup(withModels: PostComment4Models())
         let post = Post(title: "title")
         try await mutate(.create(post))
-        let connected = asyncExpectation(description: "subscription connected")
-        let onCreatedComment = asyncExpectation(description: "onCreatedComment received")
+        let connected = expectation(description: "subscription connected")
+        let onCreatedComment = expectation(description: "onCreatedComment received")
         let subscription = Amplify.API.subscribe(request: .subscription(of: Comment.self, type: .onCreate))
         Task {
             do {
@@ -181,7 +181,7 @@ final class GraphQLLazyLoadPostComment4Tests: GraphQLLazyLoadBaseTest {
                     case .connection(let subscriptionConnectionState):
                         log.verbose("Subscription connect state is \(subscriptionConnectionState)")
                         if case .connected = subscriptionConnectionState {
-                            await connected.fulfill()
+                            connected.fulfill()
                         }
                     case .data(let result):
                         switch result {
@@ -189,7 +189,7 @@ final class GraphQLLazyLoadPostComment4Tests: GraphQLLazyLoadBaseTest {
                             log.verbose("Successfully got createdComment from subscription: \(createdComment)")
                             XCTAssertEqual(createdComment.post4CommentsPostId, post.postId)
                             XCTAssertEqual(createdComment.post4CommentsTitle, post.title)
-                            await onCreatedComment.fulfill()
+                            onCreatedComment.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")
                         }
@@ -200,10 +200,10 @@ final class GraphQLLazyLoadPostComment4Tests: GraphQLLazyLoadBaseTest {
             }
         }
         
-        await waitForExpectations([connected], timeout: 10)
+        await fulfillment(of: [connected], timeout: 10)
         let comment = Comment(content: "content", post: post)
         try await mutate(.create(comment))
-        await waitForExpectations([onCreatedComment], timeout: 10)
+        await fulfillment(of: [onCreatedComment], timeout: 10)
         subscription.cancel()
     }
     
@@ -211,8 +211,8 @@ final class GraphQLLazyLoadPostComment4Tests: GraphQLLazyLoadBaseTest {
         await setup(withModels: PostComment4Models())
         let post = Post(title: "title")
         
-        let connected = asyncExpectation(description: "subscription connected")
-        let onCreatedPost = asyncExpectation(description: "onCreatedPost received")
+        let connected = expectation(description: "subscription connected")
+        let onCreatedPost = expectation(description: "onCreatedPost received")
         let subscription = Amplify.API.subscribe(request: .subscription(of: Post.self, type: .onCreate))
         Task {
             do {
@@ -221,7 +221,7 @@ final class GraphQLLazyLoadPostComment4Tests: GraphQLLazyLoadBaseTest {
                     case .connection(let subscriptionConnectionState):
                         log.verbose("Subscription connect state is \(subscriptionConnectionState)")
                         if case .connected = subscriptionConnectionState {
-                            await connected.fulfill()
+                            connected.fulfill()
                         }
                     case .data(let result):
                         switch result {
@@ -231,7 +231,7 @@ final class GraphQLLazyLoadPostComment4Tests: GraphQLLazyLoadBaseTest {
                                                                                                           post.title],
                                                                                   associatedFields: ["post4CommentsPostId",
                                                                                                      "post4CommentsTitle"]))
-                            await onCreatedPost.fulfill()
+                            onCreatedPost.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")
                         }
@@ -242,9 +242,9 @@ final class GraphQLLazyLoadPostComment4Tests: GraphQLLazyLoadBaseTest {
             }
         }
         
-        await waitForExpectations([connected], timeout: 10)
+        await fulfillment(of: [connected], timeout: 10)
         try await mutate(.create(post))
-        await waitForExpectations([onCreatedPost], timeout: 10)
+        await fulfillment(of: [onCreatedPost], timeout: 10)
         subscription.cancel()
     }
     
@@ -252,8 +252,8 @@ final class GraphQLLazyLoadPostComment4Tests: GraphQLLazyLoadBaseTest {
         await setup(withModels: PostComment4Models())
         let post = Post(title: "title")
         
-        let connected = asyncExpectation(description: "subscription connected")
-        let onCreatedPost = asyncExpectation(description: "onCreatedPost received")
+        let connected = expectation(description: "subscription connected")
+        let onCreatedPost = expectation(description: "onCreatedPost received")
         let subscriptionIncludes = Amplify.API.subscribe(request: .subscription(of: Post.self,
                                                                                 type: .onCreate,
                                                                                 includes: { post in [post.comments]}))
@@ -264,14 +264,14 @@ final class GraphQLLazyLoadPostComment4Tests: GraphQLLazyLoadBaseTest {
                     case .connection(let subscriptionConnectionState):
                         log.verbose("Subscription connect state is \(subscriptionConnectionState)")
                         if case .connected = subscriptionConnectionState {
-                            await connected.fulfill()
+                            connected.fulfill()
                         }
                     case .data(let result):
                         switch result {
                         case .success(let createdPost):
                             log.verbose("Successfully got createdPost from subscription: \(createdPost)")
                             assertList(createdPost.comments!, state: .isLoaded(count: 0))
-                            await onCreatedPost.fulfill()
+                            onCreatedPost.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")
                         }
@@ -282,9 +282,9 @@ final class GraphQLLazyLoadPostComment4Tests: GraphQLLazyLoadBaseTest {
             }
         }
         
-        await waitForExpectations([connected], timeout: 10)
+        await fulfillment(of: [connected], timeout: 10)
         try await mutate(.create(post, includes: { post in [post.comments]}))
-        await waitForExpectations([onCreatedPost], timeout: 10)
+        await fulfillment(of: [onCreatedPost], timeout: 10)
         subscriptionIncludes.cancel()
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL8/GraphQLLazyLoadProjectTeam5Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL8/GraphQLLazyLoadProjectTeam5Tests.swift
@@ -236,8 +236,8 @@ class GraphQLLazyLoadProjectTeam5Tests: GraphQLLazyLoadBaseTest {
     
     func testSubscribeToTeam() async throws {
         await setup(withModels: ProjectTeam5Models())
-        let connected = asyncExpectation(description: "subscription connected")
-        let onCreatedTeam = asyncExpectation(description: "onCreate received")
+        let connected = expectation(description: "subscription connected")
+        let onCreatedTeam = expectation(description: "onCreate received")
         let subscription = Amplify.API.subscribe(request: .subscription(of: Team.self, type: .onCreate))
         Task {
             do {
@@ -246,13 +246,13 @@ class GraphQLLazyLoadProjectTeam5Tests: GraphQLLazyLoadBaseTest {
                     case .connection(let subscriptionConnectionState):
                         log.verbose("Subscription connect state is \(subscriptionConnectionState)")
                         if case .connected = subscriptionConnectionState {
-                            await connected.fulfill()
+                            connected.fulfill()
                         }
                     case .data(let result):
                         switch result {
                         case .success(let createdTeam):
                             log.verbose("Successfully got createdTeam from subscription: \(createdTeam)")
-                            await onCreatedTeam.fulfill()
+                            onCreatedTeam.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")
                         }
@@ -263,18 +263,19 @@ class GraphQLLazyLoadProjectTeam5Tests: GraphQLLazyLoadBaseTest {
             }
         }
         
-        await waitForExpectations([connected], timeout: 10)
+        await fulfillment(of: [connected], timeout: 10)
         
         let team = Team(teamId: UUID().uuidString, name: "name")
         let savedTeam = try await mutate(.create(team))
-        await waitForExpectations([onCreatedTeam], timeout: 10)
+        _ = savedTeam
+        await fulfillment(of: [onCreatedTeam], timeout: 10)
         subscription.cancel()
     }
     
     func testSubscribeProject() async throws {
         await setup(withModels: ProjectTeam5Models())
-        let connected = asyncExpectation(description: "subscription connected")
-        let onCreated = asyncExpectation(description: "onCreate received")
+        let connected = expectation(description: "subscription connected")
+        let onCreated = expectation(description: "onCreate received")
         let subscription = Amplify.API.subscribe(request: .subscription(of: Project.self, type: .onCreate))
         Task {
             do {
@@ -283,13 +284,13 @@ class GraphQLLazyLoadProjectTeam5Tests: GraphQLLazyLoadBaseTest {
                     case .connection(let subscriptionConnectionState):
                         log.verbose("Subscription connect state is \(subscriptionConnectionState)")
                         if case .connected = subscriptionConnectionState {
-                            await connected.fulfill()
+                            connected.fulfill()
                         }
                     case .data(let result):
                         switch result {
                         case .success(let created):
                             log.verbose("Successfully got model from subscription: \(created)")
-                            await onCreated.fulfill()
+                            onCreated.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")
                         }
@@ -300,13 +301,14 @@ class GraphQLLazyLoadProjectTeam5Tests: GraphQLLazyLoadBaseTest {
             }
         }
         
-        await waitForExpectations([connected], timeout: 10)
+        await fulfillment(of: [connected], timeout: 10)
         
         let project = Project(projectId: UUID().uuidString,
                               name: "name")
         let savedProject = try await mutate(.create(project))
-        
-        await waitForExpectations([onCreated], timeout: 10)
+        _ = savedProject
+
+        await fulfillment(of: [onCreated], timeout: 10)
         subscription.cancel()
     }
 }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL9/GraphQLLazyLoadProjectTeam6Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/LL9/GraphQLLazyLoadProjectTeam6Tests.swift
@@ -207,8 +207,8 @@ class GraphQLLazyLoadProjectTeam6Tests: GraphQLLazyLoadBaseTest {
     
     func testSubscribeToTeam() async throws {
         await setup(withModels: ProjectTeam6Models())
-        let connected = asyncExpectation(description: "subscription connected")
-        let onCreatedTeam = asyncExpectation(description: "onCreate received")
+        let connected = expectation(description: "subscription connected")
+        let onCreatedTeam = expectation(description: "onCreate received")
         let subscription = Amplify.API.subscribe(request: .subscription(of: Team.self, type: .onCreate))
         Task {
             do {
@@ -217,13 +217,13 @@ class GraphQLLazyLoadProjectTeam6Tests: GraphQLLazyLoadBaseTest {
                     case .connection(let subscriptionConnectionState):
                         log.verbose("Subscription connect state is \(subscriptionConnectionState)")
                         if case .connected = subscriptionConnectionState {
-                            await connected.fulfill()
+                            connected.fulfill()
                         }
                     case .data(let result):
                         switch result {
                         case .success(let createdTeam):
                             log.verbose("Successfully got createdTeam from subscription: \(createdTeam)")
-                            await onCreatedTeam.fulfill()
+                            onCreatedTeam.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")
                         }
@@ -234,18 +234,18 @@ class GraphQLLazyLoadProjectTeam6Tests: GraphQLLazyLoadBaseTest {
             }
         }
         
-        await waitForExpectations([connected], timeout: 10)
+        await fulfillment(of: [connected], timeout: 10)
         
         let team = Team(teamId: UUID().uuidString, name: "name")
         let savedTeam = try await mutate(.create(team))
-        await waitForExpectations([onCreatedTeam], timeout: 10)
+        await fulfillment(of: [onCreatedTeam], timeout: 10)
         subscription.cancel()
     }
     
     func testSubscribeProject() async throws {
         await setup(withModels: ProjectTeam6Models())
-        let connected = asyncExpectation(description: "subscription connected")
-        let onCreated = asyncExpectation(description: "onCreate received")
+        let connected = expectation(description: "subscription connected")
+        let onCreated = expectation(description: "onCreate received")
         let subscription = Amplify.API.subscribe(request: .subscription(of: Project.self, type: .onCreate))
         Task {
             do {
@@ -254,13 +254,13 @@ class GraphQLLazyLoadProjectTeam6Tests: GraphQLLazyLoadBaseTest {
                     case .connection(let subscriptionConnectionState):
                         log.verbose("Subscription connect state is \(subscriptionConnectionState)")
                         if case .connected = subscriptionConnectionState {
-                            await connected.fulfill()
+                            connected.fulfill()
                         }
                     case .data(let result):
                         switch result {
                         case .success(let created):
                             log.verbose("Successfully got model from subscription: \(created)")
-                            await onCreated.fulfill()
+                            onCreated.fulfill()
                         case .failure(let error):
                             XCTFail("Got failed result with \(error.errorDescription)")
                         }
@@ -271,13 +271,14 @@ class GraphQLLazyLoadProjectTeam6Tests: GraphQLLazyLoadBaseTest {
             }
         }
         
-        await waitForExpectations([connected], timeout: 10)
+        await fulfillment(of: [connected], timeout: 10)
         
         let project = Project(projectId: UUID().uuidString,
                               name: "name")
         let savedProject = try await mutate(.create(project))
-        
-        await waitForExpectations([onCreated], timeout: 10)
+        _ = savedProject
+
+        await fulfillment(of: [onCreated], timeout: 10)
         subscription.cancel()
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListProviderTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListProviderTests.swift
@@ -108,14 +108,14 @@ class AppSyncListProviderTests: XCTestCase {
     func testLoadedStateLoadSuccess() async throws {
         let elements = [Post4(title: "title"), Post4(title: "title")]
         let listProvider = AppSyncListProvider(elements: elements)
-        let loadCompleted = asyncExpectation(description: "Load Completed")
+        let loadCompleted = expectation(description: "Load Completed")
         
         Task {
             let posts = try await listProvider.load()
             XCTAssertEqual(posts.count, 2)
-            await loadCompleted.fulfill()
+            loadCompleted.fulfill()
         }
-        await waitForExpectations([loadCompleted], timeout: 1)
+        await fulfillment(of: [loadCompleted], timeout: 1)
     }
 
     func testNotLoadedStateLoadSuccess() async throws {
@@ -144,13 +144,13 @@ class AppSyncListProviderTests: XCTestCase {
             XCTFail("Should not be loaded")
             return
         }
-        let loadCompleted = asyncExpectation(description: "Load Completed")
+        let loadCompleted = expectation(description: "Load Completed")
         
         Task {
             _ = try await provider.load()
-            await loadCompleted.fulfill()
+            loadCompleted.fulfill()
         }
-        await waitForExpectations([loadCompleted], timeout: 1)
+        await fulfillment(of: [loadCompleted], timeout: 1)
         
         guard case .loaded(let elements, let nextToken, let filterOptional) = provider.loadedState else {
             XCTFail("Should be loaded")
@@ -181,7 +181,7 @@ class AppSyncListProviderTests: XCTestCase {
             XCTFail("Should not be loaded")
             return
         }
-        let loadCompleted = asyncExpectation(description: "Load Completed")
+        let loadCompleted = expectation(description: "Load Completed")
         Task {
             do {
                 _ = try await provider.load()
@@ -196,10 +196,10 @@ class AppSyncListProviderTests: XCTestCase {
                     XCTFail("Should not be loaded")
                     return
                 }
-                await loadCompleted.fulfill()
+                loadCompleted.fulfill()
             }
         }
-        await waitForExpectations([loadCompleted], timeout: 1)
+        await fulfillment(of: [loadCompleted], timeout: 1)
     }
     
     func testNotLoadedStateLoadWithCompletionSuccess() async {
@@ -228,13 +228,13 @@ class AppSyncListProviderTests: XCTestCase {
             XCTFail("Should not be loaded")
             return
         }
-        let loadComplete = asyncExpectation(description: "Load completed")
+        let loadComplete = expectation(description: "Load completed")
         Task {
             _ = try await provider.load()
-            await loadComplete.fulfill()
+            loadComplete.fulfill()
         }
         
-        await waitForExpectations([loadComplete], timeout: 1)
+        await fulfillment(of: [loadComplete], timeout: 1)
         
         guard case .loaded(let elements, let nextToken, let filterOptional) = provider.loadedState else {
             XCTFail("Should be loaded")
@@ -265,7 +265,7 @@ class AppSyncListProviderTests: XCTestCase {
             XCTFail("Should not be loaded")
             return
         }
-        let loadComplete = asyncExpectation(description: "Load completed")
+        let loadComplete = expectation(description: "Load completed")
         Task {
             do {
                 _ = try await provider.load()
@@ -276,10 +276,10 @@ class AppSyncListProviderTests: XCTestCase {
                     XCTFail("Unexpected error \(error)")
                     return
                 }
-                await loadComplete.fulfill()
+                loadComplete.fulfill()
             }
         }
-        await waitForExpectations([loadComplete], timeout: 1)
+        await fulfillment(of: [loadComplete], timeout: 1)
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
             return
@@ -301,7 +301,7 @@ class AppSyncListProviderTests: XCTestCase {
             XCTFail("Should not be loaded")
             return
         }
-        let loadComplete = asyncExpectation(description: "Load completed")
+        let loadComplete = expectation(description: "Load completed")
         Task {
             
             do {
@@ -313,11 +313,11 @@ class AppSyncListProviderTests: XCTestCase {
                     XCTFail("Unexpected error \(error)")
                     return
                 }
-                await loadComplete.fulfill()
+                loadComplete.fulfill()
             }
             
         }
-        await waitForExpectations([loadComplete], timeout: 1)
+        await fulfillment(of: [loadComplete], timeout: 1)
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
             return
@@ -350,7 +350,7 @@ class AppSyncListProviderTests: XCTestCase {
             XCTFail("Should not be loaded")
             return
         }
-        let loadComplete = asyncExpectation(description: "Load completed")
+        let loadComplete = expectation(description: "Load completed")
         Task {
             do {
                 _ = try await provider.load()
@@ -360,11 +360,11 @@ class AppSyncListProviderTests: XCTestCase {
                     XCTFail("Unexpected error \(error)")
                     return
                 }
-                await loadComplete.fulfill()
+                loadComplete.fulfill()
                 
             }
         }
-        await waitForExpectations([loadComplete], timeout: 1)
+        await fulfillment(of: [loadComplete], timeout: 1)
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
             return

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
@@ -110,8 +110,8 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
             valueListener: valueListener,
             completionListener: completionListener
         )
-        await waitForExpectations(timeout: 5)
-        
+        await fulfillment(of: [receivedValueConnecting], timeout: 5)
+
         let receivedCompletion = expectation(description: "Received completion")
         let receivedFailure = expectation(description: "Received failure")
         receivedFailure.isInverted = true
@@ -145,7 +145,11 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
         
         operation.cancel()
         XCTAssert(operation.isCancelled)
-        await waitForExpectations(timeout: 5)
+
+        await fulfillment(
+            of: [receivedCompletion, receivedFailure, receivedValueDisconnected],
+            timeout: 5
+        )
     }
     
     func testFailureOnConnection() async {
@@ -184,7 +188,12 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
             valueListener: valueListener,
             completionListener: completionListener
         )
-        await waitForExpectations(timeout: 0.3)
+
+        await fulfillment(
+            of: [receivedCompletion, receivedFailure, receivedValue],
+            timeout: 0.3
+        )
+
         XCTAssert(operation.isFinished)
     }
 
@@ -221,7 +230,11 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
             valueListener: valueListener,
             completionListener: nil
         )
-        await waitForExpectations(timeout: 5)
+        await fulfillment(
+            of: [receivedValue, connectionCreation],
+            timeout: 5
+        )
+
         let receivedFailure = expectation(description: "Received failure")
         receivedFailure.isInverted = true
         let receivedCompletion = expectation(description: "Received completion")
@@ -237,6 +250,9 @@ class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
         
         operation.cancel()
         XCTAssert(operation.isCancelled)
-        await waitForExpectations(timeout: 5)
+        await fulfillment(
+            of: [receivedCompletion, receivedFailure],
+            timeout: 5
+        )
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionTaskRunnerCancelTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionTaskRunnerCancelTests.swift
@@ -84,10 +84,11 @@ class AWSGraphQLSubscriptionTaskRunnerCancelTests: XCTestCase {
                                      variables: nil,
                                      responseType: JSONValue.self)
 
-        let receivedValueConnecting = asyncExpectation(description: "Received value for connecting")
-        let receivedValueDisconnected = asyncExpectation(description: "Received value for disconnected")
-        let receivedCompletion = asyncExpectation(description: "Received completion")
-        let receivedFailure = asyncExpectation(description: "Received failure", isInverted: true)
+        let receivedValueConnecting = expectation(description: "Received value for connecting")
+        let receivedValueDisconnected = expectation(description: "Received value for disconnected")
+        let receivedCompletion = expectation(description: "Received completion")
+        let receivedFailure = expectation(description: "Received failure")
+        receivedFailure.isInverted = true
         let subscriptionEvents = apiPlugin.subscribe(request: request)
         Task {
             do {
@@ -96,9 +97,9 @@ class AWSGraphQLSubscriptionTaskRunnerCancelTests: XCTestCase {
                     case .connection(let state):
                         switch state {
                         case .connecting:
-                            await receivedValueConnecting.fulfill()
+                            receivedValueConnecting.fulfill()
                         case .disconnected:
-                            await receivedValueDisconnected.fulfill()
+                            receivedValueDisconnected.fulfill()
                         default:
                             XCTFail("Unexpected value on value listener: \(state)")
                         }
@@ -106,14 +107,14 @@ class AWSGraphQLSubscriptionTaskRunnerCancelTests: XCTestCase {
                         XCTFail("Unexpected value on on value listener: \(subscriptionEvent)")
                     }
                 }
-                await receivedCompletion.fulfill()
+                receivedCompletion.fulfill()
             } catch {
-                await receivedFailure.fulfill()
+                receivedFailure.fulfill()
             }
         }
-        await waitForExpectations([receivedValueConnecting])
+        await fulfillment(of: [receivedValueConnecting], timeout: 1)
         subscriptionEvents.cancel()
-        await waitForExpectations([receivedValueDisconnected, receivedCompletion, receivedFailure])
+        await fulfillment(of: [receivedValueDisconnected, receivedCompletion, receivedFailure], timeout: 1)
     }
     
     func testFailureOnConnection() async {
@@ -128,29 +129,31 @@ class AWSGraphQLSubscriptionTaskRunnerCancelTests: XCTestCase {
                                      variables: nil,
                                      responseType: JSONValue.self)
 
-        let receivedCompletion = asyncExpectation(description: "Received completion", isInverted: true)
-        let receivedFailure = asyncExpectation(description: "Received failure")
-        let receivedValue = asyncExpectation(description: "Received value for connecting", isInverted: true)
+        let receivedCompletion = expectation(description: "Received completion")
+        receivedCompletion.isInverted = true
+        let receivedFailure = expectation(description: "Received failure")
+        let receivedValue = expectation(description: "Received value for connecting")
+        receivedValue.isInverted = true
 
         let subscriptionEvents = apiPlugin.subscribe(request: request)
         Task {
             do {
                 for try await _ in subscriptionEvents {
-                    await receivedValue.fulfill()
+                    receivedValue.fulfill()
                 }
-                await receivedCompletion.fulfill()
+                receivedCompletion.fulfill()
             } catch {
-                await receivedFailure.fulfill()
+                receivedFailure.fulfill()
             }
         }
         
-        await waitForExpectations([receivedValue, receivedFailure, receivedCompletion], timeout: 0.3)
+        await fulfillment(of: [receivedValue, receivedFailure, receivedCompletion], timeout: 0.3)
     }
 
     func testCallingCancelWhileCreatingConnectionShouldCallCompletionListener() async {
-        let connectionCreation = asyncExpectation(description: "connection factory called")
+        let connectionCreation = expectation(description: "connection factory called")
         let mockSubscriptionConnectionFactory = MockSubscriptionConnectionFactory(onGetOrCreateConnection: { _, _, _, _, _ in
-            Task { await connectionCreation.fulfill() }
+            connectionCreation.fulfill()
             return MockSubscriptionConnection(onSubscribe: { (_, _, eventHandler) -> SubscriptionItem in
                 let item = SubscriptionItem(requestString: "", variables: nil, eventHandler: { _, _ in
                 })
@@ -167,23 +170,28 @@ class AWSGraphQLSubscriptionTaskRunnerCancelTests: XCTestCase {
                                      variables: nil,
                                      responseType: JSONValue.self)
         
-        let receivedValue = asyncExpectation(description: "Received value for connecting", expectedFulfillmentCount: 1)
-        let receivedFailure = asyncExpectation(description: "Received failure", isInverted: true)
-        let receivedCompletion = asyncExpectation(description: "Received completion")
+        let receivedValue = expectation(description: "Received value for connecting")
+        receivedValue.expectedFulfillmentCount = 1
+        receivedValue.assertForOverFulfill = false
+
+        let receivedFailure = expectation(description: "Received failure")
+        receivedFailure.isInverted = true
+
+        let receivedCompletion = expectation(description: "Received completion")
         
         let subscriptionEvents = apiPlugin.subscribe(request: request)
         Task {
             do {
                 for try await _ in subscriptionEvents {
-                    await receivedValue.fulfill()
+                    receivedValue.fulfill()
                 }
-                await receivedCompletion.fulfill()
+                receivedCompletion.fulfill()
             } catch {
-                await receivedFailure.fulfill()
+                receivedFailure.fulfill()
             }
         }
-        await waitForExpectations([receivedValue, connectionCreation], timeout: 5)
+        await fulfillment(of: [receivedValue, connectionCreation], timeout: 5)
         subscriptionEvents.cancel()
-        await waitForExpectations([receivedFailure, receivedCompletion], timeout: 5)
+        await fulfillment(of: [receivedFailure, receivedCompletion], timeout: 5)
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTaskTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTaskTests.swift
@@ -17,18 +17,18 @@ import AppSyncRealTimeClient
 class GraphQLSubscribeTasksTests: OperationTestBase {
 
     // Setup expectations
-    var onSubscribeInvoked: AsyncExpectation!
-    var receivedCompletionSuccess: AsyncExpectation!
-    var receivedCompletionFailure: AsyncExpectation!
-    
+    var onSubscribeInvoked: XCTestExpectation!
+    var receivedCompletionSuccess: XCTestExpectation!
+    var receivedCompletionFailure: XCTestExpectation!
+
     // Subscription state expectations
-    var receivedStateValueConnecting: AsyncExpectation!
-    var receivedStateValueConnected: AsyncExpectation!
-    var receivedStateValueDisconnected: AsyncExpectation!
+    var receivedStateValueConnecting: XCTestExpectation!
+    var receivedStateValueConnected: XCTestExpectation!
+    var receivedStateValueDisconnected: XCTestExpectation!
 
     // Subscription item expectations
-    var receivedDataValueSuccess: AsyncExpectation!
-    var receivedDataValueError: AsyncExpectation!
+    var receivedDataValueSuccess: XCTestExpectation!
+    var receivedDataValueError: XCTestExpectation!
 
     // Handles to the subscription item and event handler used to make mock calls into the
     // subscription system
@@ -42,45 +42,44 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
     override func setUp() async throws {
         try await super.setUp()
 
-        onSubscribeInvoked = asyncExpectation(description: "onSubscribeInvoked")
+        onSubscribeInvoked = expectation(description: "onSubscribeInvoked")
 
-        receivedCompletionSuccess = asyncExpectation(description: "receivedStateCompletionSuccess")
-        receivedCompletionFailure = asyncExpectation(description: "receivedStateCompletionFailure")
-        receivedStateValueConnecting = asyncExpectation(description: "receivedStateValueConnecting")
-        receivedStateValueConnected = asyncExpectation(description: "receivedStateValueConnected")
-        receivedStateValueDisconnected = asyncExpectation(description: "receivedStateValueDisconnected")
+        receivedCompletionSuccess = expectation(description: "receivedStateCompletionSuccess")
+        receivedCompletionFailure = expectation(description: "receivedStateCompletionFailure")
+        receivedStateValueConnecting = expectation(description: "receivedStateValueConnecting")
+        receivedStateValueConnected = expectation(description: "receivedStateValueConnected")
+        receivedStateValueDisconnected = expectation(description: "receivedStateValueDisconnected")
 
-        receivedDataValueSuccess = asyncExpectation(description: "receivedDataValueSuccess")
-        receivedDataValueError = asyncExpectation(description: "receivedDataValueError")
+        receivedDataValueSuccess = expectation(description: "receivedDataValueSuccess")
+        receivedDataValueError = expectation(description: "receivedDataValueError")
 
         try setUpMocksAndSubscriptionItems()
     }
 
     func waitForSubscriptionExpectations() async {
-        await waitForExpectations([receivedCompletionSuccess,
-                                   receivedCompletionFailure,
-                                   receivedStateValueConnecting,
-                                   receivedStateValueConnected,
-                                   receivedStateValueDisconnected,
-                                   receivedDataValueSuccess,
-                                   receivedDataValueError], timeout: 0.05)
+        await fulfillment(
+            of: [
+                receivedCompletionSuccess,
+                receivedCompletionFailure,
+                receivedStateValueConnecting,
+                receivedStateValueConnected,
+                receivedStateValueDisconnected,
+                receivedDataValueSuccess,
+                receivedDataValueError
+            ],
+            timeout: 0.05
+        )
     }
     
     func testHappyPath() async throws {
-        await receivedCompletionSuccess.setShouldTrigger(true)
-        await receivedCompletionFailure.setShouldTrigger(false)
-        await receivedStateValueConnecting.setShouldTrigger(true)
-        await receivedStateValueConnected.setShouldTrigger(true)
-        await receivedStateValueDisconnected.setShouldTrigger(true)
-
-        await receivedDataValueSuccess.setShouldTrigger(true)
-        await receivedDataValueError.setShouldTrigger(false)
+        receivedCompletionFailure.isInverted = true
+        receivedDataValueError.isInverted = true
 
         let testJSON: JSONValue = ["foo": true]
         let testData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
 
         try await subscribe(expecting: testJSON)
-        await waitForExpectations([onSubscribeInvoked], timeout: 0.05)
+        await fulfillment(of: [onSubscribeInvoked], timeout: 0.05)
 
         subscriptionEventHandler(.connection(.connecting), subscriptionItem)
         subscriptionEventHandler(.connection(.connected), subscriptionItem)
@@ -91,17 +90,12 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
     }
 
     func testConnectionWithNoData() async throws {
-        await receivedCompletionSuccess.setShouldTrigger(true)
-        await receivedCompletionFailure.setShouldTrigger(false)
-        await receivedStateValueConnecting.setShouldTrigger(true)
-        await receivedStateValueConnected.setShouldTrigger(true)
-        await receivedStateValueDisconnected.setShouldTrigger(true)
-
-        await receivedDataValueSuccess.setShouldTrigger(false)
-        await receivedDataValueError.setShouldTrigger(false)
+        receivedCompletionFailure.isInverted = true
+        receivedDataValueSuccess.isInverted = true
+        receivedDataValueError.isInverted = true
 
         try await subscribe()
-        await waitForExpectations([onSubscribeInvoked], timeout: 0.05)
+        await fulfillment(of: [onSubscribeInvoked], timeout: 0.05)
 
         subscriptionEventHandler(.connection(.connecting), subscriptionItem)
         subscriptionEventHandler(.connection(.connected), subscriptionItem)
@@ -111,17 +105,14 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
     }
 
     func testConnectionErrorWithLimitExceeded() async throws {
-        await receivedCompletionSuccess.setShouldTrigger(false)
-        await receivedCompletionFailure.setShouldTrigger(true)
-        await receivedStateValueConnecting.setShouldTrigger(true)
-        await receivedStateValueConnected.setShouldTrigger(false)
-        await receivedStateValueDisconnected.setShouldTrigger(false)
-
-        await receivedDataValueSuccess.setShouldTrigger(false)
-        await receivedDataValueError.setShouldTrigger(false)
+        receivedCompletionSuccess.isInverted = true
+        receivedStateValueConnected.isInverted = true
+        receivedStateValueDisconnected.isInverted = true
+        receivedDataValueSuccess.isInverted = true
+        receivedDataValueError.isInverted = true
 
         try await subscribe()
-        await waitForExpectations([onSubscribeInvoked], timeout: 0.05)
+        await fulfillment(of: [onSubscribeInvoked], timeout: 0.05)
 
         subscriptionEventHandler(.connection(.connecting), subscriptionItem)
         subscriptionEventHandler(.failed(ConnectionProviderError.limitExceeded(nil)), subscriptionItem)
@@ -130,17 +121,14 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
     }
     
     func testConnectionErrorWithSubscriptionError() async throws {
-        await receivedCompletionSuccess.setShouldTrigger(false)
-        await receivedCompletionFailure.setShouldTrigger(true)
-        await receivedStateValueConnecting.setShouldTrigger(true)
-        await receivedStateValueConnected.setShouldTrigger(false)
-        await receivedStateValueDisconnected.setShouldTrigger(false)
-
-        await receivedDataValueSuccess.setShouldTrigger(false)
-        await receivedDataValueError.setShouldTrigger(false)
+        receivedCompletionSuccess.isInverted = true
+        receivedStateValueConnected.isInverted = true
+        receivedStateValueDisconnected.isInverted = true
+        receivedDataValueSuccess.isInverted = true
+        receivedDataValueError.isInverted = true
 
         try await subscribe()
-        await waitForExpectations([onSubscribeInvoked], timeout: 0.05)
+        await fulfillment(of: [onSubscribeInvoked], timeout: 0.05)
 
         subscriptionEventHandler(.connection(.connecting), subscriptionItem)
         subscriptionEventHandler(.failed(ConnectionProviderError.subscription("", nil)), subscriptionItem)
@@ -149,17 +137,14 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
     }
     
     func testConnectionErrorWithConnectionUnauthorizedError() async throws {
-        await receivedCompletionSuccess.setShouldTrigger(false)
-        await receivedCompletionFailure.setShouldTrigger(true)
-        await receivedStateValueConnecting.setShouldTrigger(true)
-        await receivedStateValueConnected.setShouldTrigger(false)
-        await receivedStateValueDisconnected.setShouldTrigger(false)
-
-        await receivedDataValueSuccess.setShouldTrigger(false)
-        await receivedDataValueError.setShouldTrigger(false)
+        receivedCompletionSuccess.isInverted = true
+        receivedStateValueConnected.isInverted = true
+        receivedStateValueDisconnected.isInverted = true
+        receivedDataValueSuccess.isInverted = true
+        receivedDataValueError.isInverted = true
 
         try await subscribe()
-        await waitForExpectations([onSubscribeInvoked], timeout: 0.05)
+        await fulfillment(of: [onSubscribeInvoked], timeout: 0.05)
 
         subscriptionEventHandler(.connection(.connecting), subscriptionItem)
         subscriptionEventHandler(.failed(ConnectionProviderError.unauthorized), subscriptionItem)
@@ -168,17 +153,14 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
     }
     
     func testConnectionErrorWithConnectionProviderConnectionError() async throws {
-        await receivedCompletionSuccess.setShouldTrigger(false)
-        await receivedCompletionFailure.setShouldTrigger(true)
-        await receivedStateValueConnecting.setShouldTrigger(true)
-        await receivedStateValueConnected.setShouldTrigger(false)
-        await receivedStateValueDisconnected.setShouldTrigger(false)
-
-        await receivedDataValueSuccess.setShouldTrigger(false)
-        await receivedDataValueError.setShouldTrigger(false)
+        receivedCompletionSuccess.isInverted = true
+        receivedStateValueConnected.isInverted = true
+        receivedStateValueDisconnected.isInverted = true
+        receivedDataValueSuccess.isInverted = true
+        receivedDataValueError.isInverted = true
 
         try await subscribe()
-        await waitForExpectations([onSubscribeInvoked], timeout: 0.05)
+        await fulfillment(of: [onSubscribeInvoked], timeout: 0.05)
 
         subscriptionEventHandler(.connection(.connecting), subscriptionItem)
         subscriptionEventHandler(.failed(ConnectionProviderError.connection), subscriptionItem)
@@ -188,17 +170,11 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
 
     func testDecodingError() async throws {
         let testData = #"{"data": {"foo": true}, "errors": []}"# .data(using: .utf8)!
-        await receivedCompletionSuccess.setShouldTrigger(true)
-        await receivedCompletionFailure.setShouldTrigger(false)
-        await receivedStateValueConnecting.setShouldTrigger(true)
-        await receivedStateValueConnected.setShouldTrigger(true)
-        await receivedStateValueDisconnected.setShouldTrigger(true)
-
-        await receivedDataValueSuccess.setShouldTrigger(false)
-        await receivedDataValueError.setShouldTrigger(true)
+        receivedCompletionFailure.isInverted = true
+        receivedDataValueSuccess.isInverted = true
 
         try await subscribe()
-        await waitForExpectations([onSubscribeInvoked], timeout: 0.05)
+        await fulfillment(of: [onSubscribeInvoked], timeout: 0.05)
 
         subscriptionEventHandler(.connection(.connecting), subscriptionItem)
         subscriptionEventHandler(.connection(.connected), subscriptionItem)
@@ -211,18 +187,13 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
     func testMultipleSuccessValues() async throws {
         let testJSON: JSONValue = ["foo": true]
         let testData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
-        await receivedCompletionSuccess.setShouldTrigger(true)
-        await receivedCompletionFailure.setShouldTrigger(false)
-        await receivedStateValueConnecting.setShouldTrigger(true)
-        await receivedStateValueConnected.setShouldTrigger(true)
-        await receivedStateValueDisconnected.setShouldTrigger(true)
 
-        await receivedDataValueSuccess.setShouldTrigger(true)
-        await receivedDataValueSuccess.setExpectedFulfillmentCount(2)
-        await receivedDataValueError.setShouldTrigger(false)
+        receivedCompletionFailure.isInverted = true
+        receivedDataValueError.isInverted = true
+        receivedDataValueSuccess.expectedFulfillmentCount = 2
 
         try await subscribe(expecting: testJSON)
-        await waitForExpectations([onSubscribeInvoked], timeout: 0.05)
+        await fulfillment(of: [onSubscribeInvoked], timeout: 0.05)
 
         subscriptionEventHandler(.connection(.connecting), subscriptionItem)
         subscriptionEventHandler(.connection(.connected), subscriptionItem)
@@ -236,18 +207,12 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
     func testMixedSuccessAndErrorValues() async throws {
         let successfulTestData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
         let invalidTestData = #"{"data": {"foo": true}, "errors": []}"# .data(using: .utf8)!
-        await receivedCompletionSuccess.setShouldTrigger(true)
-        await receivedCompletionFailure.setShouldTrigger(false)
-        await receivedStateValueConnecting.setShouldTrigger(true)
-        await receivedStateValueConnected.setShouldTrigger(true)
-        await receivedStateValueDisconnected.setShouldTrigger(true)
 
-        await receivedDataValueSuccess.setShouldTrigger(true)
-        await receivedDataValueSuccess.setExpectedFulfillmentCount(2)
-        await receivedDataValueError.setShouldTrigger(true)
+        receivedCompletionFailure.isInverted = true
+        receivedDataValueSuccess.expectedFulfillmentCount = 2
 
         try await subscribe()
-        await waitForExpectations([onSubscribeInvoked], timeout: 0.05)
+        await fulfillment(of: [onSubscribeInvoked], timeout: 0.05)
 
         subscriptionEventHandler(.connection(.connecting), subscriptionItem)
         subscriptionEventHandler(.connection(.connected), subscriptionItem)
@@ -275,7 +240,7 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
 
             self.subscriptionItem = item
             self.subscriptionEventHandler = eventHandler
-            Task { await self.onSubscribeInvoked.fulfill() }
+            self.onSubscribeInvoked.fulfill()
             return item
         }
 
@@ -307,11 +272,11 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
                     case .connection(let connectionState):
                         switch connectionState {
                         case .connecting:
-                            await self.receivedStateValueConnecting.fulfill()
+                            self.receivedStateValueConnecting.fulfill()
                         case .connected:
-                            await self.receivedStateValueConnected.fulfill()
+                            self.receivedStateValueConnected.fulfill()
                         case .disconnected:
-                            await self.receivedStateValueDisconnected.fulfill()
+                            self.receivedStateValueDisconnected.fulfill()
                         }
                     case .data(let result):
                         switch result {
@@ -319,21 +284,21 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
                             if let expectedValue = expectedValue {
                                 XCTAssertEqual(actualValue, expectedValue)
                             }
-                            await self.receivedDataValueSuccess.fulfill()
+                            self.receivedDataValueSuccess.fulfill()
                         case .failure:
-                            await self.receivedDataValueError.fulfill()
+                            self.receivedDataValueError.fulfill()
                         }
                     }
                 }
                 
-                await self.receivedCompletionSuccess.fulfill()
+                self.receivedCompletionSuccess.fulfill()
             } catch {
                 if let apiError = error as? APIError,
                    let expectedError = expectedCompletionFailureError {
                     XCTAssertEqual(apiError, expectedError)
                 }
                 
-                await self.receivedCompletionFailure.fulfill()
+                self.receivedCompletionFailure.fulfill()
             }
         }
     }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLResponseDecoder+DecodeDataTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLResponseDecoder+DecodeDataTests.swift
@@ -111,14 +111,14 @@ extension GraphQLResponseDecoderTests {
 
         let result = try decoder.decodeToResponseType(graphQLData)
         XCTAssertNotNil(result)
-        let fetchCompleted = asyncExpectation(description: "Fetch completed")
+        let fetchCompleted = expectation(description: "Fetch completed")
         Task {
             try await result.fetch()
             XCTAssertEqual(result.count, 2)
             XCTAssertFalse(result.hasNextPage())
-            await fetchCompleted.fulfill()
+            fetchCompleted.fulfill()
         }
-        await waitForExpectations([fetchCompleted], timeout: 1.0)
+        await fulfillment(of: [fetchCompleted], timeout: 1.0)
     }
 
     func testDecodeToResponseTypeForCodable() throws {

--- a/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AnalyticsStressTests/AnalyticsStressTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AnalyticsStressTests/AnalyticsStressTests.swift
@@ -49,24 +49,22 @@ final class AnalyticsStressTests: XCTestCase {
         }
         networkMonitor.start(queue: DispatchQueue(label: "AWSPinpointAnalyticsPluginIntergrationTests.NetworkMonitor"))
         
-        wait(for: [onlineExpectation], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [onlineExpectation], timeout: TestCommonConstants.networkTimeout)
         
-        let recordExpectation = asyncExpectation(description: "Records are successfully recorded",
-                                                 expectedFulfillmentCount: concurrencyLimit)
+        let recordExpectation = expectation(description: "Records are successfully recorded")
+        recordExpectation.expectedFulfillmentCount = concurrencyLimit
         for eventNumber in 0...concurrencyLimit {
-            Task {
-                let properties = ["eventPropertyStringKey1": "eventProperyStringValue1",
-                                  "eventPropertyStringKey2": "eventProperyStringValue2",
-                                  "eventPropertyStringKey3": "eventProperyStringValue3",
-                                  "eventPropertyStringKey4": "eventProperyStringValue4",
-                                  "eventPropertyStringKey5": "eventProperyStringValue5"] as [String: AnalyticsPropertyValue]
-                let event = BasicAnalyticsEvent(name: "eventName" + String(eventNumber), properties: properties)
-                Amplify.Analytics.record(event: event)
-                await recordExpectation.fulfill()
-            }
+            let properties = ["eventPropertyStringKey1": "eventProperyStringValue1",
+                              "eventPropertyStringKey2": "eventProperyStringValue2",
+                              "eventPropertyStringKey3": "eventProperyStringValue3",
+                              "eventPropertyStringKey4": "eventProperyStringValue4",
+                              "eventPropertyStringKey5": "eventProperyStringValue5"] as [String: AnalyticsPropertyValue]
+            let event = BasicAnalyticsEvent(name: "eventName" + String(eventNumber), properties: properties)
+            Amplify.Analytics.record(event: event)
+            recordExpectation.fulfill()
         }
 
-        await waitForExpectations([recordExpectation], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [recordExpectation], timeout: TestCommonConstants.networkTimeout)
     }
     
     /// - Given: Analytics plugin configured with valid configuration
@@ -82,10 +80,11 @@ final class AnalyticsStressTests: XCTestCase {
         }
         networkMonitor.start(queue: DispatchQueue(label: "AWSPinpointAnalyticsPluginIntergrationTests.NetworkMonitor"))
         
-        wait(for: [onlineExpectation], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [onlineExpectation], timeout: TestCommonConstants.networkTimeout)
         
-        let recordExpectation = asyncExpectation(description: "Records are successfully recorded",
-                                                 expectedFulfillmentCount: concurrencyLimit)
+        let recordExpectation = expectation(description: "Records are successfully recorded")
+        recordExpectation.expectedFulfillmentCount = concurrencyLimit
+
         for eventNumber in 0...concurrencyLimit {
             Task {
                 let properties = ["eventPropertyStringKey1": "eventProperyStringValue1",
@@ -110,11 +109,11 @@ final class AnalyticsStressTests: XCTestCase {
                                   "eventPropertyBoolKey5": true] as [String: AnalyticsPropertyValue]
                 let event = BasicAnalyticsEvent(name: "eventName" + String(eventNumber), properties: properties)
                 Amplify.Analytics.record(event: event)
-                await recordExpectation.fulfill()
+                recordExpectation.fulfill()
             }
         }
 
-        await waitForExpectations([recordExpectation], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [recordExpectation], timeout: TestCommonConstants.networkTimeout)
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/ClearCredentialsTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/ClearCredentialsTests.swift
@@ -50,7 +50,10 @@ class ClearCredentialsTests: XCTestCase {
         await action.execute(withDispatcher: MockDispatcher { _ in },
                         environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     /// Test is responsible to check if configuration error is correctly caught by the action
@@ -82,7 +85,10 @@ class ClearCredentialsTests: XCTestCase {
             }
         }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     /// Test is responsible to check if the clear credentials handle a known error
@@ -136,7 +142,10 @@ class ClearCredentialsTests: XCTestCase {
             }
         }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     /// Test is responsible to check if the clear credentials handle an unknown error
@@ -191,7 +200,10 @@ class ClearCredentialsTests: XCTestCase {
             }
         }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/LoadCredentialsTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/LoadCredentialsTests.swift
@@ -67,7 +67,10 @@ class LoadCredentialsTests: XCTestCase {
             }
         }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [loadCredentialHandlerInvoked],
+            timeout: 0.1
+        )
     }
 
     /// Test is responsible to check if configuration error is correctly caught by the action
@@ -99,7 +102,10 @@ class LoadCredentialsTests: XCTestCase {
             }
         }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     /// Test is responsible to check if the load credentials handle a known error
@@ -153,7 +159,10 @@ class LoadCredentialsTests: XCTestCase {
             }
         }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     /// Test is responsible to check if the load credentials handle an unknown error
@@ -210,7 +219,10 @@ class LoadCredentialsTests: XCTestCase {
             }
         }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MigrateLegacyCredentialStoreTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MigrateLegacyCredentialStoreTests.swift
@@ -72,7 +72,11 @@ class MigrateLegacyCredentialStoreTests: XCTestCase {
         let action = MigrateLegacyCredentialStore()
         await action.execute(withDispatcher: MockDispatcher { _ in }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+
+        await fulfillment(
+            of: [saveCredentialHandlerInvoked],
+            timeout: 0.1
+        )
     }
 
     /// Test is responsible for making sure that the legacy credential store clearing up is getting called for user pool and identity pool
@@ -115,8 +119,9 @@ class MigrateLegacyCredentialStoreTests: XCTestCase {
         let action = MigrateLegacyCredentialStore()
         await action.execute(withDispatcher: MockDispatcher { _ in }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
-
+        await fulfillment(
+            of: [migrationCompletionInvoked],
+            timeout: 0.1
+        )
     }
-
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchAWSCredentials/FetchAuthAWSCredentialsTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchAWSCredentials/FetchAuthAWSCredentialsTests.swift
@@ -30,7 +30,11 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
                 expectation.fulfill()
             }
         }, environment: MockInvalidEnvironment())
-        await waitForExpectations(timeout: 0.1)
+
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     func testInvalidIdentitySuccessfullResponse() async {
@@ -60,7 +64,10 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
             }
         }, environment: authEnvironment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     func testInvalidAWSCredentialSuccessfulResponse() async {
@@ -93,7 +100,10 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
             environment: authEnvironment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     func testValidSuccessfulResponse() async {
@@ -134,7 +144,11 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
             },
             environment: authEnvironment
         )
-        await waitForExpectations(timeout: 0.1)
+
+        await fulfillment(
+            of: [credentialValidExpectation],
+            timeout: 0.1
+        )
     }
 
     func testFailureResponse() async {
@@ -166,7 +180,11 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
             },
             environment: authEnvironment
         )
-        await waitForExpectations(timeout: 0.1)
+
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchUserPoolTokens/RefreshUserPoolTokensTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchUserPoolTokens/RefreshUserPoolTokensTests.swift
@@ -34,7 +34,10 @@ class RefreshUserPoolTokensTests: XCTestCase {
         }, environment: MockInvalidEnvironment()
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     func testInvalidSuccessfulResponse() async {
@@ -63,7 +66,10 @@ class RefreshUserPoolTokensTests: XCTestCase {
             userPoolFactory: identityProviderFactory)
         )
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 1
+        )
     }
 
     func testValidSuccessfulResponse() async {
@@ -93,7 +99,11 @@ class RefreshUserPoolTokensTests: XCTestCase {
         }, environment: Defaults.makeDefaultAuthEnvironment(
             userPoolFactory: identityProviderFactory)
         )
-        await waitForExpectations(timeout: 0.1)
+
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
     func testFailureResponse() async {
@@ -128,7 +138,10 @@ class RefreshUserPoolTokensTests: XCTestCase {
             }
         }, environment: environment)
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/InitializeFetchAuthSessionTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/InitializeFetchAuthSessionTests.swift
@@ -32,7 +32,10 @@ class InitializeFetchAuthSessionTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [expectation],
+            timeout: 0.1
+        )
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/InitiateAuthSRPTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/InitiateAuthSRPTests.swift
@@ -32,7 +32,10 @@ class InitiateAuthSRPTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [initiateAuthInvoked],
+            timeout: 0.1
+        )
     }
 
     func testFailedInitiateAuthPropagatesError() async {
@@ -70,7 +73,10 @@ class InitiateAuthSRPTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [errorEventSent],
+            timeout: 0.1
+        )
     }
 
     func testSuccessfulInitiateAuthPropagatesSuccess() async {
@@ -106,7 +112,9 @@ class InitiateAuthSRPTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [successEventSent],
+            timeout: 0.1
+        )
     }
-
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyPasswordSRPTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyPasswordSRPTests.swift
@@ -48,7 +48,10 @@ class VerifyPasswordSRPTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [verifyPasswordInvoked],
+            timeout: 0.1
+        )
     }
 
     /// Test empty response is returned by Cognito proper error is thrown
@@ -96,7 +99,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test invalid challenge response from initiate auth
@@ -144,7 +150,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test  challenge response with no salt from initiate auth
@@ -192,7 +201,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test  challenge response with no secretblock from initiate auth
@@ -240,7 +252,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test  challenge response with no SRPB from initiate auth
@@ -288,7 +303,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test  an exception from the SRP calculation
@@ -336,7 +354,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test  successful response from the VerifyPasswordSRP
@@ -364,7 +385,8 @@ class VerifyPasswordSRPTests: XCTestCase {
                                        clientMetadata: [:])
 
         let passwordVerifierCompletion = expectation(
-            description: "passwordVerifierCompletion")
+            description: "passwordVerifierCompletion"
+        )
 
         let dispatcher = MockDispatcher { event in
             guard let event = event as? SignInEvent else {
@@ -379,7 +401,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierCompletion],
+            timeout: 0.1
+        )
     }
 
     /// Test  successful response from the VerifyPasswordSRP
@@ -432,7 +457,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test verify password retry on device not found
@@ -478,7 +506,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test  successful response from the VerifyPasswordSRP for confirmDevice
@@ -521,7 +552,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierCompletion],
+            timeout: 0.1
+        )
     }
 
     /// Test  successful response from the VerifyPasswordSRP for verifyDevice
@@ -564,7 +598,10 @@ class VerifyPasswordSRPTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierCompletion],
+            timeout: 0.1
+        )
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/RevokeTokenTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/RevokeTokenTests.swift
@@ -38,7 +38,10 @@ class RevokeTokenTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [revokeTokenInvoked],
+            timeout: 0.1
+        )
     }
 
     func testFailedRevokeTokenTriggersClearCredentialStore() async {
@@ -79,7 +82,10 @@ class RevokeTokenTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [clearCredentialStoreEventSent],
+            timeout: 0.1
+        )
     }
 
     func testSuccessfulRevokeTokenTriggersClearCredentialStore() async {
@@ -120,7 +126,10 @@ class RevokeTokenTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [clearCredentialStoreEventSent],
+            timeout: 0.1
+        )
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/SignOutGloballyTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/SignOutGloballyTests.swift
@@ -36,7 +36,10 @@ class SignOutGloballyTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [globalSignOutInvoked],
+            timeout: 0.1
+        )
     }
 
     func testFailedGlobalSignOutTriggersBuildRevokeError() async {
@@ -75,7 +78,10 @@ class SignOutGloballyTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [revokeTokenEventSent],
+            timeout: 0.1
+        )
     }
 
     func testSuccessfulGlobalSignOutTriggersRevokeToken() async {
@@ -114,7 +120,9 @@ class SignOutGloballyTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [revokeTokenEventSent],
+            timeout: 0.1
+        )
     }
-
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/VerifySignInChallenge/VerifySignInChallengeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/VerifySignInChallenge/VerifySignInChallengeTests.swift
@@ -56,7 +56,10 @@ class VerifySignInChallengeTests: XCTestCase {
             environment: environment
         )
 
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [verifyPasswordInvoked],
+            timeout: 0.1
+        )
     }
 
     /// Test empty response is returned by Cognito proper error is thrown
@@ -103,7 +106,10 @@ class VerifySignInChallengeTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test  successful response from the VerifySignInChallenge
@@ -144,7 +150,10 @@ class VerifySignInChallengeTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [verifyChallengeComplete],
+            timeout: 0.1
+        )
     }
 
     /// Test  successful response from the VerifySignInChallenge
@@ -196,7 +205,10 @@ class VerifySignInChallengeTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test verify password retry on device not found
@@ -240,7 +252,10 @@ class VerifySignInChallengeTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [passwordVerifierError],
+            timeout: 0.1
+        )
     }
 
     /// Test  successful response from the VerifySignInChallenge for confirmDevice
@@ -281,7 +296,10 @@ class VerifySignInChallengeTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [verifyChallengeComplete],
+            timeout: 0.1
+        )
     }
 
     /// Test  successful response from the VerifySignInChallenge for verify device
@@ -322,6 +340,9 @@ class VerifySignInChallengeTests: XCTestCase {
         }
 
         await action.execute(withDispatcher: dispatcher, environment: environment)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [verifyChallengeComplete],
+            timeout: 0.1
+        )
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/HubEventTests/AuthHubEventHandlerTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/HubEventTests/AuthHubEventHandlerTests.swift
@@ -48,7 +48,10 @@ class AuthHubEventHandlerTests: XCTestCase {
             XCTFail("Received failure with error \(error)")
         }
 
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(
+            of: [hubEventExpectation],
+            timeout: networkTimeout
+        )
     }
 
     /// Test whether HubEvent emits a signOut event for mocked signOut operation
@@ -74,7 +77,10 @@ class AuthHubEventHandlerTests: XCTestCase {
         }
 
         _ = await plugin.signOut(options: nil)
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(
+            of: [hubEventExpectation],
+            timeout: networkTimeout
+        )
     }
 
     /// Test whether HubEvent emits a confirmSignedIn event for mocked signIn operation
@@ -105,7 +111,10 @@ class AuthHubEventHandlerTests: XCTestCase {
             XCTFail("Received failure with error \(error)")
         }
 
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(
+            of: [hubEventExpectation],
+            timeout: networkTimeout
+        )
     }
 
     /// Test whether HubEvent emits a deletedUser event for mocked delete user operation
@@ -136,7 +145,10 @@ class AuthHubEventHandlerTests: XCTestCase {
             XCTFail("Received failure with error \(error)")
         }
 
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(
+            of: [hubEventExpectation],
+            timeout: networkTimeout
+        )
     }
 
     /// Test whether HubEvent emits a sessionExpired event for mocked fetchSession operation with expired tokens
@@ -161,7 +173,10 @@ class AuthHubEventHandlerTests: XCTestCase {
             }
         }
         _ = try await plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options())
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(
+            of: [hubEventExpectation],
+            timeout: networkTimeout
+        )
     }
 
 #if os(iOS) || os(macOS)
@@ -195,7 +210,7 @@ class AuthHubEventHandlerTests: XCTestCase {
         } catch {
             XCTFail("Received failure with error \(error)")
         }
-        wait(for: [hubEventExpectation], timeout: 10)
+        await fulfillment(of: [hubEventExpectation], timeout: 10)
     }
 
     /// Test whether HubEvent emits a mocked signedIn event for social provider signIn
@@ -227,7 +242,7 @@ class AuthHubEventHandlerTests: XCTestCase {
         } catch {
             XCTFail("Received failure with error \(error)")
         }
-        wait(for: [hubEventExpectation], timeout: 10)
+        await fulfillment(of: [hubEventExpectation], timeout: 10)
     }
 #endif
 
@@ -254,7 +269,10 @@ class AuthHubEventHandlerTests: XCTestCase {
         }
         _ = try await  plugin.federateToIdentityPool(withProviderToken: "someToken", for: .facebook)
 
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(
+            of: [hubEventExpectation],
+            timeout: networkTimeout
+        )
     }
 
     /// Test whether HubEvent emits a federationToIdentityPoolCleared event for mocked federated operation
@@ -282,7 +300,10 @@ class AuthHubEventHandlerTests: XCTestCase {
         _ = try await plugin.federateToIdentityPool(withProviderToken: "something", for: .facebook)
         try await plugin.clearFederationToIdentityPool()
 
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(
+            of: [hubEventExpectation],
+            timeout: networkTimeout
+        )
     }
 
     private func configurePluginForSignInEvent() {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFederationToIdentityPoolTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFederationToIdentityPoolTests.swift
@@ -501,7 +501,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
         } catch {
             XCTFail("Received failure with error \(error)")
         }
-        wait(for: [cognitoAPIExpectation], timeout: apiTimeout)
+        await fulfillment(of: [cognitoAPIExpectation], timeout: apiTimeout)
     }
 
     /// Test fetchAuthSession when federated to identity pool with valid credentials
@@ -671,7 +671,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
         } catch {
             XCTFail("Received failure with error \(error)")
         }
-        wait(for: [cognitoAPIExpectation], timeout: apiTimeout)
+        await fulfillment(of: [cognitoAPIExpectation], timeout: apiTimeout)
     }
 
     /// Test federated to identity pool with developer provided identity Id

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFetchSignInSessionOperationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFetchSignInSessionOperationTests.swift
@@ -132,7 +132,7 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
         XCTAssertNotNil(tokens?.idToken)
         XCTAssertNotNil(tokens?.refreshToken)
 
-        wait(for: [resultExpectation], timeout: apiTimeout)
+        await fulfillment(of: [resultExpectation], timeout: apiTimeout)
     }
 
     /// Test signedIn session with a user signed In to  identityPool
@@ -355,7 +355,7 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
     //                XCTFail("Received failure with error \(error)")
     //            }
     //        }
-    //        wait(for: [resultExpectation], timeout: apiTimeout)
+    //        await fulfillment(of: [resultExpectation], timeout: apiTimeout)
     //    }
     //
     //    /// Test signedIn session with network error for identityId
@@ -413,7 +413,7 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
     //                XCTFail("Received failure with error \(error)")
     //            }
     //        }
-    //        wait(for: [resultExpectation], timeout: apiTimeout)
+    //        await fulfillment(of: [resultExpectation], timeout: apiTimeout)
     //    }
     //
     //    /// Test signedIn session with network error for aws credentials
@@ -471,7 +471,7 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
     //                XCTFail("Received failure with error \(error)")
     //            }
     //        }
-    //        wait(for: [resultExpectation], timeout: apiTimeout)
+    //        await fulfillment(of: [resultExpectation], timeout: apiTimeout)
     //    }
     //
     /// Test signedIn session with invalid response for tokens

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AuthenticationProviderDeleteUserTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AuthenticationProviderDeleteUserTests.swift
@@ -473,7 +473,7 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
 //                XCTFail("Received failure with error \(error)")
 //            }
 //        }
-//        wait(for: [resultExpectation], timeout: apiTimeout)
+//        await fulfillment(of: [resultExpectation], timeout: apiTimeout)
 //
 //        let deleteUserResultExpectation = expectation(description: "Should receive a result")
 //        _ = plugin.deleteUser { result in
@@ -493,7 +493,7 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
 //                }
 //            }
 //        }
-//        wait(for: [deleteUserResultExpectation], timeout: apiTimeout)
+//        await fulfillment(of: [deleteUserResultExpectation], timeout: apiTimeout)
 //    }
 //
 //    var window: UIWindow {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/ClientBehaviorResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/ClientBehaviorResetPasswordTests.swift
@@ -590,7 +590,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
 
             }
         }
-        wait(for: [resultExpectation], timeout: networkTimeout)
+        await fulfillment(of: [resultExpectation], timeout: networkTimeout)
     }
     */
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthMigrationSignInTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthMigrationSignInTaskTests.swift
@@ -84,7 +84,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
             XCTFail("Error should not be returned \(error)")
         }
 
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationInternalError() async throws {
@@ -107,7 +107,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationInvalidLambda() async throws {
@@ -134,7 +134,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationParameterException() async throws {
@@ -161,7 +161,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationSMSRoleAccessException() async throws {
@@ -190,7 +190,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationUserPoolConfiguration() async throws {
@@ -215,7 +215,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationNotAuthorized() async throws {
@@ -240,7 +240,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperatioResetPassword() async throws {
@@ -264,7 +264,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
         } catch {
             XCTFail("Should not produce a error result: \(error)")
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationResourceNotFound() async throws {
@@ -292,7 +292,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationTooManyRequest() async throws {
@@ -320,7 +320,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationUnexpectedLambda() async throws {
@@ -348,7 +348,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationUserLambdaValidation() async throws {
@@ -376,7 +376,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationUserNotConfirmed() async throws {
@@ -400,7 +400,7 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
         } catch {
             XCTFail("Should not produce an error result - \(error)")
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 
     func testSignInOperationUserNotFound() async throws {
@@ -428,6 +428,6 @@ class AWSAuthMigrationSignInTaskTests: XCTestCase {
                 return
             }
         }
-        wait(for: [initiateAuthExpectation], timeout: networkTimeout)
+        await fulfillment(of: [initiateAuthExpectation], timeout: networkTimeout)
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignUp/AWSAuthConfirmSignUpTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignUp/AWSAuthConfirmSignUpTaskTests.swift
@@ -73,6 +73,6 @@ class AWSAuthConfirmSignUpTaskTests: XCTestCase {
             XCTFail("Should not produce success response")
         } catch {
         }
-        wait(for: [functionExpectation], timeout: 1)
+        await fulfillment(of: [functionExpectation], timeout: 1)
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignUp/AWSAuthSignUpTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignUp/AWSAuthSignUpTaskTests.swift
@@ -70,7 +70,7 @@ class AWSAuthSignUpTaskTests: XCTestCase {
             XCTFail("Should not produce success response")
         } catch {
         }
-        wait(for: [functionExpectation], timeout: 1)
+        await fulfillment(of: [functionExpectation], timeout: 1)
     }
 
     /// Given: Configured AuthState machine with existing signUp flow
@@ -93,6 +93,6 @@ class AWSAuthSignUpTaskTests: XCTestCase {
             userPoolFactory: {MockIdentityProvider(mockSignUpResponse: signUp)})
         let task = AWSAuthSignUpTask(request, authEnvironment: authEnvironment)
         _ = try await task.value
-        wait(for: [functionExpectation], timeout: 1)
+        await fulfillment(of: [functionExpectation], timeout: 1)
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
@@ -157,7 +157,7 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             }
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: networkTimeout)
+        await fulfillment(of: [expectation], timeout: networkTimeout)
     }
 
     @MainActor
@@ -209,7 +209,7 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             }
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: networkTimeout)
+        await fulfillment(of: [expectation], timeout: networkTimeout)
     }
 
     @MainActor
@@ -226,7 +226,7 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             }
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: networkTimeout)
+        await fulfillment(of: [expectation], timeout: networkTimeout)
     }
 
     @MainActor
@@ -254,7 +254,7 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             }
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: networkTimeout)
+        await fulfillment(of: [expectation], timeout: networkTimeout)
     }
 
     @MainActor

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/hierarchical-state-machine-swiftTests/StateMachineListenerTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/hierarchical-state-machine-swiftTests/StateMachineListenerTests.swift
@@ -41,7 +41,10 @@ class StateMachineListenerTests: XCTestCase {
         }
         let event = Counter.Event(id: "test", eventType: .increment)
         await stateMachine.send(event)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [notified],
+            timeout: 0.1
+        )
     }
 
     func testDoesNotNotifyOnNoStateChange() async {
@@ -58,7 +61,10 @@ class StateMachineListenerTests: XCTestCase {
 
         let event = Counter.Event(id: "test", eventType: .adjustBy(0))
         await stateMachine.send(event)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [notified],
+            timeout: 0.1
+        )
     }
 
     func testDoesNotNotifyAfterUnsubscribe() async {
@@ -77,7 +83,10 @@ class StateMachineListenerTests: XCTestCase {
         seq.cancel()
         let event = Counter.Event(id: "test", eventType: .increment)
         await stateMachine.send(event)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [notified],
+            timeout: 0.1
+        )
     }
 
     func testOrderOfSubsription() async throws {
@@ -109,7 +118,10 @@ class StateMachineListenerTests: XCTestCase {
                 try await Task.sleep(nanoseconds: 1_000_000)
                 await self.stateMachine.send(Counter.Event(id: "set3", eventType: .set(12)))
             }
-            await waitForExpectations(timeout: 2)
+            await fulfillment(
+                of: [notified],
+                timeout: 2
+            )
             seq.cancel()
         }
     }
@@ -143,7 +155,10 @@ class StateMachineListenerTests: XCTestCase {
             }
         }
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(
+            of: [notified],
+            timeout: 1
+        )
         task2.cancel()
     }
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/hierarchical-state-machine-swiftTests/StateMachineTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/hierarchical-state-machine-swiftTests/StateMachineTests.swift
@@ -49,7 +49,11 @@ class StateMachineTests: XCTestCase {
                 taskCompletion.fulfill()
             }
         }
-        await waitForExpectations(timeout: 1)
+
+        await fulfillment(
+            of: [taskCompletion],
+            timeout: 0.1
+        )
         let state = await testMachine.currentState
         XCTAssertEqual(state.value, 0)
     }
@@ -106,7 +110,10 @@ class StateMachineTests: XCTestCase {
         )
 
         await testMachine.send(event)
-        await waitForExpectations(timeout: 0.1)
+        await fulfillment(
+            of: [action1WasExecuted, action2WasExecuted],
+            timeout: 0.1
+        )
     }
 
     /// Given:
@@ -148,7 +155,11 @@ class StateMachineTests: XCTestCase {
         )
 
         await testMachine.send(event)
-        await waitForExpectations(timeout: 0.1)
+
+        await fulfillment(
+            of: [action1WasExecuted, action2WasExecuted],
+            timeout: 0.1
+        )
         XCTAssertEqual(executionCount.get(), 2)
     }
 

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AuthEventTests/AuthEventIntegrationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AuthEventTests/AuthEventIntegrationTests.swift
@@ -33,18 +33,14 @@ class AuthEventIntegrationTests: AWSAuthBaseTest {
     ///    - I should get a completed signIn flow event.
     ///
     func testSuccessfulSignInEvent() async throws {
-
         let username = "integTest\(UUID().uuidString)"
         let password = "P123@\(UUID().uuidString)"
-
-        let signInExpectation = asyncExpectation(description: "SignIn event should be fired")
+        let signInExpectation = expectation(description: "SignIn event should be fired")
 
         unsubscribeToken = Amplify.Hub.listen(to: .auth) { payload in
             switch payload.eventName {
             case HubPayload.EventName.Auth.signedIn:
-                Task {
-                    await signInExpectation.fulfill()
-                }
+                signInExpectation.fulfill()
             default:
                 break
             }
@@ -55,7 +51,7 @@ class AuthEventIntegrationTests: AWSAuthBaseTest {
             password: password,
             email: defaultTestEmail)
 
-        await waitForExpectations([signInExpectation], timeout: networkTimeout)
+        await fulfillment(of: [signInExpectation], timeout: networkTimeout)
     }
 
     /// Test hub event for successful signOut of a valid user
@@ -67,18 +63,14 @@ class AuthEventIntegrationTests: AWSAuthBaseTest {
     ///    - I should get a completed signOut flow event.
     ///
     func testSuccessfulSignOutEvent() async throws {
-
         let username = "integTest\(UUID().uuidString)"
         let password = "P123@\(UUID().uuidString)"
-
-        let signOutExpectation = asyncExpectation(description: "SignOut event should be fired")
+        let signOutExpectation = expectation(description: "SignOut event should be fired")
 
         unsubscribeToken = Amplify.Hub.listen(to: .auth) { payload in
             switch payload.eventName {
             case HubPayload.EventName.Auth.signedOut:
-                Task {
-                    await signOutExpectation.fulfill()
-                }
+                signOutExpectation.fulfill()
             default:
                 break
             }
@@ -89,7 +81,7 @@ class AuthEventIntegrationTests: AWSAuthBaseTest {
             password: password,
             email: defaultTestEmail)
         _ = await Amplify.Auth.signOut()
-        await waitForExpectations([signOutExpectation], timeout: networkTimeout)
+        await fulfillment(of: [signOutExpectation], timeout: networkTimeout)
     }
 
     /// Test hub event for session expired of a valid user
@@ -105,20 +97,15 @@ class AuthEventIntegrationTests: AWSAuthBaseTest {
         let username = "integTest\(UUID().uuidString)"
         let password = "P123@\(UUID().uuidString)"
 
-        let signInExpectation = asyncExpectation(description: "SignIn event should be fired")
-        let sessionExpiredExpectation = asyncExpectation(description: "Session expired event should be fired")
+        let signInExpectation = expectation(description: "SignIn event should be fired")
+        let sessionExpiredExpectation = expectation(description: "Session expired event should be fired")
 
         unsubscribeToken = Amplify.Hub.listen(to: .auth) { payload in
             switch payload.eventName {
             case HubPayload.EventName.Auth.signedIn:
-                Task {
-                    await signInExpectation.fulfill()
-                }
+                signInExpectation.fulfill()
             case HubPayload.EventName.Auth.sessionExpired:
-                Task {
-                    await sessionExpiredExpectation.fulfill()
-                }
-
+                sessionExpiredExpectation.fulfill()
             default:
                 break
             }
@@ -134,7 +121,7 @@ class AuthEventIntegrationTests: AWSAuthBaseTest {
             AuthSessionHelper.invalidateSession(with: self.amplifyConfiguration)
             _ = try await Amplify.Auth.fetchAuthSession()
         }
-        await waitForExpectations( [signInExpectation, sessionExpiredExpectation], timeout: networkTimeout)
+        await fulfillment(of: [signInExpectation, sessionExpiredExpectation], timeout: networkTimeout)
     }
 
     /// Test hub event for successful deletion of a valid user
@@ -150,19 +137,15 @@ class AuthEventIntegrationTests: AWSAuthBaseTest {
         let username = "integTest\(UUID().uuidString)"
         let password = "P123@\(UUID().uuidString)"
 
-        let signInExpectation = asyncExpectation(description: "SignIn operation should complete")
-        let deletedUserExpectation = asyncExpectation(description: "UserDeleted event should be fired")
+        let signInExpectation = expectation(description: "SignIn operation should complete")
+        let deletedUserExpectation = expectation(description: "UserDeleted event should be fired")
 
         unsubscribeToken = Amplify.Hub.listen(to: .auth) { payload in
             switch payload.eventName {
             case HubPayload.EventName.Auth.signedIn:
-                Task {
-                    await signInExpectation.fulfill()
-                }
+                signInExpectation.fulfill()
             case HubPayload.EventName.Auth.userDeleted:
-                Task {
-                    await deletedUserExpectation.fulfill()
-                }
+                deletedUserExpectation.fulfill()
             default:
                 break
             }
@@ -172,7 +155,7 @@ class AuthEventIntegrationTests: AWSAuthBaseTest {
             username: username,
             password: password,
             email: defaultTestEmail)
-        await waitForExpectations( [signInExpectation], timeout: networkTimeout)
+        await fulfillment(of: [signInExpectation], timeout: networkTimeout)
 
         do {
             try await Amplify.Auth.deleteUser()
@@ -180,6 +163,6 @@ class AuthEventIntegrationTests: AWSAuthBaseTest {
         } catch {
             XCTFail("deleteUser should not fail - \(error)")
         }
-        await waitForExpectations( [deletedUserExpectation], timeout: networkTimeout)
+        await fulfillment(of: [deletedUserExpectation], timeout: networkTimeout)
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/AuthFetchDeviceTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/AuthFetchDeviceTests.swift
@@ -37,15 +37,12 @@ class AuthFetchDeviceTests: AWSAuthBaseTest {
         let username = "integTest\(UUID().uuidString)"
         let password = "P123@\(UUID().uuidString)"
 
-        let signInExpectation = asyncExpectation(description: "SignIn event should be fired")
+        let signInExpectation = expectation(description: "SignIn event should be fired")
 
         unsubscribeToken = Amplify.Hub.listen(to: .auth) { payload in
             switch payload.eventName {
             case HubPayload.EventName.Auth.signedIn:
-                Task {
-                    await signInExpectation.fulfill()
-                }
-
+                signInExpectation.fulfill()
             default:
                 break
             }
@@ -60,7 +57,7 @@ class AuthFetchDeviceTests: AWSAuthBaseTest {
             print(error)
         }
         
-        await waitForExpectations([signInExpectation], timeout: networkTimeout)
+        await fulfillment(of: [signInExpectation], timeout: networkTimeout)
 
         // fetch devices
         let devices = try await Amplify.Auth.fetchDevices()

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/AuthRememberDeviceTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/DeviceTests/AuthRememberDeviceTests.swift
@@ -38,14 +38,12 @@ class AuthRememberDeviceTests: AWSAuthBaseTest {
         let username = "integTest\(UUID().uuidString)"
         let password = "P123@\(UUID().uuidString)"
 
-        let signInExpectation = asyncExpectation(description: "SignIn event should be fired")
+        let signInExpectation = expectation(description: "SignIn event should be fired")
 
         unsubscribeToken = Amplify.Hub.listen(to: .auth) { payload in
             switch payload.eventName {
             case HubPayload.EventName.Auth.signedIn:
-                Task {
-                    await signInExpectation.fulfill()
-                }
+                signInExpectation.fulfill()
             default:
                 break
             }
@@ -55,7 +53,7 @@ class AuthRememberDeviceTests: AWSAuthBaseTest {
             username: username,
             password: password,
             email: defaultTestEmail)
-        await waitForExpectations([signInExpectation], timeout: networkTimeout)
+        await fulfillment(of: [signInExpectation], timeout: networkTimeout)
 
         _ = try await Amplify.Auth.rememberDevice()
 

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/ResetPasswordTests/AuthConfirmResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/ResetPasswordTests/AuthConfirmResetPasswordTests.swift
@@ -23,13 +23,10 @@ class AuthConfirmResetPasswordTests: AWSAuthBaseTest {
         do {
             try await Amplify.Auth.confirmResetPassword(for: "user-non-exists", with: "password", confirmationCode: "123", options: nil)
             XCTFail("resetPassword with non existing user should not return result")
+        } catch AuthError.service(_, _, let error as AWSCognitoAuthError) where [.userNotFound, .limitExceeded].contains(error) {
+            return
         } catch {
-            guard let authError = error as? AuthError, let cognitoError = authError.underlyingError as? AWSCognitoAuthError,
-                  case .userNotFound = cognitoError else {
-                      print(error)
-                      XCTFail("Should return userNotFound")
-                      return
-                  }
+            XCTFail("Expected .userNotFound or .limitExceeded error. received: \(error)")
         }
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/ResetPasswordTests/AuthResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/ResetPasswordTests/AuthResetPasswordTests.swift
@@ -23,13 +23,10 @@ class AuthResetPasswordTests: AWSAuthBaseTest {
         do {
             _ = try await Amplify.Auth.resetPassword(for: "user-non-exists", options: nil)
             XCTFail("resetPassword with non existing user should not return result")
+        } catch AuthError.service(_, _, let error as AWSCognitoAuthError) where [.userNotFound, .limitExceeded].contains(error) {
+            return
         } catch {
-            guard let authError = error as? AuthError, let cognitoError = authError.underlyingError as? AWSCognitoAuthError,
-                  case .userNotFound = cognitoError else {
-                print(error)
-                XCTFail("Should return userNotFound")
-                return
-            }
+            XCTFail("Expected .userNotFound or .limitExceeded error. received: \(error)")
         }
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SessionTests/SignedInAuthSessionTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SessionTests/SignedInAuthSessionTests.swift
@@ -233,7 +233,11 @@ class SignedInAuthSessionTests: AWSAuthBaseTest {
                 fetchSessionExptectation.fulfill()
             }
         }
-        await waitForExpectations(timeout: networkTimeout)
+
+        await fulfillment(
+            of: [identityIDExpectation, fetchSessionExptectation],
+            timeout: networkTimeout
+        )
     }
 
     /// Test if successful session is retrieved before and after a user sign in

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignInTests/AuthSRPSignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignInTests/AuthSRPSignInTests.swift
@@ -258,7 +258,7 @@ class AuthSRPSignInTests: AWSAuthBaseTest {
             XCTFail("SignIn with invalid auth flow should not succeed: \(error)")
         }
 
-        wait(for: [operationExpectation], timeout: networkTimeout)
+        await fulfillment(of: [operationExpectation], timeout: networkTimeout)
 
         let confirmOperationExpectation = expectation(description: "Confirm new password should succeed")
         do {
@@ -277,7 +277,7 @@ class AuthSRPSignInTests: AWSAuthBaseTest {
             XCTFail("Failed to confirm new password with error: \(error)")
         }
 
-        wait(for: [confirmOperationExpectation], timeout: networkTimeout)
+        await fulfillment(of: [confirmOperationExpectation], timeout: networkTimeout)
 
     }
 
@@ -289,8 +289,7 @@ class AuthSRPSignInTests: AWSAuthBaseTest {
     /// - Then:
     ///    - I should get success for both the API's
     ///
-    func testSignInWithFetchAuthSession() {
-
+    func testSignInWithFetchAuthSession() async {
         let fetchAuthSessionExpectation = expectation(description: "Fetch Auth Session completed")
         let signInExpectation = expectation(description: "Sign in completed")
 
@@ -326,7 +325,7 @@ class AuthSRPSignInTests: AWSAuthBaseTest {
             signInExpectation.fulfill()
         }
 
-        wait(for: [signInExpectation, fetchAuthSessionExpectation], timeout: 10)
+        await fulfillment(of: [signInExpectation, fetchAuthSessionExpectation], timeout: 10)
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignInTests/AuthSRPSignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignInTests/AuthSRPSignInTests.swift
@@ -325,7 +325,7 @@ class AuthSRPSignInTests: AWSAuthBaseTest {
             signInExpectation.fulfill()
         }
 
-        await fulfillment(of: [signInExpectation, fetchAuthSessionExpectation], timeout: 10)
+        await fulfillment(of: [signInExpectation, fetchAuthSessionExpectation], timeout: 60)
     }
 
 }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignUpTests/AuthSignUpTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/SignUpTests/AuthSignUpTests.swift
@@ -93,7 +93,7 @@ class AuthSignUpTests: AWSAuthBaseTest {
     //            }
     //        }
     //        XCTAssertNotNil(operation, "SignUp operations should not be nil")
-    //        wait(for: [operationExpectation], timeout: networkTimeout)
+    //        await fulfillment(of: [operationExpectation], timeout: networkTimeout)
     //    }
 
     /// Test is signUp return validation error

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthStressTests/AuthStressTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthStressTests/AuthStressTests.swift
@@ -43,8 +43,9 @@ final class AuthStressTests: AuthStressBaseTest {
                                                email: defaultTestEmail)
         XCTAssertTrue(didSucceed, "SignIn operation failed")
 
-        let fetchUserAttributesExpectation = asyncExpectation(description: "Fetch user attributes was successful",
-                                                              expectedFulfillmentCount: concurrencyLimit)
+        let fetchUserAttributesExpectation = expectation(description: "Fetch user attributes was successful")
+        fetchUserAttributesExpectation.expectedFulfillmentCount = concurrencyLimit
+
         for _ in 1...concurrencyLimit {
             Task {
                 let attributes = try await Amplify.Auth.fetchUserAttributes()
@@ -53,11 +54,11 @@ final class AuthStressTests: AuthStressBaseTest {
                 } else {
                     XCTFail("Email attribute not found")
                 }
-                await fetchUserAttributesExpectation.fulfill()
+                fetchUserAttributesExpectation.fulfill()
             }
         }
         
-        await waitForExpectations([fetchUserAttributesExpectation], timeout: 30)
+        await fulfillment(of: [fetchUserAttributesExpectation], timeout: 30)
     }
 
     /// Test if successful session is retreived after a user signin and tried to fetch auth session multiple times
@@ -76,17 +77,18 @@ final class AuthStressTests: AuthStressBaseTest {
                                                email: defaultTestEmail)
         XCTAssertTrue(didSucceed, "SignIn operation failed")
 
-        let fetchAuthSessionExpectation = asyncExpectation(description: "Fetch auth session was successful",
-                                                           expectedFulfillmentCount: concurrencyLimit)
+        let fetchAuthSessionExpectation = expectation(description: "Fetch auth session was successful")
+        fetchAuthSessionExpectation.expectedFulfillmentCount = concurrencyLimit
+
         for _ in 1...concurrencyLimit {
             Task {
                 let session = try await Amplify.Auth.fetchAuthSession()
                 XCTAssertTrue(session.isSignedIn, "Session state should be signed In")
-                await fetchAuthSessionExpectation.fulfill()
+                fetchAuthSessionExpectation.fulfill()
             }
         }
         
-        await waitForExpectations([fetchAuthSessionExpectation], timeout: networkTimeout)
+        await fulfillment(of: [fetchAuthSessionExpectation], timeout: networkTimeout)
     }
     
     /// Test if successful session is retrieved with random force refresh operation happening in between
@@ -108,8 +110,9 @@ final class AuthStressTests: AuthStressBaseTest {
         )
         XCTAssertTrue(didSucceed, "SignIn operation failed")
 
-        let identityIDExpectation = asyncExpectation(description: "Identity id should be fetched",
-                                                     expectedFulfillmentCount: concurrencyLimit)
+        let identityIDExpectation = expectation(description: "Identity id should be fetched")
+        identityIDExpectation.expectedFulfillmentCount = concurrencyLimit
+
         for index in 1...concurrencyLimit {
             Task {
                 // Randomly yield the task so that below execution of force refresh happens
@@ -124,11 +127,11 @@ final class AuthStressTests: AuthStressBaseTest {
                     XCTFail("Could not fetch Identity ID")
                     return
                 }
-                await identityIDExpectation.fulfill()
+                identityIDExpectation.fulfill()
             }
         }
         
-        await waitForExpectations([identityIDExpectation], timeout: networkTimeout)
+        await fulfillment(of: [identityIDExpectation], timeout: networkTimeout)
     }
     
     /// Test if we can fetch auth session in signedOut state
@@ -140,8 +143,9 @@ final class AuthStressTests: AuthStressBaseTest {
     ///    - Valid response with signedOut state = false
     ///
     func testMultipleFetchAuthSessionWhenSignedOut() async throws {
-        let fetchAuthSessionExpectation = asyncExpectation(description: "Session state should not be signedIn",
-                                           expectedFulfillmentCount: concurrencyLimit)
+        let fetchAuthSessionExpectation = expectation(description: "Session state should not be signedIn")
+        fetchAuthSessionExpectation.expectedFulfillmentCount = concurrencyLimit
+
         for _ in 1...concurrencyLimit {
             Task {
                 let result = try await Amplify.Auth.fetchAuthSession()
@@ -152,11 +156,11 @@ final class AuthStressTests: AuthStressBaseTest {
                     return
                 }
                 XCTAssertNotNil(awsCredentails.accessKeyId, "Access key should not be nil")
-                await fetchAuthSessionExpectation.fulfill()
+                fetchAuthSessionExpectation.fulfill()
             }
         }
         
-        await waitForExpectations([fetchAuthSessionExpectation], timeout: networkTimeout)
+        await fulfillment(of: [fetchAuthSessionExpectation], timeout: networkTimeout)
     }
     
     /// Test concurrent invocations of get current user API
@@ -177,17 +181,18 @@ final class AuthStressTests: AuthStressBaseTest {
 
         XCTAssertTrue(didSucceed, "SignIn operation failed")
         
-        let getCurrentUserExpectation = asyncExpectation(description: "getCurrentUser() is successful",
-                                                         expectedFulfillmentCount: concurrencyLimit)
+        let getCurrentUserExpectation = expectation(description: "getCurrentUser() is successful")
+        getCurrentUserExpectation.expectedFulfillmentCount = concurrencyLimit
+
         for _ in 1...concurrencyLimit {
             Task {
                 let authUser = try await Amplify.Auth.getCurrentUser()
                 XCTAssertEqual(authUser.username.lowercased(), username.lowercased())
                 XCTAssertNotNil(authUser.userId)
-                await getCurrentUserExpectation.fulfill()
+                getCurrentUserExpectation.fulfill()
             }
         }
         
-        await waitForExpectations([getCurrentUserExpectation], timeout: networkTimeout)
+        await fulfillment(of: [getCurrentUserExpectation], timeout: networkTimeout)
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIAppUITests/Screen/AuthenticatedScreen.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIAppUITests/Screen/AuthenticatedScreen.swift
@@ -31,7 +31,7 @@ struct AuthenticatedScreen: Screen {
 
     func dismissSignOutAlert() -> Self {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        XCTAssertTrue(springboard.buttons["Continue"].waitForExistence(timeout: 5))
+        XCTAssertTrue(springboard.buttons["Continue"].waitForExistence(timeout: 60))
         springboard.buttons["Continue"].tap()
         return self
     }

--- a/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIAppUITests/Screen/SignInScreen.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIAppUITests/Screen/SignInScreen.swift
@@ -40,13 +40,13 @@ struct SignInScreen: Screen {
 
     func dismissSignInAlert() -> Self {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        XCTAssertTrue(springboard.buttons["Continue"].waitForExistence(timeout: 5))
+        XCTAssertTrue(springboard.buttons["Continue"].waitForExistence(timeout: 60))
         springboard.buttons["Continue"].tap()
         return self
     }
 
     func signIn(username: String, password: String) -> Self {
-        _ = app.webViews.textFields["Username"].waitForExistence(timeout: 5)
+        _ = app.webViews.textFields["Username"].waitForExistence(timeout: 60)
         app.webViews.textFields["Username"].tap()
         app.webViews.textFields["Username"].typeText(username)
 
@@ -59,7 +59,7 @@ struct SignInScreen: Screen {
 
     func testSignInSucceeded() -> Self {
         let successText = app.staticTexts[Identifiers.successLabel]
-        XCTAssertTrue(successText.waitForExistence(timeout: 5), "SignIn operation failed")
+        XCTAssertTrue(successText.waitForExistence(timeout: 60), "SignIn operation failed")
         return self
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIAppUITests/Screen/SignUpScreen.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIAppUITests/Screen/SignUpScreen.swift
@@ -38,7 +38,7 @@ struct SignUpScreen: Screen {
 
     func testSignUpSucceeded() -> Self {
         let successText = app.staticTexts[Identifiers.successLabel]
-        XCTAssertTrue(successText.waitForExistence(timeout: 5), "Signup operation failed")
+        XCTAssertTrue(successText.waitForExistence(timeout: 60), "Signup operation failed")
         return self
     }
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
@@ -288,8 +288,8 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
         setUp(withModels: TestModelRegistration())
         try await Amplify.DataStore.clear()
         var snapshotCount = 0
-        let initialQueryComplete = asyncExpectation(description: "initial snapshot received")
-        let allSnapshotsReceived = asyncExpectation(description: "query snapshots received")
+        let initialQueryComplete = expectation(description: "initial snapshot received")
+        let allSnapshotsReceived = expectation(description: "query snapshots received")
 
         let subscription = Amplify.DataStore.observeQuery(for: Post.self)
         let sink = Amplify.Publisher.create(subscription).sink { completed in
@@ -302,15 +302,15 @@ class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
         } receiveValue: { querySnapshot in
             snapshotCount += 1
             if snapshotCount == 1 {
-                Task { await initialQueryComplete.fulfill() }
+                initialQueryComplete.fulfill()
             }
             if querySnapshot.items.count == 15 {
-                Task { await allSnapshotsReceived.fulfill() }
+                allSnapshotsReceived.fulfill()
             }
         }
-        await waitForExpectations([initialQueryComplete], timeout: 10)
+        await fulfillment(of: [initialQueryComplete], timeout: 10)
         _ = try await setUpLocalStore(numberOfPosts: 15)
-        await waitForExpectations([allSnapshotsReceived], timeout: 10)
+        await fulfillment(of: [allSnapshotsReceived], timeout: 10)
         XCTAssertTrue(snapshotCount >= 2)
         sink.cancel()
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginTests.swift
@@ -79,16 +79,20 @@ class AWSDataStorePluginTests: XCTestCase {
                                         validAuthPluginKey: "MockAuthCategoryPlugin")
         do {
             try plugin.configure(using: nil)
-            let queryCompleted = asyncExpectation(description: "query completed")
+            let queryCompleted = expectation(description: "query completed")
             Task {
                 _ = try await plugin.query(ExampleWithEveryType.self)
-                await queryCompleted.fulfill()
+                queryCompleted.fulfill()
             }
-            await waitForExpectations([queryCompleted], timeout: 1.0)
+            await fulfillment(of: [queryCompleted], timeout: 1.0)
         } catch {
             XCTFail("DataStore configuration should not fail with nil configuration. \(error)")
         }
-        await waitForExpectations(timeout: 1.0)
+
+        await fulfillment(
+            of: [startExpectation],
+            timeout: 1
+        )
     }
     
     func testStorageEngineStartsOnPluginStopStart() throws {
@@ -230,7 +234,11 @@ class AWSDataStorePluginTests: XCTestCase {
                 XCTAssertNotNil(plugin.storageEngine)
                 XCTAssertNotNil(plugin.dataStorePublisher)
             })
-            wait(for: [startExpectation, stopExpectation, startExpectationOnSecondStart], timeout: 1, enforceOrder: true)
+            wait(
+                for: [startExpectation, stopExpectation, startExpectationOnSecondStart],
+                timeout: 1,
+                enforceOrder: true
+            )
             wait(for: [finishNotReceived], timeout: 1)
             sink.cancel()
         } catch {
@@ -301,7 +309,12 @@ class AWSDataStorePluginTests: XCTestCase {
                 XCTAssertNotNil(plugin.storageEngine)
                 XCTAssertNotNil(plugin.dataStorePublisher)
             })
-            wait(for: [startExpectation, clearExpectation, startExpectationOnSecondStart], timeout: 1, enforceOrder: true)
+
+            wait(
+                for: [startExpectation, clearExpectation, startExpectationOnSecondStart],
+                timeout: 1,
+                enforceOrder: true
+            )
             wait(for: [finishNotReceived], timeout: 1)
             sink.cancel()
         } catch {
@@ -449,7 +462,7 @@ class AWSDataStorePluginTests: XCTestCase {
                 startCompleted.fulfill()
             })
             wait(for: [startCompleted], timeout: 1.0)
-            
+
             let clearCompleted = expectation(description: "clear completed")
             plugin.clear(completion: { _ in
                 XCTAssertNil(plugin.storageEngine)
@@ -528,7 +541,7 @@ class AWSDataStorePluginTests: XCTestCase {
                 startCompleted.fulfill()
             })
             wait(for: [startCompleted], timeout: 1.0)
-            
+
             let stopCompleted = expectation(description: "stop completed")
             plugin.stop(completion: { _ in
                 XCTAssertNotNil(plugin.storageEngine)
@@ -537,7 +550,11 @@ class AWSDataStorePluginTests: XCTestCase {
             })
             wait(for: [stopCompleted], timeout: 1.0)
 
-            wait(for: [startExpectation, stopExpectation], timeout: 1, enforceOrder: true)
+            wait(
+                for: [startExpectation, stopExpectation],
+                timeout: 1,
+                enforceOrder: true
+            )
             let mockModel = MockSynced(id: "12345")
             try plugin.dataStorePublisher?.send(input: MutationEvent(model: mockModel,
                                                                      modelSchema: mockModel.schema,

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/ListTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/ListTests.swift
@@ -49,7 +49,7 @@ class ListTests: BaseDataStoreTests {
             XCTFail("\(error)")
         }
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [expect], timeout: 1)
     }
 
     // MARK: - Helpers

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/StateMachineTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/StateMachineTests.swift
@@ -106,14 +106,16 @@ class StateMachineTests: XCTestCase {
             }
         }
 
-        wait(for: [
-            receivedOneOnSubscribe,
-            receivedTwoAfterSubscribe,
-            receivedThreeAfterSubscribe,
-            receivedOneAfterSubscribe
+        wait(
+            for: [
+                receivedOneOnSubscribe,
+                receivedTwoAfterSubscribe,
+                receivedThreeAfterSubscribe,
+                receivedOneAfterSubscribe
             ],
-             timeout: 1.0,
-             enforceOrder: true)
+            timeout: 1.0,
+            enforceOrder: true
+        )
 
         listener.cancel()
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/CascadeDeleteOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/CascadeDeleteOperationTests.swift
@@ -87,7 +87,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
         operation.start()
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [completed], timeout: 1)
         guard case .success(let queriedRestaurants) = await queryModelSynchronous(modelType: Restaurant.self,
                                                                                   predicate: predicate) else {
             XCTFail("Failed to query")
@@ -361,7 +361,8 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
         operation.start()
-        await waitForExpectations(timeout: 1)
+
+        await fulfillment(of: [receivedMutationEvent, expectedFailures, expectedSuccess, completed], timeout: 1)
         guard case .success(let queriedRestaurants) = await queryModelSynchronous(modelType: Restaurant.self,
                                                                             predicate: predicate) else {
             XCTFail("Failed to query")
@@ -422,7 +423,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
             }
         }
         operation.start()
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [receivedMutationEvent, expectedFailures, expectedSuccess, completed], timeout: 1)
         guard case .success(let queriedModels) = await queryModelSynchronous(modelType: ModelCompositePk.self,
                                                                             predicate: predicate) else {
             XCTFail("Failed to query")
@@ -595,7 +596,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         }
 
         operation.syncIfNeededAndFinish(result)
-        wait(for: [receivedMutationEvent, expectedFailures, expectedSuccess], timeout: 1)
+        await fulfillment(of: [receivedMutationEvent, expectedFailures, expectedSuccess], timeout: 1)
     }
 
     func testDeleteWithAssociatedModels() async {
@@ -660,7 +661,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         }
 
         operation.syncIfNeededAndFinish(result)
-        wait(for: [completed, receivedMutationEvent, expectedFailures, expectedSuccess], timeout: 1)
+        await fulfillment(of: [completed, receivedMutationEvent, expectedFailures, expectedSuccess], timeout: 1)
         XCTAssertEqual(submittedEvents.count, 3)
         // The delete mutations should be synced in reverse order (children to parent)
         XCTAssertEqual(submittedEvents[0].modelName, Dish.modelName)
@@ -729,7 +730,8 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         }
 
         operation.syncIfNeededAndFinish(result)
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [receivedMutationEvent, expectedFailures, expectedSuccess, completed], timeout: 1)
+
         XCTAssertEqual(submittedEvents.count, 2)
         // The delete mutations should be synced in reverse order (children to parent)
         XCTAssertEqual(submittedEvents[0].modelName, CommentWithCompositeKey.modelName)
@@ -797,7 +799,8 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
         }
 
         operation.syncIfNeededAndFinish(result)
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [receivedMutationEvent, expectedFailures, expectedSuccess, completed], timeout: 1)
+
         XCTAssertEqual(submittedEvents.count, 3)
         // The delete mutations should be synced in reverse order (children to parent)
         XCTAssertEqual(submittedEvents[0].modelName, Dish.modelName)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEnginePublisherTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEnginePublisherTests.swift
@@ -84,11 +84,15 @@ class StorageEnginePublisherTests: StorageEngineTestsBase {
         storageEngine.onReceive(receiveValue: .syncStarted)
         storageEngine.onReceive(receiveValue: .cleanedUp)
         storageEngine.onReceive(receiveValue: .cleanedUpForTermination)
-        wait(for: [receivedMutationEvent,
-                   receivedModelSyncedEvent,
-                   receivedSyncQueriesReadyEvent,
-                   receivedReadyEvent],
-                timeout: 1)
+        wait(
+            for: [
+                receivedMutationEvent,
+                receivedModelSyncedEvent,
+                receivedSyncQueriesReadyEvent,
+                receivedReadyEvent
+            ],
+            timeout: 1
+        )
         sink.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsBase.swift
@@ -47,7 +47,7 @@ class StorageEngineTestsBase: XCTestCase {
             result = sResult
             saveFinished.fulfill()
         }
-        await waitForExpectations(timeout: defaultTimeout)
+        await fulfillment(of: [saveFinished], timeout: defaultTimeout)
         guard let saveResult = result else {
             return .failure(causedBy: "Save operation timed out")
         }
@@ -105,7 +105,7 @@ class StorageEngineTestsBase: XCTestCase {
             queryFinished.fulfill()
         }
 
-        await waitForExpectations(timeout: defaultTimeout)
+        await fulfillment(of: [queryFinished], timeout: defaultTimeout)
         guard let queryResult = result else {
             return .failure(causedBy: "Query operation timed out")
         }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/ObserveQueryTaskRunnerTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/ObserveQueryTaskRunnerTests.swift
@@ -34,8 +34,8 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
     ///    - The item observed will be returned in the second snapshot
     ///
     func testItemChangedWillGenerateSnapshot() async throws {
-        let firstSnapshot = asyncExpectation(description: "first query snapshots")
-        let secondSnapshot = asyncExpectation(description: "second query snapshots")
+        let firstSnapshot = expectation(description: "first query snapshots")
+        let secondSnapshot = expectation(description: "second query snapshots")
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -54,10 +54,10 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                     querySnapshots.append(querySnapshot)
                     if querySnapshots.count == 1 {
                         XCTAssertEqual(querySnapshot.items.count, 0)
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
                         XCTAssertEqual(querySnapshot.items.count, 1)
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     }
                 }
             } catch {
@@ -65,11 +65,11 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             }
         }
     
-        await waitForExpectations([firstSnapshot], timeout: 1)
+        await fulfillment(of: [firstSnapshot], timeout: 1)
 
         let post = try createPost(id: "1")
         dataStorePublisher.send(input: post)
-        await waitForExpectations([secondSnapshot], timeout: 10)
+        await fulfillment(of: [secondSnapshot], timeout: 10)
     }
     
     ///  ObserveQuery will send a single snapshot when the sync state toggles
@@ -83,9 +83,11 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
     ///    - ObserveQuery will send a second snapshot
     ///
     func testGenerateSnapshotOnObserveQueryWhenModelSynced() async throws {
-        let firstSnapshot = asyncExpectation(description: "first query snapshots")
-        let secondSnapshot = asyncExpectation(description: "second query snapshots")
-        let thirdSnapshot = asyncExpectation(description: "third query snapshot", isInverted: true)
+        let firstSnapshot = expectation(description: "first query snapshots")
+        let secondSnapshot = expectation(description: "second query snapshots")
+        let thirdSnapshot = expectation(description: "third query snapshot")
+        thirdSnapshot.isInverted = true
+
         let dispatchedModelSyncedEvent = AtomicValue(initialValue: false)
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
@@ -106,14 +108,14 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                     if querySnapshots.count == 1 {
                         XCTAssertEqual(querySnapshot.items.count, 0)
                         XCTAssertEqual(querySnapshot.isSynced, false)
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
                         XCTAssertEqual(querySnapshot.items.count, 0)
                         XCTAssertEqual(querySnapshot.isSynced, true)
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     } else if querySnapshots.count == 3 {
                         XCTFail("Should not receive third snapshot for a Model change")
-                        await thirdSnapshot.fulfill()
+                        thirdSnapshot.fulfill()
                     }
                 }
             } catch {
@@ -121,7 +123,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             }
         }
         
-        await waitForExpectations([firstSnapshot], timeout: 5)
+        await fulfillment(of: [firstSnapshot], timeout: 5)
         
         dispatchedModelSyncedEvent.set(true)
         let modelSyncedEventPayload = HubPayload(eventName: HubPayload.EventName.DataStore.modelSynced,
@@ -129,12 +131,12 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                                                                         isDeltaSync: false, added: 0, updated: 0,
                                                                         deleted: 0))
         Amplify.Hub.dispatch(to: .dataStore, payload: modelSyncedEventPayload)
-        await waitForExpectations([secondSnapshot], timeout: 10)
+        await fulfillment(of: [secondSnapshot], timeout: 10)
         
         let modelSyncedEventNotMatch = HubPayload(eventName: HubPayload.EventName.DataStore.modelSynced,
                                                   data: ModelSyncedEvent.Builder().modelName)
         Amplify.Hub.dispatch(to: .dataStore, payload: modelSyncedEventNotMatch)
-        await waitForExpectations([thirdSnapshot], timeout: 10)
+        await fulfillment(of: [thirdSnapshot], timeout: 10)
     }
     
     /// ObserveQuery will send the first snapshot with 2 items when storage engine
@@ -147,7 +149,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
     ///    - The items queried will return two posts in the first snapshot
     ///
     func testFirstSnapshotFromStorageQueryReturnsTwoPosts() async {
-        let firstSnapshot = asyncExpectation(description: "firstSnapshot received")
+        let firstSnapshot = expectation(description: "firstSnapshot received")
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -172,7 +174,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                     querySnapshots.append(querySnapshot)
                     if querySnapshots.count == 1 {
                         XCTAssertEqual(querySnapshot.items.count, 2)
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     }
                 }
                 
@@ -180,7 +182,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                 XCTFail("Failed with error \(error)")
             }
         }
-        await waitForExpectations([firstSnapshot], timeout: 10)
+        await fulfillment(of: [firstSnapshot], timeout: 10)
     }
     
     /// Multiple item changed observed will be returned in a single snapshot
@@ -192,8 +194,8 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
     ///    - The items observed will be returned in the second snapshot
     ///
     func testMultipleItemChangesWillGenerateSecondSnapshot() async throws {
-        let firstSnapshot = asyncExpectation(description: "first query snapshot")
-        let secondSnapshot = asyncExpectation(description: "second query snapshot")
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
 
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
@@ -213,10 +215,10 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                     querySnapshots.append(querySnapshot)
                     if querySnapshots.count == 1 {
                         XCTAssertEqual(querySnapshot.items.count, 0)
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
                         XCTAssertEqual(querySnapshot.items.count, 3)
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     }
                 }
             } catch {
@@ -224,7 +226,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             }
         }
         
-        await waitForExpectations([firstSnapshot], timeout: 1)
+        await fulfillment(of: [firstSnapshot], timeout: 1)
 
         let post1 = try createPost(id: "1")
         let post2 = try createPost(id: "2")
@@ -232,7 +234,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
         dataStorePublisher.send(input: post1)
         dataStorePublisher.send(input: post2)
         dataStorePublisher.send(input: post3)
-        await waitForExpectations([secondSnapshot], timeout: 10)
+        await fulfillment(of: [secondSnapshot], timeout: 10)
     }
     
     /// Multiple published objects (more than the `.collect` count of 1000) in a relatively short time window
@@ -247,10 +249,10 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
     ///     remaining in the third query
     ///
     func testCollectOverMaxItemCountLimit() async throws {
-        let firstSnapshot = asyncExpectation(description: "first query snapshot")
-        let secondSnapshot = asyncExpectation(description: "second query snapshot")
-        let thirdSnapshot = asyncExpectation(description: "third query snapshot")
-        let validateSnapshotsComplete = asyncExpectation(description: "validate snapshots")
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
+        let thirdSnapshot = expectation(description: "third query snapshot")
+        let validateSnapshotsComplete = expectation(description: "validate snapshots")
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -268,11 +270,11 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                 for try await querySnapshot in snapshots {
                     querySnapshots.append(querySnapshot)
                     if querySnapshots.count == 1 {
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     } else if querySnapshots.count == 3 {
-                        await thirdSnapshot.fulfill()
+                        thirdSnapshot.fulfill()
                     }
                 }
                 
@@ -280,22 +282,22 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                 XCTAssertTrue(querySnapshots[0].items.count <= querySnapshots[1].items.count)
                 XCTAssertTrue(querySnapshots[1].items.count <= querySnapshots[2].items.count)
                 XCTAssertTrue(querySnapshots[2].items.count <= 1_100)
-                await validateSnapshotsComplete.fulfill()
+                validateSnapshotsComplete.fulfill()
             } catch {
                 XCTFail("Failed with error \(error)")
             }
         }
         
-        await waitForExpectations([firstSnapshot], timeout: 1)
+        await fulfillment(of: [firstSnapshot], timeout: 1)
 
         for postId in 1 ... 1_100 {
             let post = try createPost(id: "\(postId)")
             dataStorePublisher.send(input: post)
         }
 
-        await waitForExpectations([secondSnapshot, thirdSnapshot], timeout: 10)
+        await fulfillment(of: [secondSnapshot, thirdSnapshot], timeout: 10)
         snapshots.cancel()
-        await waitForExpectations([validateSnapshotsComplete], timeout: 1.0)
+        await fulfillment(of: [validateSnapshotsComplete], timeout: 1.0)
     }
     
     /// Cancelling the subscription will no longer receive snapshots
@@ -307,8 +309,10 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
     ///    - no further snapshots are received
     ///
     func testSuccessfulSubscriptionCancel() async throws {
-        let firstSnapshot = asyncExpectation(description: "first query snapshot")
-        let secondSnapshot = asyncExpectation(description: "second query snapshot", isInverted: true)
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
+        secondSnapshot.isInverted = true
+
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -326,10 +330,10 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                 for try await querySnapshot in snapshots {
                     querySnapshots.append(querySnapshot)
                     if querySnapshots.count == 1 {
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
                         XCTFail("Should not receive second snapshot after cancelling")
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     }
                 }
             } catch {
@@ -337,11 +341,11 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             }
         }
         
-        await waitForExpectations([firstSnapshot], timeout: 1)
+        await fulfillment(of: [firstSnapshot], timeout: 1)
         snapshots.cancel()
         let post1 = try createPost(id: "1")
         dataStorePublisher.send(input: post1)
-        await waitForExpectations([secondSnapshot], timeout: 1)
+        await fulfillment(of: [secondSnapshot], timeout: 1)
     }
     
     /// Cancelling the underlying operation will emit a completion to the subscribers
@@ -353,9 +357,11 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
     ///    - the subscriber receives a cancellation
     ///
     func testSuccessfulSequenceCancel() async throws {
-        let firstSnapshot = asyncExpectation(description: "first query snapshot")
-        let secondSnapshot = asyncExpectation(description: "second query snapshot", isInverted: true)
-        let completedEvent = asyncExpectation(description: "should have completed")
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
+        secondSnapshot.isInverted = true
+
+        let completedEvent = expectation(description: "should have completed")
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -373,29 +379,29 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                 for try await querySnapshot in snapshots {
                     querySnapshots.append(querySnapshot)
                     if querySnapshots.count == 1 {
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
                         XCTFail("Should not receive second snapshot after cancelling")
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     }
                 }
-                await completedEvent.fulfill()
+                completedEvent.fulfill()
             } catch {
                 XCTFail("Failed with error \(error)")
             }
         }
-        await waitForExpectations([firstSnapshot], timeout: 1)
+        await fulfillment(of: [firstSnapshot], timeout: 1)
         snapshots.cancel()
         let post1 = try createPost(id: "1")
         dataStorePublisher.send(input: post1)
 
-        await waitForExpectations([secondSnapshot, completedEvent], timeout: 1)
+        await fulfillment(of: [secondSnapshot, completedEvent], timeout: 1)
     }
     
     ///  ObserveQuery's state should be able to be reset and initial query able to be started again.
     func testObserveQueryResetStateThenStartObserveQuery() async {
-        let firstSnapshot = asyncExpectation(description: "first query snapshot")
-        let secondSnapshot = asyncExpectation(description: "second query snapshot")
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -413,9 +419,9 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                 for try await querySnapshot in snapshots {
                     querySnapshots.append(querySnapshot)
                     if querySnapshots.count == 1 {
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     }
                 }
             } catch {
@@ -423,10 +429,10 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             }
         }
         
-        await waitForExpectations([firstSnapshot], timeout: 1)
+        await fulfillment(of: [firstSnapshot], timeout: 1)
         dataStoreStateSubject.send(.stop)
         dataStoreStateSubject.send(.start(storageEngine: storageEngine))
-        await waitForExpectations([secondSnapshot], timeout: 1)
+        await fulfillment(of: [secondSnapshot], timeout: 1)
     }
     
     /// Multiple calls to start the observeQuery should not start again
@@ -437,9 +443,11 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
     /// - Then:
     ///    - Only one query should be performed / only one snapshot should be returned
     func testObserveQueryStaredShouldNotStartAgain() async {
-        let firstSnapshot = asyncExpectation(description: "first query snapshot")
-        let secondSnapshot = asyncExpectation(description: "second query snapshot")
-        let thirdSnapshot = asyncExpectation(description: "third query snapshot", isInverted: true)
+        let firstSnapshot = expectation(description: "first query snapshot")
+        let secondSnapshot = expectation(description: "second query snapshot")
+        let thirdSnapshot = expectation(description: "third query snapshot")
+        thirdSnapshot.isInverted = true
+
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -457,11 +465,11 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                 for try await querySnapshot in snapshots {
                     querySnapshots.append(querySnapshot)
                     if querySnapshots.count == 1 {
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     } else if querySnapshots.count == 3 {
-                        await thirdSnapshot.fulfill()
+                        thirdSnapshot.fulfill()
                     }
                 }
             } catch {
@@ -469,18 +477,19 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             }
         }
         
-        await waitForExpectations([firstSnapshot], timeout: 1)
+        await fulfillment(of: [firstSnapshot], timeout: 1)
         dataStoreStateSubject.send(.stop)
         dataStoreStateSubject.send(.start(storageEngine: storageEngine))
         dataStoreStateSubject.send(.start(storageEngine: storageEngine))
-        await waitForExpectations([secondSnapshot, thirdSnapshot], timeout: 1)
+        await fulfillment(of: [secondSnapshot, thirdSnapshot], timeout: 1)
         XCTAssertTrue(taskRunner.observeQueryStarted)
     }
     
     /// ObserveQuery operation entry points are `resetState`, `startObserveQuery`, and `onItemChanges(mutationEvents)`.
     /// Ensure concurrent random sequences of these API calls do not cause issues such as data race.
     func testConcurrent() async {
-        let completeReceived = asyncExpectation(description: "complete received", isInverted: true)
+        let completeReceived = expectation(description: "complete received")
+        completeReceived.isInverted = true
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -502,7 +511,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             do {
                 for try await _ in snapshots {
                 }
-                await completeReceived.fulfill()
+                completeReceived.fulfill()
             } catch {
                 XCTFail("Failed with error \(error)")
             }
@@ -529,17 +538,17 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             for await _ in group {
             }
         }
-        await waitForExpectations([completeReceived], timeout: 10)
+        await fulfillment(of: [completeReceived], timeout: 10)
     }
     
     /// When a predicate like `title.beginsWith("title")` is given, the models that matched the predicate
     /// should be added to the snapshots, like `post` and `post2`. When `post2.title` is updated to no longer
     /// match the predicate, it should be removed from the snapshot.
     func testUpdatedModelNoLongerMatchesPredicateRemovedFromSnapshot() async throws {
-        let firstSnapshot = asyncExpectation(description: "first query snapshots")
-        let secondSnapshot = asyncExpectation(description: "second query snapshots")
-        let thirdSnapshot = asyncExpectation(description: "third query snapshots")
-        let fourthSnapshot = asyncExpectation(description: "fourth query snapshots")
+        let firstSnapshot = expectation(description: "first query snapshots")
+        let secondSnapshot = expectation(description: "second query snapshots")
+        let thirdSnapshot = expectation(description: "third query snapshots")
+        let fourthSnapshot = expectation(description: "fourth query snapshots")
         let taskRunner = ObserveQueryTaskRunner(
             modelType: Post.self,
             modelSchema: Post.schema,
@@ -560,31 +569,31 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
                     if querySnapshots.count == 1 {
                         // First snapshot is empty from the initial query
                         XCTAssertEqual(querySnapshot.items.count, 0)
-                        await firstSnapshot.fulfill()
+                        firstSnapshot.fulfill()
                     } else if querySnapshots.count == 2 {
                         // Second snapshot contains `post` since it matches the predicate
                         XCTAssertEqual(querySnapshot.items.count, 1)
                         XCTAssertEqual(querySnapshot.items[0].id, "1")
-                        await secondSnapshot.fulfill()
+                        secondSnapshot.fulfill()
                     } else if querySnapshots.count == 3 {
                         // Third snapshot contains both posts since they both match the predicate
                         XCTAssertEqual(querySnapshot.items.count, 2)
                         XCTAssertEqual(querySnapshot.items[0].id, "1")
                         XCTAssertEqual(querySnapshot.items[1].id, "2")
-                        await thirdSnapshot.fulfill()
+                        thirdSnapshot.fulfill()
                     } else if querySnapshots.count == 4 {
                         // Fourth snapshot no longer has the post2 since it was updated to not match the predicate
                         // and deleted at the same time.
                         XCTAssertEqual(querySnapshot.items.count, 1)
                         XCTAssertEqual(querySnapshot.items[0].id, "1")
-                        await fourthSnapshot.fulfill()
+                        fourthSnapshot.fulfill()
                     }
                 }
             } catch {
                 XCTFail("Failed with error \(error)")
             }
         }
-        await waitForExpectations([firstSnapshot], timeout: 5)
+        await fulfillment(of: [firstSnapshot], timeout: 5)
 
         let post = try createPost(id: "1", title: "title 1")
         dataStorePublisher.send(input: post)
@@ -593,7 +602,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
         var updatedPost2 = try createPost(id: "2", title: "Does not match predicate")
         updatedPost2.mutationType = MutationEvent.MutationType.update.rawValue
         dataStorePublisher.send(input: updatedPost2)
-        await waitForExpectations([secondSnapshot, thirdSnapshot, fourthSnapshot], timeout: 10)
+        await fulfillment(of: [secondSnapshot, thirdSnapshot, fourthSnapshot], timeout: 10)
     }
     
     

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/ObserveTaskRunnerTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/ObserveTaskRunnerTests.swift
@@ -16,26 +16,27 @@ final class ObserveTaskRunnerTests: XCTestCase {
         let runner = ObserveTaskRunner(publisher: dataStorePublisher.publisher)
         let sequence = runner.sequence
         
-        let started = asyncExpectation(description: "started")
-        let mutationEventReceived = asyncExpectation(description: "mutationEvent received",
-                                                     expectedFulfillmentCount: 5)
-        let mutationEventReceivedAfterCancel = asyncExpectation(description: "mutationEvent received", isInverted: true)
-        
+        let started = expectation(description: "started")
+        let mutationEventReceived = expectation(description: "mutationEvent received")
+        mutationEventReceived.expectedFulfillmentCount = 5
+        let mutationEventReceivedAfterCancel = expectation(description: "mutationEvent received")
+        mutationEventReceivedAfterCancel.isInverted = true
+
         let task = Task {
             do {
-                await started.fulfill()
+                started.fulfill()
                 for try await mutationEvent in sequence {
                     if mutationEvent.id == "id" {
-                        await mutationEventReceived.fulfill()
+                        mutationEventReceived.fulfill()
                     } else {
-                        await mutationEventReceivedAfterCancel.fulfill()
+                        mutationEventReceivedAfterCancel.fulfill()
                     }
                 }
             } catch {
                 XCTFail("Unexpected error \(error)")
             }
         }
-        await waitForExpectations([started], timeout: 10.0)
+        await fulfillment(of: [started], timeout: 10.0)
         var mutationEvent = MutationEvent(id: "id",
                                           modelId: "id",
                                           modelName: "name",
@@ -46,7 +47,7 @@ final class ObserveTaskRunnerTests: XCTestCase {
         dataStorePublisher.send(input: mutationEvent)
         dataStorePublisher.send(input: mutationEvent)
         dataStorePublisher.send(input: mutationEvent)
-        await waitForExpectations([mutationEventReceived], timeout: 1.0)
+        await fulfillment(of: [mutationEventReceived], timeout: 1.0)
         
         task.cancel()
         mutationEvent = MutationEvent(id: "id2",
@@ -55,6 +56,6 @@ final class ObserveTaskRunnerTests: XCTestCase {
                                       json: "json",
                                       mutationType: .create)
         dataStorePublisher.send(input: mutationEvent)
-        await waitForExpectations([mutationEventReceivedAfterCancel], timeout: 1.0)
+        await fulfillment(of: [mutationEventReceivedAfterCancel], timeout: 1.0)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
@@ -97,7 +97,16 @@ class InitialSyncOrchestratorTests: XCTestCase {
             syncCallbackReceived.fulfill()
         }
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(
+            of: [
+                syncCallbackReceived,
+                syncQueriesStartedReceived,
+                syncStartedReceived,
+                finishedReceived,
+                completionFinishedReceived
+            ],
+            timeout: 1
+        )
         XCTAssertEqual(orchestrator.syncOperationQueue.maxConcurrentOperationCount, 1)
         Amplify.Hub.removeListener(hubListener)
         sink.cancel()
@@ -196,7 +205,16 @@ class InitialSyncOrchestratorTests: XCTestCase {
             syncCallbackReceived.fulfill()
         }
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(
+            of: [
+                syncCallbackReceived,
+                syncQueriesStartedReceived,
+                syncStartedReceived,
+                finishedReceived,
+                failureCompletionReceived
+            ],
+            timeout: 1
+        )
         XCTAssertEqual(orchestrator.syncOperationQueue.maxConcurrentOperationCount, 1)
         Amplify.Hub.removeListener(hubListener)
         sink.cancel()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionTests.swift
@@ -99,13 +99,13 @@ class LocalSubscriptionTests: XCTestCase {
     /// - Then:
     ///    - I receive notifications for updates to that model
     func testObserve() async throws {
-        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
-
+        let receivedMutationEvent = expectation(description: "Received mutation event")
+        receivedMutationEvent.assertForOverFulfill = false
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await _ in mutationEvents {
-                    await receivedMutationEvent.fulfill()
+                    receivedMutationEvent.fulfill()
                 }
             } catch {
                 XCTFail("Unexpected error: \(error)")
@@ -122,7 +122,7 @@ class LocalSubscriptionTests: XCTestCase {
                          comments: [])
 
         _ = try await Amplify.DataStore.save(model)
-        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
+        await fulfillment(of: [receivedMutationEvent], timeout: 1.0)
         subscription.cancel()
     }
 
@@ -132,14 +132,14 @@ class LocalSubscriptionTests: XCTestCase {
     /// - Then:
     ///    - I am notified of `create` mutations
     func testCreate() async throws {
-        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
-
+        let receivedMutationEvent = expectation(description: "Received mutation event")
+        receivedMutationEvent.assertForOverFulfill = false
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await mutationEvent in mutationEvents {
                     if mutationEvent.mutationType == MutationEvent.MutationType.create.rawValue {
-                        await receivedMutationEvent.fulfill()
+                        receivedMutationEvent.fulfill()
                     }
                 }
             } catch {
@@ -157,7 +157,7 @@ class LocalSubscriptionTests: XCTestCase {
                          comments: [])
 
         _ = try await Amplify.DataStore.save(model)
-        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
+        await fulfillment(of: [receivedMutationEvent], timeout: 1.0)
 
         subscription.cancel()
     }
@@ -185,13 +185,14 @@ class LocalSubscriptionTests: XCTestCase {
         newModel.content = newContent
         newModel.updatedAt = .now()
 
-        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
+        let receivedMutationEvent = expectation(description: "Received mutation event")
+        receivedMutationEvent.assertForOverFulfill = false
 
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await _ in mutationEvents {
-                    await receivedMutationEvent.fulfill()
+                    receivedMutationEvent.fulfill()
                 }
             } catch {
                 XCTFail("Unexpected error: \(error)")
@@ -200,7 +201,7 @@ class LocalSubscriptionTests: XCTestCase {
         
         _ = try await Amplify.DataStore.save(newModel)
 
-        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
+        await fulfillment(of: [receivedMutationEvent], timeout: 1.0)
 
         subscription.cancel()
     }
@@ -211,14 +212,15 @@ class LocalSubscriptionTests: XCTestCase {
     /// - Then:
     ///    - I am notified of `delete` mutations
     func testDelete() async throws {
-        let receivedMutationEvent = asyncExpectation(description: "Received mutation event")
+        let receivedMutationEvent = expectation(description: "Received mutation event")
+        receivedMutationEvent.assertForOverFulfill = false
 
         let subscription = Task {
             let mutationEvents = Amplify.DataStore.observe(Post.self)
             do {
                 for try await mutationEvent in mutationEvents {
                     if mutationEvent.mutationType == MutationEvent.MutationType.delete.rawValue {
-                        await receivedMutationEvent.fulfill()
+                        receivedMutationEvent.fulfill()
                     }
                 }
             } catch {
@@ -232,7 +234,7 @@ class LocalSubscriptionTests: XCTestCase {
 
         _ = try await Amplify.DataStore.save(model)
         _ = try await Amplify.DataStore.delete(model)
-        await waitForExpectations([receivedMutationEvent], timeout: 1.0)
+        await fulfillment(of: [receivedMutationEvent], timeout: 1.0)
 
         subscription.cancel()
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
@@ -96,7 +96,7 @@ class AWSMutationEventIngesterTests: XCTestCase {
             XCTAssert(mutationEvents.first?.json.contains(post.id) ?? false)
         }
 
-        wait(for: [mutationEventQueryCompleted], timeout: 1.0)
+        await fulfillment(of: [mutationEventQueryCompleted], timeout: 1.0)
 
     }
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationEventClearStateTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationEventClearStateTests.swift
@@ -49,8 +49,13 @@ class MutationEventClearStateTests: XCTestCase {
         mutationEventClearState.clearStateOutgoingMutations {
             completionExpectation.fulfill()
         }
-        wait(for: [queryExpectation,
-                   saveExpectation,
-                   completionExpectation], timeout: 1.0)
+        wait(
+            for: [
+                queryExpectation,
+                saveExpectation,
+                completionExpectation
+            ],
+            timeout: 1.0
+        )
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
@@ -73,7 +73,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [mutationEventVerified], timeout: 1)
     }
 
     /// - Given: An existing MutationEvent of type .create
@@ -123,7 +123,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
         
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     /// - Given: An existing MutationEvent of type .create
@@ -161,7 +161,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     // MARK: - Existing == .update
@@ -218,7 +218,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     /// - Given: An existing MutationEvent of type .update
@@ -268,7 +268,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
         
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     /// - Given: An existing MutationEvent of type .update
@@ -310,7 +310,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     // MARK: - Existing == .delete
@@ -358,7 +358,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     // test_<existing>_<candidate>
@@ -408,7 +408,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
                                 mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     // MARK: - Empty queue tests
@@ -454,7 +454,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     /// - Given: An empty mutation queue
@@ -499,7 +499,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     /// - Given: An empty mutation queue
@@ -539,7 +539,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        wait(for: [mutationEventVerified], timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     // MARK: - In-process queue tests
@@ -579,7 +579,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     /// - Given: A mutation queue with an in-process .create event
@@ -633,7 +633,7 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
 
     /// - Given: A mutation queue with an in-process .create event
@@ -671,7 +671,6 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             mutationEventVerified.fulfill()
         }
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [mutationEventVerified], timeout: 1.0)
     }
-
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
@@ -118,13 +118,13 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         try await startAmplifyAndWaitForSync()
 
         // Save initial model
-        let createdNewItem = asyncExpectation(description: "createdNewItem")
+        let createdNewItem = expectation(description: "createdNewItem")
         let postCopy = post
         Task {
             _ = try await Amplify.DataStore.save(postCopy)
-            await createdNewItem.fulfill()
+            createdNewItem.fulfill()
         }
-        await waitForExpectations([createdNewItem])
+        await fulfillment(of: [createdNewItem])
         await fulfillment(of: [apiRespondedWithSuccess], timeout: 1.0, enforceOrder: false)
 
         // Set the responder to reject the mutation. Make sure to push a retry advice before sending
@@ -146,13 +146,13 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         // will be scheduled and probably in "waiting" mode when we send the network unavailable
         // notification below.
         post.content = "Update 1"
-        let savedUpdate1 = asyncExpectation(description: "savedUpdate1")
+        let savedUpdate1 = expectation(description: "savedUpdate1")
         let postCopy1 = post
         Task {
             _ = try await Amplify.DataStore.save(postCopy1)
-            await savedUpdate1.fulfill()
+            savedUpdate1.fulfill()
         }
-        await waitForExpectations([savedUpdate1])
+        await fulfillment(of: [savedUpdate1])
 
         // At this point, the MutationEvent table (the backing store for the outgoing mutation
         // queue) has only a record for the interim update. It is marked as `inProcess: true`,
@@ -178,7 +178,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
 
         // Assert that DataStore has pushed the no-network event. This isn't strictly necessary for
         // correct operation of the queue.
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [networkUnavailable], timeout: 1.0)
 
         // At this point, the MutationEvent table has only a record for update1. It is marked as
         // `inProcess: false`, because the mutation queue has been fully cancelled by the cleanup
@@ -193,13 +193,13 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         // also expect that it will be overwritten by the next mutation, without ever being synced
         // to the service.
         post.content = "Update 2"
-        let savedUpdate2 = asyncExpectation(description: "savedUpdate2")
+        let savedUpdate2 = expectation(description: "savedUpdate2")
         let postCopy2 = post
         Task {
             _ = try await Amplify.DataStore.save(postCopy2)
-            await savedUpdate2.fulfill()
+            savedUpdate2.fulfill()
         }
-        await waitForExpectations([savedUpdate2])
+        await fulfillment(of: [savedUpdate2])
 
         // At this point, the MutationEvent table has only a record for update2. It is marked as
         // `inProcess: false`, because the mutation queue has been fully cancelled.
@@ -210,13 +210,13 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         // even if there were multiple not-in-process mutations, after the reconciliation completes
         // there would only be one record in the MutationEvent table.
         post.content = expectedFinalContent
-        let savedFinalUpdate = asyncExpectation(description: "savedFinalUpdate")
+        let savedFinalUpdate = expectation(description: "savedFinalUpdate")
         let postCopy3 = post
         Task {
             _ = try await Amplify.DataStore.save(postCopy3)
-            await savedFinalUpdate.fulfill()
+            savedFinalUpdate.fulfill()
         }
-        await waitForExpectations([savedFinalUpdate])
+        await fulfillment(of: [savedFinalUpdate])
 
         let syncStarted = expectation(description: "syncStarted")
         setUpSyncStartedListener(
@@ -250,7 +250,8 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         
         apiPlugin.responders = [.mutateRequestListener: acceptSubsequentMutations]
         reachabilitySubject.send(ReachabilityUpdate(isOnline: true))
-        await waitForExpectations(timeout: 5.0)
+
+        await fulfillment(of: [networkAvailableAgain, syncStarted, expectedFinalContentReceived, outboxEmpty], timeout: 5.0)
     }
 
     // MARK: - Utilities

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
@@ -81,15 +81,22 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
 
         try await startAmplifyAndWaitForSync()
 
-        let saveSuccess = asyncExpectation(description: "save success")
+        let saveSuccess = expectation(description: "save success")
         Task {
             _ = try await Amplify.DataStore.save(post)
-            await saveSuccess.fulfill()
+            saveSuccess.fulfill()
         }
-        await waitForExpectations([saveSuccess], timeout: 1.0)
-        
-        
-        await waitForExpectations(timeout: 5.0, handler: nil)
+        await fulfillment(of: [saveSuccess], timeout: 1.0)
+
+        await fulfillment(
+            of: [
+                outboxStatusOnStart,
+                outboxStatusOnMutationEnqueued,
+                outboxMutationEnqueued,
+                createMutationSent
+            ],
+            timeout: 5.0
+        )
         Amplify.Hub.removeListener(hubListener)
     }
 
@@ -142,7 +149,7 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
 
         }
 
-        wait(for: [mutationEventSaved], timeout: 1.0)
+        await fulfillment(of: [mutationEventSaved], timeout: 1.0)
 
         var outboxStatusReceivedCurrentCount = 0
         let outboxStatusOnStart = expectation(description: "On DataStore start, outboxStatus received")
@@ -188,7 +195,18 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
             try await startAmplify()
         }
 
-        await waitForExpectations(timeout: 5.0, handler: nil)
+
+
+        await fulfillment(
+            of: [
+                outboxStatusOnStart,
+                outboxStatusOnMutationEnqueued,
+                mutation1Sent,
+                mutation2Sent
+            ],
+            timeout: 5.0
+        )
+
         Amplify.Hub.removeListener(hubListener)
     }
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
@@ -75,7 +75,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
                                                      completion: completion)
         let queue = OperationQueue()
         queue.addOperation(operation)
-        wait(for: [expectFirstCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
+        await fulfillment(of: [expectFirstCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
         guard let listenerFromFirstRequest = listenerFromFirstRequestOptional else {
             XCTFail("Listener was not called through MockAPICategoryPlugin")
             return
@@ -83,7 +83,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
 
         let urlError = URLError(URLError.notConnectedToInternet)
         listenerFromFirstRequest(.failure(APIError.networkError("mock NotConnectedToInternetError", nil, urlError)))
-        wait(for: [expectSecondCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
+        await fulfillment(of: [expectSecondCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
 
         guard let listenerFromSecondRequest = listenerFromSecondRequestOptional else {
             XCTFail("Listener was not called through MockAPICategoryPlugin")
@@ -100,7 +100,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         let remoteMutationSync = MutationSync(model: anyModel, syncMetadata: remoteSyncMetadata)
         listenerFromSecondRequest(.success(.success(remoteMutationSync)))
         // waitForExpectations(timeout: 1)
-        wait(for: [expectMutationRequestCompletion], timeout: defaultAsyncWaitTimeout)
+        await fulfillment(of: [expectMutationRequestCompletion], timeout: defaultAsyncWaitTimeout)
     }
 
     func testRetryOnChangeReachability() async throws {
@@ -148,7 +148,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
                                                      completion: completion)
         let queue = OperationQueue()
         queue.addOperation(operation)
-        wait(for: [expectFirstCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
+        await fulfillment(of: [expectFirstCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
         guard let listenerFromFirstRequest = listenerFromFirstRequestOptional else {
             XCTFail("Listener was not called through MockAPICategoryPlugin")
             return
@@ -158,7 +158,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         listenerFromFirstRequest(.failure(APIError.networkError("mock NotConnectedToInternetError", nil, urlError)))
         reachabilityPublisher.send(ReachabilityUpdate(isOnline: true))
 
-        wait(for: [expectSecondCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
+        await fulfillment(of: [expectSecondCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
         guard let listenerFromSecondRequest = listenerFromSecondRequestOptional else {
             XCTFail("Listener was not called through MockAPICategoryPlugin")
             return
@@ -173,7 +173,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
                                                       version: 2)
         let remoteMutationSync = MutationSync(model: anyModel, syncMetadata: remoteSyncMetadata)
         listenerFromSecondRequest(.success(.success(remoteMutationSync)))
-        wait(for: [expectMutationRequestCompletion], timeout: defaultAsyncWaitTimeout)
+        await fulfillment(of: [expectMutationRequestCompletion], timeout: defaultAsyncWaitTimeout)
     }
 
     func testAbilityToCancel() async throws {
@@ -221,7 +221,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
                                                      completion: completion)
         let queue = OperationQueue()
         queue.addOperation(operation)
-        wait(for: [expectFirstCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
+        await fulfillment(of: [expectFirstCallToAPIMutate], timeout: defaultAsyncWaitTimeout)
         guard let listenerFromFirstRequest = listenerFromFirstRequestOptional else {
             XCTFail("Listener was not called through MockAPICategoryPlugin")
             return
@@ -232,7 +232,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
 
         // At this point, we will be "waiting forever" to retry our request or until the operation is canceled
         operation.cancel()
-        wait(for: [expectMutationRequestFailed], timeout: defaultAsyncWaitTimeout)
+        await fulfillment(of: [expectMutationRequestFailed], timeout: defaultAsyncWaitTimeout)
     }
 }
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
@@ -104,15 +104,22 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
         }
 
         try Amplify.configure(amplifyConfig)
-        let startSuccess = asyncExpectation(description: "start success")
+        let startSuccess = expectation(description: "start success")
         Task {
             _ = try await Amplify.DataStore.start()
-            await startSuccess.fulfill()
+            startSuccess.fulfill()
         }
-        await waitForExpectations([startSuccess], timeout: 1.0)
-        
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [startSuccess], timeout: 1.0)
+        await fulfillment(
+            of: [
+                createSubscriptionStarted,
+                updateSubscriptionStarted,
+                deleteSubscriptionStarted
+            ],
+            timeout: 1.0
+        )
     }
+
     // TODO: Implement the test below
 
     /// - Given: Amplify configured with an API

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
@@ -130,7 +130,20 @@ class RemoteSyncEngineTests: XCTestCase {
 
         remoteSyncEngine.start(api: apiPlugin, auth: nil)
 
-        await waitForExpectations(timeout: defaultAsyncWaitTimeout)
+        await fulfillment(
+            of: [
+                storageAdapterAvailable,
+                subscriptionsPaused,
+                mutationsPaused,
+                stateMutationsCleared,
+                subscriptionsInitialized,
+                subscriptionsEstablishedReceived,
+                cleanedup,
+                failureOnInitialSync,
+                retryAdviceReceivedNetworkError
+            ],
+            timeout: defaultAsyncWaitTimeout
+        )
         remoteSyncEngineSink.cancel()
         Amplify.Hub.removeListener(hubListener)
     }
@@ -182,15 +195,20 @@ class RemoteSyncEngineTests: XCTestCase {
 
         remoteSyncEngine.start(api: apiPlugin, auth: nil)
 
-        wait(for: [storageAdapterAvailable,
-                   subscriptionsPaused,
-                   mutationsPaused,
-                   stateMutationsCleared,
-                   subscriptionsInitialized,
-                   performedInitialSync,
-                   subscriptionActivation,
-                   mutationQueueStarted,
-                   syncStarted], timeout: defaultAsyncWaitTimeout)
+        wait(
+            for: [
+                storageAdapterAvailable,
+                subscriptionsPaused,
+                mutationsPaused,
+                stateMutationsCleared,
+                subscriptionsInitialized,
+                performedInitialSync,
+                subscriptionActivation,
+                mutationQueueStarted,
+                syncStarted
+            ],
+            timeout: defaultAsyncWaitTimeout
+        )
         remoteSyncEngineSink.cancel()
     }
 
@@ -253,17 +271,22 @@ class RemoteSyncEngineTests: XCTestCase {
 
         remoteSyncEngine.start(api: apiPlugin, auth: nil)
 
-        wait(for: [storageAdapterAvailable,
-                   subscriptionsPaused,
-                   mutationsPaused,
-                   stateMutationsCleared,
-                   subscriptionsInitialized,
-                   performedInitialSync,
-                   subscriptionActivation,
-                   mutationQueueStarted,
-                   syncStarted,
-                   cleanedUp,
-                   forceFailToNotRestartSyncEngine], timeout: defaultAsyncWaitTimeout)
+        wait(
+            for: [
+                storageAdapterAvailable,
+                subscriptionsPaused,
+                mutationsPaused,
+                stateMutationsCleared,
+                subscriptionsInitialized,
+                performedInitialSync,
+                subscriptionActivation,
+                mutationQueueStarted,
+                syncStarted,
+                cleanedUp,
+                forceFailToNotRestartSyncEngine
+            ],
+            timeout: defaultAsyncWaitTimeout
+        )
         remoteSyncEngineSink.cancel()
     }
 
@@ -330,18 +353,23 @@ class RemoteSyncEngineTests: XCTestCase {
 
         remoteSyncEngine.start(api: apiPlugin, auth: nil)
 
-        wait(for: [storageAdapterAvailable,
-                   subscriptionsPaused,
-                   mutationsPaused,
-                   stateMutationsCleared,
-                   subscriptionsInitialized,
-                   performedInitialSync,
-                   subscriptionActivation,
-                   mutationQueueStarted,
-                   syncStarted,
-                   cleanedUpForTermination,
-                   completionBlockCalled,
-                   forceFailToNotRestartSyncEngine], timeout: defaultAsyncWaitTimeout)
+        wait(
+            for: [
+                storageAdapterAvailable,
+                subscriptionsPaused,
+                mutationsPaused,
+                stateMutationsCleared,
+                subscriptionsInitialized,
+                performedInitialSync,
+                subscriptionActivation,
+                mutationQueueStarted,
+                syncStarted,
+                cleanedUpForTermination,
+                completionBlockCalled,
+                forceFailToNotRestartSyncEngine
+            ],
+            timeout: defaultAsyncWaitTimeout
+        )
         remoteSyncEngineSink.cancel()
     }
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -78,8 +78,8 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        await waitForExpectations(timeout: 2)
 
+        await fulfillment(of: [expectStarted, expectInitialized], timeout: 2)
         // Take action on the sink to prevent compiler warnings about unused variables.
         sink.cancel()
     }
@@ -113,8 +113,8 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        await waitForExpectations(timeout: 2)
 
+        await fulfillment(of: [expectStarted, expectInitialized], timeout: 2)
         sink.cancel()
     }
 
@@ -152,8 +152,8 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        await waitForExpectations(timeout: 2)
 
+        await fulfillment(of: [expectStarted, expectInitialized], timeout: 2)
         sink.cancel()
     }
 
@@ -187,8 +187,8 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        await waitForExpectations(timeout: 2)
 
+        await fulfillment(of: [expectStarted, expectInitialized], timeout: 2)
         sink.cancel()
     }
 
@@ -228,8 +228,8 @@ class AWSIncomingEventReconciliationQueueTests: XCTestCase {
             operationQueue.addOperation(cancellableOperation)
         }
         operationQueue.isSuspended = false
-        await waitForExpectations(timeout: 2)
 
+        await fulfillment(of: [expectStarted, expectInitialized], timeout: 2)
         sink.cancel()
 
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
@@ -38,7 +38,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
                                                      version: 2)
         let localMetadataSaved = expectation(description: "Local metadata saved")
         storageAdapter.save(localSyncMetadata) { _ in localMetadataSaved.fulfill() }
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [localMetadataSaved], timeout: 1)
 
         var valueListenerFromRequest: MutationSyncInProcessListener?
         let expectationListener = expectation(description: "listener")
@@ -57,8 +57,8 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
             mockRemoteSyncEngineFor_testUpdateAfterDelete()
             try await startAmplifyAndWaitForSync()
         }
-        await waitForExpectations(timeout: 2.0)
 
+        await fulfillment(of: [expectationListener], timeout: 2)
         guard let valueListener = valueListenerFromRequest else {
                 XCTFail("Incoming responder didn't set up listener")
                 return
@@ -149,8 +149,8 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
             mockRemoteSyncEngineFor_testDeleteWithNoLocalModel()
             try await startAmplifyAndWaitForSync()
         }
-        await waitForExpectations(timeout: 1)
-
+        
+        await fulfillment(of: [expectationListener], timeout: 1)
         guard let valueListener = valueListenerFromRequest else {
             XCTFail("Incoming responder didn't set up listener")
             return
@@ -176,8 +176,7 @@ class ModelReconciliationDeleteTests: SyncEngineTestBase {
         let remoteMutationSync = MutationSync(model: anyModel, syncMetadata: remoteSyncMetadata)
         valueListener(.data(.success(remoteMutationSync)))
 
-        await waitForExpectations(timeout: 1)
-
+        await fulfillment(of: [syncReceivedNotification], timeout: 1)
         let finalLocalMetadata = try storageAdapter.queryMutationSyncMetadata(for: model.id,
                                                                                  modelName: MockSynced.modelName)
         XCTAssertEqual(finalLocalMetadata?.version, 2)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -51,7 +51,7 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
             subscriptionEventsSubject.send(.mutationEvent(mutationSync))
         }
 
-        wait(for: [eventsNotSaved], timeout: 5.0)
+        await fulfillment(of: [eventsNotSaved], timeout: 5.0)
     }
 
     /// - Given: An AWSModelReconciliationQueue that has been buffering events
@@ -120,7 +120,17 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         queue.start()
 
-        await waitForExpectations(timeout: 5.0)
+        await fulfillment(
+            of: [
+                event1Saved,
+                event2Saved,
+                event3Saved,
+                eventsSentViaPublisher1,
+                eventsSentViaPublisher2,
+                eventsSentViaPublisher3
+            ],
+            timeout: 5
+        )
         queueSink.cancel()
     }
 
@@ -190,7 +200,15 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         queue.start()
 
-        await waitForExpectations(timeout: 5.0)
+        await fulfillment(
+            of: [
+                event1Saved,
+                event3Saved,
+                eventsSentViaPublisher1,
+                eventsSentViaPublisher3
+            ],
+            timeout: 5
+        )
         queueSink.cancel()
     }
 
@@ -283,7 +301,15 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         queue.start()
 
-        await waitForExpectations(timeout: 5.0)
+        await fulfillment(
+            of: [
+                eventsSentViaPublisher1,
+                eventsSentViaPublisher2,
+                eventsSentViaPublisher3,
+                allEventsProcessed
+            ],
+            timeout: 5
+        )
         queueSink.cancel()
     }
 
@@ -351,7 +377,15 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
 
         queue.start()
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(
+            of: [
+                event1ShouldBeProcessed,
+                event2ShouldBeProcessed,
+                eventsSentViaPublisher1,
+                eventsSentViaPublisher2
+            ],
+            timeout: 1
+        )
 
         let event1ShouldNotBeProcessed = expectation(description: "Event 1 should not be processed")
         event1ShouldNotBeProcessed.isInverted = true
@@ -393,7 +427,15 @@ class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
         let mutationSync = MutationSync(model: model, syncMetadata: syncMetadata)
         subscriptionEventsSubject.send(.mutationEvent(mutationSync))
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(
+            of: [
+                event1ShouldNotBeProcessed,
+                event2ShouldNotBeProcessed,
+                event3ShouldBeProcessed,
+                eventsSentViaPublisher3
+            ],
+            timeout: 1
+        )
         queueSink.cancel()
     }
 
@@ -437,7 +479,7 @@ extension ModelReconciliationQueueBehaviorTests {
         })
 
         subscriptionEventsSubject.send(completion: completion)
-        wait(for: [eventSentViaPublisher], timeout: 1.0)
+        await fulfillment(of: [eventSentViaPublisher], timeout: 1.0)
         queueSink.cancel()
     }
 
@@ -465,7 +507,7 @@ extension ModelReconciliationQueueBehaviorTests {
         })
 
         subscriptionEventsSubject.send(completion: completion)
-        wait(for: [eventSentViaPublisher], timeout: 1.0)
+        await fulfillment(of: [eventSentViaPublisher], timeout: 1.0)
         queueSink.cancel()
     }
 
@@ -493,7 +535,7 @@ extension ModelReconciliationQueueBehaviorTests {
         })
 
         subscriptionEventsSubject.send(completion: completion)
-        wait(for: [eventSentViaPublisher], timeout: 1.0)
+        await fulfillment(of: [eventSentViaPublisher], timeout: 1.0)
         queueSink.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/LocalStoreIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/LocalStoreIntegrationTestBase.swift
@@ -30,13 +30,13 @@ class LocalStoreIntegrationTestBase: XCTestCase {
     }
 
     override func tearDown() async throws {
-        let clearComplete = asyncExpectation(description: "clear completed")
+        let clearComplete = expectation(description: "clear completed")
         
         Task {
             try await Amplify.DataStore.clear()
-            await clearComplete.fulfill()
+            clearComplete.fulfill()
         }
-        await waitForExpectations([clearComplete], timeout: 5)
+        await fulfillment(of: [clearComplete], timeout: 5)
         await Amplify.reset()
     }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreAuthBaseTest.swift
@@ -85,18 +85,18 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
     // MARK: - Test Helpers
     func makeExpectations() -> AuthTestExpectations {
         AuthTestExpectations(
-            subscriptionsEstablished: asyncExpectation(description: "Subscriptions established"),
-            modelsSynced: asyncExpectation(description: "Models synced"),
+            subscriptionsEstablished: expectation(description: "Subscriptions established"),
+            modelsSynced: expectation(description: "Models synced"),
 
-            query: asyncExpectation(description: "Query success"),
+            query: expectation(description: "Query success"),
 
-            mutationSave: asyncExpectation(description: "Mutation save success"),
-            mutationSaveProcessed: asyncExpectation(description: "Mutation save processed"),
+            mutationSave: expectation(description: "Mutation save success"),
+            mutationSaveProcessed: expectation(description: "Mutation save processed"),
 
-            mutationDelete: asyncExpectation(description: "Mutation delete success"),
-            mutationDeleteProcessed: asyncExpectation(description: "Mutation delete processed"),
+            mutationDelete: expectation(description: "Mutation delete success"),
+            mutationDeleteProcessed: expectation(description: "Mutation delete processed"),
 
-            ready: asyncExpectation(description: "Ready")
+            ready: expectation(description: "Ready")
         )
     }
 
@@ -292,12 +292,12 @@ extension AWSDataStoreAuthBaseTest {
             do {
                 let posts = try await Amplify.DataStore.query(modelType)
                 XCTAssertNotNil(posts)
-                await expectations.query.fulfill()
+                expectations.query.fulfill()
             } catch {
                 onFailure(error as! DataStoreError)
             }
         }
-        await waitForExpectations([expectations.query], timeout: 60)
+        await fulfillment(of: [expectations.query], timeout: 60)
     }
     
     /// Asserts that DataStore is in a ready state and subscriptions are established
@@ -315,25 +315,25 @@ extension AWSDataStoreAuthBaseTest {
             .sink { event in
                 // subscription fulfilled
                 if event.eventName == dataStoreEvents.subscriptionsEstablished {
-                    Task { await expectations.subscriptionsEstablished.fulfill() }
+                    expectations.subscriptionsEstablished.fulfill()
                 }
                 // modelsSynced fulfilled
                 if event.eventName == dataStoreEvents.modelSynced {
                     modelSyncedCount += 1
                     if modelSyncedCount == expectedModelSynced {
-                        Task { await expectations.modelsSynced.fulfill() }
+                        expectations.modelsSynced.fulfill()
                     }
                 }
                 
                 if event.eventName == dataStoreEvents.ready {
-                    Task { await expectations.ready.fulfill() }
+                    expectations.ready.fulfill()
                 }
             }
             .store(in: &requests)
         
         try await Amplify.DataStore.start()
         
-        await waitForExpectations([expectations.subscriptionsEstablished,
+        await fulfillment(of: [expectations.subscriptionsEstablished,
                                    expectations.modelsSynced,
                                    expectations.ready],
                                   timeout: 60)
@@ -361,12 +361,12 @@ extension AWSDataStoreAuthBaseTest {
                 }
 
                 if mutationEvent.mutationType == GraphQLMutationType.create.rawValue {
-                    Task { await expectations.mutationSaveProcessed.fulfill() }
+                    expectations.mutationSaveProcessed.fulfill()
                     return
                 }
 
                 if mutationEvent.mutationType == GraphQLMutationType.delete.rawValue {
-                    Task { await expectations.mutationDeleteProcessed.fulfill() }
+                    expectations.mutationDeleteProcessed.fulfill()
                     return
                 }
             }
@@ -375,23 +375,23 @@ extension AWSDataStoreAuthBaseTest {
             do {
                 let posts = try await Amplify.DataStore.save(model)
                 XCTAssertNotNil(posts)
-                Task { await expectations.mutationSave.fulfill() }
+                expectations.mutationSave.fulfill()
             } catch let error as DataStoreError {
                 onFailure(error)
             }
         }
-        await waitForExpectations([expectations.mutationSave,
+        await fulfillment(of: [expectations.mutationSave,
                                    expectations.mutationSaveProcessed], timeout: 60)
         Task {
             do {
                 let deletedposts: () = try await Amplify.DataStore.delete(model)
                 XCTAssertNotNil(deletedposts)
-                Task { await expectations.mutationDelete.fulfill() }
+                expectations.mutationDelete.fulfill()
             } catch let error as DataStoreError {
                 onFailure(error)
             }
         }
-        await waitForExpectations([expectations.mutationDelete,
+        await fulfillment(of: [expectations.mutationDelete,
                                    expectations.mutationDeleteProcessed], timeout: 60)
     }
 
@@ -408,15 +408,15 @@ extension AWSDataStoreAuthBaseTest {
 // MARK: - Expectations
 extension AWSDataStoreAuthBaseTest {
     struct AuthTestExpectations {
-        var subscriptionsEstablished: AsyncExpectation
-        var modelsSynced: AsyncExpectation
-        var query: AsyncExpectation
-        var mutationSave: AsyncExpectation
-        var mutationSaveProcessed: AsyncExpectation
-        var mutationDelete: AsyncExpectation
-        var mutationDeleteProcessed: AsyncExpectation
-        var ready: AsyncExpectation
-        var expectations: [AsyncExpectation] {
+        var subscriptionsEstablished: XCTestExpectation
+        var modelsSynced: XCTestExpectation
+        var query: XCTestExpectation
+        var mutationSave: XCTestExpectation
+        var mutationSaveProcessed: XCTestExpectation
+        var mutationDelete: XCTestExpectation
+        var mutationDeleteProcessed: XCTestExpectation
+        var ready: XCTestExpectation
+        var expectations: [XCTestExpectation] {
             return [subscriptionsEstablished,
                     modelsSynced,
                     query,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthIntegrationTests+Support.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthIntegrationTests+Support.swift
@@ -14,17 +14,17 @@ import DataStoreHostApp
 
 extension AWSDataStoreCategoryPluginAuthIntegrationTests {
     func saveModel<T: Model>(_ model: T) async throws {
-        let localSaveInvoked = asyncExpectation(description: "local model was saved")
+        let localSaveInvoked = expectation(description: "local model was saved")
         Task {
             do {
                 let savedposts = try await Amplify.DataStore.save(model)
                 print("Local model was saved: \(savedposts)")
-                await localSaveInvoked.fulfill()
+                localSaveInvoked.fulfill()
             } catch {
                 XCTFail("Failed to save model \(error)")
                 throw error
             }
         }
-        await waitForExpectations([localSaveInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [localSaveInvoked], timeout: TestCommonConstants.networkTimeout)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthIntegrationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthIntegrationTests.swift
@@ -40,7 +40,7 @@ class AWSDataStoreCategoryPluginAuthIntegrationTests: AWSDataStoreAuthBaseTest {
             return
         }
 
-        let syncReceivedInvoked = asyncExpectation(description: "Received SyncReceived event")
+        let syncReceivedInvoked = expectation(description: "Received SyncReceived event")
         var remoteTodoOptional: TodoExplicitOwnerField?
         let syncReceivedListener = Amplify.Hub.listen(to: .dataStore, eventName: syncReceived) { payload in
             guard let mutationEvent = payload.data as? MutationEvent,
@@ -50,7 +50,7 @@ class AWSDataStoreCategoryPluginAuthIntegrationTests: AWSDataStoreAuthBaseTest {
             }
             if todo.id == savedLocalTodo.id {
                 remoteTodoOptional = todo
-                Task { await syncReceivedInvoked.fulfill() }
+                syncReceivedInvoked.fulfill()
             }
         }
         guard try await HubListenerTestUtilities.waitForListener(with: syncReceivedListener, timeout: 5.0) else {
@@ -60,7 +60,7 @@ class AWSDataStoreCategoryPluginAuthIntegrationTests: AWSDataStoreAuthBaseTest {
 
         try await signIn(user: user1)
 
-        await waitForExpectations([syncReceivedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [syncReceivedInvoked], timeout: TestCommonConstants.networkTimeout)
         Amplify.Hub.removeListener(syncReceivedListener)
         guard let remoteTodo = remoteTodoOptional else {
             XCTFail("Should have received a SyncReceived event with the remote note reconciled to local store")

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthIAMTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthIAMTests/AWSDataStoreAuthBaseTest.swift
@@ -117,18 +117,18 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
     // MARK: - Test Helpers
     func makeExpectations() -> AuthTestExpectations {
         AuthTestExpectations(
-            subscriptionsEstablished: AsyncExpectation(description: "Subscriptions established"),
-            modelsSynced: AsyncExpectation(description: "Models synced"),
+            subscriptionsEstablished: expectation(description: "Subscriptions established"),
+            modelsSynced: expectation(description: "Models synced"),
 
-            query: AsyncExpectation(description: "Query success"),
+            query: expectation(description: "Query success"),
 
-            mutationSave: AsyncExpectation(description: "Mutation save success"),
-            mutationSaveProcessed: AsyncExpectation(description: "Mutation save processed"),
+            mutationSave: expectation(description: "Mutation save success"),
+            mutationSaveProcessed: expectation(description: "Mutation save processed"),
 
-            mutationDelete: AsyncExpectation(description: "Mutation delete success"),
-            mutationDeleteProcessed: AsyncExpectation(description: "Mutation delete processed"),
+            mutationDelete: expectation(description: "Mutation delete success"),
+            mutationDeleteProcessed: expectation(description: "Mutation delete processed"),
 
-            ready: AsyncExpectation(description: "Ready")
+            ready: expectation(description: "Ready")
         )
     }
 
@@ -238,21 +238,17 @@ extension AWSDataStoreAuthBaseTest {
             XCTFail("Invalid user", file: file, line: line)
             return
         }
-        let signInInvoked = AsyncExpectation(description: "sign in completed")
+        let signInInvoked = expectation(description: "sign in completed")
         do {
             _ = try await Amplify.Auth.signIn(username: user.username,
                                                        password: user.password,
                                                        options: nil)
-            Task {
-                await signInInvoked.fulfill()
-            }
+            signInInvoked.fulfill()
         } catch(let error) {
             XCTFail("Signin failure \(error)", file: file, line: line)
-            Task {
-                await signInInvoked.fulfill() // won't count as pass
-            }
+            signInInvoked.fulfill() // won't count as pass
         }
-        await waitForExpectations([signInInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [signInInvoked], timeout: TestCommonConstants.networkTimeout)
         
         let signedIn = await isSignedIn()
         XCTAssert(signedIn, file: file, line: line)
@@ -261,32 +257,30 @@ extension AWSDataStoreAuthBaseTest {
     /// Signout current signed-in user
     func signOut(file: StaticString = #file,
                  line: UInt = #line) async {
-        let signoutInvoked = AsyncExpectation(description: "sign out completed")
+        let signoutInvoked = expectation(description: "sign out completed")
         Task {
             _ = await Amplify.Auth.signOut()
-            await signoutInvoked.fulfill()
+            signoutInvoked.fulfill()
         }
         
-        await waitForExpectations([signoutInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [signoutInvoked], timeout: TestCommonConstants.networkTimeout)
         
         let signedIn = await isSignedIn()
         XCTAssert(!signedIn, file: file, line: line)
     }
 
     func isSignedIn() async -> Bool {
-        let checkIsSignedInCompleted = AsyncExpectation(description: "retrieve auth session completed")
+        let checkIsSignedInCompleted = expectation(description: "retrieve auth session completed")
         var resultOptional: Bool?
         do {
             let authSession = try await Amplify.Auth.fetchAuthSession()
             resultOptional = authSession.isSignedIn
-            Task {
-                await checkIsSignedInCompleted.fulfill()
-            }
+            checkIsSignedInCompleted.fulfill()
         } catch(let error) {
             fatalError("Failed to get auth session \(error)")
         }
         
-        await waitForExpectations([checkIsSignedInCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [checkIsSignedInCompleted], timeout: TestCommonConstants.networkTimeout)
         guard let result = resultOptional else {
             XCTFail("Could not get isSignedIn for user")
             return false
@@ -296,7 +290,7 @@ extension AWSDataStoreAuthBaseTest {
     }
 
     func getUserSub() async -> String {
-        let retrieveUserSubCompleted = AsyncExpectation(description: "retrieve userSub completed")
+        let retrieveUserSubCompleted = expectation(description: "retrieve userSub completed")
         var resultOptional: String?
         do {
             let authSession = try await Amplify.Auth.fetchAuthSession()
@@ -307,9 +301,7 @@ extension AWSDataStoreAuthBaseTest {
             switch cognitoAuthSession.getUserSub() {
             case .success(let userSub):
                 resultOptional = userSub
-                Task {
-                    await retrieveUserSubCompleted.fulfill()
-                }
+                retrieveUserSubCompleted.fulfill()
             case .failure(let error):
                 XCTFail("Failed to get auth session \(error)")
             }
@@ -317,7 +309,7 @@ extension AWSDataStoreAuthBaseTest {
             XCTFail("Failed to get auth session \(error)")
         }
 
-        await waitForExpectations([retrieveUserSubCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [retrieveUserSubCompleted], timeout: TestCommonConstants.networkTimeout)
         guard let result = resultOptional else {
             XCTFail("Could not get userSub for user")
             return ""
@@ -327,7 +319,7 @@ extension AWSDataStoreAuthBaseTest {
     }
 
     func getIdentityId() async -> String {
-        let retrieveIdentityCompleted = AsyncExpectation(description: "retrieve identity completed")
+        let retrieveIdentityCompleted = expectation(description: "retrieve identity completed")
         var resultOptional: String?
         do {
             let authSession = try await Amplify.Auth.fetchAuthSession()
@@ -338,16 +330,14 @@ extension AWSDataStoreAuthBaseTest {
             switch cognitoAuthSession.getIdentityId() {
             case .success(let identityId):
                 resultOptional = identityId
-                Task {
-                    await retrieveIdentityCompleted.fulfill()
-                }
+                retrieveIdentityCompleted.fulfill()
             case .failure(let error):
                 XCTFail("Failed to get auth session \(error)")
             }
         } catch(let error) {
             XCTFail("Failed to get auth session \(error)")
         }
-        await waitForExpectations([retrieveIdentityCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [retrieveIdentityCompleted], timeout: TestCommonConstants.networkTimeout)
         guard let result = resultOptional else {
             XCTFail("Could not get identityId for user")
             return ""
@@ -361,19 +351,17 @@ extension AWSDataStoreAuthBaseTest {
                               file: StaticString = #file,
                               line: UInt = #line) async -> M? {
         var queriedModel: M?
-        let queriedInvoked = AsyncExpectation(description: "Model queried")
+        let queriedInvoked = expectation(description: "Model queried")
 
         do {
             let model = try await Amplify.DataStore.query(M.self, byId: id)
             queriedModel = model
-            Task {
-                await queriedInvoked.fulfill()
-            }
+            queriedInvoked.fulfill()
         } catch(let error) {
             XCTFail("Failed to query model \(error)", file: file, line: line)
         }
         
-        await waitForExpectations([queriedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [queriedInvoked], timeout: TestCommonConstants.networkTimeout)
         return queriedModel
     }
 }
@@ -397,11 +385,9 @@ extension AWSDataStoreAuthBaseTest {
         }
         receiveValue: { posts in
             XCTAssertNotNil(posts)
-            Task {
-                await expectations.query.fulfill()
-            }
+            expectations.query.fulfill()
         }.store(in: &requests)
-        await waitForExpectations([expectations.query],
+        await fulfillment(of: [expectations.query],
              timeout: 60)
     }
 
@@ -417,25 +403,19 @@ extension AWSDataStoreAuthBaseTest {
             .sink { event in
                 // subscription fulfilled
                 if event.eventName == dataStoreEvents.subscriptionsEstablished {
-                    Task {
-                        await expectations.subscriptionsEstablished.fulfill()
-                    }
+                    expectations.subscriptionsEstablished.fulfill()
                 }
 
                 // modelsSynced fulfilled
                 if event.eventName == dataStoreEvents.modelSynced {
                     modelSyncedCount += 1
                     if modelSyncedCount == expectedModelSynced {
-                        Task {
-                            await expectations.modelsSynced.fulfill()
-                        }
+                        expectations.modelsSynced.fulfill()
                     }
                 }
 
                 if event.eventName == dataStoreEvents.ready {
-                    Task {
-                        await expectations.ready.fulfill()
-                    }
+                    expectations.ready.fulfill()
                 }
             }
             .store(in: &requests)
@@ -445,7 +425,7 @@ extension AWSDataStoreAuthBaseTest {
         } catch(let error) {
             XCTFail("Failure due to error: \(error)")
         }
-        await waitForExpectations([expectations.subscriptionsEstablished,
+        await fulfillment(of: [expectations.subscriptionsEstablished,
                                    expectations.modelsSynced,
                                    expectations.ready],
                              timeout: 60)
@@ -470,16 +450,12 @@ extension AWSDataStoreAuthBaseTest {
                 }
 
                 if mutationEvent.mutationType == GraphQLMutationType.create.rawValue {
-                    Task {
-                        await expectations.mutationSaveProcessed.fulfill()
-                    }
+                    expectations.mutationSaveProcessed.fulfill()
                     return
                 }
 
                 if mutationEvent.mutationType == GraphQLMutationType.delete.rawValue {
-                    Task {
-                        await expectations.mutationDeleteProcessed.fulfill()
-                    }
+                    expectations.mutationDeleteProcessed.fulfill()
                     return
                 }
             }
@@ -494,12 +470,10 @@ extension AWSDataStoreAuthBaseTest {
         }
         receiveValue: { posts in
             XCTAssertNotNil(posts)
-            Task {
-                await expectations.mutationSave.fulfill()
-            }
+            expectations.mutationSave.fulfill()
         }.store(in: &requests)
 
-        await waitForExpectations([expectations.mutationSave, expectations.mutationSaveProcessed], timeout: 60)
+        await fulfillment(of: [expectations.mutationSave, expectations.mutationSaveProcessed], timeout: 60)
 
         Amplify.Publisher.create {
             try await Amplify.DataStore.delete(model)
@@ -510,12 +484,10 @@ extension AWSDataStoreAuthBaseTest {
         }
         receiveValue: { posts in
             XCTAssertNotNil(posts)
-            Task {
-                await expectations.mutationDelete.fulfill()
-            }
+            expectations.mutationDelete.fulfill()
         }.store(in: &requests)
 
-        await waitForExpectations([expectations.mutationDelete, expectations.mutationDeleteProcessed], timeout: 60)
+        await fulfillment(of: [expectations.mutationDelete, expectations.mutationDeleteProcessed], timeout: 60)
     }
 
     func assertUsedAuthTypes(
@@ -545,15 +517,15 @@ extension AWSDataStoreAuthBaseTest {
 // MARK: - Expectations
 extension AWSDataStoreAuthBaseTest {
     struct AuthTestExpectations {
-        var subscriptionsEstablished: AsyncExpectation
-        var modelsSynced: AsyncExpectation
-        var query: AsyncExpectation
-        var mutationSave: AsyncExpectation
-        var mutationSaveProcessed: AsyncExpectation
-        var mutationDelete: AsyncExpectation
-        var mutationDeleteProcessed: AsyncExpectation
-        var ready: AsyncExpectation
-        var expectations: [AsyncExpectation] {
+        var subscriptionsEstablished: XCTestExpectation
+        var modelsSynced: XCTestExpectation
+        var query: XCTestExpectation
+        var mutationSave: XCTestExpectation
+        var mutationSaveProcessed: XCTestExpectation
+        var mutationDelete: XCTestExpectation
+        var mutationDeleteProcessed: XCTestExpectation
+        var ready: XCTestExpectation
+        var expectations: [XCTestExpectation] {
             return [subscriptionsEstablished,
                     modelsSynced,
                     query,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStorePrimaryKeyBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStorePrimaryKeyBaseTest.swift
@@ -121,8 +121,14 @@ extension AWSDataStorePrimaryKeyBaseTest {
             .store(in: &requests)
 
         try await Amplify.DataStore.start()
-
-        await waitForExpectations(timeout: 60)
+        await fulfillment(
+            of: [
+                ready,
+                subscriptionsEstablished,
+                modelsSynced
+            ],
+            timeout: 60
+        )
     }
 
     /// Assert that a save and a delete mutation complete successfully.
@@ -152,8 +158,11 @@ extension AWSDataStorePrimaryKeyBaseTest {
 
         let savedModels = try await Amplify.DataStore.save(model)
         XCTAssertNotNil(savedModels)
-        await waitForExpectations(timeout: 60)
-        
+        await fulfillment(
+            of: [mutationSaveProcessed],
+            timeout: 60
+        )
+
         let mutationDeleteProcessed = expectation(description: "mutation delete processed")
         Amplify
             .Hub
@@ -173,7 +182,10 @@ extension AWSDataStorePrimaryKeyBaseTest {
             .store(in: &requests)
         
         try await Amplify.DataStore.delete(model)
-        await waitForExpectations(timeout: 60)
+        await fulfillment(
+            of: [mutationDeleteProcessed],
+            timeout: 60
+        )
     }
 
     /// Assert that a save and a delete mutation complete successfully.
@@ -211,8 +223,8 @@ extension AWSDataStorePrimaryKeyBaseTest {
         // save child
         _ = try await Amplify.DataStore.save(child)
 
-        await waitForExpectations(timeout: 60)
-        
+        await fulfillment(of: [mutationSaveProcessed], timeout: 60)
+
         guard shouldDeleteParent else {
             return
         }
@@ -242,6 +254,6 @@ extension AWSDataStorePrimaryKeyBaseTest {
         
         // delete parent
         try await Amplify.DataStore.delete(parent)
-        await waitForExpectations(timeout: 60)
+        await fulfillment(of: [mutationDeleteProcessed], timeout: 60)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario1FlutterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario1FlutterTests.swift
@@ -62,7 +62,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [saveTeamCompleted, syncedTeamReceived], timeout: networkTimeout)
+        await fulfillment(of: [saveTeamCompleted, syncedTeamReceived], timeout: networkTimeout)
         let saveProjectCompleted = expectation(description: "save project completed")
         plugin.save(project.model, modelSchema: Project1.schema) { result in
             switch result {
@@ -72,7 +72,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [saveProjectCompleted, syncProjectReceived], timeout: networkTimeout)
+        await fulfillment(of: [saveProjectCompleted, syncProjectReceived], timeout: networkTimeout)
         let queriedProjectCompleted = expectation(description: "query project completed")
         plugin.query(FlutterSerializedModel.self, modelSchema: Project1.schema, where: Project1.keys.id.eq(project.model.id)) { result in
             switch result {
@@ -91,7 +91,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [queriedProjectCompleted], timeout: networkTimeout)
+        await fulfillment(of: [queriedProjectCompleted], timeout: networkTimeout)
     }
 
     func testUpdateProjectWithAnotherTeam() throws {
@@ -127,7 +127,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [saveTeamCompleted], timeout: networkTimeout)
+        await fulfillment(of: [saveTeamCompleted], timeout: networkTimeout)
         let saveAnotherTeamCompleted = expectation(description: "save team completed")
         plugin.save(anotherTeam.model, modelSchema: Team1.schema) { result in
             switch result {
@@ -137,7 +137,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [saveAnotherTeamCompleted], timeout: networkTimeout)
+        await fulfillment(of: [saveAnotherTeamCompleted], timeout: networkTimeout)
         let saveProjectCompleted = expectation(description: "save project completed")
         plugin.save(project.model, modelSchema: Project1.schema) { result in
             switch result {
@@ -147,7 +147,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [saveProjectCompleted], timeout: networkTimeout)
+        await fulfillment(of: [saveProjectCompleted], timeout: networkTimeout)
         let updateProjectCompleted = expectation(description: "save project completed")
         try project.setTeam(team: anotherTeam.model)
         plugin.save(project.model, modelSchema: Project1.schema) { result in
@@ -158,7 +158,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [updateProjectCompleted], timeout: networkTimeout)
+        await fulfillment(of: [updateProjectCompleted], timeout: networkTimeout)
         let queriedProjectCompleted = expectation(description: "query project completed")
         plugin.query(FlutterSerializedModel.self, modelSchema: Project1.schema, where: Project1.keys.id.eq(project.model.id)) { result in
             switch result {
@@ -175,7 +175,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [queriedProjectCompleted, syncUpdatedProjectReceived], timeout: networkTimeout)
+        await fulfillment(of: [queriedProjectCompleted, syncUpdatedProjectReceived], timeout: networkTimeout)
     }
 
     func testDeleteAndGetProject() throws {
@@ -195,7 +195,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [deleteProjectSuccessful], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteProjectSuccessful], timeout: TestCommonConstants.networkTimeout)
         let getProjectAfterDeleteCompleted = expectation(description: "get project after deleted complete")
         plugin.query(FlutterSerializedModel.self, modelSchema: Project1.schema, where: Project1.keys.id.eq(project.model.id)) { result in
             switch result {
@@ -206,7 +206,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeleteWithValidCondition() throws {
@@ -225,7 +225,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
         if queriedProjectExpect1!.count == 1 {
             queriedProjectExpect1Successful.fulfill()
         }
-        wait(for: [queriedProjectExpect1Successful], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [queriedProjectExpect1Successful], timeout: TestCommonConstants.networkTimeout)
         let deleteProjectSuccessful = expectation(description: "delete project")
         plugin.delete(project.model, modelSchema: Project1.schema, where: Project1.keys.id.eq(project.idString())) { result in
             switch result {
@@ -235,7 +235,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [deleteProjectSuccessful], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteProjectSuccessful], timeout: TestCommonConstants.networkTimeout)
         let getProjectAfterDeleteCompleted = expectation(description: "get project after deleted complete")
         let queriedProjectExpect0 = queryProject(id: project.model.id)
         XCTAssertNotNil(queriedProjectExpect0)
@@ -243,7 +243,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
         if queriedProjectExpect0!.count == 0 {
             getProjectAfterDeleteCompleted.fulfill()
         }
-        wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeleteWithInvalidCondition() throws {
@@ -262,7 +262,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
         if queriedProjectExpect1!.count == 1 {
             queriedProjectExpect1Successful.fulfill()
         }
-        wait(for: [queriedProjectExpect1Successful], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [queriedProjectExpect1Successful], timeout: TestCommonConstants.networkTimeout)
         let deleteProjectFailed = expectation(description: "delete project")
         plugin.delete(project.model, modelSchema: Project1.schema, where: Project1.keys.id.eq("invalid")) { result in
             switch result {
@@ -276,7 +276,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
                 deleteProjectFailed.fulfill()
             }
         }
-        wait(for: [deleteProjectFailed], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteProjectFailed], timeout: TestCommonConstants.networkTimeout)
         let getProjectAfterDeleteCompleted = expectation(description: "get project after deleted complete")
         let queriedProjectExpectUnDeleted = queryProject(id: project.model.id)
         XCTAssertNotNil(queriedProjectExpectUnDeleted)
@@ -285,7 +285,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
         if queriedProjectExpectUnDeleted!.count == 1 {
             getProjectAfterDeleteCompleted.fulfill()
         }
-        wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testListProjectsByTeamID() throws {
@@ -312,7 +312,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [listProjectByTeamIDCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [listProjectByTeamIDCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     func saveTeam(name: String) throws -> TeamWrapper? {
@@ -329,7 +329,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
 
         return TeamWrapper(model: result!)
     }
@@ -349,7 +349,7 @@ class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return Project1Wrapper(model: result!)
     }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario2FlutterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario2FlutterTests.swift
@@ -63,7 +63,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [saveTeamCompleted, syncedTeamReceived], timeout: networkTimeout)
+        await fulfillment(of: [saveTeamCompleted, syncedTeamReceived], timeout: networkTimeout)
         let saveProjectCompleted = expectation(description: "save project completed")
         plugin.save(project.model, modelSchema: Project2.schema) { result in
             switch result {
@@ -73,7 +73,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [saveProjectCompleted, syncProjectReceived], timeout: networkTimeout)
+        await fulfillment(of: [saveProjectCompleted, syncProjectReceived], timeout: networkTimeout)
         let queriedProjectCompleted = expectation(description: "query project completed")
         plugin.query(FlutterSerializedModel.self, modelSchema: Project2.schema, where: Project2.keys.id.eq(project.model.id)) { result in
             switch result {
@@ -85,7 +85,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [queriedProjectCompleted], timeout: networkTimeout)
+        await fulfillment(of: [queriedProjectCompleted], timeout: networkTimeout)
     }
 
     func testUpdateProjectWithAnotherTeam() throws {
@@ -124,7 +124,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [saveTeamCompleted], timeout: networkTimeout)
+        await fulfillment(of: [saveTeamCompleted], timeout: networkTimeout)
         let saveAnotherTeamCompleted = expectation(description: "save team completed")
         plugin.save(anotherTeam.model, modelSchema: Team2.schema) { result in
             switch result {
@@ -134,7 +134,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [saveAnotherTeamCompleted], timeout: networkTimeout)
+        await fulfillment(of: [saveAnotherTeamCompleted], timeout: networkTimeout)
         let saveProjectCompleted = expectation(description: "save project completed")
         plugin.save(project.model, modelSchema: Project2.schema) { result in
             switch result {
@@ -144,7 +144,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [saveProjectCompleted], timeout: networkTimeout)
+        await fulfillment(of: [saveProjectCompleted], timeout: networkTimeout)
         let updateProjectCompleted = expectation(description: "save project completed")
         try project.setTeam(name: "project1", team: anotherTeam.model, teamID: anotherTeam.idString())
         plugin.save(project.model, modelSchema: Project2.schema) { result in
@@ -155,7 +155,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [updateProjectCompleted], timeout: networkTimeout)
+        await fulfillment(of: [updateProjectCompleted], timeout: networkTimeout)
         let queriedProjectCompleted = expectation(description: "query project completed")
         plugin.query(FlutterSerializedModel.self, modelSchema: Project2.schema, where: Project2.keys.id.eq(project.model.id)) { result in
             switch result {
@@ -172,7 +172,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [queriedProjectCompleted, syncUpdatedProjectReceived], timeout: networkTimeout)
+        await fulfillment(of: [queriedProjectCompleted, syncUpdatedProjectReceived], timeout: networkTimeout)
     }
 
     func testDeleteAndGetProject() throws {
@@ -193,7 +193,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [deleteProjectSuccessful], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteProjectSuccessful], timeout: TestCommonConstants.networkTimeout)
         let getProjectAfterDeleteCompleted = expectation(description: "get project after deleted complete")
         plugin.query(FlutterSerializedModel.self, modelSchema: Project2.schema, where: Project2.keys.id.eq(project.model.id)) { result in
             switch result {
@@ -204,7 +204,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeleteWithValidCondition() throws {
@@ -222,7 +222,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [deleteProjectSuccessful], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteProjectSuccessful], timeout: TestCommonConstants.networkTimeout)
         let getProjectAfterDeleteCompleted = expectation(description: "get project after deleted complete")
         plugin.query(FlutterSerializedModel.self, modelSchema: Project2.schema, where: Project2.keys.id.eq(project!.model.id)) { result in
             switch result {
@@ -233,7 +233,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeleteWithInvalidCondition() throws {
@@ -257,7 +257,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 deleteProjectFailed.fulfill()
             }
         }
-        wait(for: [deleteProjectFailed], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteProjectFailed], timeout: TestCommonConstants.networkTimeout)
         let getProjectAfterDeleteCompleted = expectation(description: "get project after deleted complete")
         plugin.query(FlutterSerializedModel.self, modelSchema: Project2.schema, where: Project2.keys.id.eq(project.model.id)) { result in
             switch result {
@@ -268,7 +268,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeleteAlreadyDeletedItemWithCondition() throws {
@@ -288,7 +288,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [deleteProjectSuccessful], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteProjectSuccessful], timeout: TestCommonConstants.networkTimeout)
         let getProjectAfterDeleteCompleted = expectation(description: "get project after deleted complete")
         plugin.query(FlutterSerializedModel.self, modelSchema: Project2.schema, where: Project2.keys.id.eq(project.model.id)) { result in
             switch result {
@@ -300,7 +300,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getProjectAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
         let deleteProjectSuccessful2 = expectation(description: "delete project")
         plugin.delete(project.model, modelSchema: Project2.schema, where: Project2.keys.teamID.eq(team.idString())) { result in
             switch result {
@@ -310,7 +310,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [deleteProjectSuccessful2], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteProjectSuccessful2], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testListProjectsByTeamID() throws {
@@ -338,7 +338,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [listProjectByTeamIDCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [listProjectByTeamIDCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     func saveTeam(name: String, plugin: AWSDataStorePlugin) throws -> TeamWrapper? {
@@ -354,7 +354,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
@@ -373,7 +373,7 @@ class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario3FlutterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario3FlutterTests.swift
@@ -64,7 +64,7 @@ class DataStoreConnectionScenario3FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [savePostCompleted, syncedPostReceived], timeout: networkTimeout)
+        await fulfillment(of: [savePostCompleted, syncedPostReceived], timeout: networkTimeout)
         let saveCommentCompleted = expectation(description: "save comment completed")
         plugin.save(comment.model, modelSchema: Comment3.schema) { result in
             switch result {
@@ -74,7 +74,7 @@ class DataStoreConnectionScenario3FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [saveCommentCompleted, syncCommentReceived], timeout: networkTimeout)
+        await fulfillment(of: [saveCommentCompleted, syncCommentReceived], timeout: networkTimeout)
         let queriedCommentCompleted = expectation(description: "query comment completed")
         plugin.query(FlutterSerializedModel.self, modelSchema: Comment3.schema, where: Comment3.keys.id.eq(comment.model.id)) { result in
             switch result {
@@ -86,7 +86,7 @@ class DataStoreConnectionScenario3FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [queriedCommentCompleted], timeout: networkTimeout)
+        await fulfillment(of: [queriedCommentCompleted], timeout: networkTimeout)
     }
 
     /// TODO:  Include testSaveCommentAndGetPostWithComments test when nested model lazy loading is implemented
@@ -117,7 +117,7 @@ class DataStoreConnectionScenario3FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [updateCommentSuccessful], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [updateCommentSuccessful], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeleteAndGetComment() throws {
@@ -140,7 +140,7 @@ class DataStoreConnectionScenario3FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [deleteCommentSuccessful], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteCommentSuccessful], timeout: TestCommonConstants.networkTimeout)
         let getCommentAfterDeleteCompleted = expectation(description: "get comment after deleted complete")
         plugin.query(FlutterSerializedModel.self, modelSchema: Comment3.schema, where: Comment3.keys.id.eq(comment.idString())) { result in
             switch result {
@@ -154,7 +154,7 @@ class DataStoreConnectionScenario3FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [getCommentAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getCommentAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testListCommentsByPostID() throws {
@@ -179,7 +179,7 @@ class DataStoreConnectionScenario3FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [listCommentByPostIDCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [listCommentByPostIDCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     func savePost(id: String = UUID().uuidString, title: String, plugin: AWSDataStorePlugin) throws -> Post3Wrapper? {
@@ -197,7 +197,7 @@ class DataStoreConnectionScenario3FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
@@ -214,7 +214,7 @@ class DataStoreConnectionScenario3FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario4FlutterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario4FlutterTests.swift
@@ -54,7 +54,7 @@ class DataStoreConnectionScenario4FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [getCommentCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getCommentCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testUpdateComment() throws {
@@ -84,7 +84,7 @@ class DataStoreConnectionScenario4FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [updateCommentSuccessful], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [updateCommentSuccessful], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testDeleteAndGetComment() throws {
@@ -108,7 +108,7 @@ class DataStoreConnectionScenario4FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [deleteCommentSuccessful], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteCommentSuccessful], timeout: TestCommonConstants.networkTimeout)
         let getCommentAfterDeleteCompleted = expectation(description: "get comment after deleted complete")
         plugin.query(FlutterSerializedModel.self, modelSchema: Comment4.schema, where: Comment4.keys.id.eq(comment.idString())) { result in
             switch result {
@@ -122,7 +122,7 @@ class DataStoreConnectionScenario4FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [getCommentAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getCommentAfterDeleteCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testListCommentsByPostID() throws {
@@ -147,7 +147,7 @@ class DataStoreConnectionScenario4FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [listCommentByPostIDCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [listCommentByPostIDCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     func savePost(id: String = UUID().uuidString, title: String, plugin: AWSDataStorePlugin) throws -> Post4Wrapper? {
@@ -163,7 +163,7 @@ class DataStoreConnectionScenario4FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
@@ -180,7 +180,7 @@ class DataStoreConnectionScenario4FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario5FlutterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario5FlutterTests.swift
@@ -65,7 +65,7 @@ class DataStoreConnectionScenario5FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [listPostEditorByPostIDCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [listPostEditorByPostIDCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testListPostEditorByUser() throws {
@@ -93,7 +93,7 @@ class DataStoreConnectionScenario5FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("\(error)")
             }
         }
-        wait(for: [listPostEditorByEditorIdCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [listPostEditorByEditorIdCompleted], timeout: TestCommonConstants.networkTimeout)
     }
 
     /// TODO: Include testGetPostThenLoadPostEditors when nested model lazy loading is implemented
@@ -110,7 +110,7 @@ class DataStoreConnectionScenario5FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
@@ -127,7 +127,7 @@ class DataStoreConnectionScenario5FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
@@ -144,7 +144,7 @@ class DataStoreConnectionScenario5FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario6FlutterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario6FlutterTests.swift
@@ -57,7 +57,7 @@ class DataStoreConnectionScenario6FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("Failed with: \(response)")
             }
         }
-        wait(for: [getCommentCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getCommentCompleted], timeout: TestCommonConstants.networkTimeout)
         guard let fetchedComment = resultComment else {
             XCTFail("Could not get comment")
             return
@@ -90,7 +90,7 @@ class DataStoreConnectionScenario6FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
@@ -107,7 +107,7 @@ class DataStoreConnectionScenario6FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 
@@ -124,7 +124,7 @@ class DataStoreConnectionScenario6FlutterTests: SyncEngineFlutterIntegrationTest
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/DataStoreFlutterConsecutiveUpdatesTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/DataStoreFlutterConsecutiveUpdatesTests.swift
@@ -79,7 +79,7 @@ class DataStoreFlutterConsecutiveUpdatesTests: SyncEngineFlutterIntegrationTestB
                 XCTFail("Error: \(error)")
             }
         }
-        wait(for: [saveAndImmediatelyUpdate], timeout: networkTimeout)
+        await fulfillment(of: [saveAndImmediatelyUpdate], timeout: networkTimeout)
 
         // query the updated post immediately
         guard let queryResult = queryPost(id: updatedPost.idString(), plugin: plugin) else {
@@ -88,7 +88,7 @@ class DataStoreFlutterConsecutiveUpdatesTests: SyncEngineFlutterIntegrationTestB
         }
         XCTAssertEqual(queryResult, updatedPost)
 
-        wait(for: [saveSyncReceived, updateSyncReceived], timeout: networkTimeout)
+        await fulfillment(of: [saveSyncReceived, updateSyncReceived], timeout: networkTimeout)
 
         // query the updated post in eventual consistent state
         guard let queryResultAfterSync = queryPost(id: updatedPost.idString(), plugin: plugin) else {
@@ -126,7 +126,7 @@ class DataStoreFlutterConsecutiveUpdatesTests: SyncEngineFlutterIntegrationTestB
                 XCTFail("Error: \(error)")
             }
         }
-        wait(for: [apiQuerySuccess], timeout: networkTimeout)
+        await fulfillment(of: [apiQuerySuccess], timeout: networkTimeout)
     }
 
     /// - Given: API has been setup with `Post` model registered
@@ -191,13 +191,13 @@ class DataStoreFlutterConsecutiveUpdatesTests: SyncEngineFlutterIntegrationTestB
                 XCTFail("Error: \(error)")
             }
         }
-        wait(for: [saveAndImmediatelyDelete], timeout: networkTimeout)
+        await fulfillment(of: [saveAndImmediatelyDelete], timeout: networkTimeout)
 
         // query the deleted post immediately
         let queryResult = queryPost(id: newPost.idString(), plugin: plugin)
         XCTAssertNil(queryResult)
 
-        wait(for: [saveSyncReceived, deleteSyncReceived], timeout: networkTimeout)
+        await fulfillment(of: [saveSyncReceived, deleteSyncReceived], timeout: networkTimeout)
 
         // query the deleted post in eventual consistent state
         let queryResultAfterSync = queryPost(id: newPost.idString(), plugin: plugin)
@@ -231,7 +231,7 @@ class DataStoreFlutterConsecutiveUpdatesTests: SyncEngineFlutterIntegrationTestB
                 XCTFail("Error: \(error)")
             }
         }
-        wait(for: [apiQuerySuccess], timeout: networkTimeout)
+        await fulfillment(of: [apiQuerySuccess], timeout: networkTimeout)
     }
 
     /// - Given: API has been setup with `Post` model registered
@@ -304,7 +304,7 @@ class DataStoreFlutterConsecutiveUpdatesTests: SyncEngineFlutterIntegrationTestB
                 XCTFail("Error: \(error)")
             }
         }
-        wait(for: [saveCompleted, saveSyncReceived], timeout: networkTimeout)
+        await fulfillment(of: [saveCompleted, saveSyncReceived], timeout: networkTimeout)
 
         let updateAndImmediatelyDelete =
             expectation(description: "Post is updated and deleted immediately")
@@ -324,13 +324,13 @@ class DataStoreFlutterConsecutiveUpdatesTests: SyncEngineFlutterIntegrationTestB
             }
         }
 
-        wait(for: [updateAndImmediatelyDelete], timeout: networkTimeout)
+        await fulfillment(of: [updateAndImmediatelyDelete], timeout: networkTimeout)
 
         // query the deleted post immediately
         let queryResult = queryPost(id: newPost.idString(), plugin: plugin)
         XCTAssertNil(queryResult)
 
-        wait(for: [updateSyncReceived, deleteSyncReceived], timeout: networkTimeout)
+        await fulfillment(of: [updateSyncReceived, deleteSyncReceived], timeout: networkTimeout)
 
         // query the deleted post
         let queryResultAfterSync = queryPost(id: updatedPost.idString(), plugin: plugin)
@@ -364,7 +364,7 @@ class DataStoreFlutterConsecutiveUpdatesTests: SyncEngineFlutterIntegrationTestB
                 XCTFail("Error: \(error)")
             }
         }
-        wait(for: [apiQuerySuccess], timeout: networkTimeout)
+        await fulfillment(of: [apiQuerySuccess], timeout: networkTimeout)
     }
 
     private func queryPost(id: String, plugin: AWSDataStorePlugin) -> PostWrapper? {
@@ -381,7 +381,7 @@ class DataStoreFlutterConsecutiveUpdatesTests: SyncEngineFlutterIntegrationTestB
                 XCTFail("Error: \(error)")
             }
         }
-        wait(for: [queryExpectation], timeout: networkTimeout)
+        await fulfillment(of: [queryExpectation], timeout: networkTimeout)
         return queryResult
     }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/DataStoreFlutterEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/DataStoreFlutterEndToEndTests.swift
@@ -74,15 +74,15 @@ class DataStoreEndToEndTests: SyncEngineFlutterIntegrationTestBase {
 
         plugin.save(newPost.model, modelSchema: Post.schema) { _ in }
 
-        wait(for: [createReceived], timeout: networkTimeout)
+        await fulfillment(of: [createReceived], timeout: networkTimeout)
 
         plugin.save(updatedPost.model, modelSchema: Post.schema) { _ in }
 
-        wait(for: [updateReceived], timeout: networkTimeout)
+        await fulfillment(of: [updateReceived], timeout: networkTimeout)
 
         plugin.delete(updatedPost.model, modelSchema: Post.schema) { _ in }
 
-        wait(for: [deleteReceived], timeout: networkTimeout)
+        await fulfillment(of: [deleteReceived], timeout: networkTimeout)
     }
 
     /// - Given: A post that has been saved
@@ -151,11 +151,11 @@ class DataStoreEndToEndTests: SyncEngineFlutterIntegrationTestBase {
 
         plugin.save(newPost.model, modelSchema: Post.schema) { _ in }
 
-        wait(for: [createReceived], timeout: networkTimeout)
+        await fulfillment(of: [createReceived], timeout: networkTimeout)
 
         plugin.save(updatedPost.model, modelSchema: Post.schema, where: post.title == title) { _ in }
 
-        wait(for: [updateReceived], timeout: networkTimeout)
+        await fulfillment(of: [updateReceived], timeout: networkTimeout)
     }
 
     /// Ensure DataStore.stop followed by DataStore.start is successful
@@ -186,7 +186,7 @@ class DataStoreEndToEndTests: SyncEngineFlutterIntegrationTestBase {
                 XCTFail("\(error)")
             }
         }
-        wait(for: [stopStartSuccess], timeout: networkTimeout)
+        await fulfillment(of: [stopStartSuccess], timeout: networkTimeout)
         try validateSavePost(plugin: plugin)
 
     }
@@ -211,13 +211,13 @@ class DataStoreEndToEndTests: SyncEngineFlutterIntegrationTestBase {
         try startAmplify {
             amplifyStarted.fulfill()
         }
-        wait(for: [amplifyStarted], timeout: 1.0)
+        await fulfillment(of: [amplifyStarted], timeout: 1.0)
 
         // We expect the query to complete, but not to return a value. Thus, we'll ignore the error
         let queryCompleted = expectation(description: "queryCompleted")
         plugin.query(FlutterSerializedModel.self, modelSchema: Post.schema, where: Post.keys.id.eq("123")) { _ in queryCompleted.fulfill() }
 
-        wait(for: [dataStoreStarted, queryCompleted], timeout: networkTimeout)
+        await fulfillment(of: [dataStoreStarted, queryCompleted], timeout: networkTimeout)
         sink.cancel()
     }
 
@@ -249,7 +249,7 @@ class DataStoreEndToEndTests: SyncEngineFlutterIntegrationTestBase {
                 XCTFail("\(error)")
             }
         }
-        wait(for: [clearStartSuccess], timeout: networkTimeout)
+        await fulfillment(of: [clearStartSuccess], timeout: networkTimeout)
         try validateSavePost(plugin: plugin)
     }
 
@@ -290,6 +290,6 @@ class DataStoreEndToEndTests: SyncEngineFlutterIntegrationTestBase {
         }
 
         plugin.save(newPost.model, modelSchema: Post.schema) { _ in }
-        wait(for: [createReceived], timeout: networkTimeout)
+        await fulfillment(of: [createReceived], timeout: networkTimeout)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SyncEngineFlutterIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SyncEngineFlutterIntegrationTestBase.swift
@@ -86,7 +86,7 @@ class SyncEngineFlutterIntegrationTestBase: XCTestCase {
             }
         }
 
-        wait(for: [syncStarted], timeout: 100.0)
+        await fulfillment(of: [syncStarted], timeout: 100.0)
     }
 
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario2Tests.swift
@@ -88,7 +88,7 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
         let anotherTeam = Team2(name: "name1")
         var project = Project2(teamID: team.id, team: team)
         let expectedUpdatedProject = Project2(id: project.id, name: project.name, teamID: anotherTeam.id)
-        let syncUpdatedProjectReceived = asyncExpectation(description: "received updated project from sync path")
+        let syncUpdatedProjectReceived = expectation(description: "received updated project from sync path")
         let hubListener = Amplify.Hub.listen(to: .dataStore,
                                              eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
             guard let mutationEvent = payload.data as? MutationEvent else {
@@ -98,9 +98,7 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
 
             if let syncedUpdatedProject = try? mutationEvent.decodeModel() as? Project2,
                expectedUpdatedProject == syncedUpdatedProject {
-                Task {
-                    await syncUpdatedProjectReceived.fulfill()
-                }
+                syncUpdatedProjectReceived.fulfill()
             }
         }
         guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
@@ -121,7 +119,7 @@ class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
             XCTAssertEqual(queriedProject, project)
             XCTAssertEqual(queriedProject.teamID, anotherTeam.id)
         }
-        await waitForExpectations([syncUpdatedProjectReceived], timeout: networkTimeout)
+        await fulfillment(of: [syncUpdatedProjectReceived], timeout: networkTimeout)
     }
 
     func testDeleteAndGetProjectReturnsNilWithSync() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreCustomPrimaryKeyTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreCustomPrimaryKeyTests.swift
@@ -69,7 +69,7 @@ class DataStoreCustomPrimaryKeyTests: SyncEngineIntegrationTestBase {
 
         // create customer order
         _ = try await Amplify.DataStore.save(customerOrder)
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [createReceived], timeout: networkTimeout)
 
         // update customer order
         let updateReceived = expectation(description: "Update notification received")
@@ -102,8 +102,8 @@ class DataStoreCustomPrimaryKeyTests: SyncEngineIntegrationTestBase {
             return
         }
         _ = try await Amplify.DataStore.save(updatedCustomerOrder)
-        await waitForExpectations(timeout: networkTimeout)
-        
+        await fulfillment(of: [updateReceived], timeout: networkTimeout)
+
         // query the updated order
         let queriedOrder = try await Amplify.DataStore.query(CustomerOrder.self, byId: updatedCustomerOrder.id)
         guard let order = queriedOrder else {
@@ -144,8 +144,8 @@ class DataStoreCustomPrimaryKeyTests: SyncEngineIntegrationTestBase {
         }
 
         _ = try await Amplify.DataStore.delete(CustomerOrder.self, withIdentifier: updatedCustomerOrder.id)
-        await waitForExpectations(timeout: networkTimeout)
-        
+        await fulfillment(of: [deleteReceived], timeout: networkTimeout)
+
         // query the customer order after deletion
         let queriedOrder2 = try await Amplify.DataStore.query(CustomerOrder.self, byId: updatedCustomerOrder.id)
         XCTAssertNil(queriedOrder2)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -686,7 +686,7 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
 
         _ = try await Amplify.DataStore.save(newPost)
         
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [createReceived], timeout: networkTimeout)
     }
 }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreHubEventsTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreHubEventsTests.swift
@@ -44,6 +44,7 @@ class DataStoreHubEventTests: HubEventsIntegrationTestBase {
         try await Task.sleep(seconds: 1)
 
         let networkStatusReceived = expectation(description: "networkStatus received")
+        networkStatusReceived.assertForOverFulfill = false
         var networkStatusActive = false
         let subscriptionsEstablishedReceived = expectation(description: "subscriptionsEstablished received")
         let syncQueriesStartedReceived = expectation(description: "syncQueriesStarted received")

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/AWSDataStoreLazyLoadPostComment4V2.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/AWSDataStoreLazyLoadPostComment4V2.swift
@@ -18,13 +18,13 @@ class AWSDataStoreLazyLoadPostComment4V2: AWSDataStoreLazyLoadBaseTest {
         let post = Post4V2(title: "title")
         let comment = Comment4V2(content: "content", post: post)
         
-        let commentSynced = asyncExpectation(description: "DataStore start success")
+        let commentSynced = expectation(description: "DataStore start success")
         let mutationEvents = Amplify.DataStore.observe(Comment4V2.self)
         Task {
             do {
                 for try await mutationEvent in mutationEvents {
                     if mutationEvent.version == 1 && mutationEvent.modelId == comment.id {
-                        await commentSynced.fulfill()
+                        commentSynced.fulfill()
                     }
                 }
             } catch {
@@ -35,7 +35,7 @@ class AWSDataStoreLazyLoadPostComment4V2: AWSDataStoreLazyLoadBaseTest {
         try await Amplify.DataStore.save(post)
         try await Amplify.DataStore.save(comment)
         
-        await waitForExpectations([commentSynced], timeout: 10)
+        await fulfillment(of: [commentSynced], timeout: 10)
     }
 }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL1/AWSDataStoreLazyLoadPostComment4V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL1/AWSDataStoreLazyLoadPostComment4V2Tests.swift
@@ -232,7 +232,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
         try await startAndWaitForReady()
         let post = Post(title: "title")
         let comment = Comment(content: "content", post: post)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -254,7 +254,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
                     }
                     XCTAssertEqual(comments.count, 1)
                     
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -266,7 +266,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -276,7 +276,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
         let post = Post(title: "title")
         let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(content: "content", post: post)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Comment.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -285,7 +285,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
                    let receivedComment = try? mutationEvent.decodeModel(as: Comment.self),
                    receivedComment.id == comment.id {
                     try await assertComment(receivedComment, canLazyLoad: savedPost)
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -297,7 +297,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -306,7 +306,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
         try await startAndWaitForReady()
         let post = Post(title: "title")
         let comment = Comment(content: "content", post: post)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Post.self, where: Post.keys.id == post.id)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -323,7 +323,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
                     }
                     XCTAssertEqual(comments.count, 1)
                     
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -335,7 +335,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -346,13 +346,13 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
         let post = Post(title: "title")
         let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(content: "content", post: post)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Comment.self, where: Comment.keys.id == comment.id)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedComment = querySnapshot.items.first {
                     try await assertComment(receivedComment, canLazyLoad: savedPost)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -364,7 +364,7 @@ class AWSDataStoreLazyLoadPostComment4V2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL10/AWSDataStoreLazyLoadPostComment7Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL10/AWSDataStoreLazyLoadPostComment7Tests.swift
@@ -195,7 +195,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
         try await startAndWaitForReady()
         let post = Post(postId: UUID().uuidString, title: "title")
         let comment = Comment(commentId: UUID().uuidString, content: "content", post: post)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -216,7 +216,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
                     }
                     XCTAssertEqual(comments.count, 1)
                     
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -228,7 +228,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -238,7 +238,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
         let post = Post(postId: UUID().uuidString, title: "title")
         let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(commentId: UUID().uuidString, content: "content", post: post)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Comment.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -247,7 +247,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
                    let receivedComment = try? mutationEvent.decodeModel(as: Comment.self),
                    receivedComment.commentId == comment.commentId {
                     try await assertComment(receivedComment, canLazyLoad: savedPost)
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -259,7 +259,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -268,7 +268,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
         try await startAndWaitForReady()
         let post = Post(postId: UUID().uuidString, title: "title")
         let comment = Comment(commentId: UUID().uuidString, content: "content", post: post)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Post.self, where: Post.keys.postId == post.postId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -285,7 +285,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
                     }
                     XCTAssertEqual(comments.count, 1)
                     
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -297,7 +297,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -308,13 +308,13 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
         let post = Post(postId: UUID().uuidString, title: "title")
         let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(commentId: UUID().uuidString, content: "content", post: post)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Comment.self, where: Comment.keys.commentId == comment.commentId)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedComment = querySnapshot.items.first {
                     try await assertComment(receivedComment, canLazyLoad: savedPost)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -326,7 +326,7 @@ final class AWSDataStoreLazyLoadPostComment7Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL11/AWSDataStoreLazyLoadPostComment8Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL11/AWSDataStoreLazyLoadPostComment8Tests.swift
@@ -177,7 +177,7 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               postId: post.postId,
                               postTitle: post.title)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -187,7 +187,7 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
                    receivedPost.postId == post.postId {
                     let savedComment = try await createAndWaitForSync(comment)
                     try await assertPost(receivedPost, canLazyLoad: savedComment)
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -199,7 +199,7 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -212,7 +212,7 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               postId: post.postId,
                               postTitle: post.title)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Comment.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -221,7 +221,7 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
                    let receivedComment = try? mutationEvent.decodeModel(as: Comment.self),
                    receivedComment.commentId == comment.commentId {
                     assertComment(receivedComment, contains: savedPost)
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -233,7 +233,7 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -245,14 +245,14 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               postId: post.postId,
                               postTitle: post.title)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Post.self, where: Post.keys.postId == post.postId)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedPost = querySnapshot.items.first {
                     let savedComment = try await createAndWaitForSync(comment)
                     try await assertPost(receivedPost, canLazyLoad: savedComment)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -264,7 +264,7 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -278,13 +278,13 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               postId: post.postId,
                               postTitle: post.title)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Comment.self, where: Comment.keys.commentId == comment.commentId)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedComment = querySnapshot.items.first {
                     assertComment(receivedComment, contains: savedPost)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -296,7 +296,7 @@ final class AWSDataStoreLazyLoadPostComment8Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/DefaultPK/AWSDataStoreLazyLoadDefaultPKTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/DefaultPK/AWSDataStoreLazyLoadDefaultPKTests.swift
@@ -230,7 +230,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
         try await startAndWaitForReady()
         let parent = Parent()
         let child = Child(parent: parent)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Parent.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -252,7 +252,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
                     }
                     XCTAssertEqual(children.count, 1)
                     
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -264,7 +264,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -274,7 +274,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
         let parent = Parent()
         let savedParent = try await createAndWaitForSync(parent)
         let child = Child(parent: parent)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Child.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -283,7 +283,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
                    let receivedChild = try? mutationEvent.decodeModel(as: Child.self),
                    receivedChild.id == child.id {
                     try await assertChild(receivedChild, canLazyLoad: savedParent)
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -295,7 +295,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -304,7 +304,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
         try await startAndWaitForReady()
         let parent = Parent()
         let child = Child(parent: parent)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Parent.self, where: Parent.keys.id == parent.id)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -321,7 +321,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
                     }
                     XCTAssertEqual(children.count, 1)
                     
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -333,7 +333,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -344,13 +344,13 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
         let parent = Parent()
         let savedParent = try await createAndWaitForSync(parent)
         let child = Child(parent: parent)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Child.self, where: Child.keys.id == child.id)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedChild = querySnapshot.items.first {
                     try await assertChild(receivedChild, canLazyLoad: savedParent)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -362,7 +362,7 @@ class AWSDataStoreLazyLoadDefaultPKTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/HasOneParentChild/AWSDataStoreLazyLoadHasOneTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL12/HasOneParentChild/AWSDataStoreLazyLoadHasOneTests.swift
@@ -154,7 +154,7 @@ class AWSDataStoreLazyLoadHasOneTests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: HasOneModels())
         try await startAndWaitForReady()
         let child = HasOneChild()
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(HasOneChild.self)
 
         Task {
@@ -164,7 +164,7 @@ class AWSDataStoreLazyLoadHasOneTests: AWSDataStoreLazyLoadBaseTest {
                    let receivedChild = try? mutationEvent.decodeModel(as: HasOneChild.self),
                    receivedChild.identifier == child.identifier
                 {
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -176,7 +176,7 @@ class AWSDataStoreLazyLoadHasOneTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
 
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL2/AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL2/AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift
@@ -187,7 +187,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         try await startAndWaitForReady()
         let post = Post(name: "name", randomId: "randomId")
         let comment = Comment(content: "content", post: post)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -209,7 +209,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
                     }
                     XCTAssertEqual(comments.count, 1)
                     
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -221,7 +221,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -231,7 +231,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         let post = Post(name: "name", randomId: "randomId")
         let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(content: "content", post: post)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Comment.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -240,7 +240,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
                    let receivedComment = try? mutationEvent.decodeModel(as: Comment.self),
                    receivedComment.id == comment.id {
                     try await assertComment(receivedComment, canLazyLoad: savedPost)
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -252,7 +252,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -261,7 +261,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         try await startAndWaitForReady()
         let post = Post(name: "name", randomId: "randomId")
         let comment = Comment(content: "content", post: post)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Post.self, where: Post.keys.id == post.id)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -278,7 +278,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
                     }
                     XCTAssertEqual(comments.count, 1)
                     
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -290,7 +290,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -301,13 +301,13 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
         let post = Post(name: "name", randomId: "randomId")
         let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(content: "content", post: post)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Comment.self, where: Comment.keys.id == comment.id)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedComment = querySnapshot.items.first {
                     try await assertComment(receivedComment, canLazyLoad: savedPost)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -319,7 +319,7 @@ final class AWSDataStoreLazyLoadBlogPostComment8V2Tests: AWSDataStoreLazyLoadBas
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL3/AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL3/AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests.swift
@@ -180,7 +180,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
         try await startAndWaitForReady()
         let post = Post(title: "title")
         let comment = Comment(content: "content", post: post)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -201,7 +201,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
                     }
                     XCTAssertEqual(comments.count, 1)
                     
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -213,7 +213,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -223,7 +223,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
         let post = Post(title: "title")
         let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(content: "content", post: post)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Comment.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -232,7 +232,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
                    let receivedComment = try? mutationEvent.decodeModel(as: Comment.self),
                    receivedComment.id == comment.id {
                     try await assertComment(receivedComment, canLazyLoad: savedPost)
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -244,7 +244,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -253,7 +253,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
         try await startAndWaitForReady()
         let post = Post(title: "title")
         let comment = Comment(content: "content", post: post)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Post.self, where: Post.keys.id == post.id)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -270,7 +270,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
                     }
                     XCTAssertEqual(comments.count, 1)
                     
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -282,7 +282,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -293,13 +293,13 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
         let post = Post(title: "title")
         let savedPost = try await createAndWaitForSync(post)
         let comment = Comment(content: "content", post: post)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Comment.self, where: Comment.keys.id == comment.id)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedComment = querySnapshot.items.first {
                     try await assertComment(receivedComment, canLazyLoad: savedPost)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -311,7 +311,7 @@ final class AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests: AWSDataStoreLa
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL4/AWSDataStoreLazyLoadPostTagTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL4/AWSDataStoreLazyLoadPostTagTests.swift
@@ -213,7 +213,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: PostTagModels())
         try await startAndWaitForReady()
         let post = Post(postId: UUID().uuidString, title: "title")
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -233,7 +233,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
                     }
                     XCTAssertEqual(tags.count, 0)
                     
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -244,7 +244,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -253,7 +253,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         try await startAndWaitForReady()
         let tag = Tag(name: "name")
         
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Tag.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -272,7 +272,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
                     }
                     XCTAssertEqual(posts.count, 0)
                     
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -283,7 +283,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -294,10 +294,11 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         let tag = Tag(name: "name")
         let savedPost = try await createAndWaitForSync(post)
         let savedTag = try await createAndWaitForSync(tag)
-        
+        _ = savedPost; _ = savedTag
+
         let postTag = PostTag(postWithTagsCompositeKey: post, tagWithCompositeKey: tag)
         
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(PostTag.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -307,7 +308,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
                    receivedPostTag.id == postTag.id {
                     
                     try await assertPostTag(receivedPostTag, canLazyLoadTag: tag, canLazyLoadPost: post)
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -319,7 +320,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -327,7 +328,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: PostTagModels())
         try await startAndWaitForReady()
         let post = Post(postId: UUID().uuidString, title: "title")
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Post.self, where: Post.keys.postId == post.postId)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -343,7 +344,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
                     }
                     XCTAssertEqual(tags.count, 0)
                     
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -354,7 +355,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -363,7 +364,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         try await startAndWaitForReady()
         let tag = Tag(name: "name")
         
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Tag.self, where: Tag.keys.id == tag.id)
         Task {
             for try await querySnapshot in querySnapshots {
@@ -379,7 +380,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
                     }
                     XCTAssertEqual(posts.count, 0)
                     
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -390,7 +391,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -404,13 +405,13 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
         
         let postTag = PostTag(postWithTagsCompositeKey: post, tagWithCompositeKey: tag)
         
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: PostTag.self, where: PostTag.keys.id == postTag.id)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedPostTag = querySnapshot.items.first {
                     try await assertPostTag(receivedPostTag, canLazyLoadTag: tag, canLazyLoadPost: post)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -422,7 +423,7 @@ final class AWSDataStoreLazyLoadPostTagTests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL5/AWSDataStoreLazyLoadProjectTeam1Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL5/AWSDataStoreLazyLoadProjectTeam1Tests.swift
@@ -220,7 +220,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
         let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Project.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -229,7 +229,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
                    let receivedProject = try? mutationEvent.decodeModel(as: Project.self),
                    receivedProject.projectId == project.projectId {
                     assertProject(receivedProject, hasTeam: savedTeam)
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -241,7 +241,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -249,7 +249,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam1Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Team.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -258,7 +258,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
                    let receivedTeam = try? mutationEvent.decodeModel(as: Team.self),
                    receivedTeam.teamId == team.teamId {
                         
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -270,7 +270,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -281,13 +281,13 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
         let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Project.self, where: Project.keys.projectId == project.projectId)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedProject = querySnapshot.items.first {
                     assertProject(receivedProject, hasTeam: savedTeam)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -299,7 +299,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -307,13 +307,13 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam1Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Team.self, where: Team.keys.teamId == team.teamId)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedTeam = querySnapshot.items.first {
                     XCTAssertEqual(receivedTeam.teamId, team.teamId)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -325,7 +325,7 @@ class AWSDataStoreLazyLoadProjectTeam1Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL6/AWSDataStoreLazyLoadProjectTeam2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL6/AWSDataStoreLazyLoadProjectTeam2Tests.swift
@@ -187,7 +187,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
         let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Project.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -196,7 +196,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
                    let receivedProject = try? mutationEvent.decodeModel(as: Project.self),
                    receivedProject.projectId == project.projectId {
                     assertProject(receivedProject, hasTeam: savedTeam)
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -208,7 +208,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -216,7 +216,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam2Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Team.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -225,7 +225,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
                    let receivedTeam = try? mutationEvent.decodeModel(as: Team.self),
                    receivedTeam.teamId == team.teamId {
                         
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -237,7 +237,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -248,13 +248,13 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
         let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Project.self, where: Project.keys.projectId == project.projectId)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedProject = querySnapshot.items.first {
                     assertProject(receivedProject, hasTeam: savedTeam)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -266,7 +266,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -274,13 +274,13 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam2Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Team.self, where: Team.keys.teamId == team.teamId)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedTeam = querySnapshot.items.first {
                     XCTAssertEqual(receivedTeam.teamId, team.teamId)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -292,7 +292,7 @@ class AWSDataStoreLazyLoadProjectTeam2Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL7/AWSDataStoreLazyLoadPostComment4Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL7/AWSDataStoreLazyLoadPostComment4Tests.swift
@@ -180,7 +180,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               post4CommentsPostId: post.postId,
                               post4CommentsTitle: post.title)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -190,7 +190,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                    receivedPost.postId == post.postId {
                     let savedComment = try await createAndWaitForSync(comment)
                     try await assertPost(receivedPost, canLazyLoad: savedComment)
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -202,7 +202,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -215,7 +215,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               post4CommentsPostId: post.postId,
                               post4CommentsTitle: post.title)
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Comment.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -224,7 +224,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                    let receivedComment = try? mutationEvent.decodeModel(as: Comment.self),
                    receivedComment.commentId == comment.commentId {
                     assertComment(receivedComment, contains: savedPost)
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -236,7 +236,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -248,14 +248,14 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               post4CommentsPostId: post.postId,
                               post4CommentsTitle: post.title)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Post.self, where: Post.keys.postId == post.postId)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedPost = querySnapshot.items.first {
                     let savedComment = try await createAndWaitForSync(comment)
                     try await assertPost(receivedPost, canLazyLoad: savedComment)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -267,7 +267,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -281,13 +281,13 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
                               content: "content",
                               post4CommentsPostId: post.postId,
                               post4CommentsTitle: post.title)
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Comment.self, where: Comment.keys.commentId == comment.commentId)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedComment = querySnapshot.items.first {
                     assertComment(receivedComment, contains: savedPost)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -299,7 +299,7 @@ final class AWSDataStoreLazyLoadPostComment4Tests: AWSDataStoreLazyLoadBaseTest 
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL8/AWSDataStoreLazyLoadProjectTeam5Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL8/AWSDataStoreLazyLoadProjectTeam5Tests.swift
@@ -138,6 +138,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
         queriedProject.teamId = newTeam.teamId
         queriedProject.teamName = newTeam.name
         let savedProjectWithNewTeam = try await updateAndWaitForSync(queriedProject)
+        _ = savedProjectWithNewTeam
         assertProject(queriedProject, hasTeam: savedNewTeam)
     }
     
@@ -189,7 +190,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
         let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Project.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -198,7 +199,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
                    let receivedProject = try? mutationEvent.decodeModel(as: Project.self),
                    receivedProject.projectId == project.projectId {
                     assertProject(receivedProject, hasTeam: savedTeam)
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -210,7 +211,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -218,7 +219,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam5Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Team.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -227,7 +228,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
                    let receivedTeam = try? mutationEvent.decodeModel(as: Team.self),
                    receivedTeam.teamId == team.teamId {
                         
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -239,7 +240,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -250,13 +251,13 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
         let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Project.self, where: Project.keys.projectId == project.projectId)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedProject = querySnapshot.items.first {
                     assertProject(receivedProject, hasTeam: savedTeam)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -268,7 +269,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -276,13 +277,13 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam5Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Team.self, where: Team.keys.teamId == team.teamId)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedTeam = querySnapshot.items.first {
                     XCTAssertEqual(receivedTeam.teamId, team.teamId)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -294,7 +295,7 @@ class AWSDataStoreLazyLoadProjectTeam5Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL9/AWSDataStoreLazyLoadProjectTeam6Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LL9/AWSDataStoreLazyLoadProjectTeam6Tests.swift
@@ -185,7 +185,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
         let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Project.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -194,7 +194,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
                    let receivedProject = try? mutationEvent.decodeModel(as: Project.self),
                    receivedProject.projectId == project.projectId {
                     assertProject(receivedProject, hasTeam: savedTeam)
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -206,7 +206,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -214,7 +214,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam6Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let mutationEventReceived = asyncExpectation(description: "Received mutation event")
+        let mutationEventReceived = expectation(description: "Received mutation event")
         let mutationEvents = Amplify.DataStore.observe(Team.self)
         Task {
             for try await mutationEvent in mutationEvents {
@@ -222,8 +222,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
                    version == 1,
                    let receivedTeam = try? mutationEvent.decodeModel(as: Team.self),
                    receivedTeam.teamId == team.teamId {
-                        
-                    await mutationEventReceived.fulfill()
+                    mutationEventReceived.fulfill()
                 }
             }
         }
@@ -235,7 +234,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([mutationEventReceived], timeout: 60)
+        await fulfillment(of: [mutationEventReceived], timeout: 60)
         mutationEvents.cancel()
     }
     
@@ -246,13 +245,13 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
         let savedTeam = try await createAndWaitForSync(team)
         let project = initializeProjectWithTeam(team)
         
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Project.self, where: Project.keys.projectId == project.projectId)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedProject = querySnapshot.items.first {
                     assertProject(receivedProject, hasTeam: savedTeam)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -264,7 +263,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
     
@@ -272,13 +271,13 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
         await setup(withModels: ProjectTeam6Models())
         try await startAndWaitForReady()
         let team = Team(teamId: UUID().uuidString, name: "name")
-        let snapshotReceived = asyncExpectation(description: "Received query snapshot")
+        let snapshotReceived = expectation(description: "Received query snapshot")
         let querySnapshots = Amplify.DataStore.observeQuery(for: Team.self, where: Team.keys.teamId == team.teamId)
         Task {
             for try await querySnapshot in querySnapshots {
                 if let receivedTeam = querySnapshot.items.first {
                     XCTAssertEqual(receivedTeam.teamId, team.teamId)
-                    await snapshotReceived.fulfill()
+                    snapshotReceived.fulfill()
                 }
             }
         }
@@ -290,7 +289,7 @@ class AWSDataStoreLazyLoadProjectTeam6Tests: AWSDataStoreLazyLoadBaseTest {
             XCTFail("Failed to send mutation request \(error)")
         }
         
-        await waitForExpectations([snapshotReceived], timeout: 60)
+        await fulfillment(of: [snapshotReceived], timeout: 60)
         querySnapshots.cancel()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreAuthBaseTest.swift
@@ -120,18 +120,18 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
     // MARK: - Test Helpers
     func makeExpectations() -> AuthTestExpectations {
         AuthTestExpectations(
-            subscriptionsEstablished: AsyncExpectation(description: "Subscriptions established"),
-            modelsSynced: AsyncExpectation(description: "Models synced"),
+            subscriptionsEstablished: expectation(description: "Subscriptions established"),
+            modelsSynced: expectation(description: "Models synced"),
 
-            query: AsyncExpectation(description: "Query success"),
+            query: expectation(description: "Query success"),
 
-            mutationSave: AsyncExpectation(description: "Mutation save success"),
-            mutationSaveProcessed: AsyncExpectation(description: "Mutation save processed"),
+            mutationSave: expectation(description: "Mutation save success"),
+            mutationSaveProcessed: expectation(description: "Mutation save processed"),
 
-            mutationDelete: AsyncExpectation(description: "Mutation delete success"),
-            mutationDeleteProcessed: AsyncExpectation(description: "Mutation delete processed"),
+            mutationDelete: expectation(description: "Mutation delete success"),
+            mutationDeleteProcessed: expectation(description: "Mutation delete processed"),
 
-            ready: AsyncExpectation(description: "Ready")
+            ready: expectation(description: "Ready")
         )
     }
 
@@ -241,21 +241,17 @@ extension AWSDataStoreAuthBaseTest {
             XCTFail("Invalid user", file: file, line: line)
             return
         }
-        let signInInvoked = AsyncExpectation(description: "sign in completed")
+        let signInInvoked = expectation(description: "sign in completed")
         do {
             _ = try await Amplify.Auth.signIn(username: user.username,
                                                        password: user.password,
                                                        options: nil)
-            Task {
-                await signInInvoked.fulfill()
-            }
+            signInInvoked.fulfill()
         } catch(let error) {
             XCTFail("Signin failure \(error)", file: file, line: line)
-            Task {
-                await signInInvoked.fulfill() // won't count as pass
-            }
+            signInInvoked.fulfill() // won't count as pass
         }
-        await waitForExpectations([signInInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [signInInvoked], timeout: TestCommonConstants.networkTimeout)
         
         let signedIn = await isSignedIn()
         XCTAssert(signedIn, file: file, line: line)
@@ -264,13 +260,13 @@ extension AWSDataStoreAuthBaseTest {
     /// Signout current signed-in user
     func signOut(file: StaticString = #file,
                  line: UInt = #line) async {
-        let signoutInvoked = AsyncExpectation(description: "sign out completed")
+        let signoutInvoked = expectation(description: "sign out completed")
         Task {
             _ = await Amplify.Auth.signOut()
-            await signoutInvoked.fulfill()
+            signoutInvoked.fulfill()
         }
         
-        await waitForExpectations([signoutInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [signoutInvoked], timeout: TestCommonConstants.networkTimeout)
         
         let signedIn = await isSignedIn()
         XCTAssert(!signedIn, file: file, line: line)
@@ -278,19 +274,17 @@ extension AWSDataStoreAuthBaseTest {
 
 
     func isSignedIn() async -> Bool {
-        let checkIsSignedInCompleted = AsyncExpectation(description: "retrieve auth session completed")
+        let checkIsSignedInCompleted = expectation(description: "retrieve auth session completed")
         var resultOptional: Bool?
         do {
             let authSession = try await Amplify.Auth.fetchAuthSession()
             resultOptional = authSession.isSignedIn
-            Task {
-                await checkIsSignedInCompleted.fulfill()
-            }
+            checkIsSignedInCompleted.fulfill()
         } catch(let error) {
             fatalError("Failed to get auth session \(error)")
         }
         
-        await waitForExpectations([checkIsSignedInCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [checkIsSignedInCompleted], timeout: TestCommonConstants.networkTimeout)
         guard let result = resultOptional else {
             XCTFail("Could not get isSignedIn for user")
             return false
@@ -300,7 +294,7 @@ extension AWSDataStoreAuthBaseTest {
     }
 
     func getUserSub() async -> String {
-        let retrieveUserSubCompleted = AsyncExpectation(description: "retrieve userSub completed")
+        let retrieveUserSubCompleted = expectation(description: "retrieve userSub completed")
         var resultOptional: String?
         do {
             let authSession = try await Amplify.Auth.fetchAuthSession()
@@ -311,9 +305,7 @@ extension AWSDataStoreAuthBaseTest {
             switch cognitoAuthSession.getUserSub() {
             case .success(let userSub):
                 resultOptional = userSub
-                Task {
-                    await retrieveUserSubCompleted.fulfill()
-                }
+                retrieveUserSubCompleted.fulfill()
             case .failure(let error):
                 XCTFail("Failed to get auth session \(error)")
             }
@@ -321,7 +313,7 @@ extension AWSDataStoreAuthBaseTest {
             XCTFail("Failed to get auth session \(error)")
         }
 
-        await waitForExpectations([retrieveUserSubCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [retrieveUserSubCompleted], timeout: TestCommonConstants.networkTimeout)
         guard let result = resultOptional else {
             XCTFail("Could not get userSub for user")
             return ""
@@ -331,7 +323,7 @@ extension AWSDataStoreAuthBaseTest {
     }
 
     func getIdentityId() async -> String {
-        let retrieveIdentityCompleted = AsyncExpectation(description: "retrieve identity completed")
+        let retrieveIdentityCompleted = expectation(description: "retrieve identity completed")
         var resultOptional: String?
         do {
             let authSession = try await Amplify.Auth.fetchAuthSession()
@@ -342,16 +334,14 @@ extension AWSDataStoreAuthBaseTest {
             switch cognitoAuthSession.getIdentityId() {
             case .success(let identityId):
                 resultOptional = identityId
-                Task {
-                    await retrieveIdentityCompleted.fulfill()
-                }
+                retrieveIdentityCompleted.fulfill()
             case .failure(let error):
                 XCTFail("Failed to get auth session \(error)")
             }
         } catch(let error) {
             XCTFail("Failed to get auth session \(error)")
         }
-        await waitForExpectations([retrieveIdentityCompleted], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [retrieveIdentityCompleted], timeout: TestCommonConstants.networkTimeout)
         guard let result = resultOptional else {
             XCTFail("Could not get identityId for user")
             return ""
@@ -365,19 +355,17 @@ extension AWSDataStoreAuthBaseTest {
                               file: StaticString = #file,
                               line: UInt = #line) async -> M? {
         var queriedModel: M?
-        let queriedInvoked = AsyncExpectation(description: "Model queried")
+        let queriedInvoked = expectation(description: "Model queried")
 
         do {
             let model = try await Amplify.DataStore.query(M.self, byId: id)
             queriedModel = model
-            Task {
-                await queriedInvoked.fulfill()
-            }
+            queriedInvoked.fulfill()
         } catch(let error) {
             XCTFail("Failed to query model \(error)", file: file, line: line)
         }
         
-        await waitForExpectations([queriedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [queriedInvoked], timeout: TestCommonConstants.networkTimeout)
         return queriedModel
     }
 }
@@ -401,11 +389,9 @@ extension AWSDataStoreAuthBaseTest {
         }
         receiveValue: { posts in
             XCTAssertNotNil(posts)
-            Task {
-                await expectations.query.fulfill()
-            }
+            expectations.query.fulfill()
         }.store(in: &requests)
-        await waitForExpectations([expectations.query],
+        await fulfillment(of: [expectations.query],
              timeout: 60)
     }
 
@@ -421,25 +407,19 @@ extension AWSDataStoreAuthBaseTest {
             .sink { event in
                 // subscription fulfilled
                 if event.eventName == dataStoreEvents.subscriptionsEstablished {
-                    Task {
-                        await expectations.subscriptionsEstablished.fulfill()
-                    }
+                    expectations.subscriptionsEstablished.fulfill()
                 }
 
                 // modelsSynced fulfilled
                 if event.eventName == dataStoreEvents.modelSynced {
                     modelSyncedCount += 1
                     if modelSyncedCount == expectedModelSynced {
-                        Task {
-                            await expectations.modelsSynced.fulfill()
-                        }
+                        expectations.modelsSynced.fulfill()
                     }
                 }
 
                 if event.eventName == dataStoreEvents.ready {
-                    Task {
-                        await expectations.ready.fulfill()
-                    }
+                    expectations.ready.fulfill()
                 }
             }
             .store(in: &requests)
@@ -449,7 +429,7 @@ extension AWSDataStoreAuthBaseTest {
         } catch(let error) {
             XCTFail("Failure due to error: \(error)")
         }
-        await waitForExpectations([expectations.subscriptionsEstablished,
+        await fulfillment(of: [expectations.subscriptionsEstablished,
                                    expectations.modelsSynced,
                                    expectations.ready],
                              timeout: 60)
@@ -474,16 +454,12 @@ extension AWSDataStoreAuthBaseTest {
                 }
 
                 if mutationEvent.mutationType == GraphQLMutationType.create.rawValue {
-                    Task {
-                        await expectations.mutationSaveProcessed.fulfill()
-                    }
+                    expectations.mutationSaveProcessed.fulfill()
                     return
                 }
 
                 if mutationEvent.mutationType == GraphQLMutationType.delete.rawValue {
-                    Task {
-                        await expectations.mutationDeleteProcessed.fulfill()
-                    }
+                    expectations.mutationDeleteProcessed.fulfill()
                     return
                 }
             }
@@ -498,12 +474,10 @@ extension AWSDataStoreAuthBaseTest {
         }
         receiveValue: { posts in
             XCTAssertNotNil(posts)
-            Task {
-                await expectations.mutationSave.fulfill()
-            }
+            expectations.mutationSave.fulfill()
         }.store(in: &requests)
 
-        await waitForExpectations([expectations.mutationSave, expectations.mutationSaveProcessed], timeout: 60)
+        await fulfillment(of: [expectations.mutationSave, expectations.mutationSaveProcessed], timeout: 60)
 
         Amplify.Publisher.create {
             try await Amplify.DataStore.delete(model)
@@ -514,12 +488,10 @@ extension AWSDataStoreAuthBaseTest {
         }
         receiveValue: { posts in
             XCTAssertNotNil(posts)
-            Task {
-                await expectations.mutationDelete.fulfill()
-            }
+            expectations.mutationDelete.fulfill()
         }.store(in: &requests)
 
-        await waitForExpectations([expectations.mutationDelete, expectations.mutationDeleteProcessed], timeout: 60)
+        await fulfillment(of: [expectations.mutationDelete, expectations.mutationDeleteProcessed], timeout: 60)
     }
     
     func assertUsedAuthTypes(
@@ -549,15 +521,15 @@ extension AWSDataStoreAuthBaseTest {
 // MARK: - Expectations
 extension AWSDataStoreAuthBaseTest {
     struct AuthTestExpectations {
-        var subscriptionsEstablished: AsyncExpectation
-        var modelsSynced: AsyncExpectation
-        var query: AsyncExpectation
-        var mutationSave: AsyncExpectation
-        var mutationSaveProcessed: AsyncExpectation
-        var mutationDelete: AsyncExpectation
-        var mutationDeleteProcessed: AsyncExpectation
-        var ready: AsyncExpectation
-        var expectations: [AsyncExpectation] {
+        var subscriptionsEstablished: XCTestExpectation
+        var modelsSynced: XCTestExpectation
+        var query: XCTestExpectation
+        var mutationSave: XCTestExpectation
+        var mutationSaveProcessed: XCTestExpectation
+        var mutationDelete: XCTestExpectation
+        var mutationDeleteProcessed: XCTestExpectation
+        var ready: XCTestExpectation
+        var expectations: [XCTestExpectation] {
             return [subscriptionsEstablished,
                     modelsSynced,
                     query,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthCombinationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthCombinationTests.swift
@@ -22,7 +22,7 @@ class AWSDataStoreMultiAuthCombinationTests: AWSDataStoreAuthBaseTest {
         await signIn(user: user1)
 
         let expectations = makeExpectations()
-        let startExpectation = asyncExpectation(description: "DataStore start success")
+        let startExpectation = expectation(description: "DataStore start success")
 
         await assertDataStoreReady(expectations)
 
@@ -30,20 +30,20 @@ class AWSDataStoreMultiAuthCombinationTests: AWSDataStoreAuthBaseTest {
         Task {
             do {
                 try await Amplify.DataStore.start()
-                await startExpectation.fulfill()
+                startExpectation.fulfill()
             } catch(let error) {
                 XCTFail("DataStore start failure \(error)")
             }
         }
 
         // we're only interested in "ready-state" expectations
-        await expectations.query.fulfill()
-        await expectations.mutationSave.fulfill()
-        await expectations.mutationSaveProcessed.fulfill()
-        await expectations.mutationDelete.fulfill()
-        await expectations.mutationDeleteProcessed.fulfill()
+        expectations.query.fulfill()
+        expectations.mutationSave.fulfill()
+        expectations.mutationSaveProcessed.fulfill()
+        expectations.mutationDelete.fulfill()
+        expectations.mutationDeleteProcessed.fulfill()
 
-        await waitForExpectations([
+        await fulfillment(of: [
                 startExpectation,
                 expectations.query,
                 expectations.mutationSave,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthSingleRuleTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreMultiAuthSingleRuleTests.swift
@@ -97,19 +97,19 @@ class AWSDataStoreMultiAuthSingleRuleTests: AWSDataStoreAuthBaseTest {
         let expectations = makeExpectations()
 
         // we're only interested in "ready-state" expectations
-        await expectations.query.fulfill()
-        await expectations.mutationSave.fulfill()
-        await expectations.mutationSaveProcessed.fulfill()
-        await expectations.mutationDelete.fulfill()
-        await expectations.mutationDeleteProcessed.fulfill()
+        expectations.query.fulfill()
+        expectations.mutationSave.fulfill()
+        expectations.mutationSaveProcessed.fulfill()
+        expectations.mutationDelete.fulfill()
+        expectations.mutationDeleteProcessed.fulfill()
 
         // GroupUPPost won't sync for user2 but DataStore should reach a
         // "ready" state
-        await expectations.modelsSynced.fulfill()
+        expectations.modelsSynced.fulfill()
         await assertDataStoreReady(expectations, expectedModelSynced: 0)
 
         await fulfillment(of: [authTypeExpecation], timeout: 5)
-        await waitForExpectations([
+        await fulfillment(of: [
                 expectations.query,
                 expectations.mutationSave,
                 expectations.mutationSaveProcessed,

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreModelWithCustomTimestampTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreModelWithCustomTimestampTests.swift
@@ -93,7 +93,7 @@ class DataStoreModelWithCustomTimestampTests: SyncEngineIntegrationV2TestBase {
             }
         }
 
-        wait(for: [getTodoCompleted, createReceived], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getTodoCompleted, createReceived], timeout: TestCommonConstants.networkTimeout)
 
         /*
           This failed with "The variables input contains a field name \'id\' that is not defined for input object
@@ -114,7 +114,7 @@ class DataStoreModelWithCustomTimestampTests: SyncEngineIntegrationV2TestBase {
 //                XCTFail("Failed \(error)")
 //            }
 //        }
-//        wait(for: [updateCompleted, updateReceived], timeout: TestCommonConstants.networkTimeout)
+//        await fulfillment(of: [updateCompleted, updateReceived], timeout: TestCommonConstants.networkTimeout)
 
         let deleteCompleted = expectation(description: "delete completed")
         Amplify.DataStore.delete(TodoCustomTimestampV2.self, withId: todo.id) { event in
@@ -125,7 +125,7 @@ class DataStoreModelWithCustomTimestampTests: SyncEngineIntegrationV2TestBase {
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [deleteCompleted, deleteReceived], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteCompleted, deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func saveTodo(content: String) -> TodoCustomTimestampV2? {
@@ -141,7 +141,7 @@ class DataStoreModelWithCustomTimestampTests: SyncEngineIntegrationV2TestBase {
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreModelWithDefaultValueTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreModelWithDefaultValueTests.swift
@@ -75,7 +75,7 @@ class DataStoreModelWithDefaultValueTests: SyncEngineIntegrationV2TestBase {
             }
         }
 
-        wait(for: [getTodoCompleted, createReceived], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getTodoCompleted, createReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func testSaveModelWithoutExplicitContentAndSync() async throws {
@@ -126,7 +126,7 @@ class DataStoreModelWithDefaultValueTests: SyncEngineIntegrationV2TestBase {
             }
         }
 
-        wait(for: [getTodoCompleted, createReceived], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getTodoCompleted, createReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func saveTodo(content: String?) -> TodoWithDefaultValueV2? {
@@ -142,7 +142,7 @@ class DataStoreModelWithDefaultValueTests: SyncEngineIntegrationV2TestBase {
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreModelWithSecondaryIndexTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreModelWithSecondaryIndexTests.swift
@@ -86,7 +86,7 @@ class DataStoreModelWithSecondaryIndexTests: SyncEngineIntegrationV2TestBase {
             }
         }
 
-        wait(for: [getCustomerCompleted, createReceived], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [getCustomerCompleted, createReceived], timeout: TestCommonConstants.networkTimeout)
 
         customer.name = updatedName
         let updateCompleted = expectation(description: "update completed")
@@ -99,7 +99,7 @@ class DataStoreModelWithSecondaryIndexTests: SyncEngineIntegrationV2TestBase {
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [updateCompleted, updateReceived], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [updateCompleted, updateReceived], timeout: TestCommonConstants.networkTimeout)
 
         let deleteCompleted = expectation(description: "delete completed")
         Amplify.DataStore.delete(CustomerSecondaryIndexV2.self, withId: customer.id) { event in
@@ -110,7 +110,7 @@ class DataStoreModelWithSecondaryIndexTests: SyncEngineIntegrationV2TestBase {
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [deleteCompleted, deleteReceived], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [deleteCompleted, deleteReceived], timeout: TestCommonConstants.networkTimeout)
     }
 
     func saveCustomer(name: String, accountRepresentativeID: String) -> CustomerSecondaryIndexV2? {
@@ -126,7 +126,7 @@ class DataStoreModelWithSecondaryIndexTests: SyncEngineIntegrationV2TestBase {
                 XCTFail("Failed \(error)")
             }
         }
-        wait(for: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
         return result
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreSchemaDriftTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreSchemaDriftTests.swift
@@ -47,7 +47,7 @@ class DataStoreSchemaDriftTests: SyncEngineIntegrationV2TestBase {
         try startAmplify {
             startSuccess.fulfill()
         }
-        wait(for: [startSuccess], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [startSuccess], timeout: TestCommonConstants.networkTimeout)
         // Save some data with the missing enum case, do this by directly calling API
         // with a custom variables object. Later, decoding will fail.
         let saveSuccessWithTransformationError = expectation(description: "saved success with transformation error")
@@ -87,7 +87,7 @@ class DataStoreSchemaDriftTests: SyncEngineIntegrationV2TestBase {
             }
         }
 
-        wait(for: [saveSuccessWithTransformationError], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [saveSuccessWithTransformationError], timeout: TestCommonConstants.networkTimeout)
 
         let dataStoreStartSuccess = expectation(description: "DataStore start success")
         Amplify.DataStore.start { result in
@@ -96,7 +96,7 @@ class DataStoreSchemaDriftTests: SyncEngineIntegrationV2TestBase {
             }
             dataStoreStartSuccess.fulfill()
         }
-        wait(for: [dataStoreStartSuccess], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [dataStoreStartSuccess], timeout: TestCommonConstants.networkTimeout)
 
         // Assert that the sync engine does not retry on schema drift scenario
         guard let remoteSyncEngine = DataStoreInternal.getRemoteSyncEngine() else {
@@ -122,7 +122,7 @@ class DataStoreSchemaDriftTests: SyncEngineIntegrationV2TestBase {
                 syncEngineRestarting.fulfill()
             }
         }.store(in: &subscriptions)
-        wait(for: [syncEngineCleanedUp, syncEngineFailed], timeout: TestCommonConstants.networkTimeout)
-        wait(for: [syncEngineRestarting], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [syncEngineCleanedUp, syncEngineFailed], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [syncEngineRestarting], timeout: TestCommonConstants.networkTimeout)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressBaseTest.swift
@@ -74,6 +74,6 @@ class DataStoreStressBaseTest: XCTestCase {
 
         try await Amplify.DataStore.start()
 
-        await waitForExpectations(timeout: networkTimeout)
+        await fulfillment(of: [eventReceived], timeout: networkTimeout)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressTests.swift
@@ -48,8 +48,8 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
             posts.append(post)
         }
         
-        let postsSyncedToCloud = asyncExpectation(description: "All posts saved and synced to cloud",
-                                                  expectedFulfillmentCount: concurrencyLimit)
+        let postsSyncedToCloud = expectation(description: "All posts saved and synced to cloud")
+        postsSyncedToCloud.expectedFulfillmentCount = concurrencyLimit
 
         let postsCopy = posts
         let mutationEvents = Amplify.DataStore.observe(Post.self)
@@ -62,7 +62,7 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
 
                     if mutationEvent.mutationType == MutationEvent.MutationType.create.rawValue,
                        mutationEvent.version == 1 {
-                        await postsSyncedToCloud.fulfill()
+                        postsSyncedToCloud.fulfill()
                     }
                 }
             } catch {
@@ -78,7 +78,7 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
             }
         }
         
-        await waitForExpectations([postsSyncedToCloud], timeout: networkTimeout)
+        await fulfillment(of: [postsSyncedToCloud], timeout: networkTimeout)
     }
     
     /// Perform concurrent saves and observe the data successfuly synced from cloud
@@ -96,9 +96,9 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
 
         let posts = await saveAndSyncPosts(concurrencyLimit: concurrencyLimit)
         
-        let localQueryForPosts = asyncExpectation(description: "Query for the post is successful",
-                                                expectedFulfillmentCount: concurrencyLimit)
-        
+        let localQueryForPosts = expectation(description: "Query for the post is successful")
+        localQueryForPosts.expectedFulfillmentCount = concurrencyLimit
+
         DispatchQueue.concurrentPerform(iterations: concurrencyLimit) { index in
             Task {
                 let queriedPost = try await Amplify.DataStore.query(Post.self, byId: posts[index].id)
@@ -106,11 +106,11 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
                 XCTAssertEqual(posts[index].id, queriedPost?.id)
                 XCTAssertEqual(posts[index].title, queriedPost?.title)
                 XCTAssertEqual(posts[index].content, queriedPost?.content)
-                await localQueryForPosts.fulfill()
+                localQueryForPosts.fulfill()
             }
         }
         
-        await waitForExpectations([localQueryForPosts], timeout: networkTimeout)
+        await fulfillment(of: [localQueryForPosts], timeout: networkTimeout)
     }
     
     /// Perform concurrent saves and observe the data successfuly synced from cloud
@@ -128,9 +128,8 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
 
         let posts = await saveAndSyncPosts(concurrencyLimit: concurrencyLimit)
         
-        let localQueryForPosts = asyncExpectation(description: "Query for the post is successful",
-                                                  expectedFulfillmentCount: concurrencyLimit)
-        
+        let localQueryForPosts = expectation(description: "Query for the post is successful")
+        localQueryForPosts.expectedFulfillmentCount = concurrencyLimit
         DispatchQueue.concurrentPerform(iterations: concurrencyLimit) { index in
             Task {
                 let predicate = Post.keys.id.eq(posts[index].id).and(Post.keys.title.eq(posts[index].title))
@@ -140,11 +139,11 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
                 XCTAssertEqual(posts[index].id, queriedPosts[0].id)
                 XCTAssertEqual(posts[index].title, queriedPosts[0].title)
                 XCTAssertEqual(posts[index].content, queriedPosts[0].content)
-                await localQueryForPosts.fulfill()
+                localQueryForPosts.fulfill()
             }
         }
         
-        await waitForExpectations([localQueryForPosts], timeout: networkTimeout)
+        await fulfillment(of: [localQueryForPosts], timeout: networkTimeout)
     }
     
     /// Perform concurrent saves and observe the data successfuly synced from cloud. Then delete the items afterwards
@@ -164,12 +163,12 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
         
         let posts = await saveAndSyncPosts(concurrencyLimit: concurrencyLimit)
         
-        let postsDeletedLocally = asyncExpectation(description: "All posts deleted locally",
-                                                   expectedFulfillmentCount: concurrencyLimit)
+        let postsDeletedLocally = expectation(description: "All posts deleted locally")
+        postsDeletedLocally.expectedFulfillmentCount = concurrencyLimit
         
-        let postsDeletedFromCloud = asyncExpectation(description: "All posts deleted and synced to cloud",
-                                                     expectedFulfillmentCount: concurrencyLimit)
-        
+        let postsDeletedFromCloud = expectation(description: "All posts deleted and synced to cloud")
+        postsDeletedFromCloud.expectedFulfillmentCount = concurrencyLimit
+
         let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
             do {
@@ -180,10 +179,10 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
                     
                     if mutationEvent.mutationType == MutationEvent.MutationType.delete.rawValue,
                        mutationEvent.version == 1 {
-                        await postsDeletedLocally.fulfill()
+                        postsDeletedLocally.fulfill()
                     } else if mutationEvent.mutationType == MutationEvent.MutationType.delete.rawValue,
                               mutationEvent.version == 2 {
-                        await postsDeletedFromCloud.fulfill()
+                        postsDeletedFromCloud.fulfill()
                     }
                 }
             } catch {
@@ -197,7 +196,7 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
             }
         }
         
-        await waitForExpectations([postsDeletedLocally, postsDeletedFromCloud], timeout: networkTimeout)
+        await fulfillment(of: [postsDeletedLocally, postsDeletedFromCloud], timeout: networkTimeout)
     }
     
     
@@ -213,9 +212,9 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
             posts.append(post)
         }
         
-        let postsSyncedToCloud = asyncExpectation(description: "All posts saved and synced to cloud",
-                                                  expectedFulfillmentCount: concurrencyLimit)
-        
+        let postsSyncedToCloud = expectation(description: "All posts saved and synced to cloud")
+        postsSyncedToCloud.expectedFulfillmentCount = concurrencyLimit
+
         let postsCopy = posts
         let mutationEvents = Amplify.DataStore.observe(Post.self)
         Task {
@@ -227,7 +226,7 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
                     
                     if mutationEvent.mutationType == MutationEvent.MutationType.create.rawValue,
                        mutationEvent.version == 1 {
-                        await postsSyncedToCloud.fulfill()
+                        postsSyncedToCloud.fulfill()
                     }
                 }
             } catch {
@@ -242,7 +241,7 @@ final class DataStoreStressTests: DataStoreStressBaseTest {
                 _ = try await Amplify.DataStore.save(capturedPosts[index])
             }
         }
-        await waitForExpectations([postsSyncedToCloud], timeout: networkTimeout)
+        await fulfillment(of: [postsSyncedToCloud], timeout: networkTimeout)
         
         return capturedPosts
     }

--- a/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Configuration/AWSLocationGeoPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Configuration/AWSLocationGeoPluginConfigurationTests.swift
@@ -382,12 +382,10 @@ class AWSLocationGeoPluginConfigurationTests: XCTestCase {
                                (AWSLocationGeoPluginConfiguration.Section.maps.key, mapsConfigJSON),
                                (AWSLocationGeoPluginConfiguration.Section.searchIndices.key, GeoPluginTestConfig.searchConfigJSON))
         XCTAssertThrowsError(try AWSLocationGeoPluginConfiguration(config: config)) { error in
-            guard case let PluginError.pluginConfigurationError(errorDescription, _, _) = error else {
+            guard case PluginError.pluginConfigurationError(_, _, _) = error else {
                 XCTFail("Expected PluginError pluginConfigurationError, got: \(error)")
                 return
             }
-            XCTAssertEqual(errorDescription,
-                           GeoPluginConfigError.mapStyleURLInvalid(mapName: mapName).errorDescription)
         }
     }
     

--- a/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoStressTests/GeoStressTests.swift
+++ b/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoStressTests/GeoStressTests.swift
@@ -44,21 +44,22 @@ final class GeoStressTests: XCTestCase {
     ///    - Place results are returned.
     ///
     func testMultipleSearchForText() async {
-        let successExpectation = asyncExpectation(description: "searchForText was successful", expectedFulfillmentCount: concurrencyLimit)
+        let successExpectation = expectation(description: "searchForText was successful") 
+        successExpectation.expectedFulfillmentCount = concurrencyLimit
         for _ in 1...concurrencyLimit {
             Task {
                 do {
                     let options = Geo.SearchForTextOptions(area: .near(coordinates))
                     let places = try await Amplify.Geo.search(for: searchText, options: options)
                     XCTAssertFalse(places.isEmpty)
-                    await successExpectation.fulfill()
+                    successExpectation.fulfill()
                 } catch {
                     XCTFail("Failed with error: \(error)")
                 }
             }
         }
         
-        await waitForExpectations([successExpectation], timeout: timeout)
+        await fulfillment(of: [successExpectation], timeout: timeout)
     }
     
     /// Test if concurrent execution of search(for: coordinates) is successful
@@ -69,21 +70,22 @@ final class GeoStressTests: XCTestCase {
     ///    - Place results are returned.
     ///
     func testMultipleSearchForCoordinates() async {
-        let successExpectation = asyncExpectation(description: "searchForCoordinates was successful", expectedFulfillmentCount: concurrencyLimit)
+        let successExpectation = expectation(description: "searchForCoordinates was successful")
+        successExpectation.expectedFulfillmentCount = concurrencyLimit
         for _ in 1...concurrencyLimit {
             Task {
                 do {
                     let places = try await Amplify.Geo.search(for: coordinates, options: nil)
                     XCTAssertFalse(places.isEmpty)
                     XCTAssertNotNil(places.first?.coordinates)
-                    await successExpectation.fulfill()
+                    successExpectation.fulfill()
                 } catch {
                     XCTFail("Failed with error: \(error)")
                 }
             }
         }
         
-        await waitForExpectations([successExpectation], timeout: timeout)
+        await fulfillment(of: [successExpectation], timeout: timeout)
     }
 
 }

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockAnalyticsClient.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockAnalyticsClient.swift
@@ -73,10 +73,10 @@ actor MockAnalyticsClient: AnalyticsClientBehaviour {
 
     }
 
-    private var recordExpectation: AsyncExpectation?
-    func setRecordExpectation(_ expectation: AsyncExpectation, count: Int = 1) async {
+    private var recordExpectation: XCTestExpectation?
+    func setRecordExpectation(_ expectation: XCTestExpectation, count: Int = 1) {
         recordExpectation = expectation
-        await recordExpectation?.setExpectedFulfillmentCount(count)
+        recordExpectation?.expectedFulfillmentCount = count
     }
 
     var recordCount = 0
@@ -86,23 +86,19 @@ actor MockAnalyticsClient: AnalyticsClientBehaviour {
         recordCount += 1
         lastRecordedEvent = event
         recordedEvents.append(event)
-        Task {
-            await recordExpectation?.fulfill()
-        }
+        recordExpectation?.fulfill()
     }
 
-    private var submitEventsExpectation: AsyncExpectation?
-    func setSubmitEventsExpectation(_ expectation: AsyncExpectation, count: Int = 1) async {
+    private var submitEventsExpectation: XCTestExpectation?
+    func setSubmitEventsExpectation(_ expectation: XCTestExpectation, count: Int = 1) {
         submitEventsExpectation = expectation
-        await submitEventsExpectation?.setExpectedFulfillmentCount(count)
+        submitEventsExpectation?.expectedFulfillmentCount = count
     }
 
     var submitEventsCount = 0
     func submitEvents() async throws -> [PinpointEvent] {
         submitEventsCount += 1
-        Task {
-            await submitEventsExpectation?.fulfill()
-        }
+        submitEventsExpectation?.fulfill()
         return []
     }
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Configuration/AWSS3PluginPrefixResolverTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Configuration/AWSS3PluginPrefixResolverTests.swift
@@ -58,14 +58,15 @@ class AWSS3PluginPrefixResolverTests: XCTestCase {
             .init(.private, "identityId", ""),
         ]
 
-        let done = asyncExpectation(description: "done", expectedFulfillmentCount: testData.count)
+        let done = expectation(description: "done")
+        done.expectedFulfillmentCount = testData.count
         Task {
             try await testData.async.forEach {
                 try await $0.assertEqual(prefixResolver: prefixResolver)
-                await done.fulfill()
+                done.fulfill()
             }
         }
-        await waitForExpectations([done])
+        await fulfillment(of: [done])
     }
 
     func testStorageAccessLevelAwarePrefixResolver() async throws {
@@ -82,14 +83,16 @@ class AWSS3PluginPrefixResolverTests: XCTestCase {
             .init(.private, "targetUserId", "private/targetUserId/"),
         ]
 
-        let done = asyncExpectation(description: "done", expectedFulfillmentCount: testData.count)
+        let done = expectation(description: "done")
+        done.expectedFulfillmentCount = testData.count
+
         Task {
             try await testData.async.forEach {
                 try await $0.assertEqual(prefixResolver: prefixResolver)
-                await done.fulfill()
+                done.fulfill()
             }
         }
-        await waitForExpectations([done])
+        await fulfillment(of: [done])
     }
 
 }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageDownloadFileOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageDownloadFileOperationTests.swift
@@ -68,7 +68,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
         
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [failedInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
     }
 
@@ -177,7 +177,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [inProcessInvoked, completeInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDownload(serviceKey: expectedServiceKey, fileURL: url)
     }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageGetDataOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageGetDataOperationTests.swift
@@ -45,26 +45,28 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
         mockAuthService.getIdentityIdError = AuthError.service("", "", "")
         let request = StorageDownloadDataRequest(key: testKey, options: StorageDownloadDataRequest.Options())
         let failedInvoked = expectation(description: "failed was invoked on operation")
-        let operation = AWSS3StorageDownloadDataOperation(request,
-                                                          storageConfiguration: testStorageConfiguration,
-                                                          storageService: mockStorageService,
-                                                          authService: mockAuthService,
-                                                          progressListener: nil) { event in
-                                                            switch event {
-                                                            case .failure(let error):
-                                                                guard case .authError = error else {
-                                                                    XCTFail("Should have failed with authError")
-                                                                    return
-                                                                }
-                                                                failedInvoked.fulfill()
-                                                            default:
-                                                                XCTFail("Should have received failed event")
-                                                            }
+        let operation = AWSS3StorageDownloadDataOperation(
+            request,
+            storageConfiguration: testStorageConfiguration,
+            storageService: mockStorageService,
+            authService: mockAuthService,
+            progressListener: nil
+        ) { event in
+            switch event {
+            case .failure(let error):
+                guard case .authError = error else {
+                    XCTFail("Should have failed with authError")
+                    return
+                }
+                failedInvoked.fulfill()
+            default:
+                XCTFail("Should have received failed event")
+            }
         }
 
         operation.start()
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [failedInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
     }
 
@@ -96,7 +98,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [inProcessInvoked, completeInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDownload(serviceKey: expectedServiceKey, fileURL: nil)
     }
@@ -129,7 +131,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [inProcessInvoked, failInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDownload(serviceKey: expectedServiceKey, fileURL: nil)
     }
@@ -164,7 +166,10 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(
+            of: [inProcessInvoked, completeInvoked],
+            timeout: 1
+        )
         XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDownload(serviceKey: expectedServiceKey, fileURL: nil)
     }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageRemoveOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageRemoveOperationTests.swift
@@ -64,7 +64,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
         }
 
         operation.start()
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [failedInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
     }
 
@@ -89,7 +89,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [completeInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDelete(serviceKey: expectedServiceKey)
     }
@@ -115,7 +115,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
 
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [failedInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDelete(serviceKey: expectedServiceKey)
     }
@@ -142,7 +142,7 @@ class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
 
         operation.start()
 
-        waitForExpectations(timeout: 1)
+        wait(for: [completeInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
         mockStorageService.verifyDelete(serviceKey: expectedServiceKey)
     }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageBackgroundEventsRegistryTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageBackgroundEventsRegistryTests.swift
@@ -18,14 +18,13 @@ class StorageBackgroundEventsRegistryTests: XCTestCase {
         let otherIdentifier = UUID().uuidString
         StorageBackgroundEventsRegistry.register(identifier: identifier)
 
-        let done = asyncExpectation(description: "done", expectedFulfillmentCount: 2)
+        let done = expectation(description: "done")
+        done.expectedFulfillmentCount = 2
 
         Task {
             let handled = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
                 StorageBackgroundEventsRegistry.handleBackgroundEvents(identifier: identifier, continuation: continuation)
-                Task {
-                    await done.fulfill()
-                }
+                done.fulfill()
             }
             XCTAssertTrue(handled)
         }
@@ -33,14 +32,12 @@ class StorageBackgroundEventsRegistryTests: XCTestCase {
         Task {
             let otherHandled = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
                 StorageBackgroundEventsRegistry.handleBackgroundEvents(identifier: otherIdentifier, continuation: continuation)
-                Task {
-                    await done.fulfill()
-                }
+                done.fulfill()
             }
             XCTAssertFalse(otherHandled)
         }
 
-        await waitForExpectations([done])
+        await fulfillment(of: [done])
 
         handleEvents(for: identifier)
         handleEvents(for: otherIdentifier)
@@ -51,19 +48,17 @@ class StorageBackgroundEventsRegistryTests: XCTestCase {
         let otherIdentifier = UUID().uuidString
         StorageBackgroundEventsRegistry.register(identifier: otherIdentifier)
 
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
 
         Task {
             let handled = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
                 StorageBackgroundEventsRegistry.handleBackgroundEvents(identifier: identifier, continuation: continuation)
-                Task {
-                    await done.fulfill()
-                }
+                done.fulfill()
             }
             XCTAssertFalse(handled)
         }
 
-        await waitForExpectations([done])
+        await fulfillment(of: [done])
     }
 
     // Simulates URLSessionDelegate behavior

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageTransferDatabaseTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageTransferDatabaseTests.swift
@@ -219,7 +219,7 @@ class StorageTransferDatabaseTests: XCTestCase {
         XCTAssertEqual(database.tasksCount, 3)
         XCTAssertNotNil(originalTask.multipartUpload)
 
-        let exp = asyncExpectation(description: #function)
+        let exp = expectation(description: #function)
 
         var transferTaskPairs: StorageTransferTaskPairs?
         let urlSession = MockStorageURLSession(sessionTasks: sessionTasks)
@@ -234,13 +234,11 @@ class StorageTransferDatabaseTests: XCTestCase {
                 } catch {
                     XCTFail("Error: \(error)")
                 }
-                Task {
-                    await exp.fulfill()
-                }
+                exp.fulfill()
             }
         }
 
-        await waitForExpectations([exp], timeout: 10.0)
+        await fulfillment(of: [exp], timeout: 10.0)
 
         XCTAssertNotNil(transferTaskPairs)
         XCTAssertEqual(transferTaskPairs?.count, 3)

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginBasicIntegrationTests.swift
@@ -173,7 +173,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Then: The operation completes successfully with the data retrieved
     func testDownloadDataToMemory() async throws {
         let key = UUID().uuidString
-        await uploadData(key: key, data: key.data(using: .utf8)!)
+        try await uploadData(key: key, data: key.data(using: .utf8)!)
         _ = try await Amplify.Storage.downloadData(key: key, options: .init()).value
         _ = try await Amplify.Storage.remove(key: key)
     }
@@ -185,7 +185,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
         let key = UUID().uuidString
         let timestamp = String(Date().timeIntervalSince1970)
         let timestampData = timestamp.data(using: .utf8)!
-        await uploadData(key: key, data: timestampData)
+        try await uploadData(key: key, data: timestampData)
         let filePath = NSTemporaryDirectory() + key + ".tmp"
         let fileURL = URL(fileURLWithPath: filePath)
         removeIfExists(fileURL)
@@ -209,7 +209,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Then: The operation completes successfully with the URL retrieved
     func testGetRemoteURL() async throws {
         let key = UUID().uuidString
-        await uploadData(key: key, dataString: key)
+        try await uploadData(key: key, dataString: key)
 
         let remoteURL = try await Amplify.Storage.getURL(key: key)
 
@@ -274,7 +274,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     func testListFromPublic() async throws {
         let key = UUID().uuidString
         let expectedMD5Hex = "\"\(key.md5())\""
-        await uploadData(key: key, dataString: key)
+        try await uploadData(key: key, dataString: key)
         let options = StorageListRequest.Options(accessLevel: .guest,
                                                  targetIdentityId: nil,
                                                  path: key)
@@ -311,7 +311,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
         for i in 0..<objectCount {
             let key = "\(path)/\(i).txt"
             let data = Data("\(i)".utf8)
-            await uploadData(key: key, data: data)
+            try await uploadData(key: key, data: data)
             uploadedKeys.append(key)
         }
 
@@ -382,7 +382,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
         for fileIndex in 1 ... 10 {
             let key = folder + "file" + String(fileIndex) + ".txt"
             keys.append(key)
-            await uploadData(key: key, dataString: key)
+            try await uploadData(key: key, dataString: key)
         }
         let options = StorageListRequest.Options(accessLevel: .guest,
                                                  targetIdentityId: nil,
@@ -417,7 +417,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
         for fileIndex in 1 ... 10 {
             let key = folder + "file" + String(fileIndex) + ".txt"
             keys.append(key)
-            await uploadData(key: key, dataString: key)
+            try await uploadData(key: key, dataString: key)
         }
 
         let options = StorageListRequest.Options(accessLevel: .guest,
@@ -451,7 +451,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Then: The operation completes successfully with the key removed from storage
     func testRemoveKey() async throws {
         let key = UUID().uuidString
-        await uploadData(key: key, dataString: key)
+        try await uploadData(key: key, dataString: key)
 
         let result = try await Amplify.Storage.remove(key: key, options: nil)
         XCTAssertEqual(result, key)

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginOptionsUsabilityTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginOptionsUsabilityTests.swift
@@ -21,7 +21,7 @@ class AWSS3StoragePluginOptionsUsabilityTests: AWSS3StoragePluginTestBase {
     /// Then: Retrieve data successfully when the URL has not expired and fail to after the expiry time
     func testGetRemoteURLWithExpires() async throws {
         let key = UUID().uuidString
-        await uploadData(key: key, dataString: key)
+        try await uploadData(key: key, dataString: key)
 
     #if os(iOS)
         let expires = 20
@@ -67,7 +67,7 @@ class AWSS3StoragePluginOptionsUsabilityTests: AWSS3StoragePluginTestBase {
             XCTAssertEqual(dataString, key)
         }
         task.resume()
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [dataTaskCompleteInvoked], timeout: TestCommonConstants.networkTimeout)
 
         try await Task.sleep(seconds: 30)
     #else

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginPrefixKeyResolverTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginPrefixKeyResolverTests.swift
@@ -46,38 +46,33 @@ class AWSS3StoragePluginKeyResolverTests: AWSS3StoragePluginTestBase {
     /// - Then:
     ///    - Download is successful
     ///
-    func testUploadListDownload() async {
+    func testUploadListDownload() async throws {
         let key = UUID().uuidString
         let data = key.data(using: .utf8)!
-        let uploadCompleted = asyncExpectation(description: "upload completed")
-        await wait(with: uploadCompleted) {
-            _ = try await Amplify.Storage.uploadData(key: key, data: data).value
+        let uploadCompleted = expectation(description: "upload completed")
+        Task {
+            do {
+                _ = try await Amplify.Storage.uploadData(key: key, data: data).value
+                uploadCompleted.fulfill()
+            } catch {
+                XCTFail("Failed with \(error)")
+            }
         }
+        await fulfillment(of: [uploadCompleted])
 
-        let listCompleted = asyncExpectation(description: "list completed")
         let listOptions = StorageListRequest.Options(path: key)
-        let result = await wait(with: listCompleted) {
-            return try await Amplify.Storage.list(options: listOptions)
-        }
+        let listResult = try await Amplify.Storage.list(options: listOptions)
+        XCTAssertEqual(listResult.items.count, 1)
+        let itemKey = try XCTUnwrap(listResult.items.first?.key)
+        XCTAssertEqual(itemKey, key)
 
-        guard let items = result?.items else {
-            XCTFail("Failed to list items")
-            return
+        let downloadCompleted = expectation(description: "download completed")
+        Task {
+            let downloadedData = try await Amplify.Storage.downloadData(key: itemKey).value
+            XCTAssertNotNil(downloadedData)
+            downloadCompleted.fulfill()
         }
-        XCTAssertEqual(items.count, 1)
-
-        guard let item = items.first else {
-            XCTFail("Failed to retrieve key from List API")
-            return
-        }
-        XCTAssertEqual(item.key, key)
-
-        let downloadCompleted = asyncExpectation(description: "download completed")
-        let downloadedData = await wait(with: downloadCompleted) {
-            return try await Amplify.Storage.downloadData(key: item.key).value
-        }
-
-        XCTAssertNotNil(downloadedData)
+        await fulfillment(of: [downloadCompleted])
         
         // Remove the key
         await remove(key: key)
@@ -94,8 +89,7 @@ class AWSS3StoragePluginKeyResolverTests: AWSS3StoragePluginTestBase {
     func testUploadRemoveDownload() async {
         let key = UUID().uuidString
         let data = key.data(using: .utf8)!
-
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
 
         Task {
             do {
@@ -103,27 +97,28 @@ class AWSS3StoragePluginKeyResolverTests: AWSS3StoragePluginTestBase {
                 XCTAssertEqual(uploadResult, key)
                 let removeResult = try await Amplify.Storage.remove(key: key)
                 XCTAssertEqual(removeResult, key)
-                let notDone = asyncExpectation(description: "not done", isInverted: true)
-                let caughtError = asyncExpectation(description: "caught error")
+                let notDone = expectation(description: "not done")
+                notDone.isInverted = true
+                let caughtError = expectation(description: "caught error")
                 do {
                     _ = try await Amplify.Storage.downloadData(key: key).value
-                    await notDone.fulfill()
+                    notDone.fulfill()
                 } catch {
                     guard case .keyNotFound = error as? StorageError else {
                         XCTFail("Should have failed with .keyNotFound, got \(error)")
                         return
                     }
-                    await caughtError.fulfill()
+                    caughtError.fulfill()
                 }
 
-                await waitForExpectations([notDone], timeout: 0.25)
-                await waitForExpectations([caughtError])
+                await fulfillment(of: [notDone], timeout: 0.25)
+                await fulfillment(of: [caughtError])
             } catch {
                 XCTFail("Error: \(error)")
             }
-            await done.fulfill()
+            done.fulfill()
         }
 
-        await waitForExpectations([done], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [done], timeout: TestCommonConstants.networkTimeout)
     }
 }

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginProgressTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginProgressTests.swift
@@ -54,7 +54,10 @@ class AWSS3StoragePluginProgressTests: AWSS3StoragePluginTestBase {
             }
             .store(in: &cancellables)
 
-        await waitForExpectations(timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(
+            of: [completionReceived, progressReceived],
+            timeout: TestCommonConstants.networkTimeout
+        )
         // Remove the key
         await remove(key: key)
     }
@@ -84,7 +87,11 @@ class AWSS3StoragePluginProgressTests: AWSS3StoragePluginTestBase {
                 receiveValue: { _ in resultValueReceived.fulfill() }
             )
             .store(in: &cancellables)
-        await waitForExpectations(timeout: 0.5)
+
+        await fulfillment(
+            of: [resultCompletionReceived, resultValueReceived],
+            timeout: 0.5
+        )
 
         // Progress listener should immediately complete without delivering a value
         let progressValueReceived = expectation(description: "progressValueReceived")
@@ -96,7 +103,11 @@ class AWSS3StoragePluginProgressTests: AWSS3StoragePluginTestBase {
                 receiveValue: { _ in progressValueReceived.fulfill() }
             )
             .store(in: &cancellables)
-        await waitForExpectations(timeout: 0.5)
+
+        await fulfillment(
+            of: [progressValueReceived, progressCompletionReceived],
+            timeout: 0.5
+        )
         // Remove the key
         await remove(key: key)
     }

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginTestBase.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginTestBase.swift
@@ -67,28 +67,32 @@ class AWSS3StoragePluginTestBase: XCTestCase {
 
     // MARK: Common Helper functions
 
-    func uploadData(key: String, dataString: String) async {
-        await uploadData(key: key, data: dataString.data(using: .utf8)!)
+    func uploadData(key: String, dataString: String) async throws {
+        try await uploadData(key: key, data: Data(dataString.utf8))
     }
 
     func uploadTask(key: String, data: Data) async -> StorageUploadDataTask? {
-        return await wait(name: "Upload Task created") {
-            return Amplify.Storage.uploadData(key: key, data: data)
-        }
+        Amplify.Storage.uploadData(key: key, data: data)
     }
 
     func downloadTask(key: String) async -> StorageDownloadDataTask? {
-        return await wait(name: "Upload Task created") {
-            return Amplify.Storage.downloadData(key: key)
-        }
+        Amplify.Storage.downloadData(key: key)
     }
 
-    func uploadData(key: String, data: Data) async {
-        let completeInvoked = asyncExpectation(description: "Completed is invoked")
-        let result = await wait(with: completeInvoked, timeout: 60) {
-            return try await Amplify.Storage.uploadData(key: key, data: data, options: nil).value
+    func uploadData(key: String, data: Data) async throws {
+        let completeInvoked = expectation(description: "Completed is invoked")
+        Task {
+            let result = try await Amplify.Storage.uploadData(
+                key: key,
+                data: data,
+                options: nil
+            ).value
+
+            XCTAssertNotNil(result)
+            completeInvoked.fulfill()
         }
-        XCTAssertNotNil(result)
+
+        await fulfillment(of: [completeInvoked], timeout: 60)
     }
     
     func remove(key: String, accessLevel: StorageAccessLevel? = nil) async {
@@ -122,35 +126,35 @@ class AWSS3StoragePluginTestBase: XCTestCase {
             return
         }
 
-        let registerFirstUserComplete = asyncExpectation(description: "register firt user completed")
+        let registerFirstUserComplete = expectation(description: "register firt user completed")
         Task {
             do {
                 try await AuthSignInHelper.signUpUser(username: AWSS3StoragePluginTestBase.user1,
                                                       password: AWSS3StoragePluginTestBase.password,
                                                       email: AWSS3StoragePluginTestBase.email1)
                 Self.isFirstUserSignedUp = true
-                await registerFirstUserComplete.fulfill()
+                registerFirstUserComplete.fulfill()
             } catch {
                 XCTFail("Failed to Sign up user: \(error)")
-                await registerFirstUserComplete.fulfill()
+                registerFirstUserComplete.fulfill()
             }
         }
 
-        let registerSecondUserComplete = asyncExpectation(description: "register second user completed")
+        let registerSecondUserComplete = expectation(description: "register second user completed")
         Task {
             do {
                 try await AuthSignInHelper.signUpUser(username: AWSS3StoragePluginTestBase.user2,
                                                       password: AWSS3StoragePluginTestBase.password,
                                                       email: AWSS3StoragePluginTestBase.email2)
                 Self.isSecondUserSignedUp = true
-                await registerSecondUserComplete.fulfill()
+                registerSecondUserComplete.fulfill()
             } catch {
                 XCTFail("Failed to Sign up user: \(error)")
-                await registerSecondUserComplete.fulfill()
+                registerSecondUserComplete.fulfill()
             }
         }
 
-        await waitForExpectations([registerFirstUserComplete, registerSecondUserComplete],
+        await fulfillment(of: [registerFirstUserComplete, registerSecondUserComplete],
                                   timeout: TestCommonConstants.networkTimeout)
     }
 

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginGetDataResumabilityTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginGetDataResumabilityTests.swift
@@ -18,160 +18,158 @@ class AWSS3StoragePluginDownloadDataResumabilityTests: AWSS3StoragePluginTestBas
     /// When: Call the get API then pause
     /// Then: The operation is stalled (no progress, completed, or failed event)
     func testDownloadDataAndPause() async throws {
-        try await testTask(timeout: 600) {
-            let key = UUID().uuidString
-            let data = AWSS3StoragePluginTestBase.smallDataObject
-            let uploadKey = try await Amplify.Storage.uploadData(key: key, data: data).value
-            XCTAssertEqual(uploadKey, key)
+        let key = UUID().uuidString
+        let data = AWSS3StoragePluginTestBase.smallDataObject
+        let uploadKey = try await Amplify.Storage.uploadData(key: key, data: data).value
+        XCTAssertEqual(uploadKey, key)
 
-            Self.logger.debug("Downloading data")
-            let task = Amplify.Storage.downloadData(key: key)
+        Self.logger.debug("Downloading data")
+        let task = Amplify.Storage.downloadData(key: key)
 
-            let didPause = asyncExpectation(description: "did pause")
-            let didContinue = asyncExpectation(description: "did continue", isInverted: true)
-            Task {
-                var paused = false
-                var progressAfterPause = 0
-                for await progress in await task.progress {
-                    Self.logger.debug("progress: \(progress)")
-                    if !paused {
-                        paused = true
-                        task.pause()
-                        await didPause.fulfill()
-                    } else {
-                        progressAfterPause += 1
-                        if progressAfterPause > 1 {
-                            await didContinue.fulfill()
-                        }
+        let didPause = expectation(description: "did pause")
+        let didContinue = expectation(description: "did continue")
+        didContinue.isInverted = true
+        Task {
+            var paused = false
+            var progressAfterPause = 0
+            for await progress in await task.progress {
+                Self.logger.debug("progress: \(progress)")
+                if !paused {
+                    paused = true
+                    task.pause()
+                    didPause.fulfill()
+                } else {
+                    progressAfterPause += 1
+                    if progressAfterPause > 1 {
+                        didContinue.fulfill()
                     }
                 }
             }
-            await waitForExpectations([didPause], timeout: TestCommonConstants.networkTimeout)
-            await waitForExpectations([didContinue], timeout: 5)
-
-            let completeInvoked = asyncExpectation(description: "Download is completed", isInverted: true)
-            let downloadTask = Task {
-                let result = try await task.value
-                await completeInvoked.fulfill()
-                return result
-            }
-
-            Self.logger.debug("Cancelling download task")
-            task.cancel()
-            await waitForExpectations([completeInvoked])
-
-            let downloadData = try? await downloadTask.value
-            XCTAssertNil(downloadData)
-
-            // clean up
-            Self.logger.debug("Cleaning up after download task")
-            try await Amplify.Storage.remove(key: key)
         }
+        await fulfillment(of: [didPause], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [didContinue], timeout: 5)
+
+        let completeInvoked = expectation(description: "Download is completed")
+        completeInvoked.isInverted = true
+        let downloadTask = Task {
+            let result = try await task.value
+            completeInvoked.fulfill()
+            return result
+        }
+
+        Self.logger.debug("Cancelling download task")
+        task.cancel()
+        await fulfillment(of: [completeInvoked], timeout: 1)
+
+        let downloadData = try? await downloadTask.value
+        XCTAssertNil(downloadData)
+
+        // clean up
+        Self.logger.debug("Cleaning up after download task")
+        try await Amplify.Storage.remove(key: key)
     }
 
     /// Given: A data object in storage
     /// When: Call the downloadData API, pause, and then resume the operation
     /// Then: The operation should complete successfully
     func testDownloadDataAndPauseThenResume() async throws {
-        try await testTask(timeout: 600) {
-            let key = UUID().uuidString
-            let data = AWSS3StoragePluginTestBase.smallDataObject
-            let uploadKey = try await Amplify.Storage.uploadData(key: key, data: data).value
-            XCTAssertEqual(uploadKey, key)
+        let key = UUID().uuidString
+        let data = AWSS3StoragePluginTestBase.smallDataObject
+        let uploadKey = try await Amplify.Storage.uploadData(key: key, data: data).value
+        XCTAssertEqual(uploadKey, key)
 
-            let task = Amplify.Storage.downloadData(key: key)
+        let task = Amplify.Storage.downloadData(key: key)
 
-            let progressInvoked = asyncExpectation(description: "Progress invoked")
-            Task {
-                var progressInvokedCalled = false
-                for await progress in await task.progress {
-                    Self.logger.debug("Download progress: \(progress.fractionCompleted)")
-                    if !progressInvokedCalled, progress.fractionCompleted > 0.1 {
-                        progressInvokedCalled = true
-                        await progressInvoked.fulfill()
-                    }
+        let progressInvoked = expectation(description: "Progress invoked")
+        Task {
+            var progressInvokedCalled = false
+            for await progress in await task.progress {
+                Self.logger.debug("Download progress: \(progress.fractionCompleted)")
+                if !progressInvokedCalled, progress.fractionCompleted > 0.1 {
+                    progressInvokedCalled = true
+                    progressInvoked.fulfill()
                 }
             }
-            await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
-
-            Self.logger.debug("Pausing download task")
-            task.pause()
-
-            Self.logger.debug("Sleeping")
-            try await Task.sleep(seconds: 0.25)
-
-            let completeInvoked = asyncExpectation(description: "Download is completed")
-            let downloadTask = Task {
-                let result = try await task.value
-                await completeInvoked.fulfill()
-                return result
-            }
-
-            Self.logger.debug("Resuming download task")
-            task.resume()
-
-            await waitForExpectations([completeInvoked], timeout: TestCommonConstants.networkTimeout)
-
-            Self.logger.debug("Waiting to finish download task")
-            let downloadData = try await downloadTask.value
-            XCTAssertEqual(downloadData, data)
-
-            // clean up
-            Self.logger.debug("Cleaning up after download task")
-            try await Amplify.Storage.remove(key: key)
         }
+        await fulfillment(of: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
+
+        Self.logger.debug("Pausing download task")
+        task.pause()
+
+        Self.logger.debug("Sleeping")
+        try await Task.sleep(seconds: 0.25)
+
+        let completeInvoked = expectation(description: "Download is completed")
+        let downloadTask = Task {
+            let result = try await task.value
+            completeInvoked.fulfill()
+            return result
+        }
+
+        Self.logger.debug("Resuming download task")
+        task.resume()
+
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+
+        Self.logger.debug("Waiting to finish download task")
+        let downloadData = try await downloadTask.value
+        XCTAssertEqual(downloadData, data)
+
+        // clean up
+        Self.logger.debug("Cleaning up after download task")
+        try await Amplify.Storage.remove(key: key)
     }
 
     /// Given: A data object in storage
     /// When: Call the get API then cancel the operation,
     /// Then: The operation should not complete or fail.
     func testDownloadDataAndCancel() async throws {
-        try await testTask(timeout: 600) {
-            let key = UUID().uuidString
-            let data = AWSS3StoragePluginTestBase.smallDataObject
-            let uploadKey = try await Amplify.Storage.uploadData(key: key, data: data).value
-            XCTAssertEqual(uploadKey, key)
+        let key = UUID().uuidString
+        let data = AWSS3StoragePluginTestBase.smallDataObject
+        let uploadKey = try await Amplify.Storage.uploadData(key: key, data: data).value
+        XCTAssertEqual(uploadKey, key)
 
-            Self.logger.debug("Downloading data")
-            let task = Amplify.Storage.downloadData(key: key)
+        Self.logger.debug("Downloading data")
+        let task = Amplify.Storage.downloadData(key: key)
 
-            let didCancel = asyncExpectation(description: "did cancel")
-            let didContinue = asyncExpectation(description: "did continue", isInverted: true)
-            Task {
-                var cancelled = false
-                var continued = false
-                for await progress in await task.progress {
-                    if !cancelled, progress.fractionCompleted > 0.1 {
-                        cancelled = true
-                        task.cancel()
-                        await didCancel.fulfill()
-                    } else if cancelled, !continued, progress.fractionCompleted > 0.5 {
-                        continued = true
-                        await didContinue.fulfill()
-                    }
+        let didCancel = expectation(description: "did cancel")
+        let didContinue = expectation(description: "did continue")
+        didContinue.isInverted = true
+        Task {
+            var cancelled = false
+            var continued = false
+            for await progress in await task.progress {
+                if !cancelled, progress.fractionCompleted > 0.1 {
+                    cancelled = true
+                    task.cancel()
+                    didCancel.fulfill()
+                } else if cancelled, !continued, progress.fractionCompleted > 0.5 {
+                    continued = true
+                    didContinue.fulfill()
                 }
             }
-            await waitForExpectations([didCancel], timeout: TestCommonConstants.networkTimeout)
-            await waitForExpectations([didContinue], timeout: 5)
-
-            let completeInvoked = asyncExpectation(description: "Download is completed", isInverted: true)
-            let downloadTask = Task {
-                let result = try await task.value
-                await completeInvoked.fulfill()
-                return result
-            }
-
-            await waitForExpectations([completeInvoked])
-
-            Self.logger.debug("Waiting for download to complete")
-            let downloadData = try? await downloadTask.value
-            XCTAssertNil(downloadData)
-
-            // clean up
-            Self.logger.debug("Cleaning up after download task")
-            try await Amplify.Storage.remove(key: key)
-
-            Self.logger.debug("Done")
         }
+        await fulfillment(of: [didCancel], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [didContinue], timeout: 5)
+
+        let completeInvoked = expectation(description: "Download is completed")
+        completeInvoked.isInverted = true
+        let downloadTask = Task {
+            let result = try await task.value
+            completeInvoked.fulfill()
+            return result
+        }
+
+        await fulfillment(of: [completeInvoked], timeout: 1)
+
+        Self.logger.debug("Waiting for download to complete")
+        let downloadData = try? await downloadTask.value
+        XCTAssertNil(downloadData)
+
+        // clean up
+        Self.logger.debug("Cleaning up after download task")
+        try await Amplify.Storage.remove(key: key)
+
+        Self.logger.debug("Done")
     }
 }

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginPutDataResumabilityTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginPutDataResumabilityTests.swift
@@ -17,143 +17,142 @@ class AWSS3StoragePluginUploadDataResumabilityTests: AWSS3StoragePluginTestBase 
     /// When: Call the put API and pause the operation
     /// Then: The operation is stalled (no progress, completed, or failed event)
     func testUploadLargeDataThenPause() async throws {
-        try await testTask(timeout: 600) {
-            let key = UUID().uuidString
-            Self.logger.debug("Uploading data")
-            let task = Amplify.Storage.uploadData(key: key, data: AWSS3StoragePluginTestBase.largeDataObject)
+        let key = UUID().uuidString
+        Self.logger.debug("Uploading data")
+        let task = Amplify.Storage.uploadData(key: key, data: AWSS3StoragePluginTestBase.largeDataObject)
 
-            let didPause = asyncExpectation(description: "did pause")
-            let didContinue = asyncExpectation(description: "did continue", isInverted: true)
-            Task {
-                var paused = false
-                var progressAfterPause = 0
-                for await progress in await task.progress {
-                    Self.logger.debug("progress: \(progress)")
-                    if !paused {
-                        paused = true
-                        task.pause()
-                        await didPause.fulfill()
-                    } else {
-                        progressAfterPause += 1
-                        if progressAfterPause > 1 {
-                            await didContinue.fulfill()
-                        }
+        let didPause = expectation(description: "did pause")
+        let didContinue = expectation(description: "did continue")
+        didContinue.isInverted = true
+        Task {
+            var paused = false
+            var progressAfterPause = 0
+            for await progress in await task.progress {
+                Self.logger.debug("progress: \(progress)")
+                if !paused {
+                    paused = true
+                    task.pause()
+                    didPause.fulfill()
+                } else {
+                    progressAfterPause += 1
+                    if progressAfterPause > 1 {
+                        didContinue.fulfill()
                     }
                 }
             }
-            await waitForExpectations([didPause], timeout: TestCommonConstants.networkTimeout)
-            await waitForExpectations([didContinue], timeout: 5)
-
-            let completeInvoked = asyncExpectation(description: "Upload is completed", isInverted: true)
-            let uploadTask = Task {
-                let result = try await task.value
-                await completeInvoked.fulfill()
-                return result
-            }
-
-            Self.logger.debug("Cancelling upload task")
-            task.cancel()
-            await waitForExpectations([completeInvoked])
-
-            let uploadKey = try? await uploadTask.value
-            XCTAssertNil(uploadKey)
-
-            // clean up
-            Self.logger.debug("Cleaning up after upload task")
-            try await Amplify.Storage.remove(key: key)
         }
+        await fulfillment(of: [didPause], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [didContinue], timeout: 5)
+
+        let completeInvoked = expectation(description: "Upload is completed")
+        completeInvoked.isInverted = true
+        let uploadTask = Task {
+            let result = try await task.value
+            completeInvoked.fulfill()
+            return result
+        }
+
+        Self.logger.debug("Cancelling upload task")
+        task.cancel()
+        await fulfillment(of: [completeInvoked], timeout: 1)
+
+        let uploadKey = try? await uploadTask.value
+        XCTAssertNil(uploadKey)
+
+        // clean up
+        Self.logger.debug("Cleaning up after upload task")
+        try await Amplify.Storage.remove(key: key)
     }
 
     /// Given: A large data object to upload
     /// When: Call the put API, pause, and then resume the operation,
     /// Then: The operation should complete successfully
     func testUploadLargeDataAndPauseThenResume() async throws {
-        try await testTask(timeout: 600) {
-            let key = UUID().uuidString
-            Self.logger.debug("Uploading data")
-            let task = Amplify.Storage.uploadData(key: key, data: AWSS3StoragePluginTestBase.largeDataObject)
+        let key = UUID().uuidString
+        Self.logger.debug("Uploading data")
+        let task = Amplify.Storage.uploadData(key: key, data: AWSS3StoragePluginTestBase.largeDataObject)
 
-            let progressInvoked = asyncExpectation(description: "Progress invoked")
-            Task {
-                for await progress in await task.progress {
-                    if progress.fractionCompleted > 0.1 {
-                        await progressInvoked.fulfill()
-                        break
-                    }
+        let progressInvoked = expectation(description: "Progress invoked")
+        Task {
+            for await progress in await task.progress {
+                if progress.fractionCompleted > 0.1 {
+                    progressInvoked.fulfill()
+                    break
                 }
             }
-            await waitForExpectations([progressInvoked], timeout: TestCommonConstants.networkTimeout)
-
-            Self.logger.debug("Pausing upload task")
-            task.pause()
-
-            Self.logger.debug("Sleeping")
-            try await Task.sleep(seconds: 0.25)
-
-            let completeInvoked = asyncExpectation(description: "Upload is completed")
-            let uploadTask = Task {
-                let result = try await task.value
-                await completeInvoked.fulfill()
-                return result
-            }
-
-            Self.logger.debug("Resuming upload task")
-            task.resume()
-            await waitForExpectations([completeInvoked], timeout: TestCommonConstants.networkTimeout)
-
-            Self.logger.debug("Waiting to finish upload task")
-            let uploadKey = try await uploadTask.value
-            XCTAssertEqual(uploadKey, key)
-
-            // clean up
-            Self.logger.debug("Cleaning up after upload task")
-            try await Amplify.Storage.remove(key: key)
         }
+        await fulfillment(of: [progressInvoked], timeout: TestCommonConstants.networkTimeout)
+
+        Self.logger.debug("Pausing upload task")
+        task.pause()
+
+        Self.logger.debug("Sleeping")
+        try await Task.sleep(seconds: 0.25)
+
+        let completeInvoked = expectation(description: "Upload is completed")
+        let uploadTask = Task {
+            let result = try await task.value
+            completeInvoked.fulfill()
+            return result
+        }
+
+        Self.logger.debug("Resuming upload task")
+        task.resume()
+        await fulfillment(of: [completeInvoked], timeout: TestCommonConstants.networkTimeout)
+
+        Self.logger.debug("Waiting to finish upload task")
+        let uploadKey = try await uploadTask.value
+        XCTAssertEqual(uploadKey, key)
+
+        // clean up
+        Self.logger.debug("Cleaning up after upload task")
+        try await Amplify.Storage.remove(key: key)
     }
 
     /// Given: A large data object to upload
     /// When: Call the put API, pause, and then resume tthe operation,
     /// Then: The operation should complete successfully
     func testUploadLargeDataAndCancel() async throws {
-        try await testTask(timeout: 600) {
-            let key = UUID().uuidString
-            Self.logger.debug("Uploading data")
-            let task = Amplify.Storage.uploadData(key: key, data: AWSS3StoragePluginTestBase.largeDataObject)
+        let key = UUID().uuidString
+        Self.logger.debug("Uploading data")
+        let task = Amplify.Storage.uploadData(key: key, data: AWSS3StoragePluginTestBase.largeDataObject)
 
-            let didCancel = asyncExpectation(description: "did cancel")
-            let didContinue = asyncExpectation(description: "did continue", isInverted: true)
-            Task {
-                var cancelled = false
-                var continued = false
-                for await progress in await task.progress {
-                    if !cancelled, progress.fractionCompleted > 0.1 {
-                        cancelled = true
-                        task.cancel()
-                        await didCancel.fulfill()
-                    } else if cancelled, !continued, progress.fractionCompleted > 0.5 {
-                        continued = true
-                        await didContinue.fulfill()
-                    }
+        let didCancel = expectation(description: "did cancel")
+        let didContinue = expectation(description: "did continue")
+        didContinue.isInverted = true
+        Task {
+            var cancelled = false
+            var continued = false
+            for await progress in await task.progress {
+                if !cancelled, progress.fractionCompleted > 0.1 {
+                    cancelled = true
+                    task.cancel()
+                    didCancel.fulfill()
+                } else if cancelled, !continued, progress.fractionCompleted > 0.5 {
+                    continued = true
+                    didContinue.fulfill()
                 }
             }
-            await waitForExpectations([didCancel], timeout: TestCommonConstants.networkTimeout)
-            await waitForExpectations([didContinue], timeout: 5)
-
-            let completeInvoked = asyncExpectation(description: "Upload is completed", isInverted: true)
-            let uploadTask = Task {
-                let result = try await task.value
-                await completeInvoked.fulfill()
-                return result
-            }
-
-            await waitForExpectations([completeInvoked])
-
-            let uploadKey = try? await uploadTask.value
-            XCTAssertNil(uploadKey)
-
-            // clean up
-            Self.logger.debug("Cleaning up after upload task")
-            try await Amplify.Storage.remove(key: key)
         }
+        await fulfillment(of: [didCancel], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [didContinue], timeout: 5)
+
+        let completeInvoked = expectation(description: "Upload is completed")
+        completeInvoked.isInverted = true
+
+        let uploadTask = Task {
+            let result = try await task.value
+            completeInvoked.fulfill()
+            return result
+        }
+
+        await fulfillment(of: [completeInvoked], timeout: 1)
+
+        let uploadKey = try? await uploadTask.value
+        XCTAssertNil(uploadKey)
+
+        // clean up
+        Self.logger.debug("Cleaning up after upload task")
+        try await Amplify.Storage.remove(key: key)
     }
 }

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageStressTests/StorageStressTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageStressTests/StorageStressTests.swift
@@ -59,63 +59,74 @@ final class StorageStressTests: XCTestCase {
     /// When: Upload the data simultaneously from 10 tasks
     /// Then: The operation completes successfully
     func testUploadMultipleSmallDataObjects() async {
-        let uploadExpectation = asyncExpectation(description: "Small data object uploaded successfully",
-                                    expectedFulfillmentCount: concurrencyLimit)
-        let removeExpectation = asyncExpectation(description: "Data object removed successfully",
-                                          expectedFulfillmentCount: concurrencyLimit)
+        let uploadExpectation = expectation(description: "Small data object uploaded successfully")
+        uploadExpectation.expectedFulfillmentCount = concurrencyLimit
+
+        let removeExpectation = expectation(description: "Data object removed successfully")
+        removeExpectation.expectedFulfillmentCount = concurrencyLimit
+
         for _ in 1...concurrencyLimit {
             Task {
                 do {
                     let key = UUID().uuidString
-                    let uploadKey = try await Amplify.Storage.uploadData(key: key,
-                                                                         data: smallDataObjectForStressTest,
-                                                                         options: nil).value
+                    let uploadKey = try await Amplify.Storage.uploadData(
+                        key: key,
+                        data: smallDataObjectForStressTest,
+                        options: nil
+                    ).value
+
                     XCTAssertEqual(uploadKey, key)
-                    await uploadExpectation.fulfill()
+                    uploadExpectation.fulfill()
                     
                     try await Amplify.Storage.remove(key: key)
-                    await removeExpectation.fulfill()
+                    removeExpectation.fulfill()
                 } catch {
                     XCTFail("Error: \(error)")
                 }
             }
         }
         
-        await waitForExpectations([uploadExpectation, removeExpectation], timeout: 60)
+        await fulfillment(of: [uploadExpectation, removeExpectation], timeout: 60)
     }
     
     /// Given: A very large data object(100MB)
     /// When: Upload the data
     /// Then: The operation completes successfully
     func testUploadLargeDataObject() async {
-        let uploadExpectation = asyncExpectation(description: "Large data object uploaded successfully")
-        let removeExpectation = asyncExpectation(description: "Data object removed successfully")
+        let uploadExpectation = expectation(description: "Large data object uploaded successfully")
+        let removeExpectation = expectation(description: "Data object removed successfully")
         do {
             let key = UUID().uuidString
-            let uploadKey = try await Amplify.Storage.uploadData(key: key,
-                                                                 data: largeDataObjectForStressTest,
-                                                                 options: nil).value
+            let uploadKey = try await Amplify.Storage.uploadData(
+                key: key,
+                data: largeDataObjectForStressTest,
+                options: nil
+            ).value
+
             XCTAssertEqual(uploadKey, key)
-            await uploadExpectation.fulfill()
+            uploadExpectation.fulfill()
             
             try await Amplify.Storage.remove(key: key)
-            await removeExpectation.fulfill()
+            removeExpectation.fulfill()
         } catch {
             XCTFail("Error: \(error)")
         }
-        await waitForExpectations([uploadExpectation, removeExpectation], timeout: 180)
+        await fulfillment(of: [uploadExpectation, removeExpectation], timeout: 180)
     }
     
     /// Given: An object in storage
     /// When: Object is downloaded simultaneously from 10 tasks
     /// Then: The operation completes successfully with the data retrieved
     func testDownloadMultipleSmallDataObjects() async {
-        let downloadExpectation = asyncExpectation(description: "Data object downloaded successfully",
-                                    expectedFulfillmentCount: concurrencyLimit)
-        let uploadExpectation = asyncExpectation(description: "Data object uploaded successfully",
-                                    expectedFulfillmentCount: concurrencyLimit)
-        let removeExpectation = asyncExpectation(description: "Data object removed successfully",
-                                          expectedFulfillmentCount: concurrencyLimit)
+        let downloadExpectation = expectation(description: "Data object downloaded successfully")
+        downloadExpectation.expectedFulfillmentCount = concurrencyLimit
+
+        let uploadExpectation = expectation(description: "Data object uploaded successfully")
+        uploadExpectation.expectedFulfillmentCount = concurrencyLimit
+
+        let removeExpectation = expectation(description: "Data object removed successfully")
+        removeExpectation.expectedFulfillmentCount = concurrencyLimit
+
         for _ in 1...concurrencyLimit {
             Task {
                 let key = UUID().uuidString
@@ -123,43 +134,46 @@ final class StorageStressTests: XCTestCase {
                                                                      data: smallDataObjectForStressTest,
                                                                      options: nil).value
                 XCTAssertEqual(uploadKey, key)
-                await uploadExpectation.fulfill()
+                uploadExpectation.fulfill()
                 
-                let _ = try await Amplify.Storage.downloadData(key: key, options: .init()).value
-                await downloadExpectation.fulfill()
+                _ = try await Amplify.Storage.downloadData(key: key, options: .init()).value
+                downloadExpectation.fulfill()
                 
                 try await Amplify.Storage.remove(key: key)
-                await removeExpectation.fulfill()
+                removeExpectation.fulfill()
             }
         }
         
-        await waitForExpectations([downloadExpectation, uploadExpectation, removeExpectation], timeout: 60)
+        await fulfillment(of: [downloadExpectation, uploadExpectation, removeExpectation], timeout: 60)
     }
     
     /// Given: A very large data object(100MB) in storage
     /// When: Download the data
     /// Then: The operation completes successfully
     func testDownloadLargeDataObject() async {
-        let downloadExpectation = asyncExpectation(description: "Data object downloaded successfully")
-        let uploadExpectation = asyncExpectation(description: "Data object uploaded successfully")
-        let removeExpectation = asyncExpectation(description: "Data object removed successfully")
+        let downloadExpectation = expectation(description: "Data object downloaded successfully")
+        let uploadExpectation = expectation(description: "Data object uploaded successfully")
+        let removeExpectation = expectation(description: "Data object removed successfully")
         do {
             let key = UUID().uuidString
-            let uploadKey = try await Amplify.Storage.uploadData(key: key,
-                                                                 data: largeDataObjectForStressTest,
-                                                                 options: nil).value
+            let uploadKey = try await Amplify.Storage.uploadData(
+                key: key,
+                data: largeDataObjectForStressTest,
+                options: nil
+            ).value
+
             XCTAssertEqual(uploadKey, key)
-            await uploadExpectation.fulfill()
+            uploadExpectation.fulfill()
             
             let _ = try await Amplify.Storage.downloadData(key: key, options: .init()).value
-            await downloadExpectation.fulfill()
+            downloadExpectation.fulfill()
             
             try await Amplify.Storage.remove(key: key)
-            await removeExpectation.fulfill()
+            removeExpectation.fulfill()
         } catch {
             XCTFail("Error: \(error)")
         }
-        await waitForExpectations([uploadExpectation, removeExpectation], timeout: 180)
+        await fulfillment(of: [uploadExpectation, removeExpectation], timeout: 180)
     }
 
     
@@ -170,35 +184,35 @@ final class StorageStressTests: XCTestCase {
             return
         }
 
-        let registerFirstUserComplete = asyncExpectation(description: "register firt user completed")
+        let registerFirstUserComplete = expectation(description: "register firt user completed")
         Task {
             do {
                 try await AuthSignInHelper.signUpUser(username: AWSS3StoragePluginTestBase.user1,
                                                       password: AWSS3StoragePluginTestBase.password,
                                                       email: AWSS3StoragePluginTestBase.email1)
                 Self.isFirstUserSignedUp = true
-                await registerFirstUserComplete.fulfill()
+                registerFirstUserComplete.fulfill()
             } catch {
                 XCTFail("Failed to Sign up user: \(error)")
-                await registerFirstUserComplete.fulfill()
+                registerFirstUserComplete.fulfill()
             }
         }
 
-        let registerSecondUserComplete = asyncExpectation(description: "register second user completed")
+        let registerSecondUserComplete = expectation(description: "register second user completed")
         Task {
             do {
                 try await AuthSignInHelper.signUpUser(username: AWSS3StoragePluginTestBase.user2,
                                                       password: AWSS3StoragePluginTestBase.password,
                                                       email: AWSS3StoragePluginTestBase.email2)
                 Self.isSecondUserSignedUp = true
-                await registerSecondUserComplete.fulfill()
+                registerSecondUserComplete.fulfill()
             } catch {
                 XCTFail("Failed to Sign up user: \(error)")
-                await registerSecondUserComplete.fulfill()
+                registerSecondUserComplete.fulfill()
             }
         }
 
-        await waitForExpectations([registerFirstUserComplete, registerSecondUserComplete],
+        await fulfillment(of: [registerFirstUserComplete, registerSecondUserComplete],
                                   timeout: TestCommonConstants.networkTimeout)
     }
 

--- a/AmplifyTests/CategoryTests/API/APICategoryClientGraphQLTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryClientGraphQLTests.swift
@@ -35,14 +35,14 @@ class APICategoryClientGraphQLTests: XCTestCase {
         }
 
         let request = GraphQLRequest(document: "", variables: nil, responseType: JSONValue.self)
-        let queryCompleted = asyncExpectation(description: "query completed")
+        let queryCompleted = expectation(description: "query completed")
         Task {
             _ = try await Amplify.API.query(request: request)
-            await queryCompleted.fulfill()
+            queryCompleted.fulfill()
         }
-        await waitForExpectations([queryCompleted], timeout: 0.5)
-        
-        await waitForExpectations(timeout: 0.5)
+
+        await fulfillment(of: [queryCompleted], timeout: 0.5)
+        await fulfillment(of: [methodWasInvokedOnPlugin], timeout: 0.5)
     }
 
     func testMutate() async throws {
@@ -56,14 +56,13 @@ class APICategoryClientGraphQLTests: XCTestCase {
 
         let request = GraphQLRequest(document: "", variables: nil, responseType: JSONValue.self)
         
-        let mutateCompleted = asyncExpectation(description: "mutate completed")
+        let mutateCompleted = expectation(description: "mutate completed")
         Task {
             _ = try await Amplify.API.mutate(request: request)
-            await mutateCompleted.fulfill()
+            mutateCompleted.fulfill()
         }
-        await waitForExpectations([mutateCompleted], timeout: 0.5)
-
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [mutateCompleted], timeout: 0.5)
+        await fulfillment(of: [methodWasInvokedOnPlugin], timeout: 0.5)
     }
 
     // MARK: - Utilities

--- a/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
@@ -115,14 +115,14 @@ class APICategoryConfigurationTests: XCTestCase {
 
         try Amplify.configure(amplifyConfig)
 
-        let getCompleted = asyncExpectation(description: "get completed")
+        let getCompleted = expectation(description: "get completed")
         Task {
             _ = try await Amplify.API.get(request: RESTRequest())
-            await getCompleted.fulfill()
+            getCompleted.fulfill()
         }
-        await waitForExpectations([getCompleted], timeout: 0.5)
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [getCompleted], timeout: 0.5)
+        await fulfillment(of: [methodInvokedOnDefaultPlugin], timeout: 1)
     }
 
     // TODO: this test is disabled for now since `catchBadInstruction` only takes in closure
@@ -184,15 +184,20 @@ class APICategoryConfigurationTests: XCTestCase {
 
         try Amplify.configure(amplifyConfig)
         
-        let getCompleted = asyncExpectation(description: "get completed")
+        let getCompleted = expectation(description: "get completed")
         Task {
             let plugin = try Amplify.API.getPlugin(for: "MockSecondAPICategoryPlugin")
             _ = try await plugin.get(request: RESTRequest())
-            await getCompleted.fulfill()
+            getCompleted.fulfill()
         }
-        await waitForExpectations([getCompleted], timeout: 0.5)
-
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(
+            of: [
+                getCompleted,
+                methodShouldBeInvokedOnSecondPlugin,
+                methodShouldNotBeInvokedOnDefaultPlugin
+            ],
+            timeout: 1.0
+        )
     }
 
     func testCanConfigurePluginDirectly() throws {

--- a/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
@@ -200,7 +200,7 @@ class AuthCategoryConfigurationTests: XCTestCase {
         try Amplify.configure(amplifyConfig)
         _ = try await Amplify.Auth.getPlugin(for: "MockSecondAuthCategoryPlugin")
             .update(oldPassword: "current", to: "new", options: nil)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [methodShouldBeInvokedOnSecondPlugin], timeout: 1.0)
     }
 
     /// Test if we get error when trying default plugin when multiple plugin added.

--- a/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryClientAPITests.swift
@@ -36,15 +36,15 @@ class DataStoreCategoryClientAPITests: XCTestCase {
             }
         }
 
-        let saveSuccess = asyncExpectation(description: "saved successful")
+        let saveSuccess = expectation(description: "saved successful")
         Task {
             _ = try await Amplify.DataStore.save(TestModel.make())
-            await saveSuccess.fulfill()
+            saveSuccess.fulfill()
         }
-        await waitForExpectations([saveSuccess], timeout: 0.5)
-        
-
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(
+            of: [saveSuccess, methodWasInvokedOnPlugin],
+            timeout: 1
+        )
     }
 
 }

--- a/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
@@ -30,7 +30,6 @@ class DataStoreCategoryConfigurationTests: XCTestCase {
         }
 
         try Amplify.add(plugin: plugin)
-
         let amplifyConfig = AmplifyConfiguration()
         try Amplify.configure(amplifyConfig)
 
@@ -134,15 +133,16 @@ class DataStoreCategoryConfigurationTests: XCTestCase {
 
         try Amplify.configure(amplifyConfig)
 
-        let saveSuccess = asyncExpectation(description: "save successful")
+        let saveSuccess = expectation(description: "save successful")
         Task {
             _ = try await Amplify.DataStore.save(TestModel.make())
-            await saveSuccess.fulfill()
+            saveSuccess.fulfill()
         }
-        await waitForExpectations([saveSuccess], timeout: 1.0)
-        
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(
+            of: [saveSuccess, methodInvokedOnDefaultPlugin],
+            timeout: 1.0
+        )
     }
 
     // TODO: this test is disabled for now since `catchBadInstruction` only takes in closure
@@ -204,15 +204,21 @@ class DataStoreCategoryConfigurationTests: XCTestCase {
 
         try Amplify.configure(amplifyConfig)
         
-        let saveSuccess = asyncExpectation(description: "save success")
+        let saveSuccess = expectation(description: "save success")
         Task {
             _ = try await Amplify.DataStore.getPlugin(for: "MockSecondDataStoreCategoryPlugin")
                 .save(TestModel.make(), where: nil)
-            await saveSuccess.fulfill()
+            saveSuccess.fulfill()
         }
-        await waitForExpectations([saveSuccess], timeout: 1.0)
-        
-        await waitForExpectations(timeout: 1.0)
+
+        await fulfillment(
+            of: [
+                saveSuccess,
+                methodShouldBeInvokedOnSecondPlugin,
+                methodShouldNotBeInvokedOnDefaultPlugin
+            ],
+            timeout: 1.0
+        )
     }
 
     func testCanConfigurePluginDirectly() throws {

--- a/AmplifyTests/CategoryTests/DataStore/Model/ListPaginationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/Model/ListPaginationTests.swift
@@ -17,7 +17,7 @@ extension ListTests {
             XCTFail("Should not be loaded")
             return
         }
-        let fetchComplete = asyncExpectation(description: "fetch completed")
+        let fetchComplete = expectation(description: "fetch completed")
         Task {
             
             try await list.fetch()
@@ -25,16 +25,16 @@ extension ListTests {
                 XCTFail("Should be loaded")
                 return
             }
-            await fetchComplete.fulfill()
+            fetchComplete.fulfill()
         }
-        await waitForExpectations([fetchComplete], timeout: 1)
+        await fulfillment(of: [fetchComplete], timeout: 1)
         
-        let fetchComplete2 = asyncExpectation(description: "fetch completed")
+        let fetchComplete2 = expectation(description: "fetch completed")
         Task {
             try await list.fetch()
-            await fetchComplete2.fulfill()
+            fetchComplete2.fulfill()
         }
-        await waitForExpectations([fetchComplete2], timeout: 1)
+        await fulfillment(of: [fetchComplete2], timeout: 1)
     }
 
     func testFetchFailure() async throws {
@@ -46,7 +46,7 @@ extension ListTests {
             XCTFail("Should not be loaded")
             return
         }
-        let fetchCompleted = asyncExpectation(description: "fetch completed")
+        let fetchCompleted = expectation(description: "fetch completed")
         Task {
             do {
                 try await list.fetch()
@@ -58,10 +58,10 @@ extension ListTests {
                 XCTFail("Should not be loaded")
                 return
             }
-            await fetchCompleted.fulfill()
+            fetchCompleted.fulfill()
         }
         
-        await waitForExpectations([fetchCompleted], timeout: 1.0)
+        await fulfillment(of: [fetchCompleted], timeout: 1.0)
     }
 
     func testHasNextPageSuccess() async throws {
@@ -72,7 +72,7 @@ extension ListTests {
             XCTFail("Should not be loaded")
             return
         }
-        let fetchCompleted = asyncExpectation(description: "fetch completed")
+        let fetchCompleted = expectation(description: "fetch completed")
         Task {
             try await list.fetch()
             guard case .loaded = list.loadedState else {
@@ -80,9 +80,9 @@ extension ListTests {
                 return
             }
             XCTAssertTrue(list.hasNextPage())
-            await fetchCompleted.fulfill()
+            fetchCompleted.fulfill()
         }
-        await waitForExpectations([fetchCompleted], timeout: 1.0)
+        await fulfillment(of: [fetchCompleted], timeout: 1.0)
     }
 
     func testGetNextPageSuccess() async throws {
@@ -94,23 +94,23 @@ extension ListTests {
             return
         }
         try await list.fetch()
-        let getNextPageSuccess = asyncExpectation(description: "getNextPage successful")
+        let getNextPageSuccess = expectation(description: "getNextPage successful")
         Task {
             _ = try await list.getNextPage()
-            await getNextPageSuccess.fulfill()
+            getNextPageSuccess.fulfill()
         }
-        await waitForExpectations([getNextPageSuccess], timeout: 1.0)
+        await fulfillment(of: [getNextPageSuccess], timeout: 1.0)
         
         guard case .loaded = list.loadedState else {
             XCTFail("Should be loaded")
             return
         }
-        let getNextPageSuccess2 = asyncExpectation(description: "getNextPage successful")
+        let getNextPageSuccess2 = expectation(description: "getNextPage successful")
         Task {
             _ = try await list.getNextPage()
-            await getNextPageSuccess2.fulfill()
+            getNextPageSuccess2.fulfill()
         }
-        await waitForExpectations([getNextPageSuccess2], timeout: 1.0)
+        await fulfillment(of: [getNextPageSuccess2], timeout: 1.0)
 
     }
 
@@ -122,14 +122,14 @@ extension ListTests {
             XCTFail("Should not be loaded")
             return
         }
-        let fetchCompleted = asyncExpectation(description: "fetch completed")
+        let fetchCompleted = expectation(description: "fetch completed")
         Task {
             try await list.fetch()
-            await fetchCompleted.fulfill()
+            fetchCompleted.fulfill()
         }
-        await waitForExpectations([fetchCompleted], timeout: 1.0)
+        await fulfillment(of: [fetchCompleted], timeout: 1.0)
         
-        let getNextPageSuccess = asyncExpectation(description: "getNextPage successful")
+        let getNextPageSuccess = expectation(description: "getNextPage successful")
         Task {
             do {
                 _ = try await list.getNextPage()
@@ -137,8 +137,8 @@ extension ListTests {
             } catch {
                 XCTAssertNotNil(error)
             }
-            await getNextPageSuccess.fulfill()
+            getNextPageSuccess.fulfill()
         }
-        await waitForExpectations([getNextPageSuccess], timeout: 1.0)
+        await fulfillment(of: [getNextPageSuccess], timeout: 1.0)
     }
 }

--- a/AmplifyTests/CategoryTests/DataStore/Model/ListTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/Model/ListTests.swift
@@ -131,12 +131,12 @@ class ListTests: XCTestCase {
 
         let serializedData = try ListTests.encode(json: data)
         let list = try ListTests.decode(serializedData, responseType: BasicModel.self)
-        let fetchSuccess = asyncExpectation(description: "fetch successful")
+        let fetchSuccess = expectation(description: "fetch successful")
         Task {
             try await list.fetch()
-            await fetchSuccess.fulfill()
+            fetchSuccess.fulfill()
         }
-        await waitForExpectations([fetchSuccess], timeout: 1.0)
+        await fulfillment(of: [fetchSuccess], timeout: 1.0)
         
         XCTAssertEqual(list.count, 2)
         XCTAssertEqual(list.startIndex, 0)
@@ -148,7 +148,7 @@ class ListTests: XCTestCase {
         list.makeIterator().forEach { _ in
             iterateSuccess.fulfill()
         }
-        wait(for: [iterateSuccess], timeout: 1)
+        await fulfillment(of: [iterateSuccess], timeout: 1)
         let json = try? ListTests.toJSON(list: list)
         XCTAssertEqual(json, """
             [{\"id\":\"1\"},{\"id\":\"2\"}]
@@ -165,12 +165,12 @@ class ListTests: XCTestCase {
         let serializedData = try ListTests.encode(json: data)
         let list = try ListTests.decode(serializedData, responseType: BasicModel.self)
         XCTAssertNotNil(list)
-        let fetchSuccess = asyncExpectation(description: "fetch successful")
+        let fetchSuccess = expectation(description: "fetch successful")
         Task {
             try await list.fetch()
-            await fetchSuccess.fulfill()
+            fetchSuccess.fulfill()
         }
-        await waitForExpectations([fetchSuccess], timeout: 1.0)
+        await fulfillment(of: [fetchSuccess], timeout: 1.0)
         XCTAssertEqual(list.count, 2)
         XCTAssertEqual(list.startIndex, 0)
         XCTAssertEqual(list.endIndex, 2)
@@ -181,7 +181,7 @@ class ListTests: XCTestCase {
         list.makeIterator().forEach { _ in
             iterateSuccess.fulfill()
         }
-        await waitForExpectations(timeout: 1)
+        await fulfillment(of: [iterateSuccess], timeout: 1)
         XCTAssertFalse(list.listProvider.hasNextPage())
         do {
             _ = try await list.listProvider.getNextPage()
@@ -197,12 +197,12 @@ class ListTests: XCTestCase {
         let serializedData = try ListTests.encode(json: data)
         let list = try ListTests.decode(serializedData, responseType: BasicModel.self)
         XCTAssertNotNil(list)
-        let fetchSuccess = asyncExpectation(description: "fetch successful")
+        let fetchSuccess = expectation(description: "fetch successful")
         Task {
             try await list.fetch()
-            await fetchSuccess.fulfill()
+            fetchSuccess.fulfill()
         }
-        await waitForExpectations([fetchSuccess], timeout: 1.0)
+        await fulfillment(of: [fetchSuccess], timeout: 1.0)
         XCTAssertEqual(list.count, 0)
         let json = try? ListTests.toJSON(list: list)
         XCTAssertEqual(json, "[]")
@@ -217,7 +217,7 @@ class ListTests: XCTestCase {
             XCTFail("Should not be loaded")
             return
         }
-        let fetchCompleted = asyncExpectation(description: "fetch completed")
+        let fetchCompleted = expectation(description: "fetch completed")
         Task {
             do {
                 _ = try await list.fetch()
@@ -225,9 +225,9 @@ class ListTests: XCTestCase {
             } catch {
                 XCTAssertNotNil(error)
             }
-            await fetchCompleted.fulfill()
+            fetchCompleted.fulfill()
         }
-        await waitForExpectations([fetchCompleted], timeout: 1.0)
+        await fulfillment(of: [fetchCompleted], timeout: 1.0)
     }
 
     // MARK: - Helpers

--- a/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
@@ -48,7 +48,7 @@ class AmplifyOperationHubTests: XCTestCase {
 
         operation.doMockDispatch()
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [listenerWasInvoked], timeout: 1.0)
     }
 
     /// Given: A configured system

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeHubListenToOperationTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeHubListenToOperationTests.swift
@@ -63,11 +63,11 @@ class AutoUnsubscribeHubListenToOperationTests: XCTestCase {
 //        }
 //
 //        operation.doMockDispatch()
-//        wait(for: [listenerWasInvokedForCompleted], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForCompleted], timeout: 0.1)
 //
 //        operation.doMockProgress()
 //        operation.doMockDispatch(result: .failure(StorageError.accessDenied("", "")))
-//        wait(for: [listenerWasInvokedForInProcess, listenerWasInvokedForFailed], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForInProcess, listenerWasInvokedForFailed], timeout: 0.1)
     }
 
     /// - Given: An Amplify operation class
@@ -104,11 +104,11 @@ class AutoUnsubscribeHubListenToOperationTests: XCTestCase {
 //        }
 //
 //        operation.doMockDispatch(result: .failure(StorageError.accessDenied("", "")))
-//        wait(for: [listenerWasInvokedForFailed], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForFailed], timeout: 0.1)
 //
 //        operation.doMockProgress()
 //        operation.doMockDispatch()
-//        wait(for: [listenerWasInvokedForInProcess, listenerWasInvokedForCompleted], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForInProcess, listenerWasInvokedForCompleted], timeout: 0.1)
     }
 
     /// - Given: An Amplify operation class
@@ -162,12 +162,12 @@ class AutoUnsubscribeHubListenToOperationTests: XCTestCase {
 //        }
 //
 //        operation.doMockProgress()
-//        wait(for: [listenerWasInvokedForInProcess], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForInProcess], timeout: 0.1)
 //        operation.doMockDispatch()
-//        wait(for: [listenerWasInvokedForCompleted], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForCompleted], timeout: 0.1)
 //
 //        operation.doMockDispatch(result: .failure(StorageError.accessDenied("", "")))
-//        wait(for: [listenerWasInvokedForFailed], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForFailed], timeout: 0.1)
     }
 
     /// - Given: An Amplify operation class
@@ -222,10 +222,10 @@ class AutoUnsubscribeHubListenToOperationTests: XCTestCase {
 //
 //        operation.doMockProgress()
 //        operation.doMockDispatch(result: .failure(StorageError.accessDenied("", "")))
-//        wait(for: [listenerWasInvokedForInProcess, listenerWasInvokedForFailed], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForInProcess, listenerWasInvokedForFailed], timeout: 0.1)
 //
 //        operation.doMockDispatch()
-//        wait(for: [listenerWasInvokedForCompleted], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForCompleted], timeout: 0.1)
     }
 
 }

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeOperationTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeOperationTests.swift
@@ -64,11 +64,11 @@ class AutoUnsubscribeOperationTests: XCTestCase {
 //        }
 //
 //        operation.doMockDispatch()
-//        wait(for: [listenerWasInvokedForCompleted], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForCompleted], timeout: 0.1)
 //
 //        operation.doMockProgress()
 //        operation.doMockDispatch(result: .failure(StorageError.accessDenied("", "")))
-//        wait(for: [listenerWasInvokedForInProcess, listenerWasInvokedForFailed], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForInProcess, listenerWasInvokedForFailed], timeout: 0.1)
     }
 
     /// - Given: An Amplify operation class
@@ -106,11 +106,11 @@ class AutoUnsubscribeOperationTests: XCTestCase {
 //        }
 //
 //        operation.doMockDispatch(result: .failure(StorageError.accessDenied("", "")))
-//        wait(for: [listenerWasInvokedForFailed], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForFailed], timeout: 0.1)
 //
 //        operation.doMockProgress()
 //        operation.doMockDispatch()
-//        wait(for: [listenerWasInvokedForInProcess, listenerWasInvokedForCompleted], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForInProcess, listenerWasInvokedForCompleted], timeout: 0.1)
     }
 
     /// - Given: An Amplify operation class
@@ -149,10 +149,10 @@ class AutoUnsubscribeOperationTests: XCTestCase {
 //
 //        operation.doMockProgress()
 //        operation.doMockDispatch()
-//        wait(for: [listenerWasInvokedForInProcess, listenerWasInvokedForCompleted], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForInProcess, listenerWasInvokedForCompleted], timeout: 0.1)
 //
 //        operation.doMockDispatch(result: .failure(StorageError.accessDenied("", "")))
-//        wait(for: [listenerWasInvokedForFailed], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForFailed], timeout: 0.1)
     }
 
     /// - Given: An Amplify operation class
@@ -191,10 +191,10 @@ class AutoUnsubscribeOperationTests: XCTestCase {
 //
 //        operation.doMockProgress()
 //        operation.doMockDispatch(result: .failure(StorageError.accessDenied("", "")))
-//        wait(for: [listenerWasInvokedForInProcess, listenerWasInvokedForFailed], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForInProcess, listenerWasInvokedForFailed], timeout: 0.1)
 //
 //        operation.doMockProgress()
-//        wait(for: [listenerWasInvokedForCompleted], timeout: 0.1)
+//        await fulfillment(of: [listenerWasInvokedForCompleted], timeout: 0.1)
     }
 
 }

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginConcurrencyTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginConcurrencyTests.swift
@@ -79,7 +79,7 @@ class DefaultHubPluginConcurrencyTests: XCTestCase {
             }
         }
 
-        await waitForExpectations(timeout: 5.0)
+        await fulfillment(of: messagesReceived, timeout: 5.0)
     }
 
 }

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginCustomChannelTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginCustomChannelTests.swift
@@ -51,7 +51,7 @@ class DefaultHubPluginCustomChannelTests: XCTestCase {
 
         plugin.dispatch(to: .custom("CustomChannel1"), payload: HubPayload(eventName: "TEST_EVENT"))
 
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [eventReceived], timeout: 0.5)
     }
 
     /// Given: A listener to a custom channel
@@ -72,7 +72,7 @@ class DefaultHubPluginCustomChannelTests: XCTestCase {
 
         plugin.dispatch(to: .custom("CustomChannel2"), payload: HubPayload(eventName: "TEST_EVENT"))
 
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [eventReceived], timeout: 0.5)
     }
 
     /// Given: Multiple listeners to a custom channel
@@ -102,7 +102,7 @@ class DefaultHubPluginCustomChannelTests: XCTestCase {
 
         plugin.dispatch(to: .custom("CustomChannel1"), payload: HubPayload(eventName: "TEST_EVENT"))
 
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [listener1Invoked, listener2Invoked], timeout: 0.5)
     }
 
 }

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginTests.swift
@@ -69,7 +69,7 @@ class DefaultHubPluginTests: XCTestCase {
         }
 
         plugin.dispatch(to: .storage, payload: HubPayload(eventName: "TEST_EVENT"))
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [expectedMessageReceived], timeout: 0.5)
     }
 
     /// Given: The default Hub plugin with a registered listener
@@ -92,7 +92,7 @@ class DefaultHubPluginTests: XCTestCase {
         }
 
         plugin.dispatch(to: .storage, payload: HubPayload(eventName: "TEST_EVENT"))
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [messageReceived], timeout: 0.5)
     }
 
     /// Given: A subscription token from a previous call to the default Hub plugin's `listen` method
@@ -129,7 +129,7 @@ class DefaultHubPluginTests: XCTestCase {
         }
 
         plugin.dispatch(to: .storage, payload: HubPayload(eventName: "TEST_EVENT"))
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [try XCTUnwrap(currentExpectation)], timeout: 0.5)
 
         plugin.removeListener(unsubscribeToken)
         try? await Task.sleep(seconds: 0.01)
@@ -147,7 +147,7 @@ class DefaultHubPluginTests: XCTestCase {
         XCTAssertFalse(isStillRegistered.get(), "Should not be registered after removeListener")
 
         plugin.dispatch(to: .storage, payload: HubPayload(eventName: "TEST_EVENT"))
-        await waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [try XCTUnwrap(currentExpectation)], timeout: 0.5)
     }
 
     /// Given: The default Hub plugin

--- a/AmplifyTests/CategoryTests/Notifications/Push/PushNotificationsCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Notifications/Push/PushNotificationsCategoryClientAPITests.swift
@@ -44,7 +44,7 @@ class PushNotificationsCategoryClientAPITests: XCTestCase {
         }
 
         try await category.identifyUser(userId: "test")
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [methodInvoked], timeout: 1.0)
     }
 
     func testRegisterDeviceToken_shouldSucceed() async throws {
@@ -58,7 +58,7 @@ class PushNotificationsCategoryClientAPITests: XCTestCase {
         }
 
         try await category.registerDevice(apnsToken: data)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [methodInvoked], timeout: 1.0)
     }
 
     func testRecordNotificationReceived_shouldSucceed() async throws {
@@ -72,7 +72,7 @@ class PushNotificationsCategoryClientAPITests: XCTestCase {
         }
 
         try await category.recordNotificationReceived(userInfo)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [methodInvoked], timeout: 1.0)
     }
 
 #if !os(tvOS)
@@ -87,7 +87,7 @@ class PushNotificationsCategoryClientAPITests: XCTestCase {
         }
 
         try await category.recordNotificationOpened(response)
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [methodInvoked], timeout: 1.0)
     }
 #endif
 

--- a/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
@@ -102,12 +102,10 @@ class StorageCategoryConfigurationTests: XCTestCase {
 
     func testCanUseDefaultPluginIfOnlyOnePlugin() async throws {
         let plugin = MockStorageCategoryPlugin()
-        let methodInvokedOnDefaultPlugin = asyncExpectation(description: "test method invoked on default plugin")
+        let methodInvokedOnDefaultPlugin = expectation(description: "test method invoked on default plugin")
         plugin.listeners.append { message in
             if message == "downloadData" {
-                Task {
-                    await methodInvokedOnDefaultPlugin.fulfill()
-                }
+                methodInvokedOnDefaultPlugin.fulfill()
             }
         }
         try Amplify.add(plugin: plugin)
@@ -122,11 +120,12 @@ class StorageCategoryConfigurationTests: XCTestCase {
     func testCanUseSpecifiedPlugin() async throws {
         let plugin1 = MockStorageCategoryPlugin()
         let methodShouldNotBeInvokedOnDefaultPlugin =
-            asyncExpectation(description: "test method should not be invoked on default plugin", isInverted: true)
+            expectation(description: "test method should not be invoked on default plugin")
+        methodShouldNotBeInvokedOnDefaultPlugin.isInverted = true
         plugin1.listeners.append { message in
             if message == "downloadData" {
                 Task {
-                    await methodShouldNotBeInvokedOnDefaultPlugin.fulfill()
+                    methodShouldNotBeInvokedOnDefaultPlugin.fulfill()
                 }
             }
         }
@@ -134,11 +133,11 @@ class StorageCategoryConfigurationTests: XCTestCase {
 
         let plugin2 = MockSecondStorageCategoryPlugin()
         let methodShouldBeInvokedOnSecondPlugin =
-            asyncExpectation(description: "test method should be invoked on second plugin")
+            expectation(description: "test method should be invoked on second plugin")
         plugin2.listeners.append { message in
             if message == "downloadData" {
                 Task {
-                    await methodShouldBeInvokedOnSecondPlugin.fulfill()
+                    methodShouldBeInvokedOnSecondPlugin.fulfill()
                 }
             }
         }
@@ -158,7 +157,7 @@ class StorageCategoryConfigurationTests: XCTestCase {
         _ = try Amplify.Storage.getPlugin(for: "MockSecondStorageCategoryPlugin")
             .downloadData(key: "", options: nil)
 
-        await waitForExpectations([methodShouldNotBeInvokedOnDefaultPlugin, methodShouldBeInvokedOnSecondPlugin])
+        await fulfillment(of: [methodShouldNotBeInvokedOnDefaultPlugin, methodShouldBeInvokedOnSecondPlugin])
     }
 
     func testPreconditionFailureInvokingWithMultiplePlugins() async throws {
@@ -192,17 +191,17 @@ class StorageCategoryConfigurationTests: XCTestCase {
     func testCanConfigurePluginDirectly() async throws {
         let plugin = MockStorageCategoryPlugin()
         let configureShouldBeInvokedFromCategory =
-            asyncExpectation(description: "Configure should be invoked by Amplify.configure()")
+            expectation(description: "Configure should be invoked by Amplify.configure()")
         let configureShouldBeInvokedDirectly =
-        asyncExpectation(description: "Configure should be invoked by getPlugin().configure()")
+        expectation(description: "Configure should be invoked by getPlugin().configure()")
 
         var invocationCount = 0
         plugin.listeners.append { message in
             if message == "configure(using:)" {
                 invocationCount += 1
                 switch invocationCount {
-                case 1: Task { await configureShouldBeInvokedFromCategory.fulfill() }
-                case 2: Task { await configureShouldBeInvokedDirectly.fulfill() }
+                case 1: configureShouldBeInvokedFromCategory.fulfill()
+                case 2: configureShouldBeInvokedDirectly.fulfill()
                 default: XCTFail("Expected configure() to be called only two times, but got \(invocationCount)")
                 }
             }
@@ -218,7 +217,7 @@ class StorageCategoryConfigurationTests: XCTestCase {
         try Amplify.configure(amplifyConfig)
         try Amplify.Storage.getPlugin(for: "MockStorageCategoryPlugin").configure(using: true)
 
-        await waitForExpectations([configureShouldBeInvokedFromCategory, configureShouldBeInvokedDirectly])
+        await fulfillment(of: [configureShouldBeInvokedFromCategory, configureShouldBeInvokedDirectly])
     }
 
     func testPreconditionFailureInvokingBeforeConfig() async throws {

--- a/AmplifyTests/CoreTests/AmplifyAsyncSequenceTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyAsyncSequenceTests.swift
@@ -122,64 +122,64 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
         // parent task is canceled while reducing values from sequence
         // before a value is sent which should result in a sum of zero
         let input = 2006
-        let reduced = asyncExpectation(description: "reduced")
-        let done = asyncExpectation(description: "done")
+        let reduced = expectation(description: "reduced")
+        let done = expectation(description: "done")
         let channel = AmplifyAsyncSequence<Int>()
 
         let task = Task<Int, Never> {
             let sum = await channel.reduce(0, +)
-            await reduced.fulfill()
+            reduced.fulfill()
             return sum
         }
 
         // cancel before value is sent
         task.cancel()
 
-        await waitForExpectations([reduced])
+        await fulfillment(of: [reduced])
         channel.send(input)
 
         Task {
             let output = await task.value
             XCTAssertNotEqual(input, output)
             XCTAssertEqual(0, output)
-            await done.fulfill()
+            done.fulfill()
         }
 
-        await waitForExpectations([done])
+        await fulfillment(of: [done])
     }
 
     func testThrowingChannelCancelled() async throws {
         // parent task is canceled while reducing values from sequence
         // before a value is sent which should result in a sum of zero
         let input = 2006
-        let reduced = asyncExpectation(description: "reduced")
-        let done = asyncExpectation(description: "done")
+        let reduced = expectation(description: "reduced")
+        let done = expectation(description: "done")
         let channel = AmplifyAsyncThrowingSequence<Int>()
 
         let task = Task<Int, Error> {
             let sum = try await channel.reduce(0, +)
-            await reduced.fulfill()
+            reduced.fulfill()
             return sum
         }
 
         // cancel before any value is sent
         task.cancel()
-        await waitForExpectations([reduced])
+        await fulfillment(of: [reduced])
         channel.send(input)
 
         Task {
             let output = try await task.value
             XCTAssertNotEqual(input, output)
             XCTAssertEqual(0, output)
-            await done.fulfill()
+            done.fulfill()
         }
 
-        await waitForExpectations([done])
+        await fulfillment(of: [done])
     }
 
     func testValueProducingParentOperation() async throws {
-        let sent = asyncExpectation(description: "sent")
-        let received = asyncExpectation(description: "received")
+        let sent = expectation(description: "sent")
+        let received = expectation(description: "received")
         let steps = 10
         let delay = 0.01
         let request = LongOperationRequest(steps: steps, delay: delay)
@@ -191,9 +191,7 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
             channel.send(value)
             if value.totalUnitCount == value.completedUnitCount {
                 channel.finish()
-                Task {
-                    await sent.fulfill()
-                }
+                sent.fulfill()
             }
         }
         queue.addOperation(operation)
@@ -204,10 +202,10 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
             }
             let count = await values.elements.count
             XCTAssertGreaterThanOrEqual(count, steps)
-            await received.fulfill()
+            received.fulfill()
         }
 
-        await waitForExpectations([sent, received])
+        await fulfillment(of: [sent, received])
 
         XCTAssertFalse(operation.isCancelled)
         XCTAssertGreaterThanOrEqual(count, steps)
@@ -216,8 +214,8 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
     }
 
     func testCancellingWithParentOperation() async throws {
-        let sent = asyncExpectation(description: "sent")
-        let received = asyncExpectation(description: "received")
+        let sent = expectation(description: "sent")
+        let received = expectation(description: "received")
         let steps = 10
         let delay = 0.01
         let request = LongOperationRequest(steps: steps, delay: delay)
@@ -229,9 +227,7 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
             channel.send(value)
             if value.completedUnitCount >= steps/2 {
                 channel.cancel()
-                Task {
-                    await sent.fulfill()
-                }
+                sent.fulfill()
             }
         }
         queue.addOperation(operation)
@@ -242,10 +238,10 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
             }
             let count = await values.elements.count
             XCTAssertLessThan(count, steps)
-            await received.fulfill()
+            received.fulfill()
         }
 
-        await waitForExpectations([sent, received])
+        await fulfillment(of: [sent, received])
 
         XCTAssertTrue(operation.isCancelled)
         XCTAssertLessThan(count, steps)
@@ -254,8 +250,8 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
     }
 
     func testThrowingValueProducingParentOperation() async throws {
-        let sent = asyncExpectation(description: "sent")
-        let received = asyncExpectation(description: "received")
+        let sent = expectation(description: "sent")
+        let received = expectation(description: "received")
         let steps = 10
         let delay = 0.01
         let request = LongOperationRequest(steps: steps, delay: delay)
@@ -267,9 +263,7 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
             channel.send(value)
             if value.totalUnitCount == value.completedUnitCount {
                 channel.finish()
-                Task {
-                    await sent.fulfill()
-                }
+                sent.fulfill()
             }
         }
         queue.addOperation(operation)
@@ -280,10 +274,10 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
             }
             let count = await values.elements.count
             XCTAssertGreaterThanOrEqual(count, steps)
-            await received.fulfill()
+            received.fulfill()
         }
 
-        await waitForExpectations([sent, received])
+        await fulfillment(of: [sent, received])
 
         XCTAssertFalse(operation.isCancelled)
         XCTAssertGreaterThanOrEqual(count, steps)
@@ -292,8 +286,8 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
     }
 
     func testThrowingCancellingWithParentOperation() async throws {
-        let sent = asyncExpectation(description: "sent")
-        let received = asyncExpectation(description: "received")
+        let sent = expectation(description: "sent")
+        let received = expectation(description: "received")
         let steps = 10
         let delay = 0.01
         let request = LongOperationRequest(steps: steps, delay: delay)
@@ -305,9 +299,7 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
             channel.send(value)
             if value.completedUnitCount >= steps/2 {
                 channel.cancel()
-                Task {
-                    await sent.fulfill()
-                }
+                sent.fulfill()
             }
         }
         queue.addOperation(operation)
@@ -318,10 +310,10 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
             }
             let count = await values.elements.count
             XCTAssertLessThan(count, steps)
-            await received.fulfill()
+            received.fulfill()
         }
 
-        await waitForExpectations([sent, received])
+        await fulfillment(of: [sent, received])
 
         XCTAssertTrue(operation.isCancelled)
         XCTAssertLessThan(count, steps)

--- a/AmplifyTests/CoreTests/AmplifyConfigurationInitializationTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyConfigurationInitializationTests.swift
@@ -167,7 +167,7 @@ class AmplifyConfigurationInitializationTests: XCTestCase {
         let config = AmplifyConfiguration(analytics: analyticsConfiguration)
         try Amplify.configure(config)
 
-        await waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [notificationReceived], timeout: 1.0)
     }
 
     // MARK: - Utilities

--- a/AmplifyTests/CoreTests/AmplifyTaskTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyTaskTests.swift
@@ -146,7 +146,7 @@ class AmplifyTaskTests: XCTestCase {
             resultSink.cancel()
         }
 
-        wait(for: [exp1, exp2], timeout: 10.0)
+        await fulfillment(of: [exp1, exp2], timeout: 10.0)
 
         XCTAssertGreaterThanOrEqual(progressCount, 10)
         XCTAssertEqual(lastProgress, 1)

--- a/AmplifyTests/CoreTests/ChildTaskTests.swift
+++ b/AmplifyTests/CoreTests/ChildTaskTests.swift
@@ -85,7 +85,7 @@ class ChildTaskTests: XCTestCase {
             XCTAssertTrue(thrown is CancellationError)
         }
 
-        await waitForExpectations(timeout: 0.01)
+        await fulfillment(of: [cancelExp], timeout: 0.01)
         task.cancel()
 
         // Ensure the channel's AsyncSequence does not block after completion
@@ -115,7 +115,7 @@ class ChildTaskTests: XCTestCase {
             XCTAssertTrue(thrown is CancellationError)
         }
 
-        await waitForExpectations(timeout: 0.01)
+        await fulfillment(of: [cancelExp], timeout: 0.01)
 
         // Ensure the channel's AsyncSequence does not block after completion
         for await _ in progressSequence {

--- a/AmplifyTests/CoreTests/InternalTaskTests.swift
+++ b/AmplifyTests/CoreTests/InternalTaskTests.swift
@@ -21,29 +21,27 @@ class InternalTaskTests: XCTestCase {
     // MARK: - Magic Eight Ball (Non-Throwing) -
 
     func testMagicEightBallTaskRunner() async throws {
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
         let delay = 0.01
         let total = 10
         let timeout = Double(total) * 2.0 * delay
         let request = MagicEightBallRequest(total: total, delay: delay)
         let runner = MagicEightBallTaskRunner(request: request)
         let task = Task<[String], Never> {
-            let hubDone = asyncExpectation(description: "hub done")
+            let hubDone = expectation(description: "hub done")
             var emojis = [String]()
             var hubValues = [String]()
             let token = runner.subscribe { emoji in
                 hubValues.append(emoji)
                 if hubValues.count == total {
-                    Task {
-                        await hubDone.fulfill()
-                    }
+                    hubDone.fulfill()
                 }
             }
             await runner.sequence.forEach { emoji in
                 emojis.append(emoji)
             }
-            await waitForExpectations([hubDone])
-            await done.fulfill()
+            await fulfillment(of: [hubDone])
+            done.fulfill()
             XCTAssertEqual(total, hubValues.count)
             XCTAssertEqual(total, emojis.count)
             runner.unsubscribe(token)
@@ -53,11 +51,11 @@ class InternalTaskTests: XCTestCase {
         let output = await task.value
         XCTAssertEqual(request.total, output.count)
 
-        await waitForExpectations([done], timeout: timeout)
+        await fulfillment(of: [done], timeout: timeout)
     }
 
     func testMagicEightBallTaskRunnerWithRunnerCancellation() async throws {
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
         let delay = 0.01
         let total = 10
         let timeout = Double(total) * 2.0 * delay
@@ -70,7 +68,7 @@ class InternalTaskTests: XCTestCase {
             await sequence.forEach { emoji in
                 emojis.append(emoji)
             }
-            await done.fulfill()
+            done.fulfill()
             XCTAssertEqual(0, emojis.count)
             return emojis
         }
@@ -80,11 +78,11 @@ class InternalTaskTests: XCTestCase {
         let output = await task.value
         XCTAssertEqual(0, output.count)
 
-        await waitForExpectations([done], timeout: timeout)
+        await fulfillment(of: [done], timeout: timeout)
     }
 
     func testMagicEightBallTaskRunnerWithSequenceCancellation() async throws {
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
         let delay = 0.01
         let total = 10
         let timeout = Double(total) * 2.0 * delay
@@ -97,7 +95,7 @@ class InternalTaskTests: XCTestCase {
             await sequence.forEach { emoji in
                 emojis.append(emoji)
             }
-            await done.fulfill()
+            done.fulfill()
             XCTAssertEqual(0, emojis.count)
             return emojis
         }
@@ -105,11 +103,11 @@ class InternalTaskTests: XCTestCase {
         let output = await task.value
         XCTAssertEqual(0, output.count)
 
-        await waitForExpectations([done], timeout: timeout)
+        await fulfillment(of: [done], timeout: timeout)
     }
 
     func testMagicEightBallPluginAPI() async throws {
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
         let total = 10
         let delay = 0.01
         let timeout = Double(total) * 2.0 * delay
@@ -119,7 +117,7 @@ class InternalTaskTests: XCTestCase {
             await plugin.getAnswers(total: total, delay: delay).forEach { emoji in
                 answers.append(emoji)
             }
-            await done.fulfill()
+            done.fulfill()
             XCTAssertEqual(total, answers.count)
             return answers
         }
@@ -127,13 +125,13 @@ class InternalTaskTests: XCTestCase {
         let answers = await task.value
         XCTAssertEqual(answers.count, total)
 
-        await waitForExpectations([done], timeout: timeout)
+        await fulfillment(of: [done], timeout: timeout)
     }
     
     // MARK: - Random Emoji (Throwing) -
 
     func testRandomEmojiTaskRunner() async throws {
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
         let delay = 0.01
         let total = 10
         let timeout = Double(total) * 2.0 * delay
@@ -146,7 +144,7 @@ class InternalTaskTests: XCTestCase {
                 try await runner.sequence.forEach { emoji in
                     emojis.append(emoji)
                 }
-                await done.fulfill()
+                done.fulfill()
                 XCTAssertEqual(total, emojis.count)
             } catch {
                 thrown = error
@@ -158,11 +156,11 @@ class InternalTaskTests: XCTestCase {
         let output = await task.value
         XCTAssertEqual(request.total, output.count)
 
-        await waitForExpectations([done], timeout: timeout)
+        await fulfillment(of: [done], timeout: timeout)
     }
 
     func testRandomEmojiTaskRunnerWithRunnerCancellation() async throws {
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
         let delay = 0.01
         let total = 10
         let timeout = Double(total) * 2.0 * delay
@@ -177,7 +175,7 @@ class InternalTaskTests: XCTestCase {
                 try await sequence.forEach { emoji in
                     emojis.append(emoji)
                 }
-                await done.fulfill()
+                done.fulfill()
                 XCTAssertEqual(0, emojis.count)
             } catch {
                 thrown = error
@@ -191,11 +189,11 @@ class InternalTaskTests: XCTestCase {
         let output = await task.value
         XCTAssertEqual(0, output.count)
 
-        await waitForExpectations([done], timeout: timeout)
+        await fulfillment(of: [done], timeout: timeout)
     }
 
     func testRandomEmojiTaskRunnerWithSequenceCancellation() async throws {
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
         let delay = 0.01
         let total = 10
         let timeout = Double(total) * 2.0 * delay
@@ -210,7 +208,7 @@ class InternalTaskTests: XCTestCase {
                 try await sequence.forEach { emoji in
                     emojis.append(emoji)
                 }
-                await done.fulfill()
+                done.fulfill()
                 XCTAssertEqual(0, emojis.count)
             } catch {
                 thrown = error
@@ -222,11 +220,11 @@ class InternalTaskTests: XCTestCase {
         let output = await task.value
         XCTAssertEqual(0, output.count)
 
-        await waitForExpectations([done], timeout: timeout)
+        await fulfillment(of: [done], timeout: timeout)
     }
 
     func testEmojisPluginAPI() async throws {
-        let done = asyncExpectation(description: "done")
+        let done = expectation(description: "done")
         let total = 10
         let delay = 0.01
         let timeout = Double(total) * 2.0 * delay
@@ -236,7 +234,7 @@ class InternalTaskTests: XCTestCase {
             try await plugin.getEmojis(total: total, delay: delay).forEach { emoji in
                 emojis.append(emoji)
             }
-            await done.fulfill()
+            done.fulfill()
             XCTAssertEqual(total, emojis.count)
             return emojis
         }
@@ -244,7 +242,7 @@ class InternalTaskTests: XCTestCase {
         let emojis = try await task.value
         XCTAssertEqual(emojis.count, total)
 
-        await waitForExpectations([done], timeout: timeout)
+        await fulfillment(of: [done], timeout: timeout)
     }
 
 }


### PR DESCRIPTION
## Description
<!-- Why is this change required? What problem does it solve? -->
Our E2E test suites have some intermittent failures for a variety of reasons. These changes address most of them:
- https://github.com/aws-amplify/amplify-swift/pull/3300
  - All integration test suites now use >= Xcode 14.3
  - Some timeout intervals were increased to account for slower CI machines.
- https://github.com/aws-amplify/amplify-swift/pull/3304
  - Increases timeout intervals for HostedUI UI test suites.
- https://github.com/aws-amplify/amplify-swift/pull/3303
  - API (GraphQL) tests append a UUID to some String typed model values to prevent query collisions in parallel executed test suites that led assertion failures.
- https://github.com/aws-amplify/amplify-swift/pull/3302
- https://github.com/aws-amplify/amplify-swift/pull/3301
  - Use `XCTestCase.fulfillment(of:)` API when waiting on `XCTestExpectation`s in async contexts. 

### *Note:
All changes have been individually reviewed and approved already with the exception of a few minor changes. These can be seen here: https://github.com/aws-amplify/amplify-swift/compare/416a0987b5a9d3e0fdfd358b97e24cc5477e8bb3...integrating-integration

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
