### PR TITLE
fix(datastore): multi auth rule for read subscription

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/Schema/AuthRule.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/AuthRule.swift
@@ -68,3 +68,7 @@ public struct AuthRule {
         self.operations = operations
     }
 }
+
+extension AuthRule: Hashable {
+
+}

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthModeStrategy.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthModeStrategy.swift
@@ -42,6 +42,8 @@ public protocol AuthModeStrategy: AnyObject {
     init()
 
     func authTypesFor(schema: ModelSchema, operation: ModelOperation) async -> AWSAuthorizationTypeIterator
+    
+    func authTypesFor(schema: ModelSchema, operations: [ModelOperation]) async -> AWSAuthorizationTypeIterator
 }
 
 /// AuthorizationType iterator with an extra `count` property used
@@ -91,6 +93,11 @@ public class AWSDefaultAuthModeStrategy: AuthModeStrategy {
 
     public func authTypesFor(schema: ModelSchema,
                              operation: ModelOperation) -> AWSAuthorizationTypeIterator {
+        return AWSAuthorizationTypeIterator(withValues: [])
+    }
+    
+    public func authTypesFor(schema: ModelSchema,
+                             operations: [ModelOperation]) -> AWSAuthorizationTypeIterator {
         return AWSAuthorizationTypeIterator(withValues: [])
     }
 }
