### PR TITLE
test: [skip ci] add workflow dispatch inputs for platform-specific integration tests

### DIFF
--- a/.github/workflows/integ_test_analytics.yml
+++ b/.github/workflows/integ_test_analytics.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | Analytics
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   analytics-integration-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -36,6 +53,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   analytics-integration-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -64,6 +82,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   analytics-integration-test-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_api_functional.yml
+++ b/.github/workflows/integ_test_api_functional.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | API - Functional
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   api-functional-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -36,6 +53,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-functional-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -64,6 +82,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-functional-test-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_api_graphql_auth_directive.yml
+++ b/.github/workflows/integ_test_api_graphql_auth_directive.yml
@@ -12,11 +12,6 @@ on:
         required: true
         default: true
         type: boolean
-      watchos:
-        description: '⌚️ watchOS'
-        required: true
-        default: true
-        type: boolean
   workflow_call:
 
 permissions:

--- a/.github/workflows/integ_test_api_graphql_auth_directive.yml
+++ b/.github/workflows/integ_test_api_graphql_auth_directive.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | API - GraphQL Auth Directive
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   api-graphql-auth-directive-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -36,6 +53,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-auth-directive-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_api_graphql_iam.yml
+++ b/.github/workflows/integ_test_api_graphql_iam.yml
@@ -12,11 +12,6 @@ on:
         required: true
         default: true
         type: boolean
-      watchos:
-        description: '⌚️ watchOS'
-        required: true
-        default: true
-        type: boolean
   workflow_call:
 
 permissions:

--- a/.github/workflows/integ_test_api_graphql_iam.yml
+++ b/.github/workflows/integ_test_api_graphql_iam.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | API - GraphQL IAM
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   api-graphql-iam-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -36,6 +53,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-iam-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_api_graphql_lambda_auth.yml
+++ b/.github/workflows/integ_test_api_graphql_lambda_auth.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | API - GraphQL Lambda
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   api-graphql-lambda-auth-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -36,6 +53,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-lambda-auth-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -64,6 +82,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-lambda-auth-test-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_api_graphql_lazy_load.yml
+++ b/.github/workflows/integ_test_api_graphql_lazy_load.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | API - GraphQL Lazy Load
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   api-lazy-load-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -36,6 +53,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-lazy-load-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_api_graphql_lazy_load.yml
+++ b/.github/workflows/integ_test_api_graphql_lazy_load.yml
@@ -12,11 +12,6 @@ on:
         required: true
         default: true
         type: boolean
-      watchos:
-        description: '⌚️ watchOS'
-        required: true
-        default: true
-        type: boolean
   workflow_call:
 
 permissions:

--- a/.github/workflows/integ_test_api_graphql_user_pool.yml
+++ b/.github/workflows/integ_test_api_graphql_user_pool.yml
@@ -12,11 +12,6 @@ on:
         required: true
         default: true
         type: boolean
-      watchos:
-        description: '⌚️ watchOS'
-        required: true
-        default: true
-        type: boolean
   workflow_call:
 
 permissions:

--- a/.github/workflows/integ_test_api_graphql_user_pool.yml
+++ b/.github/workflows/integ_test_api_graphql_user_pool.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | API - GraphQL User Pool
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   api-graphql-user-pool-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -36,6 +53,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-graphql-user-pool-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_api_rest_iam.yml
+++ b/.github/workflows/integ_test_api_rest_iam.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | API - REST IAM
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   api-rest-iam-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -36,6 +53,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-rest-iam-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -64,6 +82,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-rest-iam-test-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_api_rest_user_pool.yml
+++ b/.github/workflows/integ_test_api_rest_user_pool.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | API - REST User Pool
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   api-rest-user-pool-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -36,6 +53,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-rest-user-pool-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_api_rest_user_pool.yml
+++ b/.github/workflows/integ_test_api_rest_user_pool.yml
@@ -12,11 +12,6 @@ on:
         required: true
         default: true
         type: boolean
-      watchos:
-        description: '⌚️ watchOS'
-        required: true
-        default: true
-        type: boolean
   workflow_call:
 
 permissions:
@@ -53,7 +48,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   api-rest-user-pool-test-tvOS:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_auth.yml
+++ b/.github/workflows/integ_test_auth.yml
@@ -1,6 +1,27 @@
 name: Integration Tests | Auth
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
+      hostedui-ios:
+        description: '🌵 HostedUI iOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +30,7 @@ permissions:
 
 jobs:
   auth-integration-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -36,6 +58,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   auth-integration-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -64,6 +87,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   auth-integration-test-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -92,6 +116,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   auth-ui-integration-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.hostedui-ios }}
     runs-on: macos-12
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_datastore_auth_cognito.yml
+++ b/.github/workflows/integ_test_datastore_auth_cognito.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | DataStore - Auth Cognito
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   datastore-integration-auth-cognito-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
@@ -37,6 +54,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-cognito-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
@@ -66,6 +84,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-cognito-test-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest

