### PR TITLE
fix(PushNotifications): Fixing .network errors not being correctly identified

### DIFF
--- a/AmplifyPlugins/Notifications/Push/Sources/AWSPinpointPushNotificationsPlugin/Error/CommonRunTimeError+PushNotificationsErrorConvertible.swift
+++ b/AmplifyPlugins/Notifications/Push/Sources/AWSPinpointPushNotificationsPlugin/Error/CommonRunTimeError+PushNotificationsErrorConvertible.swift
@@ -12,12 +12,17 @@ import AwsCommonRuntimeKit
 
 extension CommonRunTimeError: PushNotificationsErrorConvertible {
     var pushNotificationsError: PushNotificationsError {
+        if isConnectivityError {
+            return .network(
+                PushNotificationsPluginErrorConstants.deviceOffline.errorDescription,
+                PushNotificationsPluginErrorConstants.deviceOffline.recoverySuggestion,
+                self
+            )
+        }
+
         switch self {
         case .crtError(let crtError):
-            let errorDescription = isConnectivityError
-            ? AWSPinpointErrorConstants.deviceOffline.errorDescription
-            : crtError.message
-            return .unknown(errorDescription, self)
+            return .unknown(crtError.message, self)
         }
     }
 }


### PR DESCRIPTION
## Description
Fixing the `CommonRunTimeError: PushNotificationsErrorConvertible` conformance to correctly report a `.network` error as such.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
