### PR TITLE
fix(Analytics): Fixing crash when attempting to submit events while a previous submission is in progress

### DIFF
--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/AnalyticsClient.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/AnalyticsClient.swift
@@ -23,7 +23,7 @@ public protocol AnalyticsClientBehaviour: Actor {
     func removeGlobalAttribute(forKey key: String, forEventType eventType: String)
     func removeGlobalMetric(forKey key: String)
     func removeGlobalMetric(forKey key: String, forEventType eventType: String)
-    func record(_ event: PinpointEvent) throws
+    func record(_ event: PinpointEvent) async throws
 
     func setRemoteGlobalAttributes(_ attributes: [String: String])
     func removeAllRemoteGlobalAttributes()
@@ -231,7 +231,7 @@ actor AnalyticsClient: AnalyticsClientBehaviour {
                              session: sessionProvider())
     }
 
-    func record(_ event: PinpointEvent) throws {
+    func record(_ event: PinpointEvent) async throws {
         // Add event type attributes
         if let eventAttributes = eventTypeAttributes[event.eventType] {
             for (key, attribute) in eventAttributes {
@@ -256,7 +256,7 @@ actor AnalyticsClient: AnalyticsClientBehaviour {
             event.addMetric(metric, forKey: key)
         }
 
-        try eventRecorder.save(event)
+        try await eventRecorder.save(event)
     }
 
     @discardableResult

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AnalyticsClientTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AnalyticsClientTests.swift
@@ -85,8 +85,9 @@ class AnalyticsClientTests: XCTestCase {
 
         do {
             try await analyticsClient.record(event)
-            XCTAssertEqual(eventRecorder.saveCount, 1)
-            guard let savedEvent = eventRecorder.lastSavedEvent else {
+            let saveCount = await eventRecorder.saveCount
+            XCTAssertEqual(saveCount, 1)
+            guard let savedEvent = await eventRecorder.lastSavedEvent else {
                 XCTFail("Expected saved event")
                 return
             }
@@ -118,8 +119,9 @@ class AnalyticsClientTests: XCTestCase {
 
         do {
             try await analyticsClient.record(event)
-            XCTAssertEqual(eventRecorder.saveCount, 1)
-            guard let savedEvent = eventRecorder.lastSavedEvent else {
+            let saveCount = await eventRecorder.saveCount
+            XCTAssertEqual(saveCount, 1)
+            guard let savedEvent = await eventRecorder.lastSavedEvent else {
                 XCTFail("Expected saved event")
                 return
             }
@@ -142,7 +144,8 @@ class AnalyticsClientTests: XCTestCase {
     func testSubmit() async {
         do {
             try await analyticsClient.submitEvents()
-            XCTAssertEqual(eventRecorder.submitCount, 1)
+            let submitCount = await eventRecorder.submitCount
+            XCTAssertEqual(submitCount, 1)
         } catch {
             XCTFail("Unexpected exception while attempting to submit events")
         }

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EventRecorderTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EventRecorderTests.swift
@@ -48,7 +48,7 @@ class EventRecorderTests: XCTestCase {
     /// - Given: a event recorder
     /// - When: a new pinpoint event is aved
     /// - Then: the event is saved to storage followed by a disk size check
-    func testSaveEvent() {
+    func testSaveEvent() async {
         let session = PinpointSession(sessionId: "1", startTime: Date(), stopTime: nil)
         let event = PinpointEvent(id: "1", eventType: "eventType", eventDate: Date(), session: session)
 
@@ -56,7 +56,7 @@ class EventRecorderTests: XCTestCase {
         XCTAssertEqual(storage.checkDiskSizeCallCount, 1)
 
         do {
-            try recorder.save(event)
+            try await recorder.save(event)
         } catch {
             XCTFail("Failed to save events")
         }

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockEventRecorder.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockEventRecorder.swift
@@ -9,8 +9,10 @@
 import AWSPinpoint
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
-class MockEventRecorder: AnalyticsEventRecording {
-    var pinpointClient: PinpointClientProtocol = MockPinpointClient()
+actor MockEventRecorder: AnalyticsEventRecording {
+    nonisolated var pinpointClient: PinpointClientProtocol {
+        MockPinpointClient()
+    }
 
     var saveCount = 0
     var lastSavedEvent: PinpointEvent?


### PR DESCRIPTION
## Issue \#
- https://github.com/aws-amplify/amplify-swift/issues/3328

## Description
This PR fixes a crash that was happening when `EventRecorder.submitAllEvents()` was called while a previous submission was still ongoing.
This happened because the `submittedEvents` array was being populated by the previous submission, while the very first thing a new one does is to set it to `[]`.

I am changing the behaviour so that `submitAllEvents` now waits until the previous submission ends before continuing. I've explored just using a lock to manipulate the array instead, but while that did fix the crash, it would still produce undetermined behaviour when the array was emptied.

## General Checklist

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
