### PR TITLE
test: fix datastore integration tests

### DIFF
--- a/.github/workflows/integ_test_datastore_auth_cognito.yml
+++ b/.github/workflows/integ_test_datastore_auth_cognito.yml
@@ -35,6 +35,7 @@ jobs:
           scheme: AWSDataStorePluginAuthCognitoTests
           destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'
 
   datastore-integration-auth-cognito-test-tvOS:
     timeout-minutes: 60
@@ -64,6 +65,7 @@ jobs:
           destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=latest
           sdk: appletvsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'
 
   datastore-integration-auth-cognito-test-watchOS:
     timeout-minutes: 60
@@ -93,3 +95,4 @@ jobs:
           destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=latest
           sdk: watchsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'

--- a/.github/workflows/integ_test_datastore_auth_iam.yml
+++ b/.github/workflows/integ_test_datastore_auth_iam.yml
@@ -35,6 +35,7 @@ jobs:
           scheme: AWSDataStorePluginAuthIAMTests
           destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'
 
   datastore-integration-auth-iam-test-tvOS:
     timeout-minutes: 60
@@ -64,6 +65,7 @@ jobs:
           destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=latest
           sdk: appletvsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'
 
   datastore-integration-auth-iam-test-watchOS:
     timeout-minutes: 60
@@ -93,3 +95,4 @@ jobs:
           destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=latest
           sdk: watchsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'

--- a/.github/workflows/integ_test_datastore_base.yml
+++ b/.github/workflows/integ_test_datastore_base.yml
@@ -35,6 +35,7 @@ jobs:
           scheme: AWSDataStorePluginIntegrationTests
           destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'
 
   datastore-integration-test-base-tvOS:
     timeout-minutes: 60
@@ -64,6 +65,7 @@ jobs:
           destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=latest
           sdk: appletvsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'
 
   datastore-integration-test-base-watchOS:
     timeout-minutes: 60
@@ -93,3 +95,4 @@ jobs:
           destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=latest
           sdk: watchsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'

--- a/.github/workflows/integ_test_datastore_cpk.yml
+++ b/.github/workflows/integ_test_datastore_cpk.yml
@@ -35,6 +35,7 @@ jobs:
           scheme: AWSDataStorePluginCPKTests
           destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'
 
   datastore-integration-cpk-test-tvOS:
     timeout-minutes: 60
@@ -64,6 +65,7 @@ jobs:
           destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=latest
           sdk: appletvsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'
 
   datastore-integration-cpk-test-watchOS:
     timeout-minutes: 60
@@ -93,3 +95,4 @@ jobs:
           destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=latest
           sdk: watchsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'

--- a/.github/workflows/integ_test_datastore_lazy_load.yml
+++ b/.github/workflows/integ_test_datastore_lazy_load.yml
@@ -35,6 +35,7 @@ jobs:
           scheme: AWSDataStorePluginLazyLoadTests
           destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'
 
   datastore-integration-lazy-load-test-tvOS:
     timeout-minutes: 60
@@ -64,6 +65,7 @@ jobs:
           destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=latest
           sdk: appletvsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'
 
   datastore-integration-lazy-load-test-watchOS:
     timeout-minutes: 60
@@ -93,3 +95,4 @@ jobs:
           destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=latest
           sdk: watchsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'

--- a/.github/workflows/integ_test_datastore_multi_auth.yml
+++ b/.github/workflows/integ_test_datastore_multi_auth.yml
@@ -35,6 +35,7 @@ jobs:
           scheme: AWSDataStorePluginMultiAuthTests
           destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'
 
   datastore-integration-multi-auth-test-tvOS:
     timeout-minutes: 60
@@ -64,6 +65,7 @@ jobs:
           destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=latest
           sdk: appletvsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'
 
   datastore-integration-multi-auth-test-watchOS:
     timeout-minutes: 60
@@ -93,3 +95,4 @@ jobs:
           destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=latest
           sdk: watchsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -35,6 +35,7 @@ jobs:
           scheme: AWSDataStorePluginV2Tests
           destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'
 
   datastore-integration-v2-test-tvOS:
     timeout-minutes: 60
@@ -64,6 +65,7 @@ jobs:
           destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=latest
           sdk: appletvsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'
 
   datastore-integration-v2-test-watchOS:
     timeout-minutes: 60
@@ -93,3 +95,4 @@ jobs:
           destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=latest
           sdk: watchsimulator
           xcode_path: '/Applications/Xcode_14.3.app'
+          other_flags: '-test-iterations 3 -retry-tests-on-failure'

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthIntegrationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreCategoryPluginAuthIntegrationTests.swift
@@ -60,7 +60,7 @@ class AWSDataStoreCategoryPluginAuthIntegrationTests: AWSDataStoreAuthBaseTest {
 
         try await signIn(user: user1)
 
-        await fulfillment(of: [syncReceivedInvoked], timeout: TestCommonConstants.networkTimeout)
+        await fulfillment(of: [syncReceivedInvoked], timeout: 60)
         Amplify.Hub.removeListener(syncReceivedListener)
         guard let remoteTodo = remoteTodoOptional else {
             XCTFail("Should have received a SyncReceived event with the remote note reconciled to local store")

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
@@ -97,9 +97,16 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
             }
         }.store(in: &cancellables)
         let receivedPost = expectation(description: "received Post")
-        try await savePostAndWaitForSync(Post(title: "title", content: "content", createdAt: .now()),
-                                         postSyncedExpctation: receivedPost)
-        await fulfillment(of: [snapshotWithIsSynced, receivedPost], timeout: 100)
+        receivedPost.assertForOverFulfill = false
+        try await savePostAndWaitForSync(
+            Post(
+                title: "title",
+                content: "content",
+                createdAt: .now()
+            ),
+            postSyncedExpctation: receivedPost
+        )
+        await fulfillment(of: [snapshotWithIsSynced], timeout: 100)
         
         XCTAssertTrue(snapshots.count >= 2)
         XCTAssertFalse(snapshots[0].isSynced)
@@ -296,7 +303,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         let receivedPost = expectation(description: "received Post")
         try await savePostAndWaitForSync(Post(title: "title", content: "content", createdAt: .now()),
                                          postSyncedExpctation: receivedPost)
-        await fulfillment(of: [snapshotWithIsSynced, receivedPost], timeout: 30)
+        await fulfillment(of: [snapshotWithIsSynced], timeout: 30)
         XCTAssertTrue(snapshots.count >= 2)
         XCTAssertFalse(snapshots[0].isSynced)
         XCTAssertTrue(snapshots.last!.isSynced)


### PR DESCRIPTION
## Description
<!-- Why is this change required? What problem does it solve? -->
A few DataStore integration tests were consistently failing after moving away from `AsyncExpectation` / `await wait(for:)` to `XCTestExpectation` / `await fulfillment(of:)` in https://github.com/aws-amplify/amplify-swift/pull/3305

These failures were caused by double waits on a single expectation.
- Removes double wait in two remaining cases.

Another test was somewhat consistently failing due to a timeout. The test takes almost 10 seconds to run on my M1 Pro, so there's little chance it's going to make it before timing out in our CI.
- Increases timeout from 10 to 60 seconds.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