@@ -188,19 +195,34 @@ public class AWSMultiAuthModeStrategy: AuthModeStrategy {
     /// - Returns: an iterator for the applicable auth rules
     public func authTypesFor(schema: ModelSchema,
                              operation: ModelOperation) async -> AWSAuthorizationTypeIterator {
-        var applicableAuthRules = schema.authRules
-            .filter(modelOperation: operation)
-            .sorted(by: AWSMultiAuthModeStrategy.comparator)
+        return await authTypesFor(schema: schema, operations: [operation])
+    }
+    
+    /// Returns the union of authorization types for the provided schema for the given list of operations
+    /// - Parameters:
+    ///   - schema: model schema
+    ///   - operations: model operations
+    /// - Returns: an iterator for the applicable auth rules
+    public func authTypesFor(schema: ModelSchema,
+                             operations: [ModelOperation])  async -> AWSAuthorizationTypeIterator {
+        var applicableAuthRules = Set<AuthRule>()
+        for operation in operations {
+            let rules = schema.authRules.filter(modelOperation: operation)
+            applicableAuthRules = applicableAuthRules.union(Set(rules))
+        }
+        
+        var sortedRules = applicableAuthRules.sorted(by: AWSMultiAuthModeStrategy.comparator)
 
         // if there isn't a user signed in, returns only public or custom rules
         if let authDelegate = authDelegate, await !authDelegate.isUserLoggedIn() {
-            applicableAuthRules = applicableAuthRules.filter { rule in
+            sortedRules = sortedRules.filter { rule in
                 return rule.allow == .public || rule.allow == .custom
             }
         }
-        let applicableAuthTypes = applicableAuthRules.map {
+        let applicableAuthTypes = sortedRules.map {
             AWSMultiAuthModeStrategy.authTypeFor(authRule: $0)
         }
         return AWSAuthorizationTypeIterator(withValues: applicableAuthTypes)
     }
+    
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AuthModeStrategyTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AuthModeStrategyTests.swift
@@ -11,7 +11,7 @@ import XCTest
 @testable import AWSPluginsCore
 
 class AuthModeStrategyTests: XCTestCase {
-    
+
     // Given: default strategy and a model schema
     // When: authTypesFor for .create operation is called
     // Then: an empty iterator is returned
@@ -20,7 +20,7 @@ class AuthModeStrategyTests: XCTestCase {
         let authTypesIterator = authMode.authTypesFor(schema: AnyModelTester.schema, operation: .create)
         XCTAssertEqual(authTypesIterator.count, 0)
     }
-    
+
     // Given: multi-auth strategy and a model schema
     // When: authTypesFor for .create operation is called
     // Then: auth types are returned in order according to priority rules
@@ -31,7 +31,7 @@ class AuthModeStrategyTests: XCTestCase {
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
         XCTAssertEqual(authTypesIterator.next(), .apiKey)
     }
-    
+
     // Given: multi-auth strategy and a model schema without auth provider
     // When: auth types are requested
     // Then: default values based on the auth strategy should be returned
@@ -42,7 +42,7 @@ class AuthModeStrategyTests: XCTestCase {
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
         XCTAssertEqual(authTypesIterator.next(), .apiKey)
     }
-    
+
     // Given: multi-auth strategy and a model schema with 4 auth rules
     // When: authTypesFor for .create operation is called
     // Then: applicable auth types are ordered according to priority rules
@@ -55,7 +55,7 @@ class AuthModeStrategyTests: XCTestCase {
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
         XCTAssertEqual(authTypesIterator.next(), .awsIAM)
     }
-    
+
     // Given: multi-auth strategy and a model schema multiple public rules
     // When: authTypesFor for .create operation is called
     // Then: applicable auth types are ordered according to priority rules
@@ -68,7 +68,7 @@ class AuthModeStrategyTests: XCTestCase {
         XCTAssertEqual(authTypesIterator.next(), .awsIAM)
         XCTAssertEqual(authTypesIterator.next(), .apiKey)
     }
-    
+
     // Given: multi-auth strategy and a model schema
     // When: authTypesFor for .create operation is called
     // Then: applicable auth types returned are only the
@@ -80,7 +80,7 @@ class AuthModeStrategyTests: XCTestCase {
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
     }
-    
+
     // Given: multi-auth strategy a model schema
     // When: authTypesFor for .create operation is called for unauthenticated user
     // Then: applicable auth types returned are only public rules
@@ -94,7 +94,7 @@ class AuthModeStrategyTests: XCTestCase {
         XCTAssertEqual(authTypesIterator.count, 1)
         XCTAssertEqual(authTypesIterator.next(), .apiKey)
     }
-    
+
     // Given: multi-auth model schema with a custom strategy
     // When: authTypesFor for .create operation is called
     // Then: applicable auth types returned respect the priority rules
@@ -107,7 +107,7 @@ class AuthModeStrategyTests: XCTestCase {
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
         XCTAssertEqual(authTypesIterator.next(), .awsIAM)
     }
-    
+
     // Given: multi-auth model schema with a custom strategy
     // When: authTypesFor for .create operation is called for unauthenticated user
     // Then: applicable auth types returned are public rules or custom
@@ -115,14 +115,14 @@ class AuthModeStrategyTests: XCTestCase {
         let authMode = AWSMultiAuthModeStrategy()
         let delegate = UnauthenticatedUserDelegate()
         authMode.authDelegate = delegate
-        
+
         var authTypesIterator = await authMode.authTypesFor(schema: ModelWithCustomStrategy.schema,
                                                             operation: .create)
         XCTAssertEqual(authTypesIterator.count, 2)
         XCTAssertEqual(authTypesIterator.next(), .function)
         XCTAssertEqual(authTypesIterator.next(), .awsIAM)
     }
-    
+
     // Given: multi-auth strategy and a model schema without auth provider
     // When: auth types are requested with multiple operation
     // Then: default values based on the auth strategy should be returned
@@ -133,7 +133,7 @@ class AuthModeStrategyTests: XCTestCase {
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
         XCTAssertEqual(authTypesIterator.next(), .apiKey)
     }
-    
+
     // Given: multi-auth strategy and a model schema with auth provider
     // When: auth types are requested with multiple operation
     // Then: auth rule for public access should be returned
@@ -145,7 +145,7 @@ class AuthModeStrategyTests: XCTestCase {
         XCTAssertEqual(authTypesIterator.count, 1)
         XCTAssertEqual(authTypesIterator.next(), .apiKey)
     }
-    
+
 }
 
 // MARK: - Test models

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AuthModeStrategyTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AuthModeStrategyTests.swift
@@ -11,7 +11,7 @@ import XCTest
 @testable import AWSPluginsCore
 
 class AuthModeStrategyTests: XCTestCase {
-
+    
     // Given: default strategy and a model schema
     // When: authTypesFor for .create operation is called
     // Then: an empty iterator is returned
@@ -20,7 +20,7 @@ class AuthModeStrategyTests: XCTestCase {
         let authTypesIterator = authMode.authTypesFor(schema: AnyModelTester.schema, operation: .create)
         XCTAssertEqual(authTypesIterator.count, 0)
     }
-
+    
     // Given: multi-auth strategy and a model schema
     // When: authTypesFor for .create operation is called
     // Then: auth types are returned in order according to priority rules
@@ -31,7 +31,7 @@ class AuthModeStrategyTests: XCTestCase {
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
         XCTAssertEqual(authTypesIterator.next(), .apiKey)
     }
-
+    
     // Given: multi-auth strategy and a model schema without auth provider
     // When: auth types are requested
     // Then: default values based on the auth strategy should be returned
@@ -42,7 +42,7 @@ class AuthModeStrategyTests: XCTestCase {
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
         XCTAssertEqual(authTypesIterator.next(), .apiKey)
     }
-
+    
     // Given: multi-auth strategy and a model schema with 4 auth rules
     // When: authTypesFor for .create operation is called
     // Then: applicable auth types are ordered according to priority rules
@@ -55,7 +55,7 @@ class AuthModeStrategyTests: XCTestCase {
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
         XCTAssertEqual(authTypesIterator.next(), .awsIAM)
     }
-
+    
     // Given: multi-auth strategy and a model schema multiple public rules
     // When: authTypesFor for .create operation is called
     // Then: applicable auth types are ordered according to priority rules
@@ -68,7 +68,7 @@ class AuthModeStrategyTests: XCTestCase {
         XCTAssertEqual(authTypesIterator.next(), .awsIAM)
         XCTAssertEqual(authTypesIterator.next(), .apiKey)
     }
-
+    
     // Given: multi-auth strategy and a model schema
     // When: authTypesFor for .create operation is called
     // Then: applicable auth types returned are only the
@@ -80,7 +80,7 @@ class AuthModeStrategyTests: XCTestCase {
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
     }
-
+    
     // Given: multi-auth strategy a model schema
     // When: authTypesFor for .create operation is called for unauthenticated user
     // Then: applicable auth types returned are only public rules
@@ -88,26 +88,26 @@ class AuthModeStrategyTests: XCTestCase {
         let authMode = AWSMultiAuthModeStrategy()
         let delegate = UnauthenticatedUserDelegate()
         authMode.authDelegate = delegate
-
+        
         var authTypesIterator = await authMode.authTypesFor(schema: ModelWithOwnerAndPublicAuth.schema,
-                                                      operation: .create)
+                                                            operation: .create)
         XCTAssertEqual(authTypesIterator.count, 1)
         XCTAssertEqual(authTypesIterator.next(), .apiKey)
     }
-
+    
     // Given: multi-auth model schema with a custom strategy
     // When: authTypesFor for .create operation is called
     // Then: applicable auth types returned respect the priority rules
     func testMultiAuthPriorityWithCustomStrategy() async {
         let authMode = AWSMultiAuthModeStrategy()
         var authTypesIterator = await authMode.authTypesFor(schema: ModelWithCustomStrategy.schema,
-                                                      operation: .create)
+                                                            operation: .create)
         XCTAssertEqual(authTypesIterator.count, 3)
         XCTAssertEqual(authTypesIterator.next(), .function)
         XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
         XCTAssertEqual(authTypesIterator.next(), .awsIAM)
     }
-
+    
     // Given: multi-auth model schema with a custom strategy
     // When: authTypesFor for .create operation is called for unauthenticated user
     // Then: applicable auth types returned are public rules or custom
@@ -115,14 +115,37 @@ class AuthModeStrategyTests: XCTestCase {
         let authMode = AWSMultiAuthModeStrategy()
         let delegate = UnauthenticatedUserDelegate()
         authMode.authDelegate = delegate
-
+        
         var authTypesIterator = await authMode.authTypesFor(schema: ModelWithCustomStrategy.schema,
-                                                      operation: .create)
+                                                            operation: .create)
         XCTAssertEqual(authTypesIterator.count, 2)
         XCTAssertEqual(authTypesIterator.next(), .function)
         XCTAssertEqual(authTypesIterator.next(), .awsIAM)
     }
-
+    
+    // Given: multi-auth strategy and a model schema without auth provider
+    // When: auth types are requested with multiple operation
+    // Then: default values based on the auth strategy should be returned
+    func testMultiAuthShouldReturnDefaultAuthTypesForMultipleOperation() async {
+        let authMode = AWSMultiAuthModeStrategy()
+        var authTypesIterator = await authMode.authTypesFor(schema: ModelNoProvider.schema, operations: [.read, .create])
+        XCTAssertEqual(authTypesIterator.count, 2)
+        XCTAssertEqual(authTypesIterator.next(), .amazonCognitoUserPools)
+        XCTAssertEqual(authTypesIterator.next(), .apiKey)
+    }
+    
+    // Given: multi-auth strategy and a model schema with auth provider
+    // When: auth types are requested with multiple operation
+    // Then: auth rule for public access should be returned
+    func testMultiAuthReturnDefaultAuthTypesForMultipleOperationWithProvider() async {
+        let authMode = AWSMultiAuthModeStrategy()
+        let delegate = UnauthenticatedUserDelegate()
+        authMode.authDelegate = delegate
+        var authTypesIterator = await authMode.authTypesFor(schema: ModelNoProvider.schema, operations: [.read, .create])
+        XCTAssertEqual(authTypesIterator.count, 1)
+        XCTAssertEqual(authTypesIterator.next(), .apiKey)
+    }
+    
 }
 
 // MARK: - Test models

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -73,7 +73,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
         // onCreate operation
         let onCreateValueListener = onCreateValueListenerHandler(event:)
         let onCreateAuthTypeProvider = await authModeStrategy.authTypesFor(schema: modelSchema,
-                                                                     operation: .create)
+                                                                           operations: [.create, .read])
         self.onCreateValueListener = onCreateValueListener
         self.onCreateOperation = RetryableGraphQLSubscriptionOperation(
             requestFactory: IncomingAsyncSubscriptionEventPublisher.apiRequestFactoryFor(
@@ -94,7 +94,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
         // onUpdate operation
         let onUpdateValueListener = onUpdateValueListenerHandler(event:)
         let onUpdateAuthTypeProvider = await authModeStrategy.authTypesFor(schema: modelSchema,
-                                                                     operation: .update)
+                                                                           operations: [.update, .read])
         self.onUpdateValueListener = onUpdateValueListener
         self.onUpdateOperation = RetryableGraphQLSubscriptionOperation(
             requestFactory: IncomingAsyncSubscriptionEventPublisher.apiRequestFactoryFor(
@@ -115,7 +115,7 @@ final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
         // onDelete operation
         let onDeleteValueListener = onDeleteValueListenerHandler(event:)
         let onDeleteAuthTypeProvider = await authModeStrategy.authTypesFor(schema: modelSchema,
-                                                                     operation: .delete)
+                                                                           operations: [.delete, .read])
         self.onDeleteValueListener = onDeleteValueListener
         self.onDeleteOperation = RetryableGraphQLSubscriptionOperation(
             requestFactory: IncomingAsyncSubscriptionEventPublisher.apiRequestFactoryFor(


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/2873

## Description
<!-- Why is this change required? What problem does it solve? -->
Subscriptions for read auth rule were not processed inside Datastore. read auth rule can subscribe to onCreateX, onUpdateX and onDeleteX.
This PR is ported from `v1` to `main` : https://github.com/aws-amplify/amplify-swift/pull/3029
## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

## Testing
A Test app was setup with the same schema as in https://github.com/aws-amplify/amplify-swift/issues/2873 and `Amplify.Datastore.start()` was called without no user signed in. The logs below capture the difference where in ModelB and ModelC subscriptions are succesfully connected for the unauthenticated user.

### Before the fix
```
[InitializeSubscription] initializeSubscriptions(api:storageAdapter:)
[InitializeSubscription.5] Sink reconciliationQueues ModelB 1
[InitializeSubscription.5] Sink done reconciliationQueues ModelB 1
[InitializeSubscription.5] Sink reconciliationQueues ModelA 2
[InitializeSubscription.5] Sink done reconciliationQueues ModelA 2
[InitializeSubscription.5] Sink reconciliationQueues ModelC 3
[InitializeSubscription.5] Sink done reconciliationQueues ModelC 3
[InitializeSubscription.5] Sink reconciliationQueues UserProfile 4
[InitializeSubscription.5] Sink done reconciliationQueues UserProfile 4
[InitializeSubscription.1] API.subscribe failed for `ModelC` error: Subscription item event failed with error: Unauthorized
[InitializeSubscription.1] API.subscribe failed for `ModelB` error: Subscription item event failed with error: Unauthorized
[InitializeSubscription.1] API.subscribe failed for `ModelB` error: Subscription item event failed with error: Unauthorized
[InitializeSubscription.1] API.subscribe failed for `UserProfile` error: Subscription item event failed with error: Unauthorized
[InitializeSubscription.1] API.subscribe failed for `ModelC` error: Subscription item event failed with error: Unauthorized
[InitializeSubscription.1] API.subscribe failed for `ModelB` error: Subscription item event failed with error: Unauthorized
[InitializeSubscription.1] API.subscribe failed for `ModelC` error: Subscription item event failed with error: Unauthorized
[InitializeSubscription.1] API.subscribe failed for `UserProfile` error: Subscription item event failed with error: Unauthorized
[InitializeSubscription.1] API.subscribe failed for `UserProfile` error: Subscription item event failed with error: Unauthorized
[InitializeSubscription.3] AWSModelReconciliationQueue determined unauthorized ModelC
[InitializeSubscription.3] AWSModelReconciliationQueue determined unauthorized UserProfile
[InitializeSubscription.3] AWSModelReconciliationQueue determined unauthorized ModelB
[InitializeSubscription.4] subscription disconnected [ModelC] reason: [disconnected(modelName: "ModelC", reason: AWSDataStorePlugin.ModelConnectionDisconnectedReason.unauthorized)]
[InitializeSubscription.5] 1/4 initialized
[InitializeSubscription.4] subscription disconnected [UserProfile] reason: [disconnected(modelName: "UserProfile", reason: AWSDataStorePlugin.ModelConnectionDisconnectedReason.unauthorized)]
[InitializeSubscription.5] 2/4 initialized
[InitializeSubscription.4] subscription disconnected [ModelB] reason: [disconnected(modelName: "ModelB", reason: AWSDataStorePlugin.ModelConnectionDisconnectedReason.unauthorized)]
[InitializeSubscription.5] 3/4 initialized
[InitializeSubscription.4] .connected ModelA
[InitializeSubscription.5] 4/4 initialized
[InitializeSubscription.6] connected isInitialized
[InitializeSubscription.5] RemoteSyncEngine IncomingEventReconciliationQueueEvent.initialized
[InitializeSubscription.6] performInitialSync()
```

### After the fix
```
[InitializeSubscription] initializeSubscriptions(api:storageAdapter:)
[InitializeSubscription.5] Sink reconciliationQueues ModelA 1
[InitializeSubscription.5] Sink done reconciliationQueues ModelA 1
[InitializeSubscription.5] Sink reconciliationQueues UserProfile 2
[InitializeSubscription.5] Sink done reconciliationQueues UserProfile 2
[InitializeSubscription.5] Sink reconciliationQueues ModelB 3
[InitializeSubscription.5] Sink done reconciliationQueues ModelB 3
[InitializeSubscription.5] Sink reconciliationQueues ModelC 4
[InitializeSubscription.5] Sink done reconciliationQueues ModelC 4
[InitializeSubscription.1] API.subscribe failed for `UserProfile` error: Subscription item event failed with error: Unauthorized
[InitializeSubscription.1] API.subscribe failed for `UserProfile` error: Subscription item event failed with error: Unauthorized
[InitializeSubscription.1] API.subscribe failed for `UserProfile` error: Subscription item event failed with error: Unauthorized
[InitializeSubscription.3] AWSModelReconciliationQueue determined unauthorized UserProfile
[InitializeSubscription.4] subscription disconnected [UserProfile] reason: [disconnected(modelName: "UserProfile", reason: AWSDataStorePlugin.ModelConnectionDisconnectedReason.unauthorized)]
[InitializeSubscription.5] 1/4 initialized
[InitializeSubscription.4] .connected ModelC
[InitializeSubscription.5] 2/4 initialized
[InitializeSubscription.4] .connected ModelB
[InitializeSubscription.5] 3/4 initialized
[InitializeSubscription.4] .connected ModelA
[InitializeSubscription.5] 4/4 initialized
[InitializeSubscription.6] connected isInitialized
[InitializeSubscription.5] RemoteSyncEngine IncomingEventReconciliationQueueEvent.initialized
[InitializeSubscription.6] performInitialSync()
[InitializeSubscription.6] RemoteSyncEngine IncomingEventReconciliationQueueEvent.started
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
