### PR TITLE
fix: bump swift sdk to 0.26.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let platforms: [SupportedPlatform] = [
     .watchOS(.v9)
 ]
 let dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/awslabs/aws-sdk-swift.git", exact: "0.26.0"),
+    .package(url: "https://github.com/awslabs/aws-sdk-swift.git", exact: "0.26.1"),
     .package(url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git", from: "3.0.0"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", exact: "0.13.2"),
     .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.1.0"),


### PR DESCRIPTION
## Issue \#
- https://github.com/aws-amplify/amplify-swift/issues/3324

## Description
<!-- Why is this change required? What problem does it solve? -->
Bumps AWS SDK for Swift from 0.26.0 to 0.26.1.

[0.26.1](https://github.com/awslabs/aws-sdk-swift/releases/tag/0.26.1) pins aws-crt-swift 0.17.0, which puts the `common_cryptor_spi.h` behind an `#ifdef` directive to prevent the non-public symbols from being included in release builds.

This fix was confirmed through manual testing - uploading an app to App Store Connect that embeds a `.framework`, which wraps Amplify Swift + plugin targets.

In addition to confirming that the upload to App Store Connect succeeded, the non-public `CCCryptorGCM...` symbols were confirmed to not be included in release build artifacts.

**Prior to Change / Before**
```bash
> nm -m <archive-path>.xcarchive/Products/Applications/my_app.app/Frameworks/wrapper.framework/wrapper | grep CCCryptorGC
                 U _CCCryptorGCMAddAAD
                 U _CCCryptorGCMFinalize
                 U _CCCryptorGCMSetIV

> dwarfdump <archive-path>.xcarchive/dSYMs/wrapper.framework.dSYM | grep CCCryptorGCM -A 1
                DW_AT_name	("CCCryptorGCMSetIV")
                DW_AT_decl_file	("/.../checkouts/aws-crt-swift/aws-common-runtime/aws-c-cal/source/darwin/common_cryptor_spi.h")
--
                DW_AT_name	("CCCryptorGCMAddAAD")
                DW_AT_decl_file	("/.../checkouts/aws-crt-swift/aws-common-runtime/aws-c-cal/source/darwin/common_cryptor_spi.h")
--
                DW_AT_name	("CCCryptorGCMFinalize")
                DW_AT_decl_file	("/.../checkouts/aws-crt-swift/aws-common-runtime/aws-c-cal/source/darwin/common_cryptor_spi.h")
```

**With Change / Now**
```bash
> nm -m <archive-path>.xcarchive/Products/Applications/my_app.app/Frameworks/wrapper.framework/wrapper | grep CCCryptorGC
# no results

> dwarfdump <archive-path>.xcarchive/dSYMs/wrapper.framework.dSYM | grep CCCryptorGCM -A 1
# no results
```
### Relevant Links
- [AWS SDK for Swift 0.26.1 release](https://github.com/awslabs/aws-sdk-swift/releases/tag/0.26.1)
- [aws-crt-swift 0.17.0 release](https://github.com/awslabs/aws-crt-swift/releases/tag/0.17.0)
- https://github.com/awslabs/aws-crt-swift/issues/206
- https://github.com/awslabs/aws-c-cal/pull/170
- https://github.com/awslabs/aws-c-cal/pull/171
- https://github.com/awslabs/aws-crt-swift/pull/207

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
