### PR TITLE
test: use macos-13 runners for stress tests and use explicit iOS version

### DIFF
--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   prepare-for-test:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/integ_test_api_functional.yml
+++ b/.github/workflows/integ_test_api_functional.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginFunctionalTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-functional-test-tvOS:

--- a/.github/workflows/integ_test_api_graphql_auth_directive.yml
+++ b/.github/workflows/integ_test_api_graphql_auth_directive.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginGraphQLAuthDirectiveTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-auth-directive-test-tvOS:

--- a/.github/workflows/integ_test_api_graphql_iam.yml
+++ b/.github/workflows/integ_test_api_graphql_iam.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginGraphQLIAMTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-iam-test-tvOS:

--- a/.github/workflows/integ_test_api_graphql_lambda_auth.yml
+++ b/.github/workflows/integ_test_api_graphql_lambda_auth.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginGraphQLLambdaAuthTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-lambda-auth-test-tvOS:

--- a/.github/workflows/integ_test_api_graphql_lazy_load.yml
+++ b/.github/workflows/integ_test_api_graphql_lazy_load.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginLazyLoadTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-lazy-load-test-tvOS:

--- a/.github/workflows/integ_test_api_graphql_user_pool.yml
+++ b/.github/workflows/integ_test_api_graphql_user_pool.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginGraphQLUserPoolTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-user-pool-test-tvOS:

--- a/.github/workflows/integ_test_api_rest_iam.yml
+++ b/.github/workflows/integ_test_api_rest_iam.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginRESTIAMTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-rest-iam-test-tvOS:

--- a/.github/workflows/integ_test_api_rest_user_pool.yml
+++ b/.github/workflows/integ_test_api_rest_user_pool.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: AWSAPIPluginRESTUserPoolTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-rest-user-pool-test-tvOS:

--- a/.github/workflows/integ_test_auth.yml
+++ b/.github/workflows/integ_test_auth.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Auth/Tests/AuthHostApp/
           scheme: AuthIntegrationTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   auth-integration-test-tvOS:

--- a/.github/workflows/integ_test_datastore.yml
+++ b/.github/workflows/integ_test_datastore.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   prepare-for-test:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/integ_test_datastore_auth_cognito.yml
+++ b/.github/workflows/integ_test_datastore_auth_cognito.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginAuthCognitoTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-cognito-test-tvOS:

--- a/.github/workflows/integ_test_datastore_auth_iam.yml
+++ b/.github/workflows/integ_test_datastore_auth_iam.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginAuthIAMTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-iam-test-tvOS:

--- a/.github/workflows/integ_test_datastore_base.yml
+++ b/.github/workflows/integ_test_datastore_base.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginIntegrationTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-test-base-tvOS:

--- a/.github/workflows/integ_test_datastore_cpk.yml
+++ b/.github/workflows/integ_test_datastore_cpk.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginCPKTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-cpk-test-tvOS:

--- a/.github/workflows/integ_test_datastore_lazy_load.yml
+++ b/.github/workflows/integ_test_datastore_lazy_load.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginLazyLoadTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-lazy-load-test-tvOS:

--- a/.github/workflows/integ_test_datastore_multi_auth.yml
+++ b/.github/workflows/integ_test_datastore_multi_auth.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginMultiAuthTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-multi-auth-test-tvOS:

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: AWSDataStorePluginV2Tests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-v2-test-tvOS:

--- a/.github/workflows/integ_test_geo.yml
+++ b/.github/workflows/integ_test_geo.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Geo/Tests/GeoHostApp/
           scheme: AWSLocationGeoPluginIntegrationTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   geo-integration-test-tvOS:

--- a/.github/workflows/integ_test_logging.yml
+++ b/.github/workflows/integ_test_logging.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginHostApp
           scheme: AWSCloudWatchLoggingPluginIntegrationTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   logging-integration-test-tvOS:

--- a/.github/workflows/integ_test_predictions.yml
+++ b/.github/workflows/integ_test_predictions.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Predictions/Tests/PredictionsHostApp
           scheme: AWSPredictionsPluginIntegrationTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   predictions-integration-test-tvOS:

--- a/.github/workflows/integ_test_storage.yml
+++ b/.github/workflows/integ_test_storage.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Storage/Tests/StorageHostApp/
           scheme: AWSS3StoragePluginIntegrationTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=latest'
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
 
   storage-integration-test-tvOS:

--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   prepare-for-test:
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -31,7 +31,7 @@ jobs:
 
   auth-stress-test:
     needs: prepare-for-test
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -54,10 +54,12 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Auth/Tests/AuthHostApp/
           scheme: AuthStressTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   geo-stress-test:
     needs: prepare-for-test
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -80,11 +82,12 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Geo/Tests/GeoHostApp/
           scheme: GeoStressTests
-
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   storage-stress-test:
     needs: prepare-for-test
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -107,10 +110,12 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Storage/Tests/StorageHostApp/
           scheme: StorageStressTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
+          xcode_path: '/Applications/Xcode_14.3.app'
   
   datastore-stress-test:
     needs: prepare-for-test
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -133,10 +138,12 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: DatastoreStressTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
+          xcode_path: '/Applications/Xcode_14.3.app'
 
   graphql-api-stress-test:
     needs: prepare-for-test
-    runs-on: macos-12
+    runs-on: macos-13
     environment: IntegrationTest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -159,3 +166,5 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: GraphQLAPIStressTests
+          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
+          xcode_path: '/Applications/Xcode_14.3.app'

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageStressTests/StorageStressTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageStressTests/StorageStressTests.swift
@@ -173,7 +173,7 @@ final class StorageStressTests: XCTestCase {
         } catch {
             XCTFail("Error: \(error)")
         }
-        await fulfillment(of: [uploadExpectation, removeExpectation], timeout: 180)
+        await fulfillment(of: [downloadExpectation, uploadExpectation, removeExpectation], timeout: 180)
     }
 
     


### PR DESCRIPTION
## Description
<!-- Why is this change required? What problem does it solve? -->
Stress tests are failing because they're still running on macos-12 runners that don't have Xcode 14.3, which added the `fulfillment(of:)` API.
- Updates stress tests to run on macos-13

It looks like tests are taking longer when using `OS=latest` for iOS test runs. Using an explicit version sped up the PushNotifications integration tests dramatically.
- Specifies exact iOS version in integration tests (`OS=16.4`)

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
