### PR TITLE
fix(Analytics): Handling certain auth errors as retryable errors

### DIFF
--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Utils/AnalyticsErrorHelper.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Support/Utils/AnalyticsErrorHelper.swift
@@ -14,6 +14,8 @@ enum AnalyticsErrorHelper {
         switch error {
         case let error as AnalyticsErrorConvertible:
             return error.analyticsError
+        case let error as AuthError:
+            return .configuration(error.errorDescription, error.recoverySuggestion, error)
         default:
             return getDefaultError(error as NSError)
         }

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EventRecorderTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EventRecorderTests.swift
@@ -7,7 +7,9 @@
 
 import XCTest
 import AWSPinpoint
+import AwsCommonRuntimeKit
 @testable import Amplify
+import ClientRuntime
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
 class EventRecorderTests: XCTestCase {
@@ -25,6 +27,13 @@ class EventRecorderTests: XCTestCase {
         } catch {
             XCTFail("Failed to setup EventRecorderTests")
         }
+    }
+    
+    override func tearDown() {
+        pinpointClient = nil
+        endpointClient = nil
+        storage = nil
+        recorder = nil
     }
 
     /// - Given: a event recorder
@@ -55,5 +64,130 @@ class EventRecorderTests: XCTestCase {
         XCTAssertEqual(storage.events.count, 1)
         XCTAssertEqual(event, storage.events[0])
         XCTAssertEqual(storage.checkDiskSizeCallCount, 2)
+    }
+    
+    /// - Given: a event recorder with events saved in the local storage
+    /// - When: submitAllEvents is invoked and successful
+    /// - Then: the events are removed from the local storage
+    func testSubmitAllEvents_withSuccess_shouldRemoveEventsFromStorage() async throws {
+        Amplify.Logging.logLevel = .verbose
+        let session = PinpointSession(sessionId: "1", startTime: Date(), stopTime: nil)
+        storage.events = [
+            .init(id: "1", eventType: "eventType1", eventDate: Date(), session: session),
+            .init(id: "2", eventType: "eventType2", eventDate: Date(), session: session)
+        ]
+
+        pinpointClient.putEventsResult = .success(.init(eventsResponse: .init(results: [
+            "endpointId": PinpointClientTypes.ItemResponse(
+                endpointItemResponse: .init(message: "Accepted", statusCode: 202),
+                eventsItemResponse: [
+                    "1": .init(message: "Accepted", statusCode: 202),
+                    "2": .init(message: "Accepted", statusCode: 202)
+                ]
+            )
+        ])))
+        let events = try await recorder.submitAllEvents()
+        
+        XCTAssertEqual(events.count, 2)
+        XCTAssertEqual(pinpointClient.putEventsCount, 1)
+        XCTAssertTrue(storage.events.isEmpty)
+        XCTAssertEqual(storage.deleteEventCallCount, 2)
+    }
+    
+    /// - Given: a event recorder with events saved in the local storage
+    /// - When: submitAllEvents is invoked and fails with a non-retryable error
+    /// - Then: the events are marked as dirty
+    func testSubmitAllEvents_withRetryableError_shouldSetEventsAsDirty() async throws {
+        Amplify.Logging.logLevel = .verbose
+        let session = PinpointSession(sessionId: "1", startTime: Date(), stopTime: nil)
+        let event1 = PinpointEvent(id: "1", eventType: "eventType1", eventDate: Date(), session: session)
+        let event2 = PinpointEvent(id: "2", eventType: "eventType2", eventDate: Date(), session: session)
+        storage.events = [ event1, event2 ]
+        pinpointClient.putEventsResult = .failure(NonRetryableError())
+        do {
+            let events = try await recorder.submitAllEvents()
+            XCTFail("Expected error")
+        } catch {
+            XCTAssertEqual(pinpointClient.putEventsCount, 1)
+            XCTAssertEqual(storage.events.count, 2)
+            XCTAssertEqual(storage.deleteEventCallCount, 0)
+            XCTAssertEqual(storage.eventRetryDictionary.count, 0)
+            XCTAssertEqual(storage.dirtyEventDictionary.count, 2)
+            XCTAssertEqual(storage.dirtyEventDictionary["1"], 1)
+            XCTAssertEqual(storage.dirtyEventDictionary["2"], 1)
+        }
+    }
+
+    /// - Given: a event recorder with events saved in the local storage
+    /// - When: submitAllEvents is invoked and fails with a retryable error
+    /// - Then: the events' retry count is increased
+    func testSubmitAllEvents_withRetryableError_shouldIncreaseRetryCount() async throws {
+        Amplify.Logging.logLevel = .verbose
+        let session = PinpointSession(sessionId: "1", startTime: Date(), stopTime: nil)
+        let event1 = PinpointEvent(id: "1", eventType: "eventType1", eventDate: Date(), session: session)
+        let event2 = PinpointEvent(id: "2", eventType: "eventType2", eventDate: Date(), session: session)
+        storage.events = [ event1, event2 ]
+        pinpointClient.putEventsResult = .failure(RetryableError())
+        do {
+            let events = try await recorder.submitAllEvents()
+            XCTFail("Expected error")
+        } catch {
+            XCTAssertEqual(pinpointClient.putEventsCount, 1)
+            XCTAssertEqual(storage.events.count, 2)
+            XCTAssertEqual(storage.deleteEventCallCount, 0)
+            XCTAssertEqual(storage.eventRetryDictionary.count, 2)
+            XCTAssertEqual(storage.eventRetryDictionary["1"], 1)
+            XCTAssertEqual(storage.eventRetryDictionary["2"], 1)
+            XCTAssertEqual(storage.dirtyEventDictionary.count, 0)
+        }
+    }
+
+    /// - Given: a event recorder with events saved in the local storage
+    /// - When: submitAllEvents is invoked and fails with a connectivity error
+    /// - Then: the events are not removed from the local storage
+    func testSubmitAllEvents_withConnectivityError_shouldNotIncreaseRetryCount_andNotSetEventsAsDirty() async throws {
+        Amplify.Logging.logLevel = .verbose
+        let session = PinpointSession(sessionId: "1", startTime: Date(), stopTime: nil)
+        let event1 = PinpointEvent(id: "1", eventType: "eventType1", eventDate: Date(), session: session)
+        let event2 = PinpointEvent(id: "2", eventType: "eventType2", eventDate: Date(), session: session)
+        storage.events = [ event1, event2 ]
+        pinpointClient.putEventsResult = .failure(ConnectivityError())
+        do {
+            let events = try await recorder.submitAllEvents()
+            XCTFail("Expected error")
+        } catch {
+            XCTAssertEqual(pinpointClient.putEventsCount, 1)
+            XCTAssertEqual(storage.events.count, 2)
+            XCTAssertEqual(storage.deleteEventCallCount, 0)
+            XCTAssertEqual(storage.eventRetryDictionary.count, 0)
+            XCTAssertEqual(storage.dirtyEventDictionary.count, 0)
+        }
+    }
+}
+
+private struct RetryableError: Error, ModeledError {
+    static var typeName = "RetriableError"
+    static var fault = ErrorFault.client
+    static var isRetryable = true
+    static var isThrottling = false
+}
+
+private struct NonRetryableError: Error, ModeledError {
+    static var typeName = "RetriableError"
+    static var fault = ErrorFault.client
+    static var isRetryable = false
+    static var isThrottling = false
+}
+
+private class ConnectivityError: NSError {
+    init() {
+        super.init(
+            domain: "ConnectivityError",
+            code: NSURLErrorNotConnectedToInternet
+        )
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
     }
 }

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockAnalyticsEventStorage.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockAnalyticsEventStorage.swift
@@ -9,6 +9,7 @@
 
 class MockAnalyticsEventStorage: AnalyticsEventStorage {
     var deletedEvent: String = ""
+    var deleteEventCallCount = 0
     var deleteDirtyEventCallCount = 0
     var initializeStorageCallCount = 0
     var deleteOldestEventCallCount = 0
@@ -22,6 +23,8 @@ class MockAnalyticsEventStorage: AnalyticsEventStorage {
 
     func deleteEvent(eventId: String) throws {
         deletedEvent = eventId
+        deleteEventCallCount += 1
+        events.removeAll { $0.id == eventId }
     }
 
     func deleteDirtyEvents() throws {

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockPinpointClient.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockPinpointClient.swift
@@ -365,8 +365,11 @@ class MockPinpointClient: PinpointClientProtocol {
         fatalError("Not supported")
     }
 
+    var putEventsCount = 0
+    var putEventsResult: Result<PutEventsOutputResponse, Error> = .failure(CancellationError())
     func putEvents(input: PutEventsInput) async throws -> PutEventsOutputResponse {
-        fatalError("Not supported")
+        putEventsCount += 1
+        return try putEventsResult.get()
     }
 
     func putEventStream(input: PutEventStreamInput) async throws -> PutEventStreamOutputResponse {


### PR DESCRIPTION
## Description
If guest/unauthenticated access is disabled, attempting to submit cached events with a user signed our or with an expired token will fail and all events will be discarded. This happens because this failure is considered non-retryable.

This PR fixes that by considering the following `AuthError`s to be retryable without affecting the events retry count:
- `.sessionExpired`
-  `.signedOut`
- `.service` with an underlying error of type `AWSCognitoAuthError.invalidAccountTypeException`

This is similar as to how connectivity issues are handled.

## General Checklist
- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