--- a/.github/workflows/integ_test_datastore_auth_iam.yml
+++ b/.github/workflows/integ_test_datastore_auth_iam.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | DataStore - Auth IAM
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   datastore-integration-auth-iam-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
@@ -37,6 +54,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-iam-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
@@ -66,6 +84,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-auth-iam-test-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest

--- a/.github/workflows/integ_test_datastore_base.yml
+++ b/.github/workflows/integ_test_datastore_base.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | DataStore - Base
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   datastore-integration-test-base-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
@@ -37,6 +54,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-test-base-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
@@ -66,6 +84,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-test-base-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest

--- a/.github/workflows/integ_test_datastore_cpk.yml
+++ b/.github/workflows/integ_test_datastore_cpk.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | DataStore - CPK
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   datastore-integration-cpk-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
@@ -37,6 +54,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-cpk-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
@@ -66,6 +84,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-cpk-test-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest

--- a/.github/workflows/integ_test_datastore_lazy_load.yml
+++ b/.github/workflows/integ_test_datastore_lazy_load.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | DataStore - Lazy Load
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   datastore-integration-lazy-load-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
@@ -37,6 +54,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-lazy-load-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
@@ -66,6 +84,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-lazy-load-test-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest

--- a/.github/workflows/integ_test_datastore_multi_auth.yml
+++ b/.github/workflows/integ_test_datastore_multi_auth.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | DataStore - Multi Auth
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   datastore-integration-multi-auth-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
@@ -37,6 +54,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-multi-auth-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
@@ -66,6 +84,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-multi-auth-test-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | DataStore - TransformerV2
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   datastore-integration-v2-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
@@ -37,6 +54,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-v2-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest
@@ -66,6 +84,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   datastore-integration-v2-test-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     timeout-minutes: 60
     runs-on: macos-13
     environment: IntegrationTest

--- a/.github/workflows/integ_test_geo.yml
+++ b/.github/workflows/integ_test_geo.yml
@@ -1,6 +1,22 @@
 name: Integration Test | Geo
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   geo-integration-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -36,6 +53,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   geo-integration-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -64,6 +82,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   geo-integration-test-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_logging.yml
+++ b/.github/workflows/integ_test_logging.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | Logging
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   logging-integration-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -36,6 +53,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   logging-integration-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -64,6 +82,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   logging-integration-test-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:

--- a/.github/workflows/integ_test_predictions.yml
+++ b/.github/workflows/integ_test_predictions.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | Predictions
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   predictions-integration-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     continue-on-error: true
     timeout-minutes: 30
     runs-on: macos-13
@@ -41,6 +58,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   predictions-integration-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     continue-on-error: true
     timeout-minutes: 30
     runs-on: macos-13
@@ -74,6 +92,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   predictions-integration-test-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     continue-on-error: true
     timeout-minutes: 30
     runs-on: macos-13

--- a/.github/workflows/integ_test_push_notifications.yml
+++ b/.github/workflows/integ_test_push_notifications.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | Push Notifications
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   push-notification-integration-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     runs-on: macos-13
     timeout-minutes: 45
     environment: IntegrationTest
@@ -49,6 +66,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   push-notification-integration-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     runs-on: macos-13
     timeout-minutes: 30
     environment: IntegrationTest
@@ -90,6 +108,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   push-notification-integration-test-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     runs-on: macos-13
     timeout-minutes: 30
     environment: IntegrationTest

--- a/.github/workflows/integ_test_storage.yml
+++ b/.github/workflows/integ_test_storage.yml
@@ -1,6 +1,22 @@
 name: Integration Tests | Storage
 on:
   workflow_dispatch:
+    inputs:
+      ios:
+        description: '📱 iOS'
+        required: true
+        default: true
+        type: boolean
+      tvos:
+        description: '📺 tvOS'
+        required: true
+        default: true
+        type: boolean
+      watchos:
+        description: '⌚️ watchOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -9,6 +25,7 @@ permissions:
 
 jobs:
   storage-integration-test-iOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.ios }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -36,6 +53,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   storage-integration-test-tvOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.tvos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:
@@ -64,6 +82,7 @@ jobs:
           xcode_path: '/Applications/Xcode_14.3.app'
 
   storage-integration-test-watchOS:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.watchos }}
     runs-on: macos-13
     environment: IntegrationTest
     steps:


### PR DESCRIPTION
## Description
Sometimes we want to manually kick off integration tests in CI for a specific platform. https://github.com/aws-amplify/amplify-swift/pull/2974 split out our integration tests into reusable workflows, but didn't get down to platform level granularity. 

- Adds `workflow_dispatch` inputs to all integration tests, allowing an operator to trigger / omit tests for any combination of available platforms.

By default, all platforms are preselected.
![workflow_dispatch_platform_inputs](https://github.com/aws-amplify/amplify-swift/assets/52051793/2e7cf215-347d-4036-82ee-23fd4abbcb8f)

And can be toggled as necessary. 
![workflow_dispatch_platform_inputs-selection](https://github.com/aws-amplify/amplify-swift/assets/52051793/73436429-59e0-425a-9167-71018eef79e0)

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
