### PR TITLE
fix: update type names from OutputResponse to Output

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/VerifyPasswordSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/VerifyPasswordSRP.swift
@@ -13,11 +13,11 @@ struct VerifyPasswordSRP: Action {
     let identifier = "VerifyPasswordSRP"
 
     let stateData: SRPStateData
-    let authResponse: InitiateAuthOutputResponse
+    let authResponse: InitiateAuthOutput
     let clientMetadata: ClientMetadata
 
     init(stateData: SRPStateData,
-         authResponse: InitiateAuthOutputResponse,
+         authResponse: InitiateAuthOutput,
          clientMetadata: ClientMetadata) {
         self.stateData = stateData
         self.authResponse = authResponse

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/CognitoIdentityBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/CognitoIdentityBehavior.swift
@@ -13,7 +13,7 @@ protocol CognitoIdentityBehavior {
     /// Generates (or retrieves) a Cognito ID. Supplying multiple logins will create an implicit linked account.
     /// This is a public API. You do not need any credentials to call this API.
     /// Throws GetIdOutputError
-    func getId(input: GetIdInput) async throws -> GetIdOutputResponse
+    func getId(input: GetIdInput) async throws -> GetIdOutput
 
     /// Returns credentials for the provided identity ID.
     /// Any provided logins will be validated against supported login providers. If the token is for cognito-identity.amazonaws.com,
@@ -21,6 +21,6 @@ protocol CognitoIdentityBehavior {
     /// This is a public API. You do not need any credentials to call this API.
     /// Throws GetCredentialsForIdentityOutputError
     func getCredentialsForIdentity(
-        input: GetCredentialsForIdentityInput) async throws -> GetCredentialsForIdentityOutputResponse
+        input: GetCredentialsForIdentityInput) async throws -> GetCredentialsForIdentityOutput
 
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/CognitoUserPoolBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/CognitoUserPoolBehavior.swift
@@ -11,82 +11,82 @@ import ClientRuntime
 protocol CognitoUserPoolBehavior {
 
     /// Throws InitiateAuthOutputError
-    func initiateAuth(input: InitiateAuthInput) async throws -> InitiateAuthOutputResponse
+    func initiateAuth(input: InitiateAuthInput) async throws -> InitiateAuthOutput
 
     /// Throws RespondToAuthChallengeOutputError
     func respondToAuthChallenge(
-        input: RespondToAuthChallengeInput) async throws -> RespondToAuthChallengeOutputResponse
+        input: RespondToAuthChallengeInput) async throws -> RespondToAuthChallengeOutput
 
     /// Throws SignUpOutputError
-    func signUp(input: SignUpInput) async throws -> SignUpOutputResponse
+    func signUp(input: SignUpInput) async throws -> SignUpOutput
 
     /// Throws ConfirmSignUpOutputError
-    func confirmSignUp(input: ConfirmSignUpInput) async throws -> ConfirmSignUpOutputResponse
+    func confirmSignUp(input: ConfirmSignUpInput) async throws -> ConfirmSignUpOutput
 
     /// Throws GlobalSignOutOutputError
-    func globalSignOut(input: GlobalSignOutInput) async throws -> GlobalSignOutOutputResponse
+    func globalSignOut(input: GlobalSignOutInput) async throws -> GlobalSignOutOutput
 
     /// Throws RevokeTokenOutputError
-    func revokeToken(input: RevokeTokenInput) async throws -> RevokeTokenOutputResponse
+    func revokeToken(input: RevokeTokenInput) async throws -> RevokeTokenOutput
 
     // MARK: - User Attribute API's
 
     /// Throws GetUserAttributeVerificationCodeOutputError
-    func getUserAttributeVerificationCode(input: GetUserAttributeVerificationCodeInput) async throws -> GetUserAttributeVerificationCodeOutputResponse
+    func getUserAttributeVerificationCode(input: GetUserAttributeVerificationCodeInput) async throws -> GetUserAttributeVerificationCodeOutput
 
     /// Throws GetUserOutputError
-    func getUser(input: GetUserInput) async throws -> GetUserOutputResponse
+    func getUser(input: GetUserInput) async throws -> GetUserOutput
 
     /// Throws UpdateUserAttributesOutputError
-    func updateUserAttributes(input: UpdateUserAttributesInput) async throws -> UpdateUserAttributesOutputResponse
+    func updateUserAttributes(input: UpdateUserAttributesInput) async throws -> UpdateUserAttributesOutput
 
     /// Verifies the specified user attributes in the user pool.
     /// Throws VerifyUserAttributeOutputError
-    func verifyUserAttribute(input: AWSCognitoIdentityProvider.VerifyUserAttributeInput) async throws -> AWSCognitoIdentityProvider.VerifyUserAttributeOutputResponse
+    func verifyUserAttribute(input: AWSCognitoIdentityProvider.VerifyUserAttributeInput) async throws -> AWSCognitoIdentityProvider.VerifyUserAttributeOutput
 
     /// Changes the password for a specified user in a user pool.
     /// Throws ChangePasswordOutputError
-    func changePassword(input: ChangePasswordInput) async throws -> ChangePasswordOutputResponse
+    func changePassword(input: ChangePasswordInput) async throws -> ChangePasswordOutput
 
     /// Delete the signed in user from the user pool.
     /// Throws DeleteUserOutputError
-    func deleteUser(input: DeleteUserInput) async throws -> DeleteUserOutputResponse
+    func deleteUser(input: DeleteUserInput) async throws -> DeleteUserOutput
 
     /// Resends sign up code
     /// Throws ResendConfirmationCodeOutputError
-    func resendConfirmationCode(input: ResendConfirmationCodeInput) async throws -> ResendConfirmationCodeOutputResponse
+    func resendConfirmationCode(input: ResendConfirmationCodeInput) async throws -> ResendConfirmationCodeOutput
 
     /// Resets password
     /// Throws ForgotPasswordOutputError
-    func forgotPassword(input: ForgotPasswordInput) async throws -> ForgotPasswordOutputResponse
+    func forgotPassword(input: ForgotPasswordInput) async throws -> ForgotPasswordOutput
 
     /// Confirm Reset password
     /// Throws ConfirmForgotPasswordOutputError
-    func confirmForgotPassword(input: ConfirmForgotPasswordInput) async throws -> ConfirmForgotPasswordOutputResponse
+    func confirmForgotPassword(input: ConfirmForgotPasswordInput) async throws -> ConfirmForgotPasswordOutput
 
     /// Lists the devices
-    func listDevices(input: ListDevicesInput) async throws -> ListDevicesOutputResponse
+    func listDevices(input: ListDevicesInput) async throws -> ListDevicesOutput
 
     /// Updates the device status
-    func updateDeviceStatus(input: UpdateDeviceStatusInput) async throws -> UpdateDeviceStatusOutputResponse
+    func updateDeviceStatus(input: UpdateDeviceStatusInput) async throws -> UpdateDeviceStatusOutput
 
     /// Forgets the specified device.
-    func forgetDevice(input: ForgetDeviceInput) async throws -> ForgetDeviceOutputResponse
+    func forgetDevice(input: ForgetDeviceInput) async throws -> ForgetDeviceOutput
 
     /// Confirms tracking of the device. This API call is the call that begins device tracking.
     /// Throws ConfirmDeviceOutputError
-    func confirmDevice(input: ConfirmDeviceInput) async throws -> ConfirmDeviceOutputResponse
+    func confirmDevice(input: ConfirmDeviceInput) async throws -> ConfirmDeviceOutput
 
     /// Creates a new request to associate a new software token for the user
     /// Throws AssociateSoftwareTokenOutputError
-    func associateSoftwareToken(input: AssociateSoftwareTokenInput) async throws -> AssociateSoftwareTokenOutputResponse
+    func associateSoftwareToken(input: AssociateSoftwareTokenInput) async throws -> AssociateSoftwareTokenOutput
 
     /// Register a user's entered time-based one-time password (TOTP) code and mark the user's software token MFA status as "verified" if successful.
     /// Throws VerifySoftwareTokenOutputError
-    func verifySoftwareToken(input: VerifySoftwareTokenInput) async throws -> VerifySoftwareTokenOutputResponse
+    func verifySoftwareToken(input: VerifySoftwareTokenInput) async throws -> VerifySoftwareTokenOutput
 
     /// Set the user's multi-factor authentication (MFA) method preference, including which MFA factors are activated and if any are preferred.
     /// Throws SetUserMFAPreferenceOutputError
-    func setUserMFAPreference(input: SetUserMFAPreferenceInput) async throws -> SetUserMFAPreferenceOutputResponse
+    func setUserMFAPreference(input: SetUserMFAPreferenceInput) async throws -> SetUserMFAPreferenceOutput
 
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/Helpers/SignInResponseBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/Helpers/SignInResponseBehavior.swift
@@ -20,6 +20,6 @@ protocol SignInResponseBehavior {
     var session: Swift.String? { get }
 }
 
-extension RespondToAuthChallengeOutputResponse: SignInResponseBehavior { }
+extension RespondToAuthChallengeOutput: SignInResponseBehavior { }
 
-extension InitiateAuthOutputResponse: SignInResponseBehavior { }
+extension InitiateAuthOutput: SignInResponseBehavior { }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/Helpers/SignUpOutputResponse+Helper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/Helpers/SignUpOutputResponse+Helper.swift
@@ -9,7 +9,7 @@ import Amplify
 import Foundation
 import AWSCognitoIdentityProvider
 
-extension SignUpOutputResponse {
+extension SignUpOutput {
 
     var authResponse: AuthSignUpResult {
         if self.userConfirmed {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInEvent.swift
@@ -28,9 +28,9 @@ struct SignInEvent: StateMachineEvent {
 
         case initiateMigrateAuth(SignInEventData, DeviceMetadata)
 
-        case respondPasswordVerifier(SRPStateData, InitiateAuthOutputResponse, ClientMetadata)
+        case respondPasswordVerifier(SRPStateData, InitiateAuthOutput, ClientMetadata)
 
-        case retryRespondPasswordVerifier(SRPStateData, InitiateAuthOutputResponse, ClientMetadata)
+        case retryRespondPasswordVerifier(SRPStateData, InitiateAuthOutput, ClientMetadata)
 
         case initiateDeviceSRP(Username, SignInResponseBehavior)
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchAWSCredentials/FetchAuthAWSCredentialsTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchAWSCredentials/FetchAuthAWSCredentialsTests.swift
@@ -42,7 +42,7 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
         let expectation = expectation(description: "fetchAWSCredentials")
         let identityProviderFactory: BasicAuthorizationEnvironment.CognitoIdentityFactory = {
             MockIdentity(mockGetCredentialsResponse: { _ in
-                return GetCredentialsForIdentityOutputResponse()
+                return GetCredentialsForIdentityOutput()
             })
         }
         let authorizationEnvironment = BasicAuthorizationEnvironment(
@@ -75,7 +75,7 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
         let expectation = expectation(description: "fetchAWSCredentials")
         let identityProviderFactory: BasicAuthorizationEnvironment.CognitoIdentityFactory = {
             MockIdentity(mockGetCredentialsResponse: { _ in
-                return GetCredentialsForIdentityOutputResponse(identityId: "identityId")
+                return GetCredentialsForIdentityOutput(identityId: "identityId")
             })
         }
         let authorizationEnvironment = BasicAuthorizationEnvironment(
@@ -117,7 +117,7 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
 
         let identityProviderFactory: BasicAuthorizationEnvironment.CognitoIdentityFactory = {
             MockIdentity(mockGetCredentialsResponse: { _ in
-                return GetCredentialsForIdentityOutputResponse(
+                return GetCredentialsForIdentityOutput(
                     credentials: CognitoIdentityClientTypes.Credentials(
                         accessKeyId: expectedAccessKey,
                         expiration: Date(),

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchUserPoolTokens/RefreshHostedUITokensTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchUserPoolTokens/RefreshHostedUITokensTests.swift
@@ -279,7 +279,7 @@ class RefreshHostedUITokensTests: XCTestCase {
     private func identityProviderFactory() throws -> CognitoUserPoolBehavior {
         return MockIdentityProvider(
             mockInitiateAuthResponse: { _ in
-                return InitiateAuthOutputResponse(
+                return InitiateAuthOutput(
                     authenticationResult: .init(
                         accessToken: "accessTokenNew",
                         expiresIn: 100,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchUserPoolTokens/RefreshUserPoolTokensTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchUserPoolTokens/RefreshUserPoolTokensTests.swift
@@ -46,7 +46,7 @@ class RefreshUserPoolTokensTests: XCTestCase {
         let identityProviderFactory: BasicSRPAuthEnvironment.CognitoUserPoolFactory = {
             MockIdentityProvider(
                 mockInitiateAuthResponse: { _ in
-                    return InitiateAuthOutputResponse()
+                    return InitiateAuthOutput()
                 }
             )
         }
@@ -78,7 +78,7 @@ class RefreshUserPoolTokensTests: XCTestCase {
         let identityProviderFactory: BasicSRPAuthEnvironment.CognitoUserPoolFactory = {
             MockIdentityProvider(
                 mockInitiateAuthResponse: { _ in
-                    return InitiateAuthOutputResponse(
+                    return InitiateAuthOutput(
                         authenticationResult: .init(
                             accessToken: "accessTokenNew",
                             expiresIn: 100,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/InitiateAuthSRPTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/InitiateAuthSRPTests.swift
@@ -18,7 +18,7 @@ class InitiateAuthSRPTests: XCTestCase {
             MockIdentityProvider(
                 mockInitiateAuthResponse: { _ in
                     initiateAuthInvoked.fulfill()
-                    return InitiateAuthOutputResponse()
+                    return InitiateAuthOutput()
                 }
             )
         }
@@ -83,7 +83,7 @@ class InitiateAuthSRPTests: XCTestCase {
         let identityProviderFactory: BasicSRPAuthEnvironment.CognitoUserPoolFactory = {
             MockIdentityProvider(
                 mockInitiateAuthResponse: { _ in
-                    return InitiateAuthOutputResponse()
+                    return InitiateAuthOutput()
                 }
             )
         }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyDevicePasswordSRPSignatureTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyDevicePasswordSRPSignatureTests.swift
@@ -111,7 +111,7 @@ class VerifyDevicePasswordSRPSignatureTests: XCTestCase {
     private func signature() throws -> String {
         let action = VerifyDevicePasswordSRP(
             stateData: .testData,
-            authResponse: InitiateAuthOutputResponse.validTestData
+            authResponse: InitiateAuthOutput.validTestData
         )
 
         return try action.signature(

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyPasswordSRPTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyPasswordSRPTests.swift
@@ -31,14 +31,14 @@ class VerifyPasswordSRPTests: XCTestCase {
             MockIdentityProvider(
                 mockRespondToAuthChallengeResponse: { _ in
                     verifyPasswordInvoked.fulfill()
-                    return RespondToAuthChallengeOutputResponse()
+                    return RespondToAuthChallengeOutput()
                 })
         }
 
         let environment = Defaults.makeDefaultAuthEnvironment(
             userPoolFactory: identityProviderFactory)
 
-        let data = InitiateAuthOutputResponse.validTestData
+        let data = InitiateAuthOutput.validTestData
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
                                        authResponse: data,
                                        clientMetadata: [:])
@@ -67,14 +67,14 @@ class VerifyPasswordSRPTests: XCTestCase {
         let identityProviderFactory: CognitoFactory = {
             MockIdentityProvider(
                 mockRespondToAuthChallengeResponse: { _ in
-                    return RespondToAuthChallengeOutputResponse()
+                    return RespondToAuthChallengeOutput()
                 })
         }
 
         let environment = Defaults.makeDefaultAuthEnvironment(
             userPoolFactory: identityProviderFactory)
 
-        let data = InitiateAuthOutputResponse.validTestData
+        let data = InitiateAuthOutput.validTestData
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
                                        authResponse: data,
                                        clientMetadata: [:])
@@ -118,14 +118,14 @@ class VerifyPasswordSRPTests: XCTestCase {
         let identityProviderFactory: CognitoFactory = {
             MockIdentityProvider(
                 mockRespondToAuthChallengeResponse: { _ in
-                    return RespondToAuthChallengeOutputResponse()
+                    return RespondToAuthChallengeOutput()
                 })
         }
 
         let environment = Defaults.makeDefaultAuthEnvironment(
             userPoolFactory: identityProviderFactory)
 
-        let data = InitiateAuthOutputResponse.invalidChallenge
+        let data = InitiateAuthOutput.invalidChallenge
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
                                        authResponse: data,
                                        clientMetadata: [:])
@@ -169,14 +169,14 @@ class VerifyPasswordSRPTests: XCTestCase {
         let identityProviderFactory: CognitoFactory = {
             MockIdentityProvider(
                 mockRespondToAuthChallengeResponse: { _ in
-                    return RespondToAuthChallengeOutputResponse()
+                    return RespondToAuthChallengeOutput()
                 })
         }
 
         let environment = Defaults.makeDefaultAuthEnvironment(
             userPoolFactory: identityProviderFactory)
 
-        let data = InitiateAuthOutputResponse.invalidTestDataWithNoSalt
+        let data = InitiateAuthOutput.invalidTestDataWithNoSalt
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
                                        authResponse: data,
                                        clientMetadata: [:])
@@ -220,14 +220,14 @@ class VerifyPasswordSRPTests: XCTestCase {
         let identityProviderFactory: CognitoFactory = {
             MockIdentityProvider(
                 mockRespondToAuthChallengeResponse: { _ in
-                    return RespondToAuthChallengeOutputResponse()
+                    return RespondToAuthChallengeOutput()
                 })
         }
 
         let environment = Defaults.makeDefaultAuthEnvironment(
             userPoolFactory: identityProviderFactory)
 
-        let data = InitiateAuthOutputResponse.invalidTestDataWithNoSecretBlock
+        let data = InitiateAuthOutput.invalidTestDataWithNoSecretBlock
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
                                        authResponse: data,
                                        clientMetadata: [:])
@@ -271,14 +271,14 @@ class VerifyPasswordSRPTests: XCTestCase {
         let identityProviderFactory: CognitoFactory = {
             MockIdentityProvider(
                 mockRespondToAuthChallengeResponse: { _ in
-                    return RespondToAuthChallengeOutputResponse()
+                    return RespondToAuthChallengeOutput()
                 })
         }
 
         let environment = Defaults.makeDefaultAuthEnvironment(
             userPoolFactory: identityProviderFactory)
 
-        let data = InitiateAuthOutputResponse.invalidTestDataWithNoSRPB
+        let data = InitiateAuthOutput.invalidTestDataWithNoSRPB
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
                                        authResponse: data,
                                        clientMetadata: [:])
@@ -322,14 +322,14 @@ class VerifyPasswordSRPTests: XCTestCase {
         let identityProviderFactory: CognitoFactory = {
             MockIdentityProvider(
                 mockRespondToAuthChallengeResponse: { _ in
-                    return RespondToAuthChallengeOutputResponse()
+                    return RespondToAuthChallengeOutput()
                 })
         }
 
         let environment = Defaults.makeDefaultAuthEnvironment(
             userPoolFactory: identityProviderFactory)
 
-        let data = InitiateAuthOutputResponse.invalidTestDataForException
+        let data = InitiateAuthOutput.invalidTestDataForException
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
                                        authResponse: data,
                                        clientMetadata: [:])
@@ -372,14 +372,14 @@ class VerifyPasswordSRPTests: XCTestCase {
         let identityProviderFactory: CognitoFactory = {
             MockIdentityProvider(
                 mockRespondToAuthChallengeResponse: { _ in
-                    return RespondToAuthChallengeOutputResponse.testData()
+                    return RespondToAuthChallengeOutput.testData()
                 })
         }
 
         let environment = Defaults.makeDefaultAuthEnvironment(
             userPoolFactory: identityProviderFactory)
 
-        let data = InitiateAuthOutputResponse.validTestData
+        let data = InitiateAuthOutput.validTestData
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
                                        authResponse: data,
                                        clientMetadata: [:])
@@ -432,7 +432,7 @@ class VerifyPasswordSRPTests: XCTestCase {
         let environment = Defaults.makeDefaultAuthEnvironment(
             userPoolFactory: identityProviderFactory)
 
-        let data = InitiateAuthOutputResponse.validTestData
+        let data = InitiateAuthOutput.validTestData
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
                                        authResponse: data,
                                        clientMetadata: [:])
@@ -483,7 +483,7 @@ class VerifyPasswordSRPTests: XCTestCase {
         let environment = Defaults.makeDefaultAuthEnvironment(
             userPoolFactory: identityProviderFactory)
 
-        let data = InitiateAuthOutputResponse.validTestData
+        let data = InitiateAuthOutput.validTestData
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
                                        authResponse: data,
                                        clientMetadata: [:])
@@ -524,14 +524,14 @@ class VerifyPasswordSRPTests: XCTestCase {
         let identityProviderFactory: CognitoFactory = {
             MockIdentityProvider(
                 mockRespondToAuthChallengeResponse: { _ in
-                    return RespondToAuthChallengeOutputResponse.testDataWithNewDevice()
+                    return RespondToAuthChallengeOutput.testDataWithNewDevice()
                 })
         }
 
         let environment = Defaults.makeDefaultAuthEnvironment(
             userPoolFactory: identityProviderFactory)
 
-        let data = InitiateAuthOutputResponse.validTestData
+        let data = InitiateAuthOutput.validTestData
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
                                        authResponse: data,
                                        clientMetadata: [:])
@@ -570,14 +570,14 @@ class VerifyPasswordSRPTests: XCTestCase {
         let identityProviderFactory: CognitoFactory = {
             MockIdentityProvider(
                 mockRespondToAuthChallengeResponse: { _ in
-                    return RespondToAuthChallengeOutputResponse.testDataWithVerifyDevice()
+                    return RespondToAuthChallengeOutput.testDataWithVerifyDevice()
                 })
         }
 
         let environment = Defaults.makeDefaultAuthEnvironment(
             userPoolFactory: identityProviderFactory)
 
-        let data = InitiateAuthOutputResponse.validTestData
+        let data = InitiateAuthOutput.validTestData
         let action = VerifyPasswordSRP(stateData: SRPStateData.testData,
                                        authResponse: data,
                                        clientMetadata: [:])

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/RevokeTokenTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/RevokeTokenTests.swift
@@ -18,7 +18,7 @@ class RevokeTokenTests: XCTestCase {
             MockIdentityProvider(
                 mockRevokeTokenResponse: { _ in
                     revokeTokenInvoked.fulfill()
-                    return try await RevokeTokenOutputResponse(httpResponse: MockHttpResponse.ok)
+                    return try await RevokeTokenOutput(httpResponse: MockHttpResponse.ok)
                 }
             )
         }
@@ -92,7 +92,7 @@ class RevokeTokenTests: XCTestCase {
         let identityProviderFactory: BasicUserPoolEnvironment.CognitoUserPoolFactory = {
             MockIdentityProvider(
                 mockRevokeTokenResponse: { _ in
-                    return try await RevokeTokenOutputResponse(httpResponse: MockHttpResponse.ok)
+                    return try await RevokeTokenOutput(httpResponse: MockHttpResponse.ok)
                 }
             )
         }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/ShowHostedUISignOutTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/ShowHostedUISignOutTests.swift
@@ -379,7 +379,7 @@ class ShowHostedUISignOutTests: XCTestCase {
     private func identityProviderFactory() throws -> CognitoUserPoolBehavior {
         return MockIdentityProvider(
             mockInitiateAuthResponse: { _ in
-                return InitiateAuthOutputResponse(
+                return InitiateAuthOutput(
                     authenticationResult: .init(
                         accessToken: "accessTokenNew",
                         expiresIn: 100,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/SignOutGloballyTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/SignOutGloballyTests.swift
@@ -18,7 +18,7 @@ class SignOutGloballyTests: XCTestCase {
             MockIdentityProvider(
                 mockGlobalSignOutResponse: { _ in
                     globalSignOutInvoked.fulfill()
-                    return try await GlobalSignOutOutputResponse(httpResponse: MockHttpResponse.ok)
+                    return try await GlobalSignOutOutput(httpResponse: MockHttpResponse.ok)
                 }
             )
         }
@@ -88,7 +88,7 @@ class SignOutGloballyTests: XCTestCase {
         let identityProviderFactory: BasicUserPoolEnvironment.CognitoUserPoolFactory = {
             MockIdentityProvider(
                 mockGlobalSignOutResponse: { _ in
-                    return try await GlobalSignOutOutputResponse(httpResponse: MockHttpResponse.ok)
+                    return try await GlobalSignOutOutput(httpResponse: MockHttpResponse.ok)
                 }
             )
         }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/VerifySignInChallenge/VerifySignInChallengeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/VerifySignInChallenge/VerifySignInChallengeTests.swift
@@ -41,7 +41,7 @@ class VerifySignInChallengeTests: XCTestCase {
             MockIdentityProvider(
                 mockRespondToAuthChallengeResponse: { _ in
                     verifyPasswordInvoked.fulfill()
-                    return RespondToAuthChallengeOutputResponse()
+                    return RespondToAuthChallengeOutput()
                 })
         }
 
@@ -75,7 +75,7 @@ class VerifySignInChallengeTests: XCTestCase {
         let identityProviderFactory: CognitoFactory = {
             MockIdentityProvider(
                 mockRespondToAuthChallengeResponse: { _ in
-                    return RespondToAuthChallengeOutputResponse()
+                    return RespondToAuthChallengeOutput()
                 })
         }
 
@@ -124,7 +124,7 @@ class VerifySignInChallengeTests: XCTestCase {
         let identityProviderFactory: CognitoFactory = {
             MockIdentityProvider(
                 mockRespondToAuthChallengeResponse: { _ in
-                    return RespondToAuthChallengeOutputResponse.testData()
+                    return RespondToAuthChallengeOutput.testData()
                 })
         }
 
@@ -270,7 +270,7 @@ class VerifySignInChallengeTests: XCTestCase {
         let identityProviderFactory: CognitoFactory = {
             MockIdentityProvider(
                 mockRespondToAuthChallengeResponse: { _ in
-                    return RespondToAuthChallengeOutputResponse.testDataWithNewDevice()
+                    return RespondToAuthChallengeOutput.testDataWithNewDevice()
                 })
         }
 
@@ -314,7 +314,7 @@ class VerifySignInChallengeTests: XCTestCase {
         let identityProviderFactory: CognitoFactory = {
             MockIdentityProvider(
                 mockRespondToAuthChallengeResponse: { _ in
-                    return RespondToAuthChallengeOutputResponse.testDataWithVerifyDevice()
+                    return RespondToAuthChallengeOutput.testDataWithVerifyDevice()
                 })
         }
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/ClientSecretConfigurationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/ClientSecretConfigurationTests.swift
@@ -84,9 +84,9 @@ class ClientSecretConfigurationTests: XCTestCase {
             destination: "Amplify@amazon.com"
         )
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { request in
+            mockForgotPasswordOutput: { request in
                 XCTAssertNotNil(request.secretHash)
-                return ForgotPasswordOutputResponse(codeDeliveryDetails: codeDeliveryDetails)
+                return ForgotPasswordOutput(codeDeliveryDetails: codeDeliveryDetails)
             }
         )
         _ = try await plugin.resetPassword(for: "user", options: nil)
@@ -102,9 +102,9 @@ class ClientSecretConfigurationTests: XCTestCase {
     ///
     func testClientSecretWithConfirmResetPassword() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { request in
+            mockConfirmForgotPasswordOutput: { request in
                 XCTAssertNotNil(request.secretHash)
-                return try await ConfirmForgotPasswordOutputResponse(httpResponse: MockHttpResponse.ok)
+                return try await ConfirmForgotPasswordOutput(httpResponse: MockHttpResponse.ok)
             }
         )
         try await plugin.confirmResetPassword(
@@ -131,9 +131,9 @@ class ClientSecretConfigurationTests: XCTestCase {
             destination: nil
         )
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { request in
+            mockResendConfirmationCodeOutput: { request in
                 XCTAssertNotNil(request.secretHash)
-                return ResendConfirmationCodeOutputResponse(
+                return ResendConfirmationCodeOutput(
                     codeDeliveryDetails: codeDeliveryDetails
                 )
             }
@@ -243,10 +243,10 @@ class ClientSecretConfigurationTests: XCTestCase {
                 return .testData
             }, mockInitiateAuthResponse: { request in
                 XCTAssertNotNil(request.authParameters?["SECRET_HASH"])
-                return InitiateAuthOutputResponse(
+                return InitiateAuthOutput(
                     authenticationResult: .none,
                     challengeName: .passwordVerifier,
-                    challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                    challengeParameters: InitiateAuthOutput.validChalengeParams,
                     session: "someSession")
 
             }, mockGlobalSignOutResponse: { _ in
@@ -254,7 +254,7 @@ class ClientSecretConfigurationTests: XCTestCase {
 
             }, mockRespondToAuthChallengeResponse: { request in
                 XCTAssertNotNil(request.challengeResponses?["SECRET_HASH"])
-                return RespondToAuthChallengeOutputResponse(
+                return RespondToAuthChallengeOutput(
                     authenticationResult: .init(
                         accessToken: Defaults.validAccessToken,
                         expiresIn: 300,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/HubEventTests/AuthHubEventHandlerTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/HubEventTests/AuthHubEventHandlerTests.swift
@@ -308,13 +308,13 @@ class AuthHubEventHandlerTests: XCTestCase {
 
     private func configurePluginForSignInEvent() {
         let mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .init(
                     accessToken: Defaults.validAccessToken,
                     expiresIn: 300,
@@ -358,12 +358,12 @@ class AuthHubEventHandlerTests: XCTestCase {
 
         let mockIdentityProvider = MockIdentityProvider(
             mockRevokeTokenResponse: { _ in
-                try await RevokeTokenOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await RevokeTokenOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }, mockGlobalSignOutResponse: { _ in
-                try await GlobalSignOutOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await GlobalSignOutOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             },
-            mockDeleteUserOutputResponse: { _ in
-                try await DeleteUserOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+            mockDeleteUserOutput: { _ in
+                try await DeleteUserOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }
         )
 
@@ -380,10 +380,10 @@ class AuthHubEventHandlerTests: XCTestCase {
 
         let mockIdentityProvider = MockIdentityProvider(
             mockRevokeTokenResponse: { _ in
-                try await RevokeTokenOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await RevokeTokenOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             },
             mockGlobalSignOutResponse: { _ in
-                try await GlobalSignOutOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await GlobalSignOutOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }
         )
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockData/GlobalSignOutOutputResponse+Mock.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockData/GlobalSignOutOutputResponse+Mock.swift
@@ -8,9 +8,9 @@
 import Foundation
 import AWSCognitoIdentityProvider
 
-extension GlobalSignOutOutputResponse {
+extension GlobalSignOutOutput {
 
-    static var testData: GlobalSignOutOutputResponse {
+    static var testData: GlobalSignOutOutput {
         return .init()
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockData/RevokeTokenOutputResponse+Mock.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockData/RevokeTokenOutputResponse+Mock.swift
@@ -8,9 +8,9 @@
 import Foundation
 import AWSCognitoIdentityProvider
 
-extension RevokeTokenOutputResponse {
+extension RevokeTokenOutput {
 
-    static var testData: RevokeTokenOutputResponse {
+    static var testData: RevokeTokenOutput {
         return .init()
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/SRPTestData.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/SRPTestData.swift
@@ -23,52 +23,52 @@ extension SRPStateData {
     )
 }
 
-extension InitiateAuthOutputResponse {
-    static let testData = InitiateAuthOutputResponse(
+extension InitiateAuthOutput {
+    static let testData = InitiateAuthOutput(
         authenticationResult: .none,
         challengeName: .passwordVerifier,
         challengeParameters: nil,
         session: nil)
 
-    static let validTestData = InitiateAuthOutputResponse(
+    static let validTestData = InitiateAuthOutput(
         authenticationResult: .none,
         challengeName: .passwordVerifier,
-        challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+        challengeParameters: InitiateAuthOutput.validChalengeParams,
         session: "session")
 
-    static let invalidChallenge = InitiateAuthOutputResponse(
+    static let invalidChallenge = InitiateAuthOutput(
         authenticationResult: .none,
         challengeName: .passwordVerifier,
         challengeParameters: [:],
         session: nil)
 
-    static let invalidTestDataWithNoSalt = InitiateAuthOutputResponse(
+    static let invalidTestDataWithNoSalt = InitiateAuthOutput(
         authenticationResult: .none,
         challengeName: .passwordVerifier,
-        challengeParameters: InitiateAuthOutputResponse.invalidChalengeParamsNoSalt,
+        challengeParameters: InitiateAuthOutput.invalidChalengeParamsNoSalt,
         session: "session")
 
-    static let invalidTestDataWithNoSecretBlock = InitiateAuthOutputResponse(
+    static let invalidTestDataWithNoSecretBlock = InitiateAuthOutput(
         authenticationResult: .none,
         challengeName: .passwordVerifier,
-        challengeParameters: InitiateAuthOutputResponse.invalidChalengeParamsNoSecretBlock,
+        challengeParameters: InitiateAuthOutput.invalidChalengeParamsNoSecretBlock,
         session: "session")
 
-    static let invalidTestDataWithNoSRPB = InitiateAuthOutputResponse(
+    static let invalidTestDataWithNoSRPB = InitiateAuthOutput(
         authenticationResult: .none,
         challengeName: .passwordVerifier,
-        challengeParameters: InitiateAuthOutputResponse.invalidChalengeParamsNoSRPB,
+        challengeParameters: InitiateAuthOutput.invalidChalengeParamsNoSRPB,
         session: "session")
 
-    static let invalidTestDataForException = InitiateAuthOutputResponse(
+    static let invalidTestDataForException = InitiateAuthOutput(
         authenticationResult: .none,
         challengeName: .passwordVerifier,
-        challengeParameters: InitiateAuthOutputResponse.invalidChalengeParamsForException,
+        challengeParameters: InitiateAuthOutput.invalidChalengeParamsForException,
         session: "session")
 }
 
-extension RespondToAuthChallengeOutputResponse {
-    static func testData() -> RespondToAuthChallengeOutputResponse {
+extension RespondToAuthChallengeOutput {
+    static func testData() -> RespondToAuthChallengeOutput {
         let result = CognitoIdentityProviderClientTypes.AuthenticationResultType(
             accessToken: Defaults.validAccessToken,
             expiresIn: 3_600,
@@ -77,14 +77,14 @@ extension RespondToAuthChallengeOutputResponse {
             refreshToken: "refreshTokenXXX",
             tokenType: "Bearer")
 
-        return RespondToAuthChallengeOutputResponse(
+        return RespondToAuthChallengeOutput(
             authenticationResult: result,
             challengeName: .none,
             challengeParameters: [:],
             session: "session")
     }
 
-    static func testDataWithNewDevice() -> RespondToAuthChallengeOutputResponse {
+    static func testDataWithNewDevice() -> RespondToAuthChallengeOutput {
         let result = CognitoIdentityProviderClientTypes.AuthenticationResultType(
             accessToken: Defaults.validAccessToken,
             expiresIn: 3_600,
@@ -93,15 +93,15 @@ extension RespondToAuthChallengeOutputResponse {
             refreshToken: "refreshTokenXXX",
             tokenType: "Bearer")
 
-        return RespondToAuthChallengeOutputResponse(
+        return RespondToAuthChallengeOutput(
             authenticationResult: result,
             challengeName: .none,
             challengeParameters: [:],
             session: "session")
     }
 
-    static func testDataWithVerifyDevice() -> RespondToAuthChallengeOutputResponse {
-        return RespondToAuthChallengeOutputResponse(
+    static func testDataWithVerifyDevice() -> RespondToAuthChallengeOutput {
+        return RespondToAuthChallengeOutput(
             authenticationResult: nil,
             challengeName: .deviceSrpAuth,
             challengeParameters: [:],
@@ -110,8 +110,8 @@ extension RespondToAuthChallengeOutputResponse {
 
     static func testData(
         challenge: CognitoIdentityProviderClientTypes.ChallengeNameType = .smsMfa,
-        challengeParameters: [String: String] = [:]) -> RespondToAuthChallengeOutputResponse {
-            return RespondToAuthChallengeOutputResponse(
+        challengeParameters: [String: String] = [:]) -> RespondToAuthChallengeOutput {
+            return RespondToAuthChallengeOutput(
                 authenticationResult: nil,
                 challengeName: challenge,
                 challengeParameters: challengeParameters,
@@ -153,7 +153,7 @@ extension SignInEvent {
 
     static let respondPasswordVerifierEvent = SignInEvent(
         id: "respondPasswordVerifierEvent",
-        eventType: .respondPasswordVerifier(.testData, InitiateAuthOutputResponse.testData, [:])
+        eventType: .respondPasswordVerifier(.testData, InitiateAuthOutput.testData, [:])
     )
 
     static func finalizeSRPSignInEvent(signedInData: SignedInData) -> SignInEvent {
@@ -216,7 +216,7 @@ extension SRPStateData {
         clientTimestamp: Date(timeIntervalSinceReferenceDate: 656_187_908.969623)
     )
 }
-extension InitiateAuthOutputResponse {
+extension InitiateAuthOutput {
 
     static let invalidChalengeParamsNoSalt: [String: String] = [
         "SALT": "",

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockIdentity.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockIdentity.swift
@@ -11,10 +11,10 @@ import ClientRuntime
 
 struct MockIdentity: CognitoIdentityBehavior {
 
-    typealias MockGetIdResponse = (GetIdInput) async throws -> GetIdOutputResponse
+    typealias MockGetIdResponse = (GetIdInput) async throws -> GetIdOutput
 
     typealias MockGetCredentialsResponse = (GetCredentialsForIdentityInput) async throws
-    -> GetCredentialsForIdentityOutputResponse
+    -> GetCredentialsForIdentityOutput
 
     let mockGetIdResponse: MockGetIdResponse?
     let mockGetCredentialsResponse: MockGetCredentialsResponse?
@@ -25,11 +25,11 @@ struct MockIdentity: CognitoIdentityBehavior {
         self.mockGetCredentialsResponse = mockGetCredentialsResponse
     }
 
-    func getId(input: GetIdInput) async throws -> GetIdOutputResponse {
+    func getId(input: GetIdInput) async throws -> GetIdOutput {
         return try await mockGetIdResponse!(input)
     }
 
-    func getCredentialsForIdentity(input: GetCredentialsForIdentityInput) async throws -> GetCredentialsForIdentityOutputResponse {
+    func getCredentialsForIdentity(input: GetCredentialsForIdentityInput) async throws -> GetCredentialsForIdentityOutput {
         return try await mockGetCredentialsResponse!(input)
     }
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockIdentityProvider.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockIdentityProvider.swift
@@ -12,70 +12,70 @@ import ClientRuntime
 struct MockIdentityProvider: CognitoUserPoolBehavior {
 
     typealias MockSignUpResponse = (SignUpInput) async throws
-    -> SignUpOutputResponse
+    -> SignUpOutput
 
     typealias MockRevokeTokenResponse = (RevokeTokenInput) async throws
-    -> RevokeTokenOutputResponse
+    -> RevokeTokenOutput
 
     typealias MockInitiateAuthResponse = (InitiateAuthInput) async throws
-    -> InitiateAuthOutputResponse
+    -> InitiateAuthOutput
 
     typealias MockConfirmSignUpResponse = (ConfirmSignUpInput) async throws
-    -> ConfirmSignUpOutputResponse
+    -> ConfirmSignUpOutput
 
     typealias MockGlobalSignOutResponse = (GlobalSignOutInput) async throws
-    -> GlobalSignOutOutputResponse
+    -> GlobalSignOutOutput
 
     typealias MockRespondToAuthChallengeResponse = (RespondToAuthChallengeInput) async throws
-    -> RespondToAuthChallengeOutputResponse
+    -> RespondToAuthChallengeOutput
 
-    typealias MockGetUserAttributeVerificationCodeOutputResponse = (GetUserAttributeVerificationCodeInput) async throws
-    -> GetUserAttributeVerificationCodeOutputResponse
+    typealias MockGetUserAttributeVerificationCodeOutput = (GetUserAttributeVerificationCodeInput) async throws
+    -> GetUserAttributeVerificationCodeOutput
 
-    typealias MockGetUserAttributesOutputResponse = (GetUserInput) async throws
-    -> GetUserOutputResponse
+    typealias MockGetUserAttributesOutput = (GetUserInput) async throws
+    -> GetUserOutput
 
-    typealias MockUpdateUserAttributesOutputResponse = (UpdateUserAttributesInput) async throws
-    -> UpdateUserAttributesOutputResponse
+    typealias MockUpdateUserAttributesOutput = (UpdateUserAttributesInput) async throws
+    -> UpdateUserAttributesOutput
 
-    typealias MockConfirmUserAttributeOutputResponse = (VerifyUserAttributeInput) async throws
-    -> VerifyUserAttributeOutputResponse
+    typealias MockConfirmUserAttributeOutput = (VerifyUserAttributeInput) async throws
+    -> VerifyUserAttributeOutput
 
-    typealias MockChangePasswordOutputResponse = (ChangePasswordInput) async throws
-    -> ChangePasswordOutputResponse
+    typealias MockChangePasswordOutput = (ChangePasswordInput) async throws
+    -> ChangePasswordOutput
 
-    typealias MockResendConfirmationCodeOutputResponse = (ResendConfirmationCodeInput) async throws
-    -> ResendConfirmationCodeOutputResponse
+    typealias MockResendConfirmationCodeOutput = (ResendConfirmationCodeInput) async throws
+    -> ResendConfirmationCodeOutput
 
-    typealias MockForgotPasswordOutputResponse = (ForgotPasswordInput) async throws
-    -> ForgotPasswordOutputResponse
+    typealias MockForgotPasswordOutput = (ForgotPasswordInput) async throws
+    -> ForgotPasswordOutput
 
-    typealias MockDeleteUserOutputResponse = (DeleteUserInput) async throws
-    -> DeleteUserOutputResponse
+    typealias MockDeleteUserOutput = (DeleteUserInput) async throws
+    -> DeleteUserOutput
 
-    typealias MockConfirmForgotPasswordOutputResponse = (ConfirmForgotPasswordInput) async throws
-    -> ConfirmForgotPasswordOutputResponse
+    typealias MockConfirmForgotPasswordOutput = (ConfirmForgotPasswordInput) async throws
+    -> ConfirmForgotPasswordOutput
 
-    typealias MockListDevicesOutputResponse = (ListDevicesInput) async throws
-    -> ListDevicesOutputResponse
+    typealias MockListDevicesOutput = (ListDevicesInput) async throws
+    -> ListDevicesOutput
 
     typealias MockRememberDeviceResponse = (UpdateDeviceStatusInput) async throws
-    -> UpdateDeviceStatusOutputResponse
+    -> UpdateDeviceStatusOutput
 
     typealias MockForgetDeviceResponse = (ForgetDeviceInput) async throws
-    -> ForgetDeviceOutputResponse
+    -> ForgetDeviceOutput
 
     typealias MockConfirmDeviceResponse = (ConfirmDeviceInput) async throws
-    -> ConfirmDeviceOutputResponse
+    -> ConfirmDeviceOutput
 
     typealias MockSetUserMFAPreferenceResponse = (SetUserMFAPreferenceInput) async throws
-    -> SetUserMFAPreferenceOutputResponse
+    -> SetUserMFAPreferenceOutput
 
     typealias MockAssociateSoftwareTokenResponse = (AssociateSoftwareTokenInput) async throws
-    -> AssociateSoftwareTokenOutputResponse
+    -> AssociateSoftwareTokenOutput
 
     typealias MockVerifySoftwareTokenResponse = (VerifySoftwareTokenInput) async throws
-    -> VerifySoftwareTokenOutputResponse
+    -> VerifySoftwareTokenOutput
 
     let mockSignUpResponse: MockSignUpResponse?
     let mockRevokeTokenResponse: MockRevokeTokenResponse?
@@ -83,16 +83,16 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
     let mockGlobalSignOutResponse: MockGlobalSignOutResponse?
     let mockConfirmSignUpResponse: MockConfirmSignUpResponse?
     let mockRespondToAuthChallengeResponse: MockRespondToAuthChallengeResponse?
-    let mockGetUserAttributeVerificationCodeOutputResponse: MockGetUserAttributeVerificationCodeOutputResponse?
-    let mockGetUserAttributeResponse: MockGetUserAttributesOutputResponse?
-    let mockUpdateUserAttributeResponse: MockUpdateUserAttributesOutputResponse?
-    let mockConfirmUserAttributeOutputResponse: MockConfirmUserAttributeOutputResponse?
-    let mockChangePasswordOutputResponse: MockChangePasswordOutputResponse?
-    let mockResendConfirmationCodeOutputResponse: MockResendConfirmationCodeOutputResponse?
-    let mockDeleteUserOutputResponse: MockDeleteUserOutputResponse?
-    let mockForgotPasswordOutputResponse: MockForgotPasswordOutputResponse?
-    let mockConfirmForgotPasswordOutputResponse: MockConfirmForgotPasswordOutputResponse?
-    let mockListDevicesOutputResponse: MockListDevicesOutputResponse?
+    let mockGetUserAttributeVerificationCodeOutput: MockGetUserAttributeVerificationCodeOutput?
+    let mockGetUserAttributeResponse: MockGetUserAttributesOutput?
+    let mockUpdateUserAttributeResponse: MockUpdateUserAttributesOutput?
+    let mockConfirmUserAttributeOutput: MockConfirmUserAttributeOutput?
+    let mockChangePasswordOutput: MockChangePasswordOutput?
+    let mockResendConfirmationCodeOutput: MockResendConfirmationCodeOutput?
+    let mockDeleteUserOutput: MockDeleteUserOutput?
+    let mockForgotPasswordOutput: MockForgotPasswordOutput?
+    let mockConfirmForgotPasswordOutput: MockConfirmForgotPasswordOutput?
+    let mockListDevicesOutput: MockListDevicesOutput?
     let mockRememberDeviceResponse: MockRememberDeviceResponse?
     let mockForgetDeviceResponse: MockForgetDeviceResponse?
     let mockConfirmDeviceResponse: MockConfirmDeviceResponse?
@@ -107,16 +107,16 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
         mockGlobalSignOutResponse: MockGlobalSignOutResponse? = nil,
         mockConfirmSignUpResponse: MockConfirmSignUpResponse? = nil,
         mockRespondToAuthChallengeResponse: MockRespondToAuthChallengeResponse? = nil,
-        mockGetUserAttributeVerificationCodeOutputResponse: MockGetUserAttributeVerificationCodeOutputResponse? = nil,
-        mockGetUserAttributeResponse: MockGetUserAttributesOutputResponse? = nil,
-        mockUpdateUserAttributeResponse: MockUpdateUserAttributesOutputResponse? = nil,
-        mockConfirmUserAttributeOutputResponse: MockConfirmUserAttributeOutputResponse? = nil,
-        mockChangePasswordOutputResponse: MockChangePasswordOutputResponse? = nil,
-        mockResendConfirmationCodeOutputResponse: MockResendConfirmationCodeOutputResponse? = nil,
-        mockDeleteUserOutputResponse: MockDeleteUserOutputResponse? = nil,
-        mockForgotPasswordOutputResponse: MockForgotPasswordOutputResponse? = nil,
-        mockConfirmForgotPasswordOutputResponse: MockConfirmForgotPasswordOutputResponse? = nil,
-        mockListDevicesOutputResponse: MockListDevicesOutputResponse? = nil,
+        mockGetUserAttributeVerificationCodeOutput: MockGetUserAttributeVerificationCodeOutput? = nil,
+        mockGetUserAttributeResponse: MockGetUserAttributesOutput? = nil,
+        mockUpdateUserAttributeResponse: MockUpdateUserAttributesOutput? = nil,
+        mockConfirmUserAttributeOutput: MockConfirmUserAttributeOutput? = nil,
+        mockChangePasswordOutput: MockChangePasswordOutput? = nil,
+        mockResendConfirmationCodeOutput: MockResendConfirmationCodeOutput? = nil,
+        mockDeleteUserOutput: MockDeleteUserOutput? = nil,
+        mockForgotPasswordOutput: MockForgotPasswordOutput? = nil,
+        mockConfirmForgotPasswordOutput: MockConfirmForgotPasswordOutput? = nil,
+        mockListDevicesOutput: MockListDevicesOutput? = nil,
         mockRememberDeviceResponse: MockRememberDeviceResponse? = nil,
         mockForgetDeviceResponse: MockForgetDeviceResponse? = nil,
         mockConfirmDeviceResponse: MockConfirmDeviceResponse? = nil,
@@ -130,16 +130,16 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
         self.mockGlobalSignOutResponse = mockGlobalSignOutResponse
         self.mockConfirmSignUpResponse = mockConfirmSignUpResponse
         self.mockRespondToAuthChallengeResponse = mockRespondToAuthChallengeResponse
-        self.mockGetUserAttributeVerificationCodeOutputResponse = mockGetUserAttributeVerificationCodeOutputResponse
+        self.mockGetUserAttributeVerificationCodeOutput = mockGetUserAttributeVerificationCodeOutput
         self.mockGetUserAttributeResponse = mockGetUserAttributeResponse
         self.mockUpdateUserAttributeResponse = mockUpdateUserAttributeResponse
-        self.mockConfirmUserAttributeOutputResponse = mockConfirmUserAttributeOutputResponse
-        self.mockChangePasswordOutputResponse = mockChangePasswordOutputResponse
-        self.mockResendConfirmationCodeOutputResponse = mockResendConfirmationCodeOutputResponse
-        self.mockDeleteUserOutputResponse = mockDeleteUserOutputResponse
-        self.mockForgotPasswordOutputResponse = mockForgotPasswordOutputResponse
-        self.mockConfirmForgotPasswordOutputResponse = mockConfirmForgotPasswordOutputResponse
-        self.mockListDevicesOutputResponse = mockListDevicesOutputResponse
+        self.mockConfirmUserAttributeOutput = mockConfirmUserAttributeOutput
+        self.mockChangePasswordOutput = mockChangePasswordOutput
+        self.mockResendConfirmationCodeOutput = mockResendConfirmationCodeOutput
+        self.mockDeleteUserOutput = mockDeleteUserOutput
+        self.mockForgotPasswordOutput = mockForgotPasswordOutput
+        self.mockConfirmForgotPasswordOutput = mockConfirmForgotPasswordOutput
+        self.mockListDevicesOutput = mockListDevicesOutput
         self.mockRememberDeviceResponse = mockRememberDeviceResponse
         self.mockForgetDeviceResponse = mockForgetDeviceResponse
         self.mockConfirmDeviceResponse = mockConfirmDeviceResponse
@@ -149,98 +149,98 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
     }
 
     /// Throws InitiateAuthOutputError
-    func initiateAuth(input: InitiateAuthInput) async throws -> InitiateAuthOutputResponse {
+    func initiateAuth(input: InitiateAuthInput) async throws -> InitiateAuthOutput {
         return try await mockInitiateAuthResponse!(input)
     }
 
     /// Throws RespondToAuthChallengeOutputError
     func respondToAuthChallenge(
         input: RespondToAuthChallengeInput
-    ) async throws -> RespondToAuthChallengeOutputResponse {
+    ) async throws -> RespondToAuthChallengeOutput {
         return try await mockRespondToAuthChallengeResponse!(input)
     }
 
     /// Throws SignUpOutputError
-    func signUp(input: SignUpInput) async throws -> SignUpOutputResponse {
+    func signUp(input: SignUpInput) async throws -> SignUpOutput {
         return try await mockSignUpResponse!(input)
     }
 
     /// Throws ConfirmSignUpOutputError
-    func confirmSignUp(input: ConfirmSignUpInput) async throws -> ConfirmSignUpOutputResponse {
+    func confirmSignUp(input: ConfirmSignUpInput) async throws -> ConfirmSignUpOutput {
         return try await mockConfirmSignUpResponse!(input)
     }
 
     /// Throws GlobalSignOutOutputError
-    func globalSignOut(input: GlobalSignOutInput) async throws -> GlobalSignOutOutputResponse {
+    func globalSignOut(input: GlobalSignOutInput) async throws -> GlobalSignOutOutput {
         return try await mockGlobalSignOutResponse!(input)
     }
 
     /// Throws RevokeTokenOutputError
-    func revokeToken(input: RevokeTokenInput) async throws -> RevokeTokenOutputResponse {
+    func revokeToken(input: RevokeTokenInput) async throws -> RevokeTokenOutput {
         return try await mockRevokeTokenResponse!(input)
     }
 
-    func getUserAttributeVerificationCode(input: GetUserAttributeVerificationCodeInput) async throws -> GetUserAttributeVerificationCodeOutputResponse {
-        return try await mockGetUserAttributeVerificationCodeOutputResponse!(input)
+    func getUserAttributeVerificationCode(input: GetUserAttributeVerificationCodeInput) async throws -> GetUserAttributeVerificationCodeOutput {
+        return try await mockGetUserAttributeVerificationCodeOutput!(input)
     }
 
-    func getUser(input: GetUserInput) async throws -> GetUserOutputResponse {
+    func getUser(input: GetUserInput) async throws -> GetUserOutput {
         return try await mockGetUserAttributeResponse!(input)
     }
 
-    func updateUserAttributes(input: UpdateUserAttributesInput) async throws -> UpdateUserAttributesOutputResponse {
+    func updateUserAttributes(input: UpdateUserAttributesInput) async throws -> UpdateUserAttributesOutput {
         return try await mockUpdateUserAttributeResponse!(input)
     }
 
-    func verifyUserAttribute(input: VerifyUserAttributeInput) async throws -> VerifyUserAttributeOutputResponse {
-        return try await mockConfirmUserAttributeOutputResponse!(input)
+    func verifyUserAttribute(input: VerifyUserAttributeInput) async throws -> VerifyUserAttributeOutput {
+        return try await mockConfirmUserAttributeOutput!(input)
     }
 
-    func changePassword(input: ChangePasswordInput) async throws -> ChangePasswordOutputResponse {
-        return try await mockChangePasswordOutputResponse!(input)
+    func changePassword(input: ChangePasswordInput) async throws -> ChangePasswordOutput {
+        return try await mockChangePasswordOutput!(input)
     }
 
-    func resendConfirmationCode(input: ResendConfirmationCodeInput) async throws -> ResendConfirmationCodeOutputResponse {
-        return try await mockResendConfirmationCodeOutputResponse!(input)
+    func resendConfirmationCode(input: ResendConfirmationCodeInput) async throws -> ResendConfirmationCodeOutput {
+        return try await mockResendConfirmationCodeOutput!(input)
     }
 
-    func deleteUser(input: DeleteUserInput) async throws -> DeleteUserOutputResponse {
-        return try await mockDeleteUserOutputResponse!(input)
+    func deleteUser(input: DeleteUserInput) async throws -> DeleteUserOutput {
+        return try await mockDeleteUserOutput!(input)
     }
 
-    func forgotPassword(input: ForgotPasswordInput) async throws -> ForgotPasswordOutputResponse {
-        return try await mockForgotPasswordOutputResponse!(input)
+    func forgotPassword(input: ForgotPasswordInput) async throws -> ForgotPasswordOutput {
+        return try await mockForgotPasswordOutput!(input)
     }
 
-    func confirmForgotPassword(input: ConfirmForgotPasswordInput) async throws -> ConfirmForgotPasswordOutputResponse {
-        return try await mockConfirmForgotPasswordOutputResponse!(input)
+    func confirmForgotPassword(input: ConfirmForgotPasswordInput) async throws -> ConfirmForgotPasswordOutput {
+        return try await mockConfirmForgotPasswordOutput!(input)
     }
 
-    func listDevices(input: ListDevicesInput) async throws -> ListDevicesOutputResponse {
-        return try await mockListDevicesOutputResponse!(input)
+    func listDevices(input: ListDevicesInput) async throws -> ListDevicesOutput {
+        return try await mockListDevicesOutput!(input)
     }
 
-    func updateDeviceStatus(input: UpdateDeviceStatusInput) async throws -> UpdateDeviceStatusOutputResponse {
+    func updateDeviceStatus(input: UpdateDeviceStatusInput) async throws -> UpdateDeviceStatusOutput {
         return try await mockRememberDeviceResponse!(input)
     }
 
-    func forgetDevice(input: ForgetDeviceInput) async throws -> ForgetDeviceOutputResponse {
+    func forgetDevice(input: ForgetDeviceInput) async throws -> ForgetDeviceOutput {
         return try await mockForgetDeviceResponse!(input)
     }
 
-    func confirmDevice(input: ConfirmDeviceInput) async throws -> ConfirmDeviceOutputResponse {
+    func confirmDevice(input: ConfirmDeviceInput) async throws -> ConfirmDeviceOutput {
         return try await mockConfirmDeviceResponse!(input)
     }
 
-    func associateSoftwareToken(input: AWSCognitoIdentityProvider.AssociateSoftwareTokenInput) async throws -> AWSCognitoIdentityProvider.AssociateSoftwareTokenOutputResponse {
+    func associateSoftwareToken(input: AWSCognitoIdentityProvider.AssociateSoftwareTokenInput) async throws -> AWSCognitoIdentityProvider.AssociateSoftwareTokenOutput {
         return try await mockAssociateSoftwareTokenResponse!(input)
     }
 
-    func verifySoftwareToken(input: AWSCognitoIdentityProvider.VerifySoftwareTokenInput) async throws -> AWSCognitoIdentityProvider.VerifySoftwareTokenOutputResponse {
+    func verifySoftwareToken(input: AWSCognitoIdentityProvider.VerifySoftwareTokenInput) async throws -> AWSCognitoIdentityProvider.VerifySoftwareTokenOutput {
         return try await mockVerifySoftwareTokenResponse!(input)
     }
 
-    func setUserMFAPreference(input: SetUserMFAPreferenceInput) async throws -> SetUserMFAPreferenceOutputResponse {
+    func setUserMFAPreference(input: SetUserMFAPreferenceInput) async throws -> SetUserMFAPreferenceOutput {
         return try await mockSetUserMFAPreferenceResponse!(input)
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFetchSignInSessionOperationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFetchSignInSessionOperationTests.swift
@@ -95,7 +95,7 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
                 AmplifyCredentials.testData))
         let initAuth: MockIdentityProvider.MockInitiateAuthResponse = { _ in
             resultExpectation.fulfill()
-            return InitiateAuthOutputResponse(authenticationResult: .init(
+            return InitiateAuthOutput(authenticationResult: .init(
                 accessToken: "accessToken",
                 expiresIn: 1000,
                 idToken: "idToken",
@@ -259,7 +259,7 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
                 AmplifyCredentials.testDataWithExpiredTokens))
 
         let initAuth: MockIdentityProvider.MockInitiateAuthResponse = { _ in
-            return InitiateAuthOutputResponse(authenticationResult: .init(accessToken: "accessToken",
+            return InitiateAuthOutput(authenticationResult: .init(accessToken: "accessToken",
                                                                           expiresIn: 1000,
                                                                           idToken: "idToken",
                                                                           refreshToken: "refreshToke"))
@@ -493,7 +493,7 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
                 AmplifyCredentials.testDataWithExpiredTokens))
 
         let initAuth: MockIdentityProvider.MockInitiateAuthResponse = { _ in
-            return InitiateAuthOutputResponse(authenticationResult: .init(accessToken: nil,
+            return InitiateAuthOutput(authenticationResult: .init(accessToken: nil,
                                                                           expiresIn: 1000,
                                                                           idToken: "idToken",
                                                                           refreshToken: "refreshToke"))
@@ -546,14 +546,14 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
                 AmplifyCredentials.testDataWithExpiredTokens))
 
         let initAuth: MockIdentityProvider.MockInitiateAuthResponse = { _ in
-            return InitiateAuthOutputResponse(authenticationResult: .init(accessToken: "accessToken",
+            return InitiateAuthOutput(authenticationResult: .init(accessToken: "accessToken",
                                                                           expiresIn: 1000,
                                                                           idToken: "idToken",
                                                                           refreshToken: "refreshToke"))
         }
 
         let awsCredentials: MockIdentity.MockGetCredentialsResponse = { _ in
-            return GetCredentialsForIdentityOutputResponse(credentials: nil, identityId: "ss")
+            return GetCredentialsForIdentityOutput(credentials: nil, identityId: "ss")
         }
         let plugin = configurePluginWith(
             userPool: { MockIdentityProvider(mockInitiateAuthResponse: initAuth) },
@@ -608,7 +608,7 @@ class AWSAuthFetchSignInSessionOperationTests: BaseAuthorizationTests {
                                                                      expiration: Date(),
                                                                      secretKey: "secret",
                                                                      sessionToken: "session")
-            return GetCredentialsForIdentityOutputResponse(credentials: credentials,
+            return GetCredentialsForIdentityOutput(credentials: credentials,
                                                            identityId: "ss")
         }
         let plugin = configurePluginWith(

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AuthenticationProviderDeleteUserTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AuthenticationProviderDeleteUserTests.swift
@@ -20,12 +20,12 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
     func testDeleteUserSuccess() async {
         mockIdentityProvider = MockIdentityProvider(
             mockRevokeTokenResponse: { _ in
-                try await RevokeTokenOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await RevokeTokenOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }, mockGlobalSignOutResponse: { _ in
-                try await GlobalSignOutOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await GlobalSignOutOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             },
-            mockDeleteUserOutputResponse: { _ in
-                try await DeleteUserOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+            mockDeleteUserOutput: { _ in
+                try await DeleteUserOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }
         )
         do {
@@ -53,8 +53,8 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
             }, mockGlobalSignOutResponse: { _ in
                 throw AWSCognitoIdentityProvider.InternalErrorException()
             },
-            mockDeleteUserOutputResponse: { _ in
-                try await DeleteUserOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+            mockDeleteUserOutput: { _ in
+                try await DeleteUserOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }
         )
         do {
@@ -79,11 +79,11 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
     func testOfflineDeleteUser() async throws {
         mockIdentityProvider = MockIdentityProvider(
             mockRevokeTokenResponse: { _ in
-                try await RevokeTokenOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await RevokeTokenOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }, mockGlobalSignOutResponse: { _ in
-                try await GlobalSignOutOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await GlobalSignOutOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             },
-            mockDeleteUserOutputResponse: { _ in
+            mockDeleteUserOutput: { _ in
                 throw CommonRunTimeError.crtError(CRTError(code: 1059))
             }
         )
@@ -113,11 +113,11 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
     func testOfflineDeleteUserAndRetry() async throws {
         mockIdentityProvider = MockIdentityProvider(
             mockRevokeTokenResponse: { _ in
-                try await RevokeTokenOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await RevokeTokenOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }, mockGlobalSignOutResponse: { _ in
-                try await GlobalSignOutOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await GlobalSignOutOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             },
-            mockDeleteUserOutputResponse: { _ in
+            mockDeleteUserOutput: { _ in
                 throw CommonRunTimeError.crtError(CRTError(code: 1059))
             }
         )
@@ -134,12 +134,12 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
 
         mockIdentityProvider = MockIdentityProvider(
             mockRevokeTokenResponse: { _ in
-                try await RevokeTokenOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await RevokeTokenOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }, mockGlobalSignOutResponse: { _ in
-                try await GlobalSignOutOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await GlobalSignOutOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             },
-            mockDeleteUserOutputResponse: { _ in
-                try await DeleteUserOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+            mockDeleteUserOutput: { _ in
+                try await DeleteUserOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }
         )
         do {
@@ -165,11 +165,11 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
     func testDeleteUserInternalErrorException() async {
         mockIdentityProvider = MockIdentityProvider(
             mockRevokeTokenResponse: { _ in
-                try await RevokeTokenOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await RevokeTokenOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }, mockGlobalSignOutResponse: { _ in
-                try await GlobalSignOutOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await GlobalSignOutOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             },
-            mockDeleteUserOutputResponse: { _ in
+            mockDeleteUserOutput: { _ in
                 throw AWSClientRuntime.UnknownAWSHTTPServiceError(
                     httpResponse: .init(body: .empty, statusCode: .badRequest),
                     message: nil,
@@ -203,11 +203,11 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
     func testDeleteUserWithInvalidParameterException() async {
         mockIdentityProvider = MockIdentityProvider(
             mockRevokeTokenResponse: { _ in
-                try await RevokeTokenOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await RevokeTokenOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }, mockGlobalSignOutResponse: { _ in
-                try await GlobalSignOutOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await GlobalSignOutOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             },
-            mockDeleteUserOutputResponse: { _ in
+            mockDeleteUserOutput: { _ in
                 throw AWSCognitoIdentityProvider.InvalidParameterException()
             }
         )
@@ -237,11 +237,11 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
     func testDeleteUserWithNotAuthorizedException() async {
         mockIdentityProvider = MockIdentityProvider(
             mockRevokeTokenResponse: { _ in
-                try await RevokeTokenOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await RevokeTokenOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }, mockGlobalSignOutResponse: { _ in
-                try await GlobalSignOutOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await GlobalSignOutOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             },
-            mockDeleteUserOutputResponse: { _ in
+            mockDeleteUserOutput: { _ in
                 throw AWSCognitoIdentityProvider.NotAuthorizedException()
             }
         )
@@ -270,11 +270,11 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
     func testDeleteUserWithPasswordResetRequiredException() async {
         mockIdentityProvider = MockIdentityProvider(
             mockRevokeTokenResponse: { _ in
-                try await RevokeTokenOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await RevokeTokenOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }, mockGlobalSignOutResponse: { _ in
-                try await GlobalSignOutOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await GlobalSignOutOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             },
-            mockDeleteUserOutputResponse: { _ in
+            mockDeleteUserOutput: { _ in
                 throw AWSCognitoIdentityProvider.PasswordResetRequiredException()
             }
         )
@@ -304,11 +304,11 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
     func testDeleteUserWithResourceNotFoundException() async {
         mockIdentityProvider = MockIdentityProvider(
             mockRevokeTokenResponse: { _ in
-                try await RevokeTokenOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await RevokeTokenOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }, mockGlobalSignOutResponse: { _ in
-                try await GlobalSignOutOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await GlobalSignOutOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             },
-            mockDeleteUserOutputResponse: { _ in
+            mockDeleteUserOutput: { _ in
                 throw AWSCognitoIdentityProvider.ResourceNotFoundException()
             }
         )
@@ -338,11 +338,11 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
     func testDeleteUserWithTooManyRequestsException() async {
         mockIdentityProvider = MockIdentityProvider(
             mockRevokeTokenResponse: { _ in
-                try await RevokeTokenOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await RevokeTokenOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }, mockGlobalSignOutResponse: { _ in
-                try await GlobalSignOutOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await GlobalSignOutOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             },
-            mockDeleteUserOutputResponse: { _ in
+            mockDeleteUserOutput: { _ in
                 throw AWSCognitoIdentityProvider.TooManyRequestsException()
             }
         )
@@ -372,11 +372,11 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
     func testDeleteUserWithUserNotConfirmedException() async {
         mockIdentityProvider = MockIdentityProvider(
             mockRevokeTokenResponse: { _ in
-                try await RevokeTokenOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await RevokeTokenOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }, mockGlobalSignOutResponse: { _ in
-                try await GlobalSignOutOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await GlobalSignOutOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             },
-            mockDeleteUserOutputResponse: { _ in
+            mockDeleteUserOutput: { _ in
                 throw AWSCognitoIdentityProvider.UserNotConfirmedException()
             }
         )
@@ -407,11 +407,11 @@ class AuthenticationProviderDeleteUserTests: BasePluginTest {
     func testDeleteUserWithUserNotFoundException() async {
         mockIdentityProvider = MockIdentityProvider(
             mockRevokeTokenResponse: { _ in
-                try await RevokeTokenOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await RevokeTokenOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }, mockGlobalSignOutResponse: { _ in
-                try await GlobalSignOutOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+                try await GlobalSignOutOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             },
-            mockDeleteUserOutputResponse: { _ in
+            mockDeleteUserOutput: { _ in
                 throw AWSCognitoIdentityProvider.UserNotFoundException()
             }
         )

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/ClientBehaviorConfirmResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/ClientBehaviorConfirmResetPasswordTests.swift
@@ -20,8 +20,8 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     override func setUp() {
         super.setUp()
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
-                try await ConfirmForgotPasswordOutputResponse(httpResponse: MockHttpResponse.ok)
+            mockConfirmForgotPasswordOutput: { _ in
+                try await ConfirmForgotPasswordOutput(httpResponse: MockHttpResponse.ok)
             }
         )
     }
@@ -62,8 +62,8 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     ///
     func testSuccessfulConfirmResetPassword() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
-                try await ConfirmForgotPasswordOutputResponse(httpResponse: MockHttpResponse.ok)
+            mockConfirmForgotPasswordOutput: { _ in
+                try await ConfirmForgotPasswordOutput(httpResponse: MockHttpResponse.ok)
             }
         )
         try await plugin.confirmResetPassword(for: "username", with: "newpassword", confirmationCode: "code", options: nil)
@@ -80,8 +80,8 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithEmptyUserName() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
-                try await ConfirmForgotPasswordOutputResponse(httpResponse: MockHttpResponse.ok)
+            mockConfirmForgotPasswordOutput: { _ in
+                try await ConfirmForgotPasswordOutput(httpResponse: MockHttpResponse.ok)
             }
         )
         do {
@@ -106,10 +106,10 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithPluginOptions() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { request in
+            mockConfirmForgotPasswordOutput: { request in
                 XCTAssertNoThrow(request.clientMetadata)
                 XCTAssertEqual(request.clientMetadata?["key"], "value")
-                return try await ConfirmForgotPasswordOutputResponse(httpResponse: MockHttpResponse.ok)
+                return try await ConfirmForgotPasswordOutput(httpResponse: MockHttpResponse.ok)
             }
         )
         let pluginOptions = AWSAuthConfirmResetPasswordOptions(metadata: ["key": "value"])
@@ -130,8 +130,8 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithEmptyNewPassword() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
-                try await ConfirmForgotPasswordOutputResponse(httpResponse: MockHttpResponse.ok)
+            mockConfirmForgotPasswordOutput: { _ in
+                try await ConfirmForgotPasswordOutput(httpResponse: MockHttpResponse.ok)
             }
         )
         do {
@@ -157,7 +157,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithCodeMismatchException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
+            mockConfirmForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.CodeMismatchException(
                     message: "code mismatch"
                 )
@@ -190,7 +190,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithExpiredCodeException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
+            mockConfirmForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.ExpiredCodeException(
                     message: "code expired"
                 )
@@ -222,7 +222,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithInternalErrorException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
+            mockConfirmForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.InternalErrorException(
                     message: "internal error"
                 )
@@ -250,7 +250,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     ///
     func testConfirmResetPasswordWithInvalidLambdaResponseException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
+            mockConfirmForgotPasswordOutput: { _ in
                 throw try await AWSCognitoIdentityProvider.InvalidLambdaResponseException(
                      httpResponse: .init(body: .empty, statusCode: .accepted)
                 )
@@ -284,7 +284,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithInvalidParameterException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
+            mockConfirmForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.InvalidParameterException(
                     message: "invalid parameter"
                 )
@@ -318,7 +318,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithInvalidPasswordException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
+            mockConfirmForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.InvalidPasswordException(
                     message: "invalid password"
                 )
@@ -352,7 +352,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithLimitExceededException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
+            mockConfirmForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.LimitExceededException(
                     message: "limit exceeded"
                 )
@@ -386,7 +386,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithNotAuthorizedException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
+            mockConfirmForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.NotAuthorizedException(
                     message: "not authorized"
                 )
@@ -416,7 +416,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithResourceNotFoundException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
+            mockConfirmForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.ResourceNotFoundException(
                     message: "resource not found"
                 )
@@ -450,7 +450,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithTooManyFailedAttemptsException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
+            mockConfirmForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.TooManyFailedAttemptsException(
                     message: "too many failed attempts"
                 )
@@ -484,7 +484,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithTooManyRequestsException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
+            mockConfirmForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.TooManyRequestsException(
                     message: "too many requests"
                 )
@@ -518,7 +518,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithUnexpectedLambdaException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
+            mockConfirmForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.UnexpectedLambdaException(
                     message: "unexpected lambda"
                 )
@@ -552,7 +552,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithUserLambdaValidationException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
+            mockConfirmForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.UserLambdaValidationException(
                     message: "user lambda invalid"
                 )
@@ -586,7 +586,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithUserNotConfirmedException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
+            mockConfirmForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.UserNotConfirmedException(
                     message: "user not confirmed"
                 )
@@ -620,7 +620,7 @@ class ClientBehaviorConfirmResetPasswordTests: AWSCognitoAuthClientBehaviorTests
     func testConfirmResetPasswordWithUserNotFoundException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockConfirmForgotPasswordOutputResponse: { _ in
+            mockConfirmForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.UserNotFoundException(
                     message: "user not found"
                 )

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/ClientBehaviorResetPasswordTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/ClientBehaviorResetPasswordTests.swift
@@ -19,8 +19,8 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     override func setUp() {
         super.setUp()
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
-                ForgotPasswordOutputResponse(codeDeliveryDetails: .init())
+            mockForgotPasswordOutput: { _ in
+                ForgotPasswordOutput(codeDeliveryDetails: .init())
             }
         )
     }
@@ -64,8 +64,8 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
                                                                                              deliveryMedium: .email,
                                                                                              destination: "Amplify@amazon.com")
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
-                ForgotPasswordOutputResponse(codeDeliveryDetails: codeDeliveryDetails)
+            mockForgotPasswordOutput: { _ in
+                ForgotPasswordOutput(codeDeliveryDetails: codeDeliveryDetails)
             }
         )
         _ = try await plugin.resetPassword(for: "user", options: nil)
@@ -82,8 +82,8 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     func testResetPasswordWithNilCodeDeliveryDetails() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
-                ForgotPasswordOutputResponse(codeDeliveryDetails: nil)
+            mockForgotPasswordOutput: { _ in
+                ForgotPasswordOutput(codeDeliveryDetails: nil)
             }
         )
 
@@ -112,8 +112,8 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
                                                                                              deliveryMedium: .email,
                                                                                              destination: "Amplify@amazon.com")
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
-                ForgotPasswordOutputResponse(codeDeliveryDetails: codeDeliveryDetails)
+            mockForgotPasswordOutput: { _ in
+                ForgotPasswordOutput(codeDeliveryDetails: codeDeliveryDetails)
             }
         )
 
@@ -140,7 +140,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     func testResetPasswordWithCodeDeliveryFailureException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
+            mockForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.CodeDeliveryFailureException(
                     message: "Code delivery failure"
                 )
@@ -172,7 +172,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     func testResetPasswordWithInternalErrorException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
+            mockForgotPasswordOutput: { _ in
                 throw try await AWSCognitoIdentityProvider.InternalErrorException(
                     httpResponse: .init(body: .empty, statusCode: .accepted)
                 )
@@ -200,7 +200,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResetPasswordWithInvalidEmailRoleAccessPolicyException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
+            mockForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.InvalidEmailRoleAccessPolicyException(
                     message: "invalid email role"
                 )
@@ -232,7 +232,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResetPasswordWithInvalidLambdaResponseException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
+            mockForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.InvalidLambdaResponseException(
                     message: "Invalid lambda response"
                 )
@@ -266,7 +266,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     func testResetPasswordWithInvalidParameterException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
+            mockForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.InvalidParameterException(
                     message: "invalid parameter"
                 )
@@ -298,7 +298,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResetPasswordWithInvalidSmsRoleAccessPolicyException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
+            mockForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.InvalidSmsRoleAccessPolicyException(
                     message: "invalid sms role"
                 )
@@ -330,7 +330,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResetPasswordWithInvalidSmsRoleTrustRelationshipException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
+            mockForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.InvalidSmsRoleTrustRelationshipException(
                     message: "invalid sms role trust relationship"
                 )
@@ -364,7 +364,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     func testResetPasswordWithLimitExceededException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
+            mockForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.LimitExceededException(
                     message: "limit exceeded"
                 )
@@ -398,7 +398,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     func testResetPasswordWithNotAuthorizedException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
+            mockForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.NotAuthorizedException(
                     message: "not authorized"
                 )
@@ -428,7 +428,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     func testResetPasswordWithResourceNotFoundException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
+            mockForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.ResourceNotFoundException(
                     message: "resource not found"
                 )
@@ -462,7 +462,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     func testResetPasswordWithTooManyRequestsException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
+            mockForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.TooManyRequestsException(
                     message: "too many requests"
                 )
@@ -496,7 +496,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     func testResetPasswordWithUnexpectedLambdaException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
+            mockForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.UnexpectedLambdaException(
                     message: "unexpected lambda"
                 )
@@ -530,7 +530,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     func testResetPasswordWithUserLambdaValidationException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
+            mockForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.UserLambdaValidationException(
                     message: "user lambda validation exception"
                 )
@@ -565,7 +565,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     func testResetPasswordWithUserNotConfirmedException() {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
+            mockForgotPasswordOutput: { _ in
                 throw ForgotPasswordOutputError.userNotConfirmedException(UserNotConfirmedException(message: "user not confirmed"))
             }
         )
@@ -607,7 +607,7 @@ class ClientBehaviorResetPasswordTests: AWSCognitoAuthClientBehaviorTests {
     func testResetPasswordWithUserNotFoundException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockForgotPasswordOutputResponse: { _ in
+            mockForgotPasswordOutput: { _ in
                 throw AWSCognitoIdentityProvider.UserNotFoundException(
                     message: "user not found"
                 )

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInOptionsTestCase.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInOptionsTestCase.swift
@@ -20,13 +20,13 @@ class AWSAuthSignInOptionsTestCase: BasePluginTest {
     override func setUp() {
         super.setUp()
         mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .init(
                     accessToken: Defaults.validAccessToken,
                     expiresIn: 300,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInPluginTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInPluginTests.swift
@@ -31,14 +31,14 @@ class AWSAuthSignInPluginTests: BasePluginTest {
         let clientMetadata = ["somekey": "somevalue"]
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
             XCTAssertEqual(clientMetadata, input.clientMetadata)
-            return InitiateAuthOutputResponse(
+            return InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { input in
             XCTAssertEqual(clientMetadata, input.clientMetadata)
-            return RespondToAuthChallengeOutputResponse(
+            return RespondToAuthChallengeOutput(
                 authenticationResult: .init(
                     accessToken: Defaults.validAccessToken,
                     expiresIn: 300,
@@ -78,13 +78,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testSuccessfulSignInWithAuthFlow() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .init(
                     accessToken: Defaults.validAccessToken,
                     expiresIn: 300,
@@ -157,13 +157,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .init(
                     accessToken: Defaults.validAccessToken,
                     expiresIn: 300,
@@ -201,7 +201,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testSignInWithInvalidResult() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse()
+            InitiateAuthOutput()
         })
         let options = AuthSignInRequest.Options()
         do {
@@ -227,7 +227,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testSecondSignInAfterSignInWithInvalidResult() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse()
+            InitiateAuthOutput()
         })
         let options = AuthSignInRequest.Options()
         do {
@@ -235,13 +235,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             XCTFail("Should not receive a success response \(result)")
         } catch {
             self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-                InitiateAuthOutputResponse(
+                InitiateAuthOutput(
                     authenticationResult: .none,
                     challengeName: .passwordVerifier,
-                    challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                    challengeParameters: InitiateAuthOutput.validChalengeParams,
                     session: "someSession")
             }, mockRespondToAuthChallengeResponse: { _ in
-                RespondToAuthChallengeOutputResponse(
+                RespondToAuthChallengeOutput(
                     authenticationResult: .init(
                         accessToken: Defaults.validAccessToken,
                         expiresIn: 300,
@@ -275,13 +275,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testSignInWithNextStepSMS() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .none,
                 challengeName: .smsMfa,
                 challengeParameters: [:],
@@ -315,14 +315,14 @@ class AWSAuthSignInPluginTests: BasePluginTest {
         let clientMetadata = ["somekey": "somevalue"]
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
             XCTAssertEqual(clientMetadata, input.clientMetadata)
-            return InitiateAuthOutputResponse(
+            return InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { input in
             XCTAssertEqual(clientMetadata, input.clientMetadata)
-            return RespondToAuthChallengeOutputResponse(
+            return RespondToAuthChallengeOutput(
                 authenticationResult: .none,
                 challengeName: .customChallenge,
                 challengeParameters: ["paramKey": "value"],
@@ -363,13 +363,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testSMSMFAWithAdditionalInfo() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .none,
                 challengeName: .smsMfa,
                 challengeParameters: ["paramKey": "value"],
@@ -406,13 +406,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testSignInWithNextStepNewPassword() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .none,
                 challengeName: .newPasswordRequired,
                 challengeParameters: ["paramKey": "value"],
@@ -445,13 +445,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testNewPasswordWithAdditionalInfo() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .none,
                 challengeName: .newPasswordRequired,
                 challengeParameters: ["paramKey": "value"],
@@ -488,13 +488,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testSignInWithNextStepCustomChallenge() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .none,
                 challengeName: .customChallenge,
                 challengeParameters: ["paramKey": "value"],
@@ -527,13 +527,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testSignInWithNextStepUnknown() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .none,
                 challengeName: .sdkUnknown("no idea"),
                 challengeParameters: ["paramKey": "value"],
@@ -564,13 +564,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testSignInWithNextDeviceSRP() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .deviceSrpAuth,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .none,
                 challengeName: .devicePasswordVerifier,
                 challengeParameters: ["paramKey": "value"],
@@ -608,13 +608,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testSignInWithCustomAuthIncorrectCode() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .customChallenge,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .none,
                 challengeName: .smsMfa,
                 challengeParameters: ["paramKey": "value"],
@@ -648,13 +648,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testSignInWithNextStepTOTP() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .none,
                 challengeName: .softwareTokenMfa,
                 challengeParameters: ["paramKey": "value"],
@@ -677,13 +677,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testSignInWithNextStepSelectMFAType() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .none,
                 challengeName: .selectMfaType,
                 challengeParameters: ["MFAS_CAN_CHOOSE": "[\"SMS_MFA\",\"SOFTWARE_TOKEN_MFA\"]"],
@@ -708,13 +708,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testSignInWithNextStepSetupMFA() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .none,
                 challengeName: .mfaSetup,
                 challengeParameters: ["MFAS_CAN_SETUP": "[\"SMS_MFA\",\"SOFTWARE_TOKEN_MFA\"]"],
@@ -741,13 +741,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testSignInWithNextStepSetupMFAWithUnavailableMFAType() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .none,
                 challengeName: .mfaSetup,
                 challengeParameters: ["MFAS_CAN_SETUP": "[\"SMS_MFA\"]"],
@@ -1194,10 +1194,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testSignInWithAliasExistsException() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
             throw AWSCognitoIdentityProvider.AliasExistsException()
@@ -1229,10 +1229,10 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testSignInWithInvalidPasswordException() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
             throw AWSCognitoIdentityProvider.InvalidPasswordException()
@@ -1263,13 +1263,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
     func testRestartSignIn() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .none,
                 challengeName: .smsMfa,
                 challengeParameters: [:],
@@ -1287,13 +1287,13 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             }
             XCTAssertFalse(result.isSignedIn)
             self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-                InitiateAuthOutputResponse(
+                InitiateAuthOutput(
                     authenticationResult: .none,
                     challengeName: .passwordVerifier,
-                    challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                    challengeParameters: InitiateAuthOutput.validChalengeParams,
                     session: "someSession")
             }, mockRespondToAuthChallengeResponse: { _ in
-                RespondToAuthChallengeOutputResponse(
+                RespondToAuthChallengeOutput(
                     authenticationResult: .init(
                         accessToken: Defaults.validAccessToken,
                         expiresIn: 300,
@@ -1338,15 +1338,15 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             mockGetCredentialsResponse: getCredentials)
 
         self.mockIdentityProvider = MockIdentityProvider(mockRevokeTokenResponse: { _ in
-            RevokeTokenOutputResponse()
+            RevokeTokenOutput()
         }, mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .init(
                     accessToken: Defaults.validAccessToken,
                     expiresIn: 300,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/SignInSetUpTOTPTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/SignInSetUpTOTPTests.swift
@@ -29,10 +29,10 @@ class SignInSetUpTOTPTests: BasePluginTest {
     ///
     func testSuccessfulTOTPSetupChallenge() async {
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
-            return InitiateAuthOutputResponse(
+            return InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { input in
             return .testData(
@@ -63,13 +63,13 @@ class SignInSetUpTOTPTests: BasePluginTest {
     func testSignInWithNextStepSetupMFAWithUnavailableMFAType() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .none,
                 challengeName: .mfaSetup,
                 challengeParameters: ["MFAS_CAN_SETUP": "[\"SMS_MFA\"]"],
@@ -102,10 +102,10 @@ class SignInSetUpTOTPTests: BasePluginTest {
     ///
     func testSuccessfulTOTPSetupChallengeWithEmptyMFASCanSetup() async {
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
-            return InitiateAuthOutputResponse(
+            return InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
             session: "someSession")
         }, mockRespondToAuthChallengeResponse: { input in
             return .testData(
@@ -143,10 +143,10 @@ class SignInSetUpTOTPTests: BasePluginTest {
     func testSignInWithInvalidResult() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
-            return InitiateAuthOutputResponse(
+            return InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { input in
             return .testData(
@@ -183,10 +183,10 @@ class SignInSetUpTOTPTests: BasePluginTest {
     func testSecondSignInAfterSignInWithInvalidResult() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
-            return InitiateAuthOutputResponse(
+            return InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { input in
             return .testData(
@@ -201,10 +201,10 @@ class SignInSetUpTOTPTests: BasePluginTest {
             XCTFail("Should not receive a success response \(result)")
         } catch {
             self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
-                return InitiateAuthOutputResponse(
+                return InitiateAuthOutput(
                     authenticationResult: .none,
                     challengeName: .passwordVerifier,
-                    challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                    challengeParameters: InitiateAuthOutput.validChalengeParams,
                     session: "someSession")
             }, mockRespondToAuthChallengeResponse: { input in
                 return .testData(
@@ -244,10 +244,10 @@ class SignInSetUpTOTPTests: BasePluginTest {
     func testSignInWithInternalErrorException() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
-            return InitiateAuthOutputResponse(
+            return InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { input in
             return .testData(
@@ -282,10 +282,10 @@ class SignInSetUpTOTPTests: BasePluginTest {
     func testSignInWithInvalidParameterException() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
-            return InitiateAuthOutputResponse(
+            return InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { input in
             return .testData(
@@ -321,10 +321,10 @@ class SignInSetUpTOTPTests: BasePluginTest {
     func testSignInWithNotAuthorizedException() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
-            return InitiateAuthOutputResponse(
+            return InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { input in
             return .testData(
@@ -359,10 +359,10 @@ class SignInSetUpTOTPTests: BasePluginTest {
     func testSignInWithResourceNotFoundException() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
-            return InitiateAuthOutputResponse(
+            return InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { input in
             return .testData(
@@ -398,10 +398,10 @@ class SignInSetUpTOTPTests: BasePluginTest {
     func testSignInWithConcurrentModificationException() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
-            return InitiateAuthOutputResponse(
+            return InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { input in
             return .testData(
@@ -436,10 +436,10 @@ class SignInSetUpTOTPTests: BasePluginTest {
     func testSignInWithForbiddenException() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
-            return InitiateAuthOutputResponse(
+            return InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { input in
             return .testData(
@@ -474,10 +474,10 @@ class SignInSetUpTOTPTests: BasePluginTest {
     func testSignInWithSoftwareTokenMFANotFoundException() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
-            return InitiateAuthOutputResponse(
+            return InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { input in
             return .testData(
@@ -513,10 +513,10 @@ class SignInSetUpTOTPTests: BasePluginTest {
     func testSignInWithUnknownAWSHttpServiceError() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
-            return InitiateAuthOutputResponse(
+            return InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { input in
             return .testData(

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignUp/AWSAuthResendSignUpCodeAPITests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignUp/AWSAuthResendSignUpCodeAPITests.swift
@@ -19,8 +19,8 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
     override func setUp() {
         super.setUp()
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
-                ResendConfirmationCodeOutputResponse(codeDeliveryDetails: .init())
+            mockResendConfirmationCodeOutput: { _ in
+                ResendConfirmationCodeOutput(codeDeliveryDetails: .init())
             }
         )
     }
@@ -65,8 +65,8 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
                                                                                              deliveryMedium: .email,
                                                                                              destination: nil)
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
-                ResendConfirmationCodeOutputResponse(codeDeliveryDetails: codeDeliveryDetails)
+            mockResendConfirmationCodeOutput: { _ in
+                ResendConfirmationCodeOutput(codeDeliveryDetails: codeDeliveryDetails)
             }
         )
 
@@ -91,8 +91,8 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
                                                                                              deliveryMedium: .email,
                                                                                              destination: nil)
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
-                ResendConfirmationCodeOutputResponse(codeDeliveryDetails: codeDeliveryDetails)
+            mockResendConfirmationCodeOutput: { _ in
+                ResendConfirmationCodeOutput(codeDeliveryDetails: codeDeliveryDetails)
             }
         )
 
@@ -118,7 +118,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
     func testResendSignupCodeWithInvalidResult() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
+            mockResendConfirmationCodeOutput: { _ in
                 throw AuthError.unknown("Unknown error", nil)
             }
         )
@@ -147,7 +147,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
     func testResendSignupCodeWithCodeDeliveryFailureException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
+            mockResendConfirmationCodeOutput: { _ in
                 throw try await AWSCognitoIdentityProvider.CodeDeliveryFailureException(
                     httpResponse: .init(body: .empty, statusCode: .accepted)
                 )
@@ -178,7 +178,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResendSignupCodeWithInternalErrorException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
+            mockResendConfirmationCodeOutput: { _ in
                 throw AWSCognitoIdentityProvider.InternalErrorException(
                     message: "internal error"
                 )
@@ -206,7 +206,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResendSignupCodeWithInvalidEmailRoleAccessPolicyException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
+            mockResendConfirmationCodeOutput: { _ in
                 throw AWSCognitoIdentityProvider.InvalidEmailRoleAccessPolicyException(
                     message: "Invalid email role access policy"
                 )
@@ -238,7 +238,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResendSignupCodeWithinvalidSmsRoleAccessPolicyException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
+            mockResendConfirmationCodeOutput: { _ in
                 throw AWSCognitoIdentityProvider.InvalidSmsRoleAccessPolicyException(
                     message: "Invalid sms role access policy"
                 )
@@ -270,7 +270,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResendSignupCodeWithInvalidSmsRoleTrustRelationshipException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
+            mockResendConfirmationCodeOutput: { _ in
                 throw AWSCognitoIdentityProvider.InvalidSmsRoleTrustRelationshipException(
                     message: "Invalid sms role trust relationship"
                 )
@@ -302,7 +302,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResendSignupCodeWithInvalidLambdaResponseException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
+            mockResendConfirmationCodeOutput: { _ in
                 throw AWSCognitoIdentityProvider.InvalidLambdaResponseException(
                     message: "Invalid lambda response"
                 )
@@ -335,7 +335,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResendSignupCodeWithInvalidParameterException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
+            mockResendConfirmationCodeOutput: { _ in
                 throw AWSCognitoIdentityProvider.InvalidParameterException(
                     message: "invalid parameter"
                 )
@@ -368,7 +368,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResendSignupCodeWithLimitExceededException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
+            mockResendConfirmationCodeOutput: { _ in
                 throw AWSCognitoIdentityProvider.LimitExceededException(
                     message: "limit exceeded"
                 )
@@ -401,7 +401,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResendSignupCodeWithNotAuthorizedException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
+            mockResendConfirmationCodeOutput: { _ in
                 throw AWSCognitoIdentityProvider.NotAuthorizedException(
                     message: "not authorized"
                 )
@@ -430,7 +430,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResendSignupCodeWithResourceNotFoundException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
+            mockResendConfirmationCodeOutput: { _ in
                 throw AWSCognitoIdentityProvider.ResourceNotFoundException(
                     message: "resource not found"
                 )
@@ -463,7 +463,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResendSignupCodeWithTooManyRequestsException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
+            mockResendConfirmationCodeOutput: { _ in
                 throw AWSCognitoIdentityProvider.TooManyRequestsException(
                     message: "too many requests"
                 )
@@ -496,7 +496,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResendSignupCodeWithUnexpectedLambdaException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
+            mockResendConfirmationCodeOutput: { _ in
                 throw AWSCognitoIdentityProvider.UnexpectedLambdaException(
                     message: "unexpected lambda"
                 )
@@ -529,7 +529,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResendSignupCodeWithUserLambdaValidationException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
+            mockResendConfirmationCodeOutput: { _ in
                 throw AWSCognitoIdentityProvider.UserLambdaValidationException(
                     message: "user lambda validation exception"
                 )
@@ -562,7 +562,7 @@ class AWSAuthResendSignUpCodeAPITests: AWSCognitoAuthClientBehaviorTests {
     ///
     func testResendSignupCodeUpWithUserNotFoundException() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockResendConfirmationCodeOutputResponse: { _ in
+            mockResendConfirmationCodeOutput: { _ in
                 throw AWSCognitoIdentityProvider.UserNotFoundException(
                     message: "user not found"
                 )

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorFetchDevicesTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorFetchDevicesTests.swift
@@ -19,8 +19,8 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
     override func setUp() {
         super.setUp()
         mockIdentityProvider = MockIdentityProvider(
-            mockListDevicesOutputResponse: { _ in
-                try await ListDevicesOutputResponse(httpResponse: MockHttpResponse.ok)
+            mockListDevicesOutput: { _ in
+                try await ListDevicesOutput(httpResponse: MockHttpResponse.ok)
             }
         )
     }
@@ -35,8 +35,8 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
     ///
     func testFetchDevicesRequest() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockListDevicesOutputResponse: { _ in
-                ListDevicesOutputResponse(devices: [CognitoIdentityProviderClientTypes.DeviceType(deviceKey: "id")], paginationToken: nil)
+            mockListDevicesOutput: { _ in
+                ListDevicesOutput(devices: [CognitoIdentityProviderClientTypes.DeviceType(deviceKey: "id")], paginationToken: nil)
             }
         )
         let options = AuthFetchDevicesRequest.Options()
@@ -53,8 +53,8 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
     ///
     func testFetchDevicesRequestWithoutOptions() async throws {
         mockIdentityProvider = MockIdentityProvider(
-            mockListDevicesOutputResponse: { _ in
-                ListDevicesOutputResponse(devices: [CognitoIdentityProviderClientTypes.DeviceType(deviceKey: "id")], paginationToken: nil)
+            mockListDevicesOutput: { _ in
+                ListDevicesOutput(devices: [CognitoIdentityProviderClientTypes.DeviceType(deviceKey: "id")], paginationToken: nil)
             }
         )
         _ = try await plugin.fetchDevices()
@@ -71,8 +71,8 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
     func testSuccessfulListDevices() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockListDevicesOutputResponse: { _ in
-                ListDevicesOutputResponse(devices: [CognitoIdentityProviderClientTypes.DeviceType(deviceKey: "id")], paginationToken: nil)
+            mockListDevicesOutput: { _ in
+                ListDevicesOutput(devices: [CognitoIdentityProviderClientTypes.DeviceType(deviceKey: "id")], paginationToken: nil)
             }
         )
         let listDevicesResult = try await plugin.fetchDevices()
@@ -93,8 +93,8 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
     func testListDevicesWithInvalidResult() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockListDevicesOutputResponse: { _ in
-                ListDevicesOutputResponse(devices: nil, paginationToken: nil)
+            mockListDevicesOutput: { _ in
+                ListDevicesOutput(devices: nil, paginationToken: nil)
             }
         )
         do {
@@ -123,7 +123,7 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
     func testListDevicesWithInternalErrorException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockListDevicesOutputResponse: { _ in
+            mockListDevicesOutput: { _ in
                 throw try await AWSCognitoIdentityProvider.InternalErrorException(
                     httpResponse: .init(body: .empty, statusCode: .accepted)
                 )
@@ -153,7 +153,7 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
     func testListDevicesWithInvalidParameterException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockListDevicesOutputResponse: { _ in
+            mockListDevicesOutput: { _ in
                 throw AWSCognitoIdentityProvider.InvalidParameterException(
                     message: "invalid parameter"
                 )
@@ -187,7 +187,7 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
     func testListDevicesWithInvalidUserPoolConfigurationException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockListDevicesOutputResponse: { _ in
+            mockListDevicesOutput: { _ in
                 throw AWSCognitoIdentityProvider.InvalidUserPoolConfigurationException(
                     message: "invalid user poo configuration"
                 )
@@ -217,7 +217,7 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
     func testListDevicesWithNotAuthorizedException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockListDevicesOutputResponse: { _ in
+            mockListDevicesOutput: { _ in
                 throw AWSCognitoIdentityProvider.NotAuthorizedException(
                     message: "not authorized"
                 )
@@ -247,7 +247,7 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
     func testListDevicesWithPasswordResetRequiredException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockListDevicesOutputResponse: { _ in
+            mockListDevicesOutput: { _ in
                 throw AWSCognitoIdentityProvider.PasswordResetRequiredException(
                     message: "password reset required"
                 )
@@ -281,7 +281,7 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
     func testListDevicesWithResourceNotFoundException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockListDevicesOutputResponse: { _ in
+            mockListDevicesOutput: { _ in
                 throw AWSCognitoIdentityProvider.ResourceNotFoundException(
                     message: "resource not found"
                 )
@@ -315,7 +315,7 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
     func testListDevicesWithTooManyRequestsException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockListDevicesOutputResponse: { _ in
+            mockListDevicesOutput: { _ in
                 throw AWSCognitoIdentityProvider.TooManyRequestsException(
                     message: "too many requests"
                 )
@@ -349,7 +349,7 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
     func testListDevicesWithUserNotConfirmedException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockListDevicesOutputResponse: { _ in
+            mockListDevicesOutput: { _ in
                 throw AWSCognitoIdentityProvider.UserNotConfirmedException(
                     message: "user not confirmed"
                 )
@@ -383,7 +383,7 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
     func testListDevicesWithUserNotFoundException() async throws {
 
         mockIdentityProvider = MockIdentityProvider(
-            mockListDevicesOutputResponse: { _ in
+            mockListDevicesOutput: { _ in
                 throw AWSCognitoIdentityProvider.UserNotFoundException(
                     message: "user not found"
                 )

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorForgetDeviceTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorForgetDeviceTests.swift
@@ -20,7 +20,7 @@ class DeviceBehaviorForgetDeviceTests: BasePluginTest {
         super.setUp()
         mockIdentityProvider = MockIdentityProvider(
             mockForgetDeviceResponse: { _ in
-                try await ForgetDeviceOutputResponse(httpResponse: MockHttpResponse.ok)
+                try await ForgetDeviceOutput(httpResponse: MockHttpResponse.ok)
             }
         )
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorRememberDeviceTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorRememberDeviceTests.swift
@@ -20,7 +20,7 @@ class DeviceBehaviorRememberDeviceTests: BasePluginTest {
         super.setUp()
         mockIdentityProvider = MockIdentityProvider(
             mockRememberDeviceResponse: { _ in
-                try await UpdateDeviceStatusOutputResponse(
+                try await UpdateDeviceStatusOutput(
                     httpResponse: MockHttpResponse.ok
                 )
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
@@ -309,13 +309,13 @@ class AWSAuthHostedUISignInTests: XCTestCase {
     func testRestartSignInWithWebUI() async {
 
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
-            InitiateAuthOutputResponse(
+            InitiateAuthOutput(
                 authenticationResult: .none,
                 challengeName: .passwordVerifier,
-                challengeParameters: InitiateAuthOutputResponse.validChalengeParams,
+                challengeParameters: InitiateAuthOutput.validChalengeParams,
                 session: "someSession")
         }, mockRespondToAuthChallengeResponse: { _ in
-            RespondToAuthChallengeOutputResponse(
+            RespondToAuthChallengeOutput(
                 authenticationResult: .none,
                 challengeName: .smsMfa,
                 challengeParameters: [:],

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/AWSCognitoAuthUserBehaviorTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/AWSCognitoAuthUserBehaviorTests.swift
@@ -17,20 +17,20 @@ class AWSCognitoAuthUserBehaviorTests: BasePluginTest {
     override func setUp() {
         super.setUp()
         mockIdentityProvider = MockIdentityProvider(
-            mockGetUserAttributeVerificationCodeOutputResponse: { _ in
-                GetUserAttributeVerificationCodeOutputResponse()
+            mockGetUserAttributeVerificationCodeOutput: { _ in
+                GetUserAttributeVerificationCodeOutput()
             },
             mockGetUserAttributeResponse: { _ in
-                GetUserOutputResponse()
+                GetUserOutput()
             },
             mockUpdateUserAttributeResponse: { _ in
-                UpdateUserAttributesOutputResponse()
+                UpdateUserAttributesOutput()
             },
-            mockConfirmUserAttributeOutputResponse: { _ in
-                try await VerifyUserAttributeOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+            mockConfirmUserAttributeOutput: { _ in
+                try await VerifyUserAttributeOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             },
-            mockChangePasswordOutputResponse: { _ in
-                try await ChangePasswordOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+            mockChangePasswordOutput: { _ in
+                try await ChangePasswordOutput(httpResponse: .init(body: .empty, statusCode: .ok))
             }
         )
     }
@@ -45,7 +45,7 @@ class AWSCognitoAuthUserBehaviorTests: BasePluginTest {
     ///
     func testFetchUserAttributesRequest() async throws {
         mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeResponse: { _ in
-            GetUserOutputResponse(
+            GetUserOutput(
                 mfaOptions: [],
                 preferredMfaSetting: "",
                 userAttributes: [.init(name: "email", value: "Amplify@amazon.com")],
@@ -67,7 +67,7 @@ class AWSCognitoAuthUserBehaviorTests: BasePluginTest {
     ///
     func testFetchUserAttributesRequestWithoutOptions() async throws {
         mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeResponse: { _ in
-            GetUserOutputResponse(
+            GetUserOutput(
                 mfaOptions: [],
                 preferredMfaSetting: "",
                 userAttributes: [.init(name: "email", value: "Amplify@amazon.com")],
@@ -145,8 +145,8 @@ class AWSCognitoAuthUserBehaviorTests: BasePluginTest {
     ///    - I should get a valid task completion
     ///
     func testResendConfirmationCodeAttributeRequest() async throws {
-        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutputResponse: { _ in
-            GetUserAttributeVerificationCodeOutputResponse(
+        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutput: { _ in
+            GetUserAttributeVerificationCodeOutput(
                 codeDeliveryDetails: .init(
                     attributeName: "attributeName",
                     deliveryMedium: .email,
@@ -166,11 +166,11 @@ class AWSCognitoAuthUserBehaviorTests: BasePluginTest {
     ///    - I should get a valid task completion
     ///
     func testResendConfirmationCodeWithPluginOptions() async throws {
-        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutputResponse: { request in
+        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutput: { request in
 
             XCTAssertNotNil(request.clientMetadata)
             XCTAssertEqual(request.clientMetadata?["key"], "value")
-            return GetUserAttributeVerificationCodeOutputResponse(
+            return GetUserAttributeVerificationCodeOutput(
                 codeDeliveryDetails: .init(
                     attributeName: "attributeName",
                     deliveryMedium: .email,
@@ -190,8 +190,8 @@ class AWSCognitoAuthUserBehaviorTests: BasePluginTest {
     ///    - I should get a valid task completion
     ///
     func testResendConfirmationCodeAttributeRequestWithoutOptions() async throws {
-        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutputResponse: { _ in
-            GetUserAttributeVerificationCodeOutputResponse(
+        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutput: { _ in
+            GetUserAttributeVerificationCodeOutput(
                 codeDeliveryDetails: .init(
                     attributeName: "attributeName",
                     deliveryMedium: .email,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorChangePasswordTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorChangePasswordTests.swift
@@ -24,8 +24,8 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
     ///    - I should get a successful result
     ///
     func testSuccessfulChangePassword() async throws {
-        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutputResponse: { _ in
-            return try await ChangePasswordOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutput: { _ in
+            return try await ChangePasswordOutput(httpResponse: .init(body: .empty, statusCode: .ok))
         })
         try await plugin.update(oldPassword: "old password", to: "new password")
     }
@@ -40,7 +40,7 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
     ///
     func testChangePasswordWithInternalErrorException() async throws {
 
-        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutputResponse: { _ in
+        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutput: { _ in
             throw AWSCognitoIdentityProvider.InternalErrorException(
                 message: "internal error exception"
             )
@@ -68,7 +68,7 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
     ///
     func testChangePasswordWithInvalidParameterException() async throws {
 
-        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutputResponse: { _ in
+        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutput: { _ in
             throw AWSCognitoIdentityProvider.InvalidParameterException(
                 message: "invalid parameter exception"
             )
@@ -100,7 +100,7 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
     ///
     func testChangePasswordWithInvalidPasswordException() async throws {
 
-        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutputResponse: { _ in
+        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutput: { _ in
             throw AWSCognitoIdentityProvider.InvalidPasswordException(
                 message: "invalid password exception"
             )
@@ -132,7 +132,7 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
     ///
     func testChangePasswordWithLimitExceededException() async throws {
 
-        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutputResponse: { _ in
+        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutput: { _ in
             throw try await AWSCognitoIdentityProvider.LimitExceededException(
                 httpResponse: .init(body: .empty, statusCode: .accepted),
                 decoder: nil,
@@ -167,7 +167,7 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
     ///
     func testChangePasswordWithNotAuthorizedException() async throws {
 
-        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutputResponse: { _ in
+        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutput: { _ in
             throw AWSCognitoIdentityProvider.NotAuthorizedException(
                 message: "not authorized exception"
             )
@@ -195,7 +195,7 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
     ///
     func testChangePasswordWithPasswordResetRequiredException() async throws {
 
-        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutputResponse: { _ in
+        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutput: { _ in
             throw AWSCognitoIdentityProvider.PasswordResetRequiredException(
                 message: "password reset required exception"
             )
@@ -227,7 +227,7 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
     ///
     func testChangePasswordWithResourceNotFoundException() async throws {
 
-        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutputResponse: { _ in
+        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutput: { _ in
             throw AWSCognitoIdentityProvider.ResourceNotFoundException(
                 message: "resource not found exception"
             )
@@ -259,7 +259,7 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
     ///
     func testChangePasswordWithTooManyRequestsException() async throws {
 
-        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutputResponse: { _ in
+        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutput: { _ in
             throw AWSCognitoIdentityProvider.TooManyRequestsException(
                 message: "too many requests exception"
             )
@@ -291,7 +291,7 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
     ///
     func testChangePasswordWithUserNotConfirmedException() async throws {
 
-        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutputResponse: { _ in
+        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutput: { _ in
             throw AWSCognitoIdentityProvider.UserNotConfirmedException(
                 message: "user not confirmed exception"
             )
@@ -323,7 +323,7 @@ class UserBehaviorChangePasswordTests: BasePluginTest {
     ///
     func testChangePasswordWithUserNotFoundException() async throws {
 
-        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutputResponse: { _ in
+        self.mockIdentityProvider = MockIdentityProvider(mockChangePasswordOutput: { _ in
             throw AWSCognitoIdentityProvider.UserNotFoundException(
                 message: "user not found exception"
             )

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorConfirmAttributeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorConfirmAttributeTests.swift
@@ -22,8 +22,8 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
     ///    - I should get a successful result
     ///
     func testSuccessfulConfirmUpdateUserAttributes() async throws {
-        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutputResponse: { _ in
-            try await VerifyUserAttributeOutputResponse(httpResponse: .init(body: .empty, statusCode: .ok))
+        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutput: { _ in
+            try await VerifyUserAttributeOutput(httpResponse: .init(body: .empty, statusCode: .ok))
         })
         try await plugin.confirm(userAttribute: .email, confirmationCode: "code")
     }
@@ -40,7 +40,7 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
     ///    - I should get a .service error with .codeMismatch as underlyingError
     ///
     func testConfirmUpdateUserAttributesWithCodeMismatchException() async throws {
-        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutput: { _ in
             throw AWSCognitoIdentityProvider.CodeMismatchException()
         })
         do {
@@ -69,7 +69,7 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
     ///
     func testConfirmUpdateUserAttributesWithExpiredCodeException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutput: { _ in
             throw AWSCognitoIdentityProvider.ExpiredCodeException()
         })
         do {
@@ -97,7 +97,7 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
     ///
     func testcConfirmUpdateUserAttributesWithInternalErrorException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutput: { _ in
             throw try await AWSCognitoIdentityProvider.InternalErrorException(
                 httpResponse: .init(body: .empty, statusCode: .accepted),
                 decoder: nil,
@@ -128,7 +128,7 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
     ///
     func testConfirmUpdateUserAttributesWithInvalidParameterException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutput: { _ in
             throw AWSCognitoIdentityProvider.InvalidParameterException()
         })
         do {
@@ -158,7 +158,7 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
     ///
     func testConfirmUpdateUserAttributesWithLimitExceededException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutput: { _ in
             throw AWSCognitoIdentityProvider.LimitExceededException()
         })
         do {
@@ -188,7 +188,7 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
     ///
     func testConfirmUpdateUserAttributesWithNotAuthorizedException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutput: { _ in
             throw AWSCognitoIdentityProvider.NotAuthorizedException()
         })
         do {
@@ -214,7 +214,7 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
     ///
     func testConfirmUpdateUserAttributesWithPasswordResetRequiredException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutput: { _ in
             throw AWSCognitoIdentityProvider.PasswordResetRequiredException()
         })
         do {
@@ -244,7 +244,7 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
     ///
     func testConfirmUpdateUserAttributesWithResourceNotFoundException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutput: { _ in
             throw AWSCognitoIdentityProvider.ResourceNotFoundException()
         })
         do {
@@ -274,7 +274,7 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
     ///
     func testConfirmUpdateUserAttributesWithTooManyRequestsException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutput: { _ in
             throw AWSCognitoIdentityProvider.TooManyRequestsException()
         })
 
@@ -305,7 +305,7 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
     ///
     func testConfirmUpdateUserAttributesWithUserNotConfirmedException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutput: { _ in
             throw AWSCognitoIdentityProvider.UserNotConfirmedException()
         })
 
@@ -336,7 +336,7 @@ class UserBehaviorConfirmAttributeTests: BasePluginTest {
     ///
     func testConfirmUpdateUserAttributesWithUserNotFoundException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockConfirmUserAttributeOutput: { _ in
             throw AWSCognitoIdentityProvider.UserNotFoundException()
         })
         do {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorFetchAttributeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorFetchAttributeTests.swift
@@ -25,7 +25,7 @@ class UserBehaviorFetchAttributesTests: BasePluginTest {
     func testSuccessfulFetchUserAttributes() async throws {
 
         mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeResponse: { _ in
-            GetUserOutputResponse(
+            GetUserOutput(
                 mfaOptions: [],
                 preferredMfaSetting: "",
                 userAttributes: [.init(name: "email", value: "Amplify@amazon.com")],
@@ -50,7 +50,7 @@ class UserBehaviorFetchAttributesTests: BasePluginTest {
     func testFetchUserAttributesWithInvalidResult() async throws {
 
         mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeResponse: { _ in
-            GetUserOutputResponse()
+            GetUserOutput()
         })
         do {
             _ = try await plugin.fetchUserAttributes()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorResendCodeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorResendCodeTests.swift
@@ -25,8 +25,8 @@ class UserBehaviorResendCodeTests: BasePluginTest {
     ///
     func testSuccessfulResendConfirmationCode() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutputResponse: { _ in
-            GetUserAttributeVerificationCodeOutputResponse(
+        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutput: { _ in
+            GetUserAttributeVerificationCodeOutput(
                 codeDeliveryDetails: .init(
                     attributeName: "attributeName",
                     deliveryMedium: .email,
@@ -50,8 +50,8 @@ class UserBehaviorResendCodeTests: BasePluginTest {
     ///
     func testResendConfirmationCodeWithInvalidResult() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutputResponse: { _ in
-            GetUserAttributeVerificationCodeOutputResponse()
+        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutput: { _ in
+            GetUserAttributeVerificationCodeOutput()
         })
         do {
             _ = try await plugin.resendConfirmationCode(forUserAttributeKey: .email)
@@ -75,7 +75,7 @@ class UserBehaviorResendCodeTests: BasePluginTest {
     ///
     func testResendConfirmationCodeWithCodeMismatchException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutput: { _ in
             throw try await AWSCognitoIdentityProvider.CodeDeliveryFailureException(
                 httpResponse: .init(body: .empty, statusCode: .accepted),
                 decoder: nil,
@@ -108,7 +108,7 @@ class UserBehaviorResendCodeTests: BasePluginTest {
     ///
     func testResendConfirmationCodeWithInternalErrorException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutput: { _ in
             throw AWSCognitoIdentityProvider.InternalErrorException()
         })
         do {
@@ -134,7 +134,7 @@ class UserBehaviorResendCodeTests: BasePluginTest {
     ///
     func testResendConfirmationCodeWithInvalidParameterException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutput: { _ in
             throw AWSCognitoIdentityProvider.InvalidParameterException()
         })
         do {
@@ -164,7 +164,7 @@ class UserBehaviorResendCodeTests: BasePluginTest {
     ///
     func testResendConfirmationCodeWithLimitExceededException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutput: { _ in
             throw AWSCognitoIdentityProvider.LimitExceededException()
         })
 
@@ -195,7 +195,7 @@ class UserBehaviorResendCodeTests: BasePluginTest {
     ///
     func testResendConfirmationCodeWithNotAuthorizedException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutput: { _ in
             throw AWSCognitoIdentityProvider.NotAuthorizedException()
         })
         do {
@@ -221,7 +221,7 @@ class UserBehaviorResendCodeTests: BasePluginTest {
     ///
     func testResendConfirmationCodeWithPasswordResetRequiredException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutput: { _ in
             throw AWSCognitoIdentityProvider.PasswordResetRequiredException()
         })
         do {
@@ -251,7 +251,7 @@ class UserBehaviorResendCodeTests: BasePluginTest {
     ///
     func testResendConfirmationCodeWithResourceNotFoundException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutput: { _ in
             throw AWSCognitoIdentityProvider.ResourceNotFoundException()
         })
         do {
@@ -281,7 +281,7 @@ class UserBehaviorResendCodeTests: BasePluginTest {
     ///
     func testResendConfirmationCodeWithTooManyRequestsException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutput: { _ in
             throw AWSCognitoIdentityProvider.TooManyRequestsException()
         })
         do {
@@ -311,7 +311,7 @@ class UserBehaviorResendCodeTests: BasePluginTest {
     ///
     func testResendConfirmationCodeWithUserNotConfirmedException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutput: { _ in
             throw AWSCognitoIdentityProvider.UserNotConfirmedException()
         })
         do {
@@ -341,7 +341,7 @@ class UserBehaviorResendCodeTests: BasePluginTest {
     ///
     func testResendConfirmationCodeWithUserNotFoundException() async throws {
 
-        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutputResponse: { _ in
+        mockIdentityProvider = MockIdentityProvider(mockGetUserAttributeVerificationCodeOutput: { _ in
             throw AWSCognitoIdentityProvider.UserNotFoundException()
         })
         do {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorUpdateAttributeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/UserBehaviorUpdateAttributeTests.swift
@@ -25,7 +25,7 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
     func testSuccessfulUpdateUserAttributes() async throws {
 
         mockIdentityProvider = MockIdentityProvider(mockUpdateUserAttributeResponse: { _ in
-            UpdateUserAttributesOutputResponse(codeDeliveryDetailsList: [
+            UpdateUserAttributesOutput(codeDeliveryDetailsList: [
                 .init(attributeName: "attributeName",
                       deliveryMedium: .email,
                       destination: "destination")])
@@ -49,7 +49,7 @@ class UserBehaviorUpdateAttributesTests: BasePluginTest {
     func testUpdateUserAttributesWithEmptyResult() async throws {
 
         mockIdentityProvider = MockIdentityProvider(mockUpdateUserAttributeResponse: { _ in
-            UpdateUserAttributesOutputResponse()
+            UpdateUserAttributesOutput()
         })
         _ = try await plugin.update(userAttribute: AuthUserAttribute(.email, value: "Amplify@amazon.com"))
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/ChangePasswordOutputResponse+Codable.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/ChangePasswordOutputResponse+Codable.swift
@@ -8,7 +8,7 @@
 import AWSCognitoIdentityProvider
 import ClientRuntime
 
-extension ChangePasswordOutputResponse: Codable {
+extension ChangePasswordOutput: Codable {
 
     enum CodingKeys: String, CodingKey {
         case httpResponse = "httpResponse"

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/ConfirmDeviceOutputResponse+Codable.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/ConfirmDeviceOutputResponse+Codable.swift
@@ -8,7 +8,7 @@
 import AWSCognitoIdentityProvider
 import ClientRuntime
 
-extension ConfirmDeviceOutputResponse: Codable {
+extension ConfirmDeviceOutput: Codable {
 
     enum CodingKeys: Swift.String, Swift.CodingKey {
         case userConfirmationNecessary = "UserConfirmationNecessary"

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/DeleteUserOutputResponse+Codable.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/DeleteUserOutputResponse+Codable.swift
@@ -8,7 +8,7 @@
 import AWSCognitoIdentityProvider
 import ClientRuntime
 
-extension DeleteUserOutputResponse: Codable {
+extension DeleteUserOutput: Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         self.init()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/ForgotPasswordOutputResponse+Codable.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/ForgotPasswordOutputResponse+Codable.swift
@@ -8,7 +8,7 @@
 import AWSCognitoIdentityProvider
 import ClientRuntime
 
-extension ForgotPasswordOutputResponse: Codable {
+extension ForgotPasswordOutput: Codable {
 
     enum CodingKeys: Swift.String, Swift.CodingKey {
         case codeDeliveryDetails = "CodeDeliveryDetails"

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/GetCredentialsForIdentityOutputResponse+Codable.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/GetCredentialsForIdentityOutputResponse+Codable.swift
@@ -8,7 +8,7 @@
 import AWSCognitoIdentity
 import ClientRuntime
 
-extension GetCredentialsForIdentityOutputResponse: Codable {
+extension GetCredentialsForIdentityOutput: Codable {
     enum CodingKeys: Swift.String, Swift.CodingKey {
         case credentials = "Credentials"
         case identityId = "IdentityId"

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/GetIdOutputResponse+Codable.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/GetIdOutputResponse+Codable.swift
@@ -8,7 +8,7 @@
 import AWSCognitoIdentity
 import ClientRuntime
 
-extension GetIdOutputResponse: Codable {
+extension GetIdOutput: Codable {
     enum CodingKeys: Swift.String, Swift.CodingKey {
         case identityId = "IdentityId"
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/GlobalSignOutOutputResponse+Codable.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/GlobalSignOutOutputResponse+Codable.swift
@@ -8,7 +8,7 @@
 import AWSCognitoIdentityProvider
 import ClientRuntime
 
-extension GlobalSignOutOutputResponse: Codable {
+extension GlobalSignOutOutput: Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         self.init()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/InitiateAuthOutputResponse+Codable.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/InitiateAuthOutputResponse+Codable.swift
@@ -8,7 +8,7 @@
 import AWSCognitoIdentityProvider
 import ClientRuntime
 
-extension InitiateAuthOutputResponse: Codable {
+extension InitiateAuthOutput: Codable {
 
     enum CodingKeys: Swift.String, Swift.CodingKey {
         case authenticationResult = "AuthenticationResult"

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/RespondToAuthChallengeOutputResponse+Codable.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/RespondToAuthChallengeOutputResponse+Codable.swift
@@ -8,7 +8,7 @@
 import AWSCognitoIdentityProvider
 import ClientRuntime
 
-extension RespondToAuthChallengeOutputResponse: Codable {
+extension RespondToAuthChallengeOutput: Codable {
     enum CodingKeys: Swift.String, Swift.CodingKey {
         case authenticationResult = "AuthenticationResult"
         case challengeName = "ChallengeName"

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/RevokeTokenOutputResponse+Codable.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/RevokeTokenOutputResponse+Codable.swift
@@ -8,7 +8,7 @@
 import AWSCognitoIdentityProvider
 import ClientRuntime
 
-extension RevokeTokenOutputResponse: Codable {
+extension RevokeTokenOutput: Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         self.init()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/SignUpOutputResponse+Codable.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/SignUpOutputResponse+Codable.swift
@@ -8,7 +8,7 @@
 import AWSCognitoIdentityProvider
 import ClientRuntime
 
-extension SignUpOutputResponse: Codable {
+extension SignUpOutput: Codable {
     enum CodingKeys: Swift.String, Swift.CodingKey {
         case codeDeliveryDetails = "CodeDeliveryDetails"
         case userConfirmed = "UserConfirmed"

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/Mocks/AuthTestHarnessInput+MockIdentityProvider.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/Mocks/AuthTestHarnessInput+MockIdentityProvider.swift
@@ -87,11 +87,11 @@ extension AuthTestHarnessInput {
                 case .failure(let error):
                     throw error
                 }
-            }, mockChangePasswordOutputResponse: { input in
+            }, mockChangePasswordOutput: { input in
                 fatalError()
                 //                    XCTAssertEqual(input, self.featureSpecification.cognitoService.changePassword.input)
                 //                    return self.featureSpecification.cognitoService.changePassword.response
-            }, mockDeleteUserOutputResponse: { input in
+            }, mockDeleteUserOutput: { input in
                 guard case .deleteUser(let apiData) = cognitoAPI[.deleteUser] else {
                     fatalError("Missing input")
                 }
@@ -101,7 +101,7 @@ extension AuthTestHarnessInput {
                 case .failure(let error):
                     throw error
                 }
-            }, mockForgotPasswordOutputResponse: { input in
+            }, mockForgotPasswordOutput: { input in
                 guard case .forgotPassword(let apiData) = cognitoAPI[.forgotPassword] else {
                     fatalError("Missing input")
                 }

--- a/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/Dependency/AWSLocationAdapter.swift
+++ b/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/Dependency/AWSLocationAdapter.swift
@@ -33,11 +33,11 @@ class AWSLocationAdapter: AWSLocationBehavior {
         location
     }
 
-    func searchPlaceIndex(forText: SearchPlaceIndexForTextInput) async throws -> SearchPlaceIndexForTextOutputResponse {
+    func searchPlaceIndex(forText: SearchPlaceIndexForTextInput) async throws -> SearchPlaceIndexForTextOutput {
         return try await location.searchPlaceIndexForText(input: forText)
     }
 
-    func searchPlaceIndex(forPosition: SearchPlaceIndexForPositionInput) async throws -> SearchPlaceIndexForPositionOutputResponse {
+    func searchPlaceIndex(forPosition: SearchPlaceIndexForPositionInput) async throws -> SearchPlaceIndexForPositionOutput {
         return try await location.searchPlaceIndexForPosition(input: forPosition)
     }
 }

--- a/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/Dependency/AWSLocationBehavior.swift
+++ b/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/Dependency/AWSLocationBehavior.swift
@@ -16,8 +16,8 @@ protocol AWSLocationBehavior {
     func getEscapeHatch() -> LocationClient
 
     func searchPlaceIndex(forText: SearchPlaceIndexForTextInput)
-            async throws -> SearchPlaceIndexForTextOutputResponse
+            async throws -> SearchPlaceIndexForTextOutput
 
     func searchPlaceIndex(forPosition: SearchPlaceIndexForPositionInput)
-            async throws -> SearchPlaceIndexForPositionOutputResponse
+            async throws -> SearchPlaceIndexForPositionOutput
 }

--- a/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Mocks/MockAWSLocation+ClientBehavior.swift
+++ b/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Mocks/MockAWSLocation+ClientBehavior.swift
@@ -12,35 +12,35 @@ import Foundation
 extension MockAWSLocation {
 
     public func searchPlaceIndex(forText: SearchPlaceIndexForTextInput,
-                                 completionHandler: ((SearchPlaceIndexForTextOutputResponse?,
+                                 completionHandler: ((SearchPlaceIndexForTextOutput?,
                                                       Error?) -> Void)?) {
         searchPlaceIndexForTextCalled += 1
         searchPlaceIndexForTextRequest = forText
         if let completionHandler = completionHandler {
-            completionHandler(SearchPlaceIndexForTextOutputResponse(), nil)
+            completionHandler(SearchPlaceIndexForTextOutput(), nil)
         }
     }
 
     public func searchPlaceIndex(forPosition: SearchPlaceIndexForPositionInput,
-                                 completionHandler: ((SearchPlaceIndexForPositionOutputResponse?,
+                                 completionHandler: ((SearchPlaceIndexForPositionOutput?,
                                                       Error?) -> Void)?) {
         searchPlaceIndexForPositionCalled += 1
         searchPlaceIndexForPositionRequest = forPosition
         if let completionHandler = completionHandler {
-            completionHandler(SearchPlaceIndexForPositionOutputResponse(), nil)
+            completionHandler(SearchPlaceIndexForPositionOutput(), nil)
         }
     }
 
-    public func searchPlaceIndex(forText: SearchPlaceIndexForTextInput) async throws -> SearchPlaceIndexForTextOutputResponse {
+    public func searchPlaceIndex(forText: SearchPlaceIndexForTextInput) async throws -> SearchPlaceIndexForTextOutput {
         searchPlaceIndexForTextCalled += 1
         searchPlaceIndexForTextRequest = forText
-        return SearchPlaceIndexForTextOutputResponse()
+        return SearchPlaceIndexForTextOutput()
     }
 
-    public func searchPlaceIndex(forPosition: SearchPlaceIndexForPositionInput) async throws -> SearchPlaceIndexForPositionOutputResponse {
+    public func searchPlaceIndex(forPosition: SearchPlaceIndexForPositionInput) async throws -> SearchPlaceIndexForPositionOutput {
         searchPlaceIndexForPositionCalled += 1
         searchPlaceIndexForPositionRequest = forPosition
-        return SearchPlaceIndexForPositionOutputResponse()
+        return SearchPlaceIndexForPositionOutput()
 
     }
 }

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/EventRecorder.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/EventRecorder.swift
@@ -140,7 +140,7 @@ actor EventRecorder: AnalyticsEventRecording {
         do {
             log.verbose("PutEventsInput: \(putEventsInput)")
             let response = try await pinpointClient.putEvents(input: putEventsInput)
-            log.verbose("PutEventsOutputResponse received: \(response)")
+            log.verbose("PutEventsOutput received: \(response)")
             guard let results = response.eventsResponse?.results else {
                 let errorMessage = "Unexpected response from server when attempting to submit events."
                 log.error(errorMessage)

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Extensions/SDKModels+AmplifyStringConvertible.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Extensions/SDKModels+AmplifyStringConvertible.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension PutEventsInput: AmplifyStringConvertible {}
 
-extension PutEventsOutputResponse: AmplifyStringConvertible {
+extension PutEventsOutput: AmplifyStringConvertible {
     enum CodingKeys: Swift.String, Swift.CodingKey {
         case eventsResponse = "EventsResponse"
     }
@@ -25,7 +25,7 @@ extension PutEventsOutputResponse: AmplifyStringConvertible {
 
 extension UpdateEndpointInput: AmplifyStringConvertible {}
 
-extension UpdateEndpointOutputResponse: AmplifyStringConvertible {
+extension UpdateEndpointOutput: AmplifyStringConvertible {
     enum CodingKeys: Swift.String, Swift.CodingKey {
         case messageBody = "MessageBody"
     }

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockPinpointClient.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockPinpointClient.swift
@@ -9,443 +9,443 @@ import AWSPinpoint
 import Foundation
 
 class MockPinpointClient: PinpointClientProtocol {
-    func getJourneyRunExecutionActivityMetrics(input: GetJourneyRunExecutionActivityMetricsInput) async throws -> GetJourneyRunExecutionActivityMetricsOutputResponse {
+    func getJourneyRunExecutionActivityMetrics(input: GetJourneyRunExecutionActivityMetricsInput) async throws -> GetJourneyRunExecutionActivityMetricsOutput {
         fatalError("Not supported")
     }
 
-    func getJourneyRunExecutionMetrics(input: GetJourneyRunExecutionMetricsInput) async throws -> GetJourneyRunExecutionMetricsOutputResponse {
+    func getJourneyRunExecutionMetrics(input: GetJourneyRunExecutionMetricsInput) async throws -> GetJourneyRunExecutionMetricsOutput {
         fatalError("Not supported")
     }
 
-    func getJourneyRuns(input: GetJourneyRunsInput) async throws -> GetJourneyRunsOutputResponse {
+    func getJourneyRuns(input: GetJourneyRunsInput) async throws -> GetJourneyRunsOutput {
         fatalError("Not supported")
     }
 
-    func createApp(input: CreateAppInput) async throws -> CreateAppOutputResponse {
+    func createApp(input: CreateAppInput) async throws -> CreateAppOutput {
         fatalError("Not supported")
     }
 
-    func createCampaign(input: CreateCampaignInput) async throws -> CreateCampaignOutputResponse {
+    func createCampaign(input: CreateCampaignInput) async throws -> CreateCampaignOutput {
         fatalError("Not supported")
     }
 
-    func createEmailTemplate(input: CreateEmailTemplateInput) async throws -> CreateEmailTemplateOutputResponse {
+    func createEmailTemplate(input: CreateEmailTemplateInput) async throws -> CreateEmailTemplateOutput {
         fatalError("Not supported")
     }
 
-    func createExportJob(input: CreateExportJobInput) async throws -> CreateExportJobOutputResponse {
+    func createExportJob(input: CreateExportJobInput) async throws -> CreateExportJobOutput {
         fatalError("Not supported")
     }
 
-    func createImportJob(input: CreateImportJobInput) async throws -> CreateImportJobOutputResponse {
+    func createImportJob(input: CreateImportJobInput) async throws -> CreateImportJobOutput {
         fatalError("Not supported")
     }
 
-    func createInAppTemplate(input: CreateInAppTemplateInput) async throws -> CreateInAppTemplateOutputResponse {
+    func createInAppTemplate(input: CreateInAppTemplateInput) async throws -> CreateInAppTemplateOutput {
         fatalError("Not supported")
     }
 
-    func createJourney(input: CreateJourneyInput) async throws -> CreateJourneyOutputResponse {
+    func createJourney(input: CreateJourneyInput) async throws -> CreateJourneyOutput {
         fatalError("Not supported")
     }
 
-    func createPushTemplate(input: CreatePushTemplateInput) async throws -> CreatePushTemplateOutputResponse {
+    func createPushTemplate(input: CreatePushTemplateInput) async throws -> CreatePushTemplateOutput {
         fatalError("Not supported")
     }
 
-    func createRecommenderConfiguration(input: CreateRecommenderConfigurationInput) async throws -> CreateRecommenderConfigurationOutputResponse {
+    func createRecommenderConfiguration(input: CreateRecommenderConfigurationInput) async throws -> CreateRecommenderConfigurationOutput {
         fatalError("Not supported")
     }
 
-    func createSegment(input: CreateSegmentInput) async throws -> CreateSegmentOutputResponse {
+    func createSegment(input: CreateSegmentInput) async throws -> CreateSegmentOutput {
         fatalError("Not supported")
     }
 
-    func createSmsTemplate(input: CreateSmsTemplateInput) async throws -> CreateSmsTemplateOutputResponse {
+    func createSmsTemplate(input: CreateSmsTemplateInput) async throws -> CreateSmsTemplateOutput {
         fatalError("Not supported")
     }
 
-    func createVoiceTemplate(input: CreateVoiceTemplateInput) async throws -> CreateVoiceTemplateOutputResponse {
+    func createVoiceTemplate(input: CreateVoiceTemplateInput) async throws -> CreateVoiceTemplateOutput {
         fatalError("Not supported")
     }
 
-    func deleteAdmChannel(input: DeleteAdmChannelInput) async throws -> DeleteAdmChannelOutputResponse {
+    func deleteAdmChannel(input: DeleteAdmChannelInput) async throws -> DeleteAdmChannelOutput {
         fatalError("Not supported")
     }
 
-    func deleteApnsChannel(input: DeleteApnsChannelInput) async throws -> DeleteApnsChannelOutputResponse {
+    func deleteApnsChannel(input: DeleteApnsChannelInput) async throws -> DeleteApnsChannelOutput {
         fatalError("Not supported")
     }
 
-    func deleteApnsSandboxChannel(input: DeleteApnsSandboxChannelInput) async throws -> DeleteApnsSandboxChannelOutputResponse {
+    func deleteApnsSandboxChannel(input: DeleteApnsSandboxChannelInput) async throws -> DeleteApnsSandboxChannelOutput {
         fatalError("Not supported")
     }
 
-    func deleteApnsVoipChannel(input: DeleteApnsVoipChannelInput) async throws -> DeleteApnsVoipChannelOutputResponse {
+    func deleteApnsVoipChannel(input: DeleteApnsVoipChannelInput) async throws -> DeleteApnsVoipChannelOutput {
         fatalError("Not supported")
     }
 
-    func deleteApnsVoipSandboxChannel(input: DeleteApnsVoipSandboxChannelInput) async throws -> DeleteApnsVoipSandboxChannelOutputResponse {
+    func deleteApnsVoipSandboxChannel(input: DeleteApnsVoipSandboxChannelInput) async throws -> DeleteApnsVoipSandboxChannelOutput {
         fatalError("Not supported")
     }
 
-    func deleteApp(input: DeleteAppInput) async throws -> DeleteAppOutputResponse {
+    func deleteApp(input: DeleteAppInput) async throws -> DeleteAppOutput {
         fatalError("Not supported")
     }
 
-    func deleteBaiduChannel(input: DeleteBaiduChannelInput) async throws -> DeleteBaiduChannelOutputResponse {
+    func deleteBaiduChannel(input: DeleteBaiduChannelInput) async throws -> DeleteBaiduChannelOutput {
         fatalError("Not supported")
     }
 
-    func deleteCampaign(input: DeleteCampaignInput) async throws -> DeleteCampaignOutputResponse {
+    func deleteCampaign(input: DeleteCampaignInput) async throws -> DeleteCampaignOutput {
         fatalError("Not supported")
     }
 
-    func deleteEmailChannel(input: DeleteEmailChannelInput) async throws -> DeleteEmailChannelOutputResponse {
+    func deleteEmailChannel(input: DeleteEmailChannelInput) async throws -> DeleteEmailChannelOutput {
         fatalError("Not supported")
     }
 
-    func deleteEmailTemplate(input: DeleteEmailTemplateInput) async throws -> DeleteEmailTemplateOutputResponse {
+    func deleteEmailTemplate(input: DeleteEmailTemplateInput) async throws -> DeleteEmailTemplateOutput {
         fatalError("Not supported")
     }
 
-    func deleteEndpoint(input: DeleteEndpointInput) async throws -> DeleteEndpointOutputResponse {
+    func deleteEndpoint(input: DeleteEndpointInput) async throws -> DeleteEndpointOutput {
         fatalError("Not supported")
     }
 
-    func deleteEventStream(input: DeleteEventStreamInput) async throws -> DeleteEventStreamOutputResponse {
+    func deleteEventStream(input: DeleteEventStreamInput) async throws -> DeleteEventStreamOutput {
         fatalError("Not supported")
     }
 
-    func deleteGcmChannel(input: DeleteGcmChannelInput) async throws -> DeleteGcmChannelOutputResponse {
+    func deleteGcmChannel(input: DeleteGcmChannelInput) async throws -> DeleteGcmChannelOutput {
         fatalError("Not supported")
     }
 
-    func deleteInAppTemplate(input: DeleteInAppTemplateInput) async throws -> DeleteInAppTemplateOutputResponse {
+    func deleteInAppTemplate(input: DeleteInAppTemplateInput) async throws -> DeleteInAppTemplateOutput {
         fatalError("Not supported")
     }
 
-    func deleteJourney(input: DeleteJourneyInput) async throws -> DeleteJourneyOutputResponse {
+    func deleteJourney(input: DeleteJourneyInput) async throws -> DeleteJourneyOutput {
         fatalError("Not supported")
     }
 
-    func deletePushTemplate(input: DeletePushTemplateInput) async throws -> DeletePushTemplateOutputResponse {
+    func deletePushTemplate(input: DeletePushTemplateInput) async throws -> DeletePushTemplateOutput {
         fatalError("Not supported")
     }
 
-    func deleteRecommenderConfiguration(input: DeleteRecommenderConfigurationInput) async throws -> DeleteRecommenderConfigurationOutputResponse {
+    func deleteRecommenderConfiguration(input: DeleteRecommenderConfigurationInput) async throws -> DeleteRecommenderConfigurationOutput {
         fatalError("Not supported")
     }
 
-    func deleteSegment(input: DeleteSegmentInput) async throws -> DeleteSegmentOutputResponse {
+    func deleteSegment(input: DeleteSegmentInput) async throws -> DeleteSegmentOutput {
         fatalError("Not supported")
     }
 
-    func deleteSmsChannel(input: DeleteSmsChannelInput) async throws -> DeleteSmsChannelOutputResponse {
+    func deleteSmsChannel(input: DeleteSmsChannelInput) async throws -> DeleteSmsChannelOutput {
         fatalError("Not supported")
     }
 
-    func deleteSmsTemplate(input: DeleteSmsTemplateInput) async throws -> DeleteSmsTemplateOutputResponse {
+    func deleteSmsTemplate(input: DeleteSmsTemplateInput) async throws -> DeleteSmsTemplateOutput {
         fatalError("Not supported")
     }
 
-    func deleteUserEndpoints(input: DeleteUserEndpointsInput) async throws -> DeleteUserEndpointsOutputResponse {
+    func deleteUserEndpoints(input: DeleteUserEndpointsInput) async throws -> DeleteUserEndpointsOutput {
         fatalError("Not supported")
     }
 
-    func deleteVoiceChannel(input: DeleteVoiceChannelInput) async throws -> DeleteVoiceChannelOutputResponse {
+    func deleteVoiceChannel(input: DeleteVoiceChannelInput) async throws -> DeleteVoiceChannelOutput {
         fatalError("Not supported")
     }
 
-    func deleteVoiceTemplate(input: DeleteVoiceTemplateInput) async throws -> DeleteVoiceTemplateOutputResponse {
+    func deleteVoiceTemplate(input: DeleteVoiceTemplateInput) async throws -> DeleteVoiceTemplateOutput {
         fatalError("Not supported")
     }
 
-    func getAdmChannel(input: GetAdmChannelInput) async throws -> GetAdmChannelOutputResponse {
+    func getAdmChannel(input: GetAdmChannelInput) async throws -> GetAdmChannelOutput {
         fatalError("Not supported")
     }
 
-    func getApnsChannel(input: GetApnsChannelInput) async throws -> GetApnsChannelOutputResponse {
+    func getApnsChannel(input: GetApnsChannelInput) async throws -> GetApnsChannelOutput {
         fatalError("Not supported")
     }
 
-    func getApnsSandboxChannel(input: GetApnsSandboxChannelInput) async throws -> GetApnsSandboxChannelOutputResponse {
+    func getApnsSandboxChannel(input: GetApnsSandboxChannelInput) async throws -> GetApnsSandboxChannelOutput {
         fatalError("Not supported")
     }
 
-    func getApnsVoipChannel(input: GetApnsVoipChannelInput) async throws -> GetApnsVoipChannelOutputResponse {
+    func getApnsVoipChannel(input: GetApnsVoipChannelInput) async throws -> GetApnsVoipChannelOutput {
         fatalError("Not supported")
     }
 
-    func getApnsVoipSandboxChannel(input: GetApnsVoipSandboxChannelInput) async throws -> GetApnsVoipSandboxChannelOutputResponse {
+    func getApnsVoipSandboxChannel(input: GetApnsVoipSandboxChannelInput) async throws -> GetApnsVoipSandboxChannelOutput {
         fatalError("Not supported")
     }
 
-    func getApp(input: GetAppInput) async throws -> GetAppOutputResponse {
+    func getApp(input: GetAppInput) async throws -> GetAppOutput {
         fatalError("Not supported")
     }
 
-    func getApplicationDateRangeKpi(input: GetApplicationDateRangeKpiInput) async throws -> GetApplicationDateRangeKpiOutputResponse {
+    func getApplicationDateRangeKpi(input: GetApplicationDateRangeKpiInput) async throws -> GetApplicationDateRangeKpiOutput {
         fatalError("Not supported")
     }
 
-    func getApplicationSettings(input: GetApplicationSettingsInput) async throws -> GetApplicationSettingsOutputResponse {
+    func getApplicationSettings(input: GetApplicationSettingsInput) async throws -> GetApplicationSettingsOutput {
         fatalError("Not supported")
     }
 
-    func getApps(input: GetAppsInput) async throws -> GetAppsOutputResponse {
+    func getApps(input: GetAppsInput) async throws -> GetAppsOutput {
         fatalError("Not supported")
     }
 
-    func getBaiduChannel(input: GetBaiduChannelInput) async throws -> GetBaiduChannelOutputResponse {
+    func getBaiduChannel(input: GetBaiduChannelInput) async throws -> GetBaiduChannelOutput {
         fatalError("Not supported")
     }
 
-    func getCampaign(input: GetCampaignInput) async throws -> GetCampaignOutputResponse {
+    func getCampaign(input: GetCampaignInput) async throws -> GetCampaignOutput {
         fatalError("Not supported")
     }
 
-    func getCampaignActivities(input: GetCampaignActivitiesInput) async throws -> GetCampaignActivitiesOutputResponse {
+    func getCampaignActivities(input: GetCampaignActivitiesInput) async throws -> GetCampaignActivitiesOutput {
         fatalError("Not supported")
     }
 
-    func getCampaignDateRangeKpi(input: GetCampaignDateRangeKpiInput) async throws -> GetCampaignDateRangeKpiOutputResponse {
+    func getCampaignDateRangeKpi(input: GetCampaignDateRangeKpiInput) async throws -> GetCampaignDateRangeKpiOutput {
         fatalError("Not supported")
     }
 
-    func getCampaigns(input: GetCampaignsInput) async throws -> GetCampaignsOutputResponse {
+    func getCampaigns(input: GetCampaignsInput) async throws -> GetCampaignsOutput {
         fatalError("Not supported")
     }
 
-    func getCampaignVersion(input: GetCampaignVersionInput) async throws -> GetCampaignVersionOutputResponse {
+    func getCampaignVersion(input: GetCampaignVersionInput) async throws -> GetCampaignVersionOutput {
         fatalError("Not supported")
     }
 
-    func getCampaignVersions(input: GetCampaignVersionsInput) async throws -> GetCampaignVersionsOutputResponse {
+    func getCampaignVersions(input: GetCampaignVersionsInput) async throws -> GetCampaignVersionsOutput {
         fatalError("Not supported")
     }
 
-    func getChannels(input: GetChannelsInput) async throws -> GetChannelsOutputResponse {
+    func getChannels(input: GetChannelsInput) async throws -> GetChannelsOutput {
         fatalError("Not supported")
     }
 
-    func getEmailChannel(input: GetEmailChannelInput) async throws -> GetEmailChannelOutputResponse {
+    func getEmailChannel(input: GetEmailChannelInput) async throws -> GetEmailChannelOutput {
         fatalError("Not supported")
     }
 
-    func getEmailTemplate(input: GetEmailTemplateInput) async throws -> GetEmailTemplateOutputResponse {
+    func getEmailTemplate(input: GetEmailTemplateInput) async throws -> GetEmailTemplateOutput {
         fatalError("Not supported")
     }
 
-    func getEndpoint(input: GetEndpointInput) async throws -> GetEndpointOutputResponse {
+    func getEndpoint(input: GetEndpointInput) async throws -> GetEndpointOutput {
         fatalError("Not supported")
     }
 
-    func getEventStream(input: GetEventStreamInput) async throws -> GetEventStreamOutputResponse {
+    func getEventStream(input: GetEventStreamInput) async throws -> GetEventStreamOutput {
         fatalError("Not supported")
     }
 
-    func getExportJob(input: GetExportJobInput) async throws -> GetExportJobOutputResponse {
+    func getExportJob(input: GetExportJobInput) async throws -> GetExportJobOutput {
         fatalError("Not supported")
     }
 
-    func getExportJobs(input: GetExportJobsInput) async throws -> GetExportJobsOutputResponse {
+    func getExportJobs(input: GetExportJobsInput) async throws -> GetExportJobsOutput {
         fatalError("Not supported")
     }
 
-    func getGcmChannel(input: GetGcmChannelInput) async throws -> GetGcmChannelOutputResponse {
+    func getGcmChannel(input: GetGcmChannelInput) async throws -> GetGcmChannelOutput {
         fatalError("Not supported")
     }
 
-    func getImportJob(input: GetImportJobInput) async throws -> GetImportJobOutputResponse {
+    func getImportJob(input: GetImportJobInput) async throws -> GetImportJobOutput {
         fatalError("Not supported")
     }
 
-    func getImportJobs(input: GetImportJobsInput) async throws -> GetImportJobsOutputResponse {
+    func getImportJobs(input: GetImportJobsInput) async throws -> GetImportJobsOutput {
         fatalError("Not supported")
     }
 
-    func getInAppMessages(input: GetInAppMessagesInput) async throws -> GetInAppMessagesOutputResponse {
+    func getInAppMessages(input: GetInAppMessagesInput) async throws -> GetInAppMessagesOutput {
         fatalError("Not supported")
     }
 
-    func getInAppTemplate(input: GetInAppTemplateInput) async throws -> GetInAppTemplateOutputResponse {
+    func getInAppTemplate(input: GetInAppTemplateInput) async throws -> GetInAppTemplateOutput {
         fatalError("Not supported")
     }
 
-    func getJourney(input: GetJourneyInput) async throws -> GetJourneyOutputResponse {
+    func getJourney(input: GetJourneyInput) async throws -> GetJourneyOutput {
         fatalError("Not supported")
     }
 
-    func getJourneyDateRangeKpi(input: GetJourneyDateRangeKpiInput) async throws -> GetJourneyDateRangeKpiOutputResponse {
+    func getJourneyDateRangeKpi(input: GetJourneyDateRangeKpiInput) async throws -> GetJourneyDateRangeKpiOutput {
         fatalError("Not supported")
     }
 
-    func getJourneyExecutionActivityMetrics(input: GetJourneyExecutionActivityMetricsInput) async throws -> GetJourneyExecutionActivityMetricsOutputResponse {
+    func getJourneyExecutionActivityMetrics(input: GetJourneyExecutionActivityMetricsInput) async throws -> GetJourneyExecutionActivityMetricsOutput {
         fatalError("Not supported")
     }
 
-    func getJourneyExecutionMetrics(input: GetJourneyExecutionMetricsInput) async throws -> GetJourneyExecutionMetricsOutputResponse {
+    func getJourneyExecutionMetrics(input: GetJourneyExecutionMetricsInput) async throws -> GetJourneyExecutionMetricsOutput {
         fatalError("Not supported")
     }
 
-    func getPushTemplate(input: GetPushTemplateInput) async throws -> GetPushTemplateOutputResponse {
+    func getPushTemplate(input: GetPushTemplateInput) async throws -> GetPushTemplateOutput {
         fatalError("Not supported")
     }
 
-    func getRecommenderConfiguration(input: GetRecommenderConfigurationInput) async throws -> GetRecommenderConfigurationOutputResponse {
+    func getRecommenderConfiguration(input: GetRecommenderConfigurationInput) async throws -> GetRecommenderConfigurationOutput {
         fatalError("Not supported")
     }
 
-    func getRecommenderConfigurations(input: GetRecommenderConfigurationsInput) async throws -> GetRecommenderConfigurationsOutputResponse {
+    func getRecommenderConfigurations(input: GetRecommenderConfigurationsInput) async throws -> GetRecommenderConfigurationsOutput {
         fatalError("Not supported")
     }
 
-    func getSegment(input: GetSegmentInput) async throws -> GetSegmentOutputResponse {
+    func getSegment(input: GetSegmentInput) async throws -> GetSegmentOutput {
         fatalError("Not supported")
     }
 
-    func getSegmentExportJobs(input: GetSegmentExportJobsInput) async throws -> GetSegmentExportJobsOutputResponse {
+    func getSegmentExportJobs(input: GetSegmentExportJobsInput) async throws -> GetSegmentExportJobsOutput {
         fatalError("Not supported")
     }
 
-    func getSegmentImportJobs(input: GetSegmentImportJobsInput) async throws -> GetSegmentImportJobsOutputResponse {
+    func getSegmentImportJobs(input: GetSegmentImportJobsInput) async throws -> GetSegmentImportJobsOutput {
         fatalError("Not supported")
     }
 
-    func getSegments(input: GetSegmentsInput) async throws -> GetSegmentsOutputResponse {
+    func getSegments(input: GetSegmentsInput) async throws -> GetSegmentsOutput {
         fatalError("Not supported")
     }
 
-    func getSegmentVersion(input: GetSegmentVersionInput) async throws -> GetSegmentVersionOutputResponse {
+    func getSegmentVersion(input: GetSegmentVersionInput) async throws -> GetSegmentVersionOutput {
         fatalError("Not supported")
     }
 
-    func getSegmentVersions(input: GetSegmentVersionsInput) async throws -> GetSegmentVersionsOutputResponse {
+    func getSegmentVersions(input: GetSegmentVersionsInput) async throws -> GetSegmentVersionsOutput {
         fatalError("Not supported")
     }
 
-    func getSmsChannel(input: GetSmsChannelInput) async throws -> GetSmsChannelOutputResponse {
+    func getSmsChannel(input: GetSmsChannelInput) async throws -> GetSmsChannelOutput {
         fatalError("Not supported")
     }
 
-    func getSmsTemplate(input: GetSmsTemplateInput) async throws -> GetSmsTemplateOutputResponse {
+    func getSmsTemplate(input: GetSmsTemplateInput) async throws -> GetSmsTemplateOutput {
         fatalError("Not supported")
     }
 
-    func getUserEndpoints(input: GetUserEndpointsInput) async throws -> GetUserEndpointsOutputResponse {
+    func getUserEndpoints(input: GetUserEndpointsInput) async throws -> GetUserEndpointsOutput {
         fatalError("Not supported")
     }
 
-    func getVoiceChannel(input: GetVoiceChannelInput) async throws -> GetVoiceChannelOutputResponse {
+    func getVoiceChannel(input: GetVoiceChannelInput) async throws -> GetVoiceChannelOutput {
         fatalError("Not supported")
     }
 
-    func getVoiceTemplate(input: GetVoiceTemplateInput) async throws -> GetVoiceTemplateOutputResponse {
+    func getVoiceTemplate(input: GetVoiceTemplateInput) async throws -> GetVoiceTemplateOutput {
         fatalError("Not supported")
     }
 
-    func listJourneys(input: ListJourneysInput) async throws -> ListJourneysOutputResponse {
+    func listJourneys(input: ListJourneysInput) async throws -> ListJourneysOutput {
         fatalError("Not supported")
     }
 
-    func listTagsForResource(input: ListTagsForResourceInput) async throws -> ListTagsForResourceOutputResponse {
+    func listTagsForResource(input: ListTagsForResourceInput) async throws -> ListTagsForResourceOutput {
         fatalError("Not supported")
     }
 
-    func listTemplates(input: ListTemplatesInput) async throws -> ListTemplatesOutputResponse {
+    func listTemplates(input: ListTemplatesInput) async throws -> ListTemplatesOutput {
         fatalError("Not supported")
     }
 
-    func listTemplateVersions(input: ListTemplateVersionsInput) async throws -> ListTemplateVersionsOutputResponse {
+    func listTemplateVersions(input: ListTemplateVersionsInput) async throws -> ListTemplateVersionsOutput {
         fatalError("Not supported")
     }
 
-    func phoneNumberValidate(input: PhoneNumberValidateInput) async throws -> PhoneNumberValidateOutputResponse {
+    func phoneNumberValidate(input: PhoneNumberValidateInput) async throws -> PhoneNumberValidateOutput {
         fatalError("Not supported")
     }
 
     var putEventsCount = 0
-    var putEventsResult: Result<PutEventsOutputResponse, Error> = .failure(CancellationError())
-    func putEvents(input: PutEventsInput) async throws -> PutEventsOutputResponse {
+    var putEventsResult: Result<PutEventsOutput, Error> = .failure(CancellationError())
+    func putEvents(input: PutEventsInput) async throws -> PutEventsOutput {
         putEventsCount += 1
         return try putEventsResult.get()
     }
 
-    func putEventStream(input: PutEventStreamInput) async throws -> PutEventStreamOutputResponse {
+    func putEventStream(input: PutEventStreamInput) async throws -> PutEventStreamOutput {
         fatalError("Not supported")
     }
 
-    func removeAttributes(input: RemoveAttributesInput) async throws -> RemoveAttributesOutputResponse {
+    func removeAttributes(input: RemoveAttributesInput) async throws -> RemoveAttributesOutput {
         fatalError("Not supported")
     }
 
-    func sendMessages(input: SendMessagesInput) async throws -> SendMessagesOutputResponse {
+    func sendMessages(input: SendMessagesInput) async throws -> SendMessagesOutput {
         fatalError("Not supported")
     }
 
-    func sendOTPMessage(input: SendOTPMessageInput) async throws -> SendOTPMessageOutputResponse {
+    func sendOTPMessage(input: SendOTPMessageInput) async throws -> SendOTPMessageOutput {
         fatalError("Not supported")
     }
 
-    func sendUsersMessages(input: SendUsersMessagesInput) async throws -> SendUsersMessagesOutputResponse {
+    func sendUsersMessages(input: SendUsersMessagesInput) async throws -> SendUsersMessagesOutput {
         fatalError("Not supported")
     }
 
-    func tagResource(input: TagResourceInput) async throws -> TagResourceOutputResponse {
+    func tagResource(input: TagResourceInput) async throws -> TagResourceOutput {
         fatalError("Not supported")
     }
 
-    func untagResource(input: UntagResourceInput) async throws -> UntagResourceOutputResponse {
+    func untagResource(input: UntagResourceInput) async throws -> UntagResourceOutput {
         fatalError("Not supported")
     }
 
-    func updateAdmChannel(input: UpdateAdmChannelInput) async throws -> UpdateAdmChannelOutputResponse {
+    func updateAdmChannel(input: UpdateAdmChannelInput) async throws -> UpdateAdmChannelOutput {
         fatalError("Not supported")
     }
 
-    func updateApnsChannel(input: UpdateApnsChannelInput) async throws -> UpdateApnsChannelOutputResponse {
+    func updateApnsChannel(input: UpdateApnsChannelInput) async throws -> UpdateApnsChannelOutput {
         fatalError("Not supported")
     }
 
-    func updateApnsSandboxChannel(input: UpdateApnsSandboxChannelInput) async throws -> UpdateApnsSandboxChannelOutputResponse {
+    func updateApnsSandboxChannel(input: UpdateApnsSandboxChannelInput) async throws -> UpdateApnsSandboxChannelOutput {
         fatalError("Not supported")
     }
 
-    func updateApnsVoipChannel(input: UpdateApnsVoipChannelInput) async throws -> UpdateApnsVoipChannelOutputResponse {
+    func updateApnsVoipChannel(input: UpdateApnsVoipChannelInput) async throws -> UpdateApnsVoipChannelOutput {
         fatalError("Not supported")
     }
 
-    func updateApnsVoipSandboxChannel(input: UpdateApnsVoipSandboxChannelInput) async throws -> UpdateApnsVoipSandboxChannelOutputResponse {
+    func updateApnsVoipSandboxChannel(input: UpdateApnsVoipSandboxChannelInput) async throws -> UpdateApnsVoipSandboxChannelOutput {
         fatalError("Not supported")
     }
 
-    func updateApplicationSettings(input: UpdateApplicationSettingsInput) async throws -> UpdateApplicationSettingsOutputResponse {
+    func updateApplicationSettings(input: UpdateApplicationSettingsInput) async throws -> UpdateApplicationSettingsOutput {
         fatalError("Not supported")
     }
 
-    func updateBaiduChannel(input: UpdateBaiduChannelInput) async throws -> UpdateBaiduChannelOutputResponse {
+    func updateBaiduChannel(input: UpdateBaiduChannelInput) async throws -> UpdateBaiduChannelOutput {
         fatalError("Not supported")
     }
 
-    func updateCampaign(input: UpdateCampaignInput) async throws -> UpdateCampaignOutputResponse {
+    func updateCampaign(input: UpdateCampaignInput) async throws -> UpdateCampaignOutput {
         fatalError("Not supported")
     }
 
-    func updateEmailChannel(input: UpdateEmailChannelInput) async throws -> UpdateEmailChannelOutputResponse {
+    func updateEmailChannel(input: UpdateEmailChannelInput) async throws -> UpdateEmailChannelOutput {
         fatalError("Not supported")
     }
 
-    func updateEmailTemplate(input: UpdateEmailTemplateInput) async throws -> UpdateEmailTemplateOutputResponse {
+    func updateEmailTemplate(input: UpdateEmailTemplateInput) async throws -> UpdateEmailTemplateOutput {
         fatalError("Not supported")
     }
 
     var updateEndpointCount = 0
-    var updateEndpointResult: Result<UpdateEndpointOutputResponse, Error>?
-    func updateEndpoint(input: UpdateEndpointInput) async throws -> UpdateEndpointOutputResponse {
+    var updateEndpointResult: Result<UpdateEndpointOutput, Error>?
+    func updateEndpoint(input: UpdateEndpointInput) async throws -> UpdateEndpointOutput {
         updateEndpointCount += 1
         guard let result = updateEndpointResult else {
-            return UpdateEndpointOutputResponse()
+            return UpdateEndpointOutput()
         }
 
         switch result {
@@ -456,59 +456,59 @@ class MockPinpointClient: PinpointClientProtocol {
         }
     }
 
-    func updateEndpointsBatch(input: UpdateEndpointsBatchInput) async throws -> UpdateEndpointsBatchOutputResponse {
+    func updateEndpointsBatch(input: UpdateEndpointsBatchInput) async throws -> UpdateEndpointsBatchOutput {
         fatalError("Not supported")
     }
 
-    func updateGcmChannel(input: UpdateGcmChannelInput) async throws -> UpdateGcmChannelOutputResponse {
+    func updateGcmChannel(input: UpdateGcmChannelInput) async throws -> UpdateGcmChannelOutput {
         fatalError("Not supported")
     }
 
-    func updateInAppTemplate(input: UpdateInAppTemplateInput) async throws -> UpdateInAppTemplateOutputResponse {
+    func updateInAppTemplate(input: UpdateInAppTemplateInput) async throws -> UpdateInAppTemplateOutput {
         fatalError("Not supported")
     }
 
-    func updateJourney(input: UpdateJourneyInput) async throws -> UpdateJourneyOutputResponse {
+    func updateJourney(input: UpdateJourneyInput) async throws -> UpdateJourneyOutput {
         fatalError("Not supported")
     }
 
-    func updateJourneyState(input: UpdateJourneyStateInput) async throws -> UpdateJourneyStateOutputResponse {
+    func updateJourneyState(input: UpdateJourneyStateInput) async throws -> UpdateJourneyStateOutput {
         fatalError("Not supported")
     }
 
-    func updatePushTemplate(input: UpdatePushTemplateInput) async throws -> UpdatePushTemplateOutputResponse {
+    func updatePushTemplate(input: UpdatePushTemplateInput) async throws -> UpdatePushTemplateOutput {
         fatalError("Not supported")
     }
 
-    func updateRecommenderConfiguration(input: UpdateRecommenderConfigurationInput) async throws -> UpdateRecommenderConfigurationOutputResponse {
+    func updateRecommenderConfiguration(input: UpdateRecommenderConfigurationInput) async throws -> UpdateRecommenderConfigurationOutput {
         fatalError("Not supported")
     }
 
-    func updateSegment(input: UpdateSegmentInput) async throws -> UpdateSegmentOutputResponse {
+    func updateSegment(input: UpdateSegmentInput) async throws -> UpdateSegmentOutput {
         fatalError("Not supported")
     }
 
-    func updateSmsChannel(input: UpdateSmsChannelInput) async throws -> UpdateSmsChannelOutputResponse {
+    func updateSmsChannel(input: UpdateSmsChannelInput) async throws -> UpdateSmsChannelOutput {
         fatalError("Not supported")
     }
 
-    func updateSmsTemplate(input: UpdateSmsTemplateInput) async throws -> UpdateSmsTemplateOutputResponse {
+    func updateSmsTemplate(input: UpdateSmsTemplateInput) async throws -> UpdateSmsTemplateOutput {
         fatalError("Not supported")
     }
 
-    func updateTemplateActiveVersion(input: UpdateTemplateActiveVersionInput) async throws -> UpdateTemplateActiveVersionOutputResponse {
+    func updateTemplateActiveVersion(input: UpdateTemplateActiveVersionInput) async throws -> UpdateTemplateActiveVersionOutput {
         fatalError("Not supported")
     }
 
-    func updateVoiceChannel(input: UpdateVoiceChannelInput) async throws -> UpdateVoiceChannelOutputResponse {
+    func updateVoiceChannel(input: UpdateVoiceChannelInput) async throws -> UpdateVoiceChannelOutput {
         fatalError("Not supported")
     }
 
-    func updateVoiceTemplate(input: UpdateVoiceTemplateInput) async throws -> UpdateVoiceTemplateOutputResponse {
+    func updateVoiceTemplate(input: UpdateVoiceTemplateInput) async throws -> UpdateVoiceTemplateOutput {
         fatalError("Not supported")
     }
 
-    func verifyOTPMessage(input: VerifyOTPMessageInput) async throws -> VerifyOTPMessageOutputResponse {
+    func verifyOTPMessage(input: VerifyOTPMessageInput) async throws -> VerifyOTPMessageOutput {
         fatalError("Not supported")
     }
 }

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Consumer/CloudWatchLoggingConsumer.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Consumer/CloudWatchLoggingConsumer.swift
@@ -121,7 +121,7 @@ extension CloudWatchLoggingConsumer: LogBatchConsumer {
         }
     }
     
-    private func retriable(entries: [LogEntry], in response: PutLogEventsOutputResponse) -> [LogEntry] {
+    private func retriable(entries: [LogEntry], in response: PutLogEventsOutput) -> [LogEntry] {
         guard let tooNewLogEventStartIndex = response.rejectedLogEventsInfo?.tooNewLogEventStartIndex else {
             return []
         }

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/MockCloudWatchLogsClient.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/MockCloudWatchLogsClient.swift
@@ -17,222 +17,222 @@ class MockCloudWatchLogsClient: CloudWatchLogsClientProtocol {
     
     var interactions: [String] = []
     
-    var putLogEventsHandler: (PutLogEventsInput) async throws -> PutLogEventsOutputResponse = { input in
-        return PutLogEventsOutputResponse()
+    var putLogEventsHandler: (PutLogEventsInput) async throws -> PutLogEventsOutput = { input in
+        return PutLogEventsOutput()
     }
 
-    func putLogEvents(input: PutLogEventsInput) async throws -> PutLogEventsOutputResponse {
+    func putLogEvents(input: PutLogEventsInput) async throws -> PutLogEventsOutput {
         interactions.append(#function)
         return try await putLogEventsHandler(input)
     }
     
-    func associateKmsKey(input: AWSCloudWatchLogs.AssociateKmsKeyInput) async throws -> AWSCloudWatchLogs.AssociateKmsKeyOutputResponse {
+    func associateKmsKey(input: AWSCloudWatchLogs.AssociateKmsKeyInput) async throws -> AWSCloudWatchLogs.AssociateKmsKeyOutput {
         throw MockError.unimplemented
     }
     
-    func cancelExportTask(input: AWSCloudWatchLogs.CancelExportTaskInput) async throws -> AWSCloudWatchLogs.CancelExportTaskOutputResponse {
+    func cancelExportTask(input: AWSCloudWatchLogs.CancelExportTaskInput) async throws -> AWSCloudWatchLogs.CancelExportTaskOutput {
         throw MockError.unimplemented
     }
     
-    func createExportTask(input: AWSCloudWatchLogs.CreateExportTaskInput) async throws -> AWSCloudWatchLogs.CreateExportTaskOutputResponse {
+    func createExportTask(input: AWSCloudWatchLogs.CreateExportTaskInput) async throws -> AWSCloudWatchLogs.CreateExportTaskOutput {
         throw MockError.unimplemented
     }
     
-    func createLogGroup(input: AWSCloudWatchLogs.CreateLogGroupInput) async throws -> AWSCloudWatchLogs.CreateLogGroupOutputResponse {
+    func createLogGroup(input: AWSCloudWatchLogs.CreateLogGroupInput) async throws -> AWSCloudWatchLogs.CreateLogGroupOutput {
         throw MockError.unimplemented
     }
     
-    var createLogStreamHandler: (CreateLogStreamInput) async throws -> CreateLogStreamOutputResponse = { _ in
-        return CreateLogStreamOutputResponse()
+    var createLogStreamHandler: (CreateLogStreamInput) async throws -> CreateLogStreamOutput = { _ in
+        return CreateLogStreamOutput()
     }
     
-    func createLogStream(input: CreateLogStreamInput) async throws -> CreateLogStreamOutputResponse {
+    func createLogStream(input: CreateLogStreamInput) async throws -> CreateLogStreamOutput {
         interactions.append(#function)
         return try await createLogStreamHandler(input)
     }
     
-    func deleteDestination(input: AWSCloudWatchLogs.DeleteDestinationInput) async throws -> AWSCloudWatchLogs.DeleteDestinationOutputResponse {
+    func deleteDestination(input: AWSCloudWatchLogs.DeleteDestinationInput) async throws -> AWSCloudWatchLogs.DeleteDestinationOutput {
         throw MockError.unimplemented
     }
     
-    func deleteLogGroup(input: AWSCloudWatchLogs.DeleteLogGroupInput) async throws -> AWSCloudWatchLogs.DeleteLogGroupOutputResponse {
+    func deleteLogGroup(input: AWSCloudWatchLogs.DeleteLogGroupInput) async throws -> AWSCloudWatchLogs.DeleteLogGroupOutput {
         throw MockError.unimplemented
     }
     
-    func deleteLogStream(input: AWSCloudWatchLogs.DeleteLogStreamInput) async throws -> AWSCloudWatchLogs.DeleteLogStreamOutputResponse {
+    func deleteLogStream(input: AWSCloudWatchLogs.DeleteLogStreamInput) async throws -> AWSCloudWatchLogs.DeleteLogStreamOutput {
         throw MockError.unimplemented
     }
     
-    func deleteMetricFilter(input: AWSCloudWatchLogs.DeleteMetricFilterInput) async throws -> AWSCloudWatchLogs.DeleteMetricFilterOutputResponse {
+    func deleteMetricFilter(input: AWSCloudWatchLogs.DeleteMetricFilterInput) async throws -> AWSCloudWatchLogs.DeleteMetricFilterOutput {
         throw MockError.unimplemented
     }
     
-    func deleteQueryDefinition(input: AWSCloudWatchLogs.DeleteQueryDefinitionInput) async throws -> AWSCloudWatchLogs.DeleteQueryDefinitionOutputResponse {
+    func deleteQueryDefinition(input: AWSCloudWatchLogs.DeleteQueryDefinitionInput) async throws -> AWSCloudWatchLogs.DeleteQueryDefinitionOutput {
         throw MockError.unimplemented
     }
     
-    func deleteResourcePolicy(input: AWSCloudWatchLogs.DeleteResourcePolicyInput) async throws -> AWSCloudWatchLogs.DeleteResourcePolicyOutputResponse {
+    func deleteResourcePolicy(input: AWSCloudWatchLogs.DeleteResourcePolicyInput) async throws -> AWSCloudWatchLogs.DeleteResourcePolicyOutput {
         throw MockError.unimplemented
     }
     
-    func deleteRetentionPolicy(input: AWSCloudWatchLogs.DeleteRetentionPolicyInput) async throws -> AWSCloudWatchLogs.DeleteRetentionPolicyOutputResponse {
+    func deleteRetentionPolicy(input: AWSCloudWatchLogs.DeleteRetentionPolicyInput) async throws -> AWSCloudWatchLogs.DeleteRetentionPolicyOutput {
         throw MockError.unimplemented
     }
     
-    func deleteSubscriptionFilter(input: AWSCloudWatchLogs.DeleteSubscriptionFilterInput) async throws -> AWSCloudWatchLogs.DeleteSubscriptionFilterOutputResponse {
+    func deleteSubscriptionFilter(input: AWSCloudWatchLogs.DeleteSubscriptionFilterInput) async throws -> AWSCloudWatchLogs.DeleteSubscriptionFilterOutput {
         throw MockError.unimplemented
     }
     
-    func deleteDataProtectionPolicy(input: AWSCloudWatchLogs.DeleteDataProtectionPolicyInput) async throws -> AWSCloudWatchLogs.DeleteDataProtectionPolicyOutputResponse {
+    func deleteDataProtectionPolicy(input: AWSCloudWatchLogs.DeleteDataProtectionPolicyInput) async throws -> AWSCloudWatchLogs.DeleteDataProtectionPolicyOutput {
         throw MockError.unexpected
     }
     
-    func describeDestinations(input: AWSCloudWatchLogs.DescribeDestinationsInput) async throws -> AWSCloudWatchLogs.DescribeDestinationsOutputResponse {
+    func describeDestinations(input: AWSCloudWatchLogs.DescribeDestinationsInput) async throws -> AWSCloudWatchLogs.DescribeDestinationsOutput {
         throw MockError.unimplemented
     }
     
-    func describeExportTasks(input: AWSCloudWatchLogs.DescribeExportTasksInput) async throws -> AWSCloudWatchLogs.DescribeExportTasksOutputResponse {
+    func describeExportTasks(input: AWSCloudWatchLogs.DescribeExportTasksInput) async throws -> AWSCloudWatchLogs.DescribeExportTasksOutput {
         throw MockError.unimplemented
     }
     
-    func describeLogGroups(input: AWSCloudWatchLogs.DescribeLogGroupsInput) async throws -> AWSCloudWatchLogs.DescribeLogGroupsOutputResponse {
+    func describeLogGroups(input: AWSCloudWatchLogs.DescribeLogGroupsInput) async throws -> AWSCloudWatchLogs.DescribeLogGroupsOutput {
         throw MockError.unimplemented
     }
     
-    var describeLogStreamsHandler: (DescribeLogStreamsInput) async throws -> DescribeLogStreamsOutputResponse = { _ in
-        return DescribeLogStreamsOutputResponse()
+    var describeLogStreamsHandler: (DescribeLogStreamsInput) async throws -> DescribeLogStreamsOutput = { _ in
+        return DescribeLogStreamsOutput()
     }
 
-    func describeLogStreams(input: DescribeLogStreamsInput) async throws -> DescribeLogStreamsOutputResponse {
+    func describeLogStreams(input: DescribeLogStreamsInput) async throws -> DescribeLogStreamsOutput {
         interactions.append(#function)
         return try await describeLogStreamsHandler(input)
     }
     
-    func describeMetricFilters(input: AWSCloudWatchLogs.DescribeMetricFiltersInput) async throws -> AWSCloudWatchLogs.DescribeMetricFiltersOutputResponse {
+    func describeMetricFilters(input: AWSCloudWatchLogs.DescribeMetricFiltersInput) async throws -> AWSCloudWatchLogs.DescribeMetricFiltersOutput {
         throw MockError.unimplemented
     }
     
-    func describeQueries(input: AWSCloudWatchLogs.DescribeQueriesInput) async throws -> AWSCloudWatchLogs.DescribeQueriesOutputResponse {
+    func describeQueries(input: AWSCloudWatchLogs.DescribeQueriesInput) async throws -> AWSCloudWatchLogs.DescribeQueriesOutput {
         throw MockError.unimplemented
     }
     
-    func describeQueryDefinitions(input: AWSCloudWatchLogs.DescribeQueryDefinitionsInput) async throws -> AWSCloudWatchLogs.DescribeQueryDefinitionsOutputResponse {
+    func describeQueryDefinitions(input: AWSCloudWatchLogs.DescribeQueryDefinitionsInput) async throws -> AWSCloudWatchLogs.DescribeQueryDefinitionsOutput {
         throw MockError.unimplemented
     }
     
-    func describeResourcePolicies(input: AWSCloudWatchLogs.DescribeResourcePoliciesInput) async throws -> AWSCloudWatchLogs.DescribeResourcePoliciesOutputResponse {
+    func describeResourcePolicies(input: AWSCloudWatchLogs.DescribeResourcePoliciesInput) async throws -> AWSCloudWatchLogs.DescribeResourcePoliciesOutput {
         throw MockError.unimplemented
     }
     
-    func describeSubscriptionFilters(input: AWSCloudWatchLogs.DescribeSubscriptionFiltersInput) async throws -> AWSCloudWatchLogs.DescribeSubscriptionFiltersOutputResponse {
+    func describeSubscriptionFilters(input: AWSCloudWatchLogs.DescribeSubscriptionFiltersInput) async throws -> AWSCloudWatchLogs.DescribeSubscriptionFiltersOutput {
         throw MockError.unimplemented
     }
     
-    func disassociateKmsKey(input: AWSCloudWatchLogs.DisassociateKmsKeyInput) async throws -> AWSCloudWatchLogs.DisassociateKmsKeyOutputResponse {
+    func disassociateKmsKey(input: AWSCloudWatchLogs.DisassociateKmsKeyInput) async throws -> AWSCloudWatchLogs.DisassociateKmsKeyOutput {
         throw MockError.unimplemented
     }
     
-    func filterLogEvents(input: AWSCloudWatchLogs.FilterLogEventsInput) async throws -> AWSCloudWatchLogs.FilterLogEventsOutputResponse {
+    func filterLogEvents(input: AWSCloudWatchLogs.FilterLogEventsInput) async throws -> AWSCloudWatchLogs.FilterLogEventsOutput {
         throw MockError.unimplemented
     }
     
-    func getDataProtectionPolicy(input: AWSCloudWatchLogs.GetDataProtectionPolicyInput) async throws -> AWSCloudWatchLogs.GetDataProtectionPolicyOutputResponse {
+    func getDataProtectionPolicy(input: AWSCloudWatchLogs.GetDataProtectionPolicyInput) async throws -> AWSCloudWatchLogs.GetDataProtectionPolicyOutput {
         throw MockError.unexpected
     }
     
-    func getLogEvents(input: AWSCloudWatchLogs.GetLogEventsInput) async throws -> AWSCloudWatchLogs.GetLogEventsOutputResponse {
+    func getLogEvents(input: AWSCloudWatchLogs.GetLogEventsInput) async throws -> AWSCloudWatchLogs.GetLogEventsOutput {
         throw MockError.unimplemented
     }
     
-    func getLogGroupFields(input: AWSCloudWatchLogs.GetLogGroupFieldsInput) async throws -> AWSCloudWatchLogs.GetLogGroupFieldsOutputResponse {
+    func getLogGroupFields(input: AWSCloudWatchLogs.GetLogGroupFieldsInput) async throws -> AWSCloudWatchLogs.GetLogGroupFieldsOutput {
         throw MockError.unimplemented
     }
     
-    func getLogRecord(input: AWSCloudWatchLogs.GetLogRecordInput) async throws -> AWSCloudWatchLogs.GetLogRecordOutputResponse {
+    func getLogRecord(input: AWSCloudWatchLogs.GetLogRecordInput) async throws -> AWSCloudWatchLogs.GetLogRecordOutput {
         throw MockError.unimplemented
     }
     
-    func getQueryResults(input: AWSCloudWatchLogs.GetQueryResultsInput) async throws -> AWSCloudWatchLogs.GetQueryResultsOutputResponse {
+    func getQueryResults(input: AWSCloudWatchLogs.GetQueryResultsInput) async throws -> AWSCloudWatchLogs.GetQueryResultsOutput {
         throw MockError.unimplemented
     }
     
-    func listTagsForResource(input: AWSCloudWatchLogs.ListTagsForResourceInput) async throws -> AWSCloudWatchLogs.ListTagsForResourceOutputResponse {
+    func listTagsForResource(input: AWSCloudWatchLogs.ListTagsForResourceInput) async throws -> AWSCloudWatchLogs.ListTagsForResourceOutput {
         throw MockError.unimplemented
     }
     
-    func listTagsLogGroup(input: AWSCloudWatchLogs.ListTagsLogGroupInput) async throws -> AWSCloudWatchLogs.ListTagsLogGroupOutputResponse {
+    func listTagsLogGroup(input: AWSCloudWatchLogs.ListTagsLogGroupInput) async throws -> AWSCloudWatchLogs.ListTagsLogGroupOutput {
         throw MockError.unimplemented
     }
     
-    func putDataProtectionPolicy(input: AWSCloudWatchLogs.PutDataProtectionPolicyInput) async throws -> AWSCloudWatchLogs.PutDataProtectionPolicyOutputResponse {
+    func putDataProtectionPolicy(input: AWSCloudWatchLogs.PutDataProtectionPolicyInput) async throws -> AWSCloudWatchLogs.PutDataProtectionPolicyOutput {
         throw MockError.unexpected
     }
 
-    func putDestination(input: AWSCloudWatchLogs.PutDestinationInput) async throws -> AWSCloudWatchLogs.PutDestinationOutputResponse {
+    func putDestination(input: AWSCloudWatchLogs.PutDestinationInput) async throws -> AWSCloudWatchLogs.PutDestinationOutput {
         throw MockError.unimplemented
     }
     
-    func putDestinationPolicy(input: AWSCloudWatchLogs.PutDestinationPolicyInput) async throws -> AWSCloudWatchLogs.PutDestinationPolicyOutputResponse {
+    func putDestinationPolicy(input: AWSCloudWatchLogs.PutDestinationPolicyInput) async throws -> AWSCloudWatchLogs.PutDestinationPolicyOutput {
         throw MockError.unimplemented
     }
     
-    func putMetricFilter(input: AWSCloudWatchLogs.PutMetricFilterInput) async throws -> AWSCloudWatchLogs.PutMetricFilterOutputResponse {
+    func putMetricFilter(input: AWSCloudWatchLogs.PutMetricFilterInput) async throws -> AWSCloudWatchLogs.PutMetricFilterOutput {
         throw MockError.unimplemented
     }
     
-    func putQueryDefinition(input: AWSCloudWatchLogs.PutQueryDefinitionInput) async throws -> AWSCloudWatchLogs.PutQueryDefinitionOutputResponse {
+    func putQueryDefinition(input: AWSCloudWatchLogs.PutQueryDefinitionInput) async throws -> AWSCloudWatchLogs.PutQueryDefinitionOutput {
         throw MockError.unimplemented
     }
     
-    func putResourcePolicy(input: AWSCloudWatchLogs.PutResourcePolicyInput) async throws -> AWSCloudWatchLogs.PutResourcePolicyOutputResponse {
+    func putResourcePolicy(input: AWSCloudWatchLogs.PutResourcePolicyInput) async throws -> AWSCloudWatchLogs.PutResourcePolicyOutput {
         throw MockError.unimplemented
     }
     
-    func putRetentionPolicy(input: AWSCloudWatchLogs.PutRetentionPolicyInput) async throws -> AWSCloudWatchLogs.PutRetentionPolicyOutputResponse {
+    func putRetentionPolicy(input: AWSCloudWatchLogs.PutRetentionPolicyInput) async throws -> AWSCloudWatchLogs.PutRetentionPolicyOutput {
         throw MockError.unimplemented
     }
     
-    func putSubscriptionFilter(input: AWSCloudWatchLogs.PutSubscriptionFilterInput) async throws -> AWSCloudWatchLogs.PutSubscriptionFilterOutputResponse {
+    func putSubscriptionFilter(input: AWSCloudWatchLogs.PutSubscriptionFilterInput) async throws -> AWSCloudWatchLogs.PutSubscriptionFilterOutput {
         throw MockError.unimplemented
     }
     
-    func startQuery(input: AWSCloudWatchLogs.StartQueryInput) async throws -> AWSCloudWatchLogs.StartQueryOutputResponse {
+    func startQuery(input: AWSCloudWatchLogs.StartQueryInput) async throws -> AWSCloudWatchLogs.StartQueryOutput {
         throw MockError.unimplemented
     }
     
-    func stopQuery(input: AWSCloudWatchLogs.StopQueryInput) async throws -> AWSCloudWatchLogs.StopQueryOutputResponse {
+    func stopQuery(input: AWSCloudWatchLogs.StopQueryInput) async throws -> AWSCloudWatchLogs.StopQueryOutput {
         throw MockError.unimplemented
     }
     
-    func tagLogGroup(input: AWSCloudWatchLogs.TagLogGroupInput) async throws -> AWSCloudWatchLogs.TagLogGroupOutputResponse {
+    func tagLogGroup(input: AWSCloudWatchLogs.TagLogGroupInput) async throws -> AWSCloudWatchLogs.TagLogGroupOutput {
         throw MockError.unimplemented
     }
     
-    func tagResource(input: AWSCloudWatchLogs.TagResourceInput) async throws -> AWSCloudWatchLogs.TagResourceOutputResponse {
+    func tagResource(input: AWSCloudWatchLogs.TagResourceInput) async throws -> AWSCloudWatchLogs.TagResourceOutput {
         throw MockError.unimplemented
     }
     
-    func testMetricFilter(input: AWSCloudWatchLogs.TestMetricFilterInput) async throws -> AWSCloudWatchLogs.TestMetricFilterOutputResponse {
+    func testMetricFilter(input: AWSCloudWatchLogs.TestMetricFilterInput) async throws -> AWSCloudWatchLogs.TestMetricFilterOutput {
         throw MockError.unimplemented
     }
     
-    func untagLogGroup(input: AWSCloudWatchLogs.UntagLogGroupInput) async throws -> AWSCloudWatchLogs.UntagLogGroupOutputResponse {
+    func untagLogGroup(input: AWSCloudWatchLogs.UntagLogGroupInput) async throws -> AWSCloudWatchLogs.UntagLogGroupOutput {
         throw MockError.unimplemented
     }
     
-    func untagResource(input: AWSCloudWatchLogs.UntagResourceInput) async throws -> AWSCloudWatchLogs.UntagResourceOutputResponse {
+    func untagResource(input: AWSCloudWatchLogs.UntagResourceInput) async throws -> AWSCloudWatchLogs.UntagResourceOutput {
         throw MockError.unimplemented
     }
     
-    func deleteAccountPolicy(input: AWSCloudWatchLogs.DeleteAccountPolicyInput) async throws -> AWSCloudWatchLogs.DeleteAccountPolicyOutputResponse {
+    func deleteAccountPolicy(input: AWSCloudWatchLogs.DeleteAccountPolicyInput) async throws -> AWSCloudWatchLogs.DeleteAccountPolicyOutput {
         throw MockError.unimplemented
     }
 
-    func describeAccountPolicies(input: AWSCloudWatchLogs.DescribeAccountPoliciesInput) async throws -> AWSCloudWatchLogs.DescribeAccountPoliciesOutputResponse {
+    func describeAccountPolicies(input: AWSCloudWatchLogs.DescribeAccountPoliciesInput) async throws -> AWSCloudWatchLogs.DescribeAccountPoliciesOutput {
         throw MockError.unimplemented
     }
 
-    func putAccountPolicy(input: AWSCloudWatchLogs.PutAccountPolicyInput) async throws -> AWSCloudWatchLogs.PutAccountPolicyOutputResponse {
+    func putAccountPolicy(input: AWSCloudWatchLogs.PutAccountPolicyInput) async throws -> AWSCloudWatchLogs.PutAccountPolicyOutput {
         throw MockError.unimplemented
     }
 }

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Rekognition.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Rekognition.swift
@@ -124,7 +124,7 @@ extension AWSPredictionsService: AWSRekognitionServiceBehavior {
         let imageData = try dataFromImage(url: image)
         let rekognitionImage = RekognitionClientTypes.Image(bytes: imageData)
         let request = DetectTextInput(image: rekognitionImage)
-        let textResult: DetectTextOutputResponse
+        let textResult: DetectTextOutput
 
         do {
             textResult = try await awsRekognition.detectText(input: request)
@@ -144,7 +144,7 @@ extension AWSPredictionsService: AWSRekognitionServiceBehavior {
         if let words = identifyTextResult.words, words.count < rekognitionWordLimit {
             return identifyTextResult
         } else {
-            let documentTextResult: DetectDocumentTextOutputResponse
+            let documentTextResult: DetectDocumentTextOutput
             do {
                 documentTextResult = try await detectDocumentText(image: imageData)
             } catch let error as PredictionsErrorConvertible {
@@ -197,7 +197,7 @@ extension AWSPredictionsService: AWSRekognitionServiceBehavior {
         let rekognitionImage = RekognitionClientTypes.Image(bytes: imageData)
         let request = DetectTextInput(image: rekognitionImage)
 
-        let textResult: DetectTextOutputResponse
+        let textResult: DetectTextOutput
         do {
             textResult = try await awsRekognition.detectText(input: request)
         } catch let error as PredictionsErrorConvertible {
@@ -217,7 +217,7 @@ extension AWSPredictionsService: AWSRekognitionServiceBehavior {
         if let words = identifyTextResult.words, words.count < rekognitionWordLimit {
             return identifyTextResult
         } else {
-            let documentTextResult: DetectDocumentTextOutputResponse
+            let documentTextResult: DetectDocumentTextOutput
             do {
                 documentTextResult = try await detectDocumentText(image: imageData)
             } catch let error as PredictionsErrorConvertible {
@@ -246,7 +246,7 @@ extension AWSPredictionsService: AWSRekognitionServiceBehavior {
 
     private func detectModerationLabels(
         image: Data
-    ) async throws -> DetectModerationLabelsOutputResponse {
+    ) async throws -> DetectModerationLabelsOutput {
         let image = RekognitionClientTypes.Image(bytes: image)
         let request = DetectModerationLabelsInput(
             image: image
@@ -256,7 +256,7 @@ extension AWSPredictionsService: AWSRekognitionServiceBehavior {
 
     private func detectLabels(
         image: Data
-    ) async throws -> DetectLabelsOutputResponse {
+    ) async throws -> DetectLabelsOutput {
         let image = RekognitionClientTypes.Image(bytes: image)
         let request = DetectLabelsInput(
             image: image

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Textract.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Textract.swift
@@ -12,7 +12,7 @@ import Foundation
 extension AWSPredictionsService: AWSTextractServiceBehavior {
     func detectDocumentText(
         image: Data
-    ) async throws -> DetectDocumentTextOutputResponse {
+    ) async throws -> DetectDocumentTextOutput {
         let document = TextractClientTypes.Document(bytes: image)
         let request = DetectDocumentTextInput(document: document)
        return try await awsTextract.detectDocumentText(input: request)
@@ -38,7 +38,7 @@ extension AWSPredictionsService: AWSTextractServiceBehavior {
             featureTypes: featureTypes
         )
 
-        let documentResult: AnalyzeDocumentOutputResponse
+        let documentResult: AnalyzeDocumentOutput
         do {
             documentResult = try await awsTextract.analyzeDocument(input: request)
         } catch let error as PredictionsErrorConvertible {

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Translate.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService+Translate.swift
@@ -32,7 +32,7 @@ extension AWSPredictionsService: AWSTranslateServiceBehavior {
             text: text
         )
 
-        let textTranslateResult: TranslateTextOutputResponse
+        let textTranslateResult: TranslateTextOutput
         do {
             textTranslateResult = try await awsTranslate.translateText(input: request)
         } catch let error as PredictionsErrorConvertible {

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSTextractServiceBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSTextractServiceBehavior.swift
@@ -17,5 +17,5 @@ protocol AWSTextractServiceBehavior {
 
     func detectDocumentText(
         image: Data
-    ) async throws -> DetectDocumentTextOutputResponse
+    ) async throws -> DetectDocumentTextOutput
 }

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Mocks/Service/MockComprehendBehavior.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Mocks/Service/MockComprehendBehavior.swift
@@ -9,33 +9,33 @@ import AWSComprehend
 @testable import AWSPredictionsPlugin
 
 class MockComprehendBehavior: ComprehendClientProtocol {
-    var sentimentResponse: ((DetectSentimentInput) async throws -> DetectSentimentOutputResponse)? = nil
-    var entitiesResponse: ((DetectEntitiesInput) async throws -> DetectEntitiesOutputResponse)? = nil
-    var languageResponse: ((DetectDominantLanguageInput) async throws -> DetectDominantLanguageOutputResponse)? = nil
-    var syntaxResponse: ((DetectSyntaxInput) async throws -> DetectSyntaxOutputResponse)? = nil
-    var keyPhrasesResponse: ((DetectKeyPhrasesInput) async throws -> DetectKeyPhrasesOutputResponse)? = nil
+    var sentimentResponse: ((DetectSentimentInput) async throws -> DetectSentimentOutput)? = nil
+    var entitiesResponse: ((DetectEntitiesInput) async throws -> DetectEntitiesOutput)? = nil
+    var languageResponse: ((DetectDominantLanguageInput) async throws -> DetectDominantLanguageOutput)? = nil
+    var syntaxResponse: ((DetectSyntaxInput) async throws -> DetectSyntaxOutput)? = nil
+    var keyPhrasesResponse: ((DetectKeyPhrasesInput) async throws -> DetectKeyPhrasesOutput)? = nil
 
-    func detectSentiment(input: DetectSentimentInput) async throws -> DetectSentimentOutputResponse {
+    func detectSentiment(input: DetectSentimentInput) async throws -> DetectSentimentOutput {
         guard let sentimentResponse else { throw MockBehaviorDefaultError() }
         return try await sentimentResponse(input)
     }
 
-    func detectEntities(input: DetectEntitiesInput) async throws -> DetectEntitiesOutputResponse {
+    func detectEntities(input: DetectEntitiesInput) async throws -> DetectEntitiesOutput {
         guard let entitiesResponse else { throw MockBehaviorDefaultError() }
         return try await entitiesResponse(input)
     }
 
-    func detectDominantLanguage(input: DetectDominantLanguageInput) async throws -> DetectDominantLanguageOutputResponse {
+    func detectDominantLanguage(input: DetectDominantLanguageInput) async throws -> DetectDominantLanguageOutput {
         guard let languageResponse else { throw MockBehaviorDefaultError() }
         return try await languageResponse(input)
     }
 
-    func detectSyntax(input: DetectSyntaxInput) async throws -> DetectSyntaxOutputResponse {
+    func detectSyntax(input: DetectSyntaxInput) async throws -> DetectSyntaxOutput {
         guard let syntaxResponse else { throw MockBehaviorDefaultError() }
         return try await syntaxResponse(input)
     }
 
-    func detectKeyPhrases(input: DetectKeyPhrasesInput) async throws -> DetectKeyPhrasesOutputResponse {
+    func detectKeyPhrases(input: DetectKeyPhrasesInput) async throws -> DetectKeyPhrasesOutput {
         guard let keyPhrasesResponse else { throw MockBehaviorDefaultError() }
         return try await keyPhrasesResponse(input)
     }
@@ -47,83 +47,83 @@ class MockComprehendBehavior: ComprehendClientProtocol {
 
 // MARK: Unused ComprehendClientProtocol Methods
 extension MockComprehendBehavior {
-    func batchDetectDominantLanguage(input: AWSComprehend.BatchDetectDominantLanguageInput) async throws -> AWSComprehend.BatchDetectDominantLanguageOutputResponse { fatalError() }
-    func batchDetectEntities(input: AWSComprehend.BatchDetectEntitiesInput) async throws -> AWSComprehend.BatchDetectEntitiesOutputResponse { fatalError() }
-    func batchDetectKeyPhrases(input: AWSComprehend.BatchDetectKeyPhrasesInput) async throws -> AWSComprehend.BatchDetectKeyPhrasesOutputResponse { fatalError() }
-    func batchDetectSentiment(input: AWSComprehend.BatchDetectSentimentInput) async throws -> AWSComprehend.BatchDetectSentimentOutputResponse { fatalError() }
-    func batchDetectSyntax(input: AWSComprehend.BatchDetectSyntaxInput) async throws -> AWSComprehend.BatchDetectSyntaxOutputResponse { fatalError() }
-    func batchDetectTargetedSentiment(input: AWSComprehend.BatchDetectTargetedSentimentInput) async throws -> AWSComprehend.BatchDetectTargetedSentimentOutputResponse { fatalError() }
-    func classifyDocument(input: AWSComprehend.ClassifyDocumentInput) async throws -> AWSComprehend.ClassifyDocumentOutputResponse { fatalError() }
-    func containsPiiEntities(input: AWSComprehend.ContainsPiiEntitiesInput) async throws -> AWSComprehend.ContainsPiiEntitiesOutputResponse { fatalError() }
-    func createDocumentClassifier(input: AWSComprehend.CreateDocumentClassifierInput) async throws -> AWSComprehend.CreateDocumentClassifierOutputResponse { fatalError() }
-    func createEndpoint(input: AWSComprehend.CreateEndpointInput) async throws -> AWSComprehend.CreateEndpointOutputResponse { fatalError() }
-    func createEntityRecognizer(input: AWSComprehend.CreateEntityRecognizerInput) async throws -> AWSComprehend.CreateEntityRecognizerOutputResponse { fatalError() }
-    func deleteDocumentClassifier(input: AWSComprehend.DeleteDocumentClassifierInput) async throws -> AWSComprehend.DeleteDocumentClassifierOutputResponse { fatalError() }
-    func deleteEndpoint(input: AWSComprehend.DeleteEndpointInput) async throws -> AWSComprehend.DeleteEndpointOutputResponse { fatalError() }
-    func deleteEntityRecognizer(input: AWSComprehend.DeleteEntityRecognizerInput) async throws -> AWSComprehend.DeleteEntityRecognizerOutputResponse { fatalError() }
-    func deleteResourcePolicy(input: AWSComprehend.DeleteResourcePolicyInput) async throws -> AWSComprehend.DeleteResourcePolicyOutputResponse { fatalError() }
-    func describeDocumentClassificationJob(input: AWSComprehend.DescribeDocumentClassificationJobInput) async throws -> AWSComprehend.DescribeDocumentClassificationJobOutputResponse { fatalError() }
-    func describeDocumentClassifier(input: AWSComprehend.DescribeDocumentClassifierInput) async throws -> AWSComprehend.DescribeDocumentClassifierOutputResponse { fatalError() }
-    func describeDominantLanguageDetectionJob(input: AWSComprehend.DescribeDominantLanguageDetectionJobInput) async throws -> AWSComprehend.DescribeDominantLanguageDetectionJobOutputResponse { fatalError() }
-    func describeEndpoint(input: AWSComprehend.DescribeEndpointInput) async throws -> AWSComprehend.DescribeEndpointOutputResponse { fatalError() }
-    func describeEntitiesDetectionJob(input: AWSComprehend.DescribeEntitiesDetectionJobInput) async throws -> AWSComprehend.DescribeEntitiesDetectionJobOutputResponse { fatalError() }
-    func describeEntityRecognizer(input: AWSComprehend.DescribeEntityRecognizerInput) async throws -> AWSComprehend.DescribeEntityRecognizerOutputResponse { fatalError() }
-    func describeEventsDetectionJob(input: AWSComprehend.DescribeEventsDetectionJobInput) async throws -> AWSComprehend.DescribeEventsDetectionJobOutputResponse { fatalError() }
-    func describeKeyPhrasesDetectionJob(input: AWSComprehend.DescribeKeyPhrasesDetectionJobInput) async throws -> AWSComprehend.DescribeKeyPhrasesDetectionJobOutputResponse { fatalError() }
-    func describePiiEntitiesDetectionJob(input: AWSComprehend.DescribePiiEntitiesDetectionJobInput) async throws -> AWSComprehend.DescribePiiEntitiesDetectionJobOutputResponse { fatalError() }
-    func describeResourcePolicy(input: AWSComprehend.DescribeResourcePolicyInput) async throws -> AWSComprehend.DescribeResourcePolicyOutputResponse { fatalError() }
-    func describeSentimentDetectionJob(input: AWSComprehend.DescribeSentimentDetectionJobInput) async throws -> AWSComprehend.DescribeSentimentDetectionJobOutputResponse { fatalError() }
-    func describeTargetedSentimentDetectionJob(input: AWSComprehend.DescribeTargetedSentimentDetectionJobInput) async throws -> AWSComprehend.DescribeTargetedSentimentDetectionJobOutputResponse { fatalError() }
-    func describeTopicsDetectionJob(input: AWSComprehend.DescribeTopicsDetectionJobInput) async throws -> AWSComprehend.DescribeTopicsDetectionJobOutputResponse { fatalError() }
-    func detectPiiEntities(input: AWSComprehend.DetectPiiEntitiesInput) async throws -> AWSComprehend.DetectPiiEntitiesOutputResponse { fatalError() }
-    func detectTargetedSentiment(input: AWSComprehend.DetectTargetedSentimentInput) async throws -> AWSComprehend.DetectTargetedSentimentOutputResponse { fatalError() }
-    func importModel(input: AWSComprehend.ImportModelInput) async throws -> AWSComprehend.ImportModelOutputResponse { fatalError() }
-    func listDocumentClassificationJobs(input: AWSComprehend.ListDocumentClassificationJobsInput) async throws -> AWSComprehend.ListDocumentClassificationJobsOutputResponse { fatalError() }
-    func listDocumentClassifiers(input: AWSComprehend.ListDocumentClassifiersInput) async throws -> AWSComprehend.ListDocumentClassifiersOutputResponse { fatalError() }
-    func listDocumentClassifierSummaries(input: AWSComprehend.ListDocumentClassifierSummariesInput) async throws -> AWSComprehend.ListDocumentClassifierSummariesOutputResponse { fatalError() }
-    func listDominantLanguageDetectionJobs(input: AWSComprehend.ListDominantLanguageDetectionJobsInput) async throws -> AWSComprehend.ListDominantLanguageDetectionJobsOutputResponse { fatalError() }
-    func listEndpoints(input: AWSComprehend.ListEndpointsInput) async throws -> AWSComprehend.ListEndpointsOutputResponse { fatalError() }
-    func listEntitiesDetectionJobs(input: AWSComprehend.ListEntitiesDetectionJobsInput) async throws -> AWSComprehend.ListEntitiesDetectionJobsOutputResponse { fatalError() }
-    func listEntityRecognizers(input: AWSComprehend.ListEntityRecognizersInput) async throws -> AWSComprehend.ListEntityRecognizersOutputResponse { fatalError() }
-    func listEntityRecognizerSummaries(input: AWSComprehend.ListEntityRecognizerSummariesInput) async throws -> AWSComprehend.ListEntityRecognizerSummariesOutputResponse { fatalError() }
-    func listEventsDetectionJobs(input: AWSComprehend.ListEventsDetectionJobsInput) async throws -> AWSComprehend.ListEventsDetectionJobsOutputResponse { fatalError() }
-    func listKeyPhrasesDetectionJobs(input: AWSComprehend.ListKeyPhrasesDetectionJobsInput) async throws -> AWSComprehend.ListKeyPhrasesDetectionJobsOutputResponse { fatalError() }
-    func listPiiEntitiesDetectionJobs(input: AWSComprehend.ListPiiEntitiesDetectionJobsInput) async throws -> AWSComprehend.ListPiiEntitiesDetectionJobsOutputResponse { fatalError() }
-    func listSentimentDetectionJobs(input: AWSComprehend.ListSentimentDetectionJobsInput) async throws -> AWSComprehend.ListSentimentDetectionJobsOutputResponse { fatalError() }
-    func listTagsForResource(input: AWSComprehend.ListTagsForResourceInput) async throws -> AWSComprehend.ListTagsForResourceOutputResponse { fatalError() }
-    func listTargetedSentimentDetectionJobs(input: AWSComprehend.ListTargetedSentimentDetectionJobsInput) async throws -> AWSComprehend.ListTargetedSentimentDetectionJobsOutputResponse { fatalError() }
-    func listTopicsDetectionJobs(input: AWSComprehend.ListTopicsDetectionJobsInput) async throws -> AWSComprehend.ListTopicsDetectionJobsOutputResponse { fatalError() }
-    func putResourcePolicy(input: AWSComprehend.PutResourcePolicyInput) async throws -> AWSComprehend.PutResourcePolicyOutputResponse { fatalError() }
-    func startDocumentClassificationJob(input: AWSComprehend.StartDocumentClassificationJobInput) async throws -> AWSComprehend.StartDocumentClassificationJobOutputResponse { fatalError() }
-    func startDominantLanguageDetectionJob(input: AWSComprehend.StartDominantLanguageDetectionJobInput) async throws -> AWSComprehend.StartDominantLanguageDetectionJobOutputResponse { fatalError() }
-    func startEntitiesDetectionJob(input: AWSComprehend.StartEntitiesDetectionJobInput) async throws -> AWSComprehend.StartEntitiesDetectionJobOutputResponse { fatalError() }
-    func startEventsDetectionJob(input: AWSComprehend.StartEventsDetectionJobInput) async throws -> AWSComprehend.StartEventsDetectionJobOutputResponse { fatalError() }
-    func startKeyPhrasesDetectionJob(input: AWSComprehend.StartKeyPhrasesDetectionJobInput) async throws -> AWSComprehend.StartKeyPhrasesDetectionJobOutputResponse { fatalError() }
-    func startPiiEntitiesDetectionJob(input: AWSComprehend.StartPiiEntitiesDetectionJobInput) async throws -> AWSComprehend.StartPiiEntitiesDetectionJobOutputResponse { fatalError() }
-    func startSentimentDetectionJob(input: AWSComprehend.StartSentimentDetectionJobInput) async throws -> AWSComprehend.StartSentimentDetectionJobOutputResponse { fatalError() }
-    func startTargetedSentimentDetectionJob(input: AWSComprehend.StartTargetedSentimentDetectionJobInput) async throws -> AWSComprehend.StartTargetedSentimentDetectionJobOutputResponse { fatalError() }
-    func startTopicsDetectionJob(input: AWSComprehend.StartTopicsDetectionJobInput) async throws -> AWSComprehend.StartTopicsDetectionJobOutputResponse { fatalError() }
-    func stopDominantLanguageDetectionJob(input: AWSComprehend.StopDominantLanguageDetectionJobInput) async throws -> AWSComprehend.StopDominantLanguageDetectionJobOutputResponse { fatalError() }
-    func stopEntitiesDetectionJob(input: AWSComprehend.StopEntitiesDetectionJobInput) async throws -> AWSComprehend.StopEntitiesDetectionJobOutputResponse { fatalError() }
-    func stopEventsDetectionJob(input: AWSComprehend.StopEventsDetectionJobInput) async throws -> AWSComprehend.StopEventsDetectionJobOutputResponse { fatalError() }
-    func stopKeyPhrasesDetectionJob(input: AWSComprehend.StopKeyPhrasesDetectionJobInput) async throws -> AWSComprehend.StopKeyPhrasesDetectionJobOutputResponse { fatalError() }
-    func stopPiiEntitiesDetectionJob(input: AWSComprehend.StopPiiEntitiesDetectionJobInput) async throws -> AWSComprehend.StopPiiEntitiesDetectionJobOutputResponse { fatalError() }
-    func stopSentimentDetectionJob(input: AWSComprehend.StopSentimentDetectionJobInput) async throws -> AWSComprehend.StopSentimentDetectionJobOutputResponse { fatalError() }
-    func stopTargetedSentimentDetectionJob(input: AWSComprehend.StopTargetedSentimentDetectionJobInput) async throws -> AWSComprehend.StopTargetedSentimentDetectionJobOutputResponse { fatalError() }
-    func stopTrainingDocumentClassifier(input: AWSComprehend.StopTrainingDocumentClassifierInput) async throws -> AWSComprehend.StopTrainingDocumentClassifierOutputResponse { fatalError() }
-    func stopTrainingEntityRecognizer(input: AWSComprehend.StopTrainingEntityRecognizerInput) async throws -> AWSComprehend.StopTrainingEntityRecognizerOutputResponse { fatalError() }
-    func tagResource(input: AWSComprehend.TagResourceInput) async throws -> AWSComprehend.TagResourceOutputResponse { fatalError() }
-    func untagResource(input: AWSComprehend.UntagResourceInput) async throws -> AWSComprehend.UntagResourceOutputResponse { fatalError() }
-    func updateEndpoint(input: AWSComprehend.UpdateEndpointInput) async throws -> AWSComprehend.UpdateEndpointOutputResponse { fatalError() }
-    func createDataset(input: AWSComprehend.CreateDatasetInput) async throws -> AWSComprehend.CreateDatasetOutputResponse { fatalError() }
-    func createFlywheel(input: AWSComprehend.CreateFlywheelInput) async throws -> AWSComprehend.CreateFlywheelOutputResponse { fatalError() }
-    func deleteFlywheel(input: AWSComprehend.DeleteFlywheelInput) async throws -> AWSComprehend.DeleteFlywheelOutputResponse { fatalError() }
-    func describeDataset(input: AWSComprehend.DescribeDatasetInput) async throws -> AWSComprehend.DescribeDatasetOutputResponse { fatalError() }
-    func describeFlywheel(input: AWSComprehend.DescribeFlywheelInput) async throws -> AWSComprehend.DescribeFlywheelOutputResponse { fatalError() }
-    func describeFlywheelIteration(input: AWSComprehend.DescribeFlywheelIterationInput) async throws -> AWSComprehend.DescribeFlywheelIterationOutputResponse { fatalError() }
-    func listDatasets(input: AWSComprehend.ListDatasetsInput) async throws -> AWSComprehend.ListDatasetsOutputResponse { fatalError() }
-    func listFlywheelIterationHistory(input: AWSComprehend.ListFlywheelIterationHistoryInput) async throws -> AWSComprehend.ListFlywheelIterationHistoryOutputResponse { fatalError() }
-    func listFlywheels(input: AWSComprehend.ListFlywheelsInput) async throws -> AWSComprehend.ListFlywheelsOutputResponse { fatalError() }
-    func startFlywheelIteration(input: AWSComprehend.StartFlywheelIterationInput) async throws -> AWSComprehend.StartFlywheelIterationOutputResponse { fatalError() }
-    func updateFlywheel(input: AWSComprehend.UpdateFlywheelInput) async throws -> AWSComprehend.UpdateFlywheelOutputResponse { fatalError() }
+    func batchDetectDominantLanguage(input: AWSComprehend.BatchDetectDominantLanguageInput) async throws -> AWSComprehend.BatchDetectDominantLanguageOutput { fatalError() }
+    func batchDetectEntities(input: AWSComprehend.BatchDetectEntitiesInput) async throws -> AWSComprehend.BatchDetectEntitiesOutput { fatalError() }
+    func batchDetectKeyPhrases(input: AWSComprehend.BatchDetectKeyPhrasesInput) async throws -> AWSComprehend.BatchDetectKeyPhrasesOutput { fatalError() }
+    func batchDetectSentiment(input: AWSComprehend.BatchDetectSentimentInput) async throws -> AWSComprehend.BatchDetectSentimentOutput { fatalError() }
+    func batchDetectSyntax(input: AWSComprehend.BatchDetectSyntaxInput) async throws -> AWSComprehend.BatchDetectSyntaxOutput { fatalError() }
+    func batchDetectTargetedSentiment(input: AWSComprehend.BatchDetectTargetedSentimentInput) async throws -> AWSComprehend.BatchDetectTargetedSentimentOutput { fatalError() }
+    func classifyDocument(input: AWSComprehend.ClassifyDocumentInput) async throws -> AWSComprehend.ClassifyDocumentOutput { fatalError() }
+    func containsPiiEntities(input: AWSComprehend.ContainsPiiEntitiesInput) async throws -> AWSComprehend.ContainsPiiEntitiesOutput { fatalError() }
+    func createDocumentClassifier(input: AWSComprehend.CreateDocumentClassifierInput) async throws -> AWSComprehend.CreateDocumentClassifierOutput { fatalError() }
+    func createEndpoint(input: AWSComprehend.CreateEndpointInput) async throws -> AWSComprehend.CreateEndpointOutput { fatalError() }
+    func createEntityRecognizer(input: AWSComprehend.CreateEntityRecognizerInput) async throws -> AWSComprehend.CreateEntityRecognizerOutput { fatalError() }
+    func deleteDocumentClassifier(input: AWSComprehend.DeleteDocumentClassifierInput) async throws -> AWSComprehend.DeleteDocumentClassifierOutput { fatalError() }
+    func deleteEndpoint(input: AWSComprehend.DeleteEndpointInput) async throws -> AWSComprehend.DeleteEndpointOutput { fatalError() }
+    func deleteEntityRecognizer(input: AWSComprehend.DeleteEntityRecognizerInput) async throws -> AWSComprehend.DeleteEntityRecognizerOutput { fatalError() }
+    func deleteResourcePolicy(input: AWSComprehend.DeleteResourcePolicyInput) async throws -> AWSComprehend.DeleteResourcePolicyOutput { fatalError() }
+    func describeDocumentClassificationJob(input: AWSComprehend.DescribeDocumentClassificationJobInput) async throws -> AWSComprehend.DescribeDocumentClassificationJobOutput { fatalError() }
+    func describeDocumentClassifier(input: AWSComprehend.DescribeDocumentClassifierInput) async throws -> AWSComprehend.DescribeDocumentClassifierOutput { fatalError() }
+    func describeDominantLanguageDetectionJob(input: AWSComprehend.DescribeDominantLanguageDetectionJobInput) async throws -> AWSComprehend.DescribeDominantLanguageDetectionJobOutput { fatalError() }
+    func describeEndpoint(input: AWSComprehend.DescribeEndpointInput) async throws -> AWSComprehend.DescribeEndpointOutput { fatalError() }
+    func describeEntitiesDetectionJob(input: AWSComprehend.DescribeEntitiesDetectionJobInput) async throws -> AWSComprehend.DescribeEntitiesDetectionJobOutput { fatalError() }
+    func describeEntityRecognizer(input: AWSComprehend.DescribeEntityRecognizerInput) async throws -> AWSComprehend.DescribeEntityRecognizerOutput { fatalError() }
+    func describeEventsDetectionJob(input: AWSComprehend.DescribeEventsDetectionJobInput) async throws -> AWSComprehend.DescribeEventsDetectionJobOutput { fatalError() }
+    func describeKeyPhrasesDetectionJob(input: AWSComprehend.DescribeKeyPhrasesDetectionJobInput) async throws -> AWSComprehend.DescribeKeyPhrasesDetectionJobOutput { fatalError() }
+    func describePiiEntitiesDetectionJob(input: AWSComprehend.DescribePiiEntitiesDetectionJobInput) async throws -> AWSComprehend.DescribePiiEntitiesDetectionJobOutput { fatalError() }
+    func describeResourcePolicy(input: AWSComprehend.DescribeResourcePolicyInput) async throws -> AWSComprehend.DescribeResourcePolicyOutput { fatalError() }
+    func describeSentimentDetectionJob(input: AWSComprehend.DescribeSentimentDetectionJobInput) async throws -> AWSComprehend.DescribeSentimentDetectionJobOutput { fatalError() }
+    func describeTargetedSentimentDetectionJob(input: AWSComprehend.DescribeTargetedSentimentDetectionJobInput) async throws -> AWSComprehend.DescribeTargetedSentimentDetectionJobOutput { fatalError() }
+    func describeTopicsDetectionJob(input: AWSComprehend.DescribeTopicsDetectionJobInput) async throws -> AWSComprehend.DescribeTopicsDetectionJobOutput { fatalError() }
+    func detectPiiEntities(input: AWSComprehend.DetectPiiEntitiesInput) async throws -> AWSComprehend.DetectPiiEntitiesOutput { fatalError() }
+    func detectTargetedSentiment(input: AWSComprehend.DetectTargetedSentimentInput) async throws -> AWSComprehend.DetectTargetedSentimentOutput { fatalError() }
+    func importModel(input: AWSComprehend.ImportModelInput) async throws -> AWSComprehend.ImportModelOutput { fatalError() }
+    func listDocumentClassificationJobs(input: AWSComprehend.ListDocumentClassificationJobsInput) async throws -> AWSComprehend.ListDocumentClassificationJobsOutput { fatalError() }
+    func listDocumentClassifiers(input: AWSComprehend.ListDocumentClassifiersInput) async throws -> AWSComprehend.ListDocumentClassifiersOutput { fatalError() }
+    func listDocumentClassifierSummaries(input: AWSComprehend.ListDocumentClassifierSummariesInput) async throws -> AWSComprehend.ListDocumentClassifierSummariesOutput { fatalError() }
+    func listDominantLanguageDetectionJobs(input: AWSComprehend.ListDominantLanguageDetectionJobsInput) async throws -> AWSComprehend.ListDominantLanguageDetectionJobsOutput { fatalError() }
+    func listEndpoints(input: AWSComprehend.ListEndpointsInput) async throws -> AWSComprehend.ListEndpointsOutput { fatalError() }
+    func listEntitiesDetectionJobs(input: AWSComprehend.ListEntitiesDetectionJobsInput) async throws -> AWSComprehend.ListEntitiesDetectionJobsOutput { fatalError() }
+    func listEntityRecognizers(input: AWSComprehend.ListEntityRecognizersInput) async throws -> AWSComprehend.ListEntityRecognizersOutput { fatalError() }
+    func listEntityRecognizerSummaries(input: AWSComprehend.ListEntityRecognizerSummariesInput) async throws -> AWSComprehend.ListEntityRecognizerSummariesOutput { fatalError() }
+    func listEventsDetectionJobs(input: AWSComprehend.ListEventsDetectionJobsInput) async throws -> AWSComprehend.ListEventsDetectionJobsOutput { fatalError() }
+    func listKeyPhrasesDetectionJobs(input: AWSComprehend.ListKeyPhrasesDetectionJobsInput) async throws -> AWSComprehend.ListKeyPhrasesDetectionJobsOutput { fatalError() }
+    func listPiiEntitiesDetectionJobs(input: AWSComprehend.ListPiiEntitiesDetectionJobsInput) async throws -> AWSComprehend.ListPiiEntitiesDetectionJobsOutput { fatalError() }
+    func listSentimentDetectionJobs(input: AWSComprehend.ListSentimentDetectionJobsInput) async throws -> AWSComprehend.ListSentimentDetectionJobsOutput { fatalError() }
+    func listTagsForResource(input: AWSComprehend.ListTagsForResourceInput) async throws -> AWSComprehend.ListTagsForResourceOutput { fatalError() }
+    func listTargetedSentimentDetectionJobs(input: AWSComprehend.ListTargetedSentimentDetectionJobsInput) async throws -> AWSComprehend.ListTargetedSentimentDetectionJobsOutput { fatalError() }
+    func listTopicsDetectionJobs(input: AWSComprehend.ListTopicsDetectionJobsInput) async throws -> AWSComprehend.ListTopicsDetectionJobsOutput { fatalError() }
+    func putResourcePolicy(input: AWSComprehend.PutResourcePolicyInput) async throws -> AWSComprehend.PutResourcePolicyOutput { fatalError() }
+    func startDocumentClassificationJob(input: AWSComprehend.StartDocumentClassificationJobInput) async throws -> AWSComprehend.StartDocumentClassificationJobOutput { fatalError() }
+    func startDominantLanguageDetectionJob(input: AWSComprehend.StartDominantLanguageDetectionJobInput) async throws -> AWSComprehend.StartDominantLanguageDetectionJobOutput { fatalError() }
+    func startEntitiesDetectionJob(input: AWSComprehend.StartEntitiesDetectionJobInput) async throws -> AWSComprehend.StartEntitiesDetectionJobOutput { fatalError() }
+    func startEventsDetectionJob(input: AWSComprehend.StartEventsDetectionJobInput) async throws -> AWSComprehend.StartEventsDetectionJobOutput { fatalError() }
+    func startKeyPhrasesDetectionJob(input: AWSComprehend.StartKeyPhrasesDetectionJobInput) async throws -> AWSComprehend.StartKeyPhrasesDetectionJobOutput { fatalError() }
+    func startPiiEntitiesDetectionJob(input: AWSComprehend.StartPiiEntitiesDetectionJobInput) async throws -> AWSComprehend.StartPiiEntitiesDetectionJobOutput { fatalError() }
+    func startSentimentDetectionJob(input: AWSComprehend.StartSentimentDetectionJobInput) async throws -> AWSComprehend.StartSentimentDetectionJobOutput { fatalError() }
+    func startTargetedSentimentDetectionJob(input: AWSComprehend.StartTargetedSentimentDetectionJobInput) async throws -> AWSComprehend.StartTargetedSentimentDetectionJobOutput { fatalError() }
+    func startTopicsDetectionJob(input: AWSComprehend.StartTopicsDetectionJobInput) async throws -> AWSComprehend.StartTopicsDetectionJobOutput { fatalError() }
+    func stopDominantLanguageDetectionJob(input: AWSComprehend.StopDominantLanguageDetectionJobInput) async throws -> AWSComprehend.StopDominantLanguageDetectionJobOutput { fatalError() }
+    func stopEntitiesDetectionJob(input: AWSComprehend.StopEntitiesDetectionJobInput) async throws -> AWSComprehend.StopEntitiesDetectionJobOutput { fatalError() }
+    func stopEventsDetectionJob(input: AWSComprehend.StopEventsDetectionJobInput) async throws -> AWSComprehend.StopEventsDetectionJobOutput { fatalError() }
+    func stopKeyPhrasesDetectionJob(input: AWSComprehend.StopKeyPhrasesDetectionJobInput) async throws -> AWSComprehend.StopKeyPhrasesDetectionJobOutput { fatalError() }
+    func stopPiiEntitiesDetectionJob(input: AWSComprehend.StopPiiEntitiesDetectionJobInput) async throws -> AWSComprehend.StopPiiEntitiesDetectionJobOutput { fatalError() }
+    func stopSentimentDetectionJob(input: AWSComprehend.StopSentimentDetectionJobInput) async throws -> AWSComprehend.StopSentimentDetectionJobOutput { fatalError() }
+    func stopTargetedSentimentDetectionJob(input: AWSComprehend.StopTargetedSentimentDetectionJobInput) async throws -> AWSComprehend.StopTargetedSentimentDetectionJobOutput { fatalError() }
+    func stopTrainingDocumentClassifier(input: AWSComprehend.StopTrainingDocumentClassifierInput) async throws -> AWSComprehend.StopTrainingDocumentClassifierOutput { fatalError() }
+    func stopTrainingEntityRecognizer(input: AWSComprehend.StopTrainingEntityRecognizerInput) async throws -> AWSComprehend.StopTrainingEntityRecognizerOutput { fatalError() }
+    func tagResource(input: AWSComprehend.TagResourceInput) async throws -> AWSComprehend.TagResourceOutput { fatalError() }
+    func untagResource(input: AWSComprehend.UntagResourceInput) async throws -> AWSComprehend.UntagResourceOutput { fatalError() }
+    func updateEndpoint(input: AWSComprehend.UpdateEndpointInput) async throws -> AWSComprehend.UpdateEndpointOutput { fatalError() }
+    func createDataset(input: AWSComprehend.CreateDatasetInput) async throws -> AWSComprehend.CreateDatasetOutput { fatalError() }
+    func createFlywheel(input: AWSComprehend.CreateFlywheelInput) async throws -> AWSComprehend.CreateFlywheelOutput { fatalError() }
+    func deleteFlywheel(input: AWSComprehend.DeleteFlywheelInput) async throws -> AWSComprehend.DeleteFlywheelOutput { fatalError() }
+    func describeDataset(input: AWSComprehend.DescribeDatasetInput) async throws -> AWSComprehend.DescribeDatasetOutput { fatalError() }
+    func describeFlywheel(input: AWSComprehend.DescribeFlywheelInput) async throws -> AWSComprehend.DescribeFlywheelOutput { fatalError() }
+    func describeFlywheelIteration(input: AWSComprehend.DescribeFlywheelIterationInput) async throws -> AWSComprehend.DescribeFlywheelIterationOutput { fatalError() }
+    func listDatasets(input: AWSComprehend.ListDatasetsInput) async throws -> AWSComprehend.ListDatasetsOutput { fatalError() }
+    func listFlywheelIterationHistory(input: AWSComprehend.ListFlywheelIterationHistoryInput) async throws -> AWSComprehend.ListFlywheelIterationHistoryOutput { fatalError() }
+    func listFlywheels(input: AWSComprehend.ListFlywheelsInput) async throws -> AWSComprehend.ListFlywheelsOutput { fatalError() }
+    func startFlywheelIteration(input: AWSComprehend.StartFlywheelIterationInput) async throws -> AWSComprehend.StartFlywheelIterationOutput { fatalError() }
+    func updateFlywheel(input: AWSComprehend.UpdateFlywheelInput) async throws -> AWSComprehend.UpdateFlywheelOutput { fatalError() }
 }

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Mocks/Service/MockPollyBehavior.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Mocks/Service/MockPollyBehavior.swift
@@ -9,11 +9,11 @@ import AWSPolly
 @testable import AWSPredictionsPlugin
 
 class MockPollyBehavior: PollyClientProtocol {
-    var synthesizeSpeechResult: ((SynthesizeSpeechInput) async throws -> SynthesizeSpeechOutputResponse)? = nil
+    var synthesizeSpeechResult: ((SynthesizeSpeechInput) async throws -> SynthesizeSpeechOutput)? = nil
 
     func synthesizeSpeech(
         input: SynthesizeSpeechInput
-    ) async throws -> SynthesizeSpeechOutputResponse {
+    ) async throws -> SynthesizeSpeechOutput {
         guard let synthesizeSpeechResult else { throw MockBehaviorDefaultError() }
         return try await synthesizeSpeechResult(input)
     }
@@ -25,12 +25,12 @@ class MockPollyBehavior: PollyClientProtocol {
 
 // MARK: Unused PolliClientProtocol Methods
 extension MockPollyBehavior {
-    func deleteLexicon(input: AWSPolly.DeleteLexiconInput) async throws -> AWSPolly.DeleteLexiconOutputResponse { fatalError() }
-    func describeVoices(input: AWSPolly.DescribeVoicesInput) async throws -> AWSPolly.DescribeVoicesOutputResponse { fatalError() }
-    func getLexicon(input: AWSPolly.GetLexiconInput) async throws -> AWSPolly.GetLexiconOutputResponse { fatalError() }
-    func getSpeechSynthesisTask(input: AWSPolly.GetSpeechSynthesisTaskInput) async throws -> AWSPolly.GetSpeechSynthesisTaskOutputResponse { fatalError() }
-    func listLexicons(input: AWSPolly.ListLexiconsInput) async throws -> AWSPolly.ListLexiconsOutputResponse { fatalError() }
-    func listSpeechSynthesisTasks(input: AWSPolly.ListSpeechSynthesisTasksInput) async throws -> AWSPolly.ListSpeechSynthesisTasksOutputResponse { fatalError() }
-    func putLexicon(input: AWSPolly.PutLexiconInput) async throws -> AWSPolly.PutLexiconOutputResponse { fatalError() }
-    func startSpeechSynthesisTask(input: AWSPolly.StartSpeechSynthesisTaskInput) async throws -> AWSPolly.StartSpeechSynthesisTaskOutputResponse { fatalError() }
+    func deleteLexicon(input: AWSPolly.DeleteLexiconInput) async throws -> AWSPolly.DeleteLexiconOutput { fatalError() }
+    func describeVoices(input: AWSPolly.DescribeVoicesInput) async throws -> AWSPolly.DescribeVoicesOutput { fatalError() }
+    func getLexicon(input: AWSPolly.GetLexiconInput) async throws -> AWSPolly.GetLexiconOutput { fatalError() }
+    func getSpeechSynthesisTask(input: AWSPolly.GetSpeechSynthesisTaskInput) async throws -> AWSPolly.GetSpeechSynthesisTaskOutput { fatalError() }
+    func listLexicons(input: AWSPolly.ListLexiconsInput) async throws -> AWSPolly.ListLexiconsOutput { fatalError() }
+    func listSpeechSynthesisTasks(input: AWSPolly.ListSpeechSynthesisTasksInput) async throws -> AWSPolly.ListSpeechSynthesisTasksOutput { fatalError() }
+    func putLexicon(input: AWSPolly.PutLexiconInput) async throws -> AWSPolly.PutLexiconOutput { fatalError() }
+    func startSpeechSynthesisTask(input: AWSPolly.StartSpeechSynthesisTaskInput) async throws -> AWSPolly.StartSpeechSynthesisTaskOutput { fatalError() }
 }

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Mocks/Service/MockRekognitionBehavior.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Mocks/Service/MockRekognitionBehavior.swift
@@ -10,39 +10,39 @@ import AWSRekognition
 @testable import AWSPredictionsPlugin
 
 class MockRekognitionBehavior: RekognitionClientProtocol {
-    var detectLabelsResponse: ((DetectLabelsInput) async throws -> DetectLabelsOutputResponse)? = nil
-    var moderationLabelsResponse: ((DetectModerationLabelsInput) async throws -> DetectModerationLabelsOutputResponse)? = nil
-    var celebritiesResponse: ((RecognizeCelebritiesInput) async throws -> RecognizeCelebritiesOutputResponse)? = nil
-    var detectTextResponse: ((DetectTextInput) async throws -> DetectTextOutputResponse)? = nil
-    var facesResponse: ((DetectFacesInput) async throws -> DetectFacesOutputResponse)? = nil
-    var facesFromCollectionResponse: ((SearchFacesByImageInput) async throws -> SearchFacesByImageOutputResponse)? = nil
+    var detectLabelsResponse: ((DetectLabelsInput) async throws -> DetectLabelsOutput)? = nil
+    var moderationLabelsResponse: ((DetectModerationLabelsInput) async throws -> DetectModerationLabelsOutput)? = nil
+    var celebritiesResponse: ((RecognizeCelebritiesInput) async throws -> RecognizeCelebritiesOutput)? = nil
+    var detectTextResponse: ((DetectTextInput) async throws -> DetectTextOutput)? = nil
+    var facesResponse: ((DetectFacesInput) async throws -> DetectFacesOutput)? = nil
+    var facesFromCollectionResponse: ((SearchFacesByImageInput) async throws -> SearchFacesByImageOutput)? = nil
 
-    func detectLabels(input: DetectLabelsInput) async throws -> DetectLabelsOutputResponse {
+    func detectLabels(input: DetectLabelsInput) async throws -> DetectLabelsOutput {
         guard let detectLabelsResponse else { throw MockBehaviorDefaultError() }
         return try await detectLabelsResponse(input)
     }
 
-    func detectModerationLabels(input: DetectModerationLabelsInput) async throws -> DetectModerationLabelsOutputResponse {
+    func detectModerationLabels(input: DetectModerationLabelsInput) async throws -> DetectModerationLabelsOutput {
         guard let moderationLabelsResponse else { throw MockBehaviorDefaultError() }
         return try await moderationLabelsResponse(input)
     }
 
-    func detectCelebrities(input: RecognizeCelebritiesInput) async throws -> RecognizeCelebritiesOutputResponse {
+    func detectCelebrities(input: RecognizeCelebritiesInput) async throws -> RecognizeCelebritiesOutput {
         guard let celebritiesResponse else { throw MockBehaviorDefaultError() }
         return try await celebritiesResponse(input)
     }
 
-    func detectText(input: DetectTextInput) async throws -> DetectTextOutputResponse {
+    func detectText(input: DetectTextInput) async throws -> DetectTextOutput {
         guard let detectTextResponse else { throw MockBehaviorDefaultError() }
         return try await detectTextResponse(input)
     }
 
-    func detectFaces(input: DetectFacesInput) async throws -> DetectFacesOutputResponse {
+    func detectFaces(input: DetectFacesInput) async throws -> DetectFacesOutput {
         guard let facesResponse else { throw MockBehaviorDefaultError() }
         return try await facesResponse(input)
     }
 
-    func searchFacesByImage(input: SearchFacesByImageInput) async throws -> SearchFacesByImageOutputResponse {
+    func searchFacesByImage(input: SearchFacesByImageInput) async throws -> SearchFacesByImageOutput {
         guard let facesFromCollectionResponse else { throw MockBehaviorDefaultError() }
         return try await facesFromCollectionResponse(input)
     }
@@ -54,71 +54,82 @@ class MockRekognitionBehavior: RekognitionClientProtocol {
 
 // MARK: Unused RekognitionClientProtocol Methods
 extension MockRekognitionBehavior {
-    func compareFaces(input: AWSRekognition.CompareFacesInput) async throws -> AWSRekognition.CompareFacesOutputResponse { fatalError() }
-    func copyProjectVersion(input: AWSRekognition.CopyProjectVersionInput) async throws -> AWSRekognition.CopyProjectVersionOutputResponse { fatalError() }
-    func createCollection(input: AWSRekognition.CreateCollectionInput) async throws -> AWSRekognition.CreateCollectionOutputResponse { fatalError() }
-    func createDataset(input: AWSRekognition.CreateDatasetInput) async throws -> AWSRekognition.CreateDatasetOutputResponse { fatalError() }
-    func createProject(input: AWSRekognition.CreateProjectInput) async throws -> AWSRekognition.CreateProjectOutputResponse { fatalError() }
-    func createProjectVersion(input: AWSRekognition.CreateProjectVersionInput) async throws -> AWSRekognition.CreateProjectVersionOutputResponse { fatalError() }
-    func createStreamProcessor(input: AWSRekognition.CreateStreamProcessorInput) async throws -> AWSRekognition.CreateStreamProcessorOutputResponse { fatalError() }
-    func deleteCollection(input: AWSRekognition.DeleteCollectionInput) async throws -> AWSRekognition.DeleteCollectionOutputResponse { fatalError() }
-    func deleteDataset(input: AWSRekognition.DeleteDatasetInput) async throws -> AWSRekognition.DeleteDatasetOutputResponse { fatalError() }
-    func deleteFaces(input: AWSRekognition.DeleteFacesInput) async throws -> AWSRekognition.DeleteFacesOutputResponse { fatalError() }
-    func deleteProject(input: AWSRekognition.DeleteProjectInput) async throws -> AWSRekognition.DeleteProjectOutputResponse { fatalError() }
-    func deleteProjectPolicy(input: AWSRekognition.DeleteProjectPolicyInput) async throws -> AWSRekognition.DeleteProjectPolicyOutputResponse { fatalError() }
-    func deleteProjectVersion(input: AWSRekognition.DeleteProjectVersionInput) async throws -> AWSRekognition.DeleteProjectVersionOutputResponse { fatalError() }
-    func deleteStreamProcessor(input: AWSRekognition.DeleteStreamProcessorInput) async throws -> AWSRekognition.DeleteStreamProcessorOutputResponse { fatalError() }
-    func describeCollection(input: AWSRekognition.DescribeCollectionInput) async throws -> AWSRekognition.DescribeCollectionOutputResponse { fatalError() }
-    func describeDataset(input: AWSRekognition.DescribeDatasetInput) async throws -> AWSRekognition.DescribeDatasetOutputResponse { fatalError() }
-    func describeProjects(input: AWSRekognition.DescribeProjectsInput) async throws -> AWSRekognition.DescribeProjectsOutputResponse { fatalError() }
-    func describeProjectVersions(input: AWSRekognition.DescribeProjectVersionsInput) async throws -> AWSRekognition.DescribeProjectVersionsOutputResponse { fatalError() }
-    func describeStreamProcessor(input: AWSRekognition.DescribeStreamProcessorInput) async throws -> AWSRekognition.DescribeStreamProcessorOutputResponse { fatalError() }
-    func detectCustomLabels(input: AWSRekognition.DetectCustomLabelsInput) async throws -> AWSRekognition.DetectCustomLabelsOutputResponse { fatalError() }
-    func detectProtectiveEquipment(input: AWSRekognition.DetectProtectiveEquipmentInput) async throws -> AWSRekognition.DetectProtectiveEquipmentOutputResponse { fatalError() }
-    func distributeDatasetEntries(input: AWSRekognition.DistributeDatasetEntriesInput) async throws -> AWSRekognition.DistributeDatasetEntriesOutputResponse { fatalError() }
-    func getCelebrityInfo(input: AWSRekognition.GetCelebrityInfoInput) async throws -> AWSRekognition.GetCelebrityInfoOutputResponse { fatalError() }
-    func getCelebrityRecognition(input: AWSRekognition.GetCelebrityRecognitionInput) async throws -> AWSRekognition.GetCelebrityRecognitionOutputResponse { fatalError() }
-    func getContentModeration(input: AWSRekognition.GetContentModerationInput) async throws -> AWSRekognition.GetContentModerationOutputResponse { fatalError() }
-    func getFaceDetection(input: AWSRekognition.GetFaceDetectionInput) async throws -> AWSRekognition.GetFaceDetectionOutputResponse { fatalError() }
-    func getFaceSearch(input: AWSRekognition.GetFaceSearchInput) async throws -> AWSRekognition.GetFaceSearchOutputResponse { fatalError() }
-    func getLabelDetection(input: AWSRekognition.GetLabelDetectionInput) async throws -> AWSRekognition.GetLabelDetectionOutputResponse { fatalError() }
-    func getPersonTracking(input: AWSRekognition.GetPersonTrackingInput) async throws -> AWSRekognition.GetPersonTrackingOutputResponse { fatalError() }
-    func getSegmentDetection(input: AWSRekognition.GetSegmentDetectionInput) async throws -> AWSRekognition.GetSegmentDetectionOutputResponse { fatalError() }
-    func getTextDetection(input: AWSRekognition.GetTextDetectionInput) async throws -> AWSRekognition.GetTextDetectionOutputResponse { fatalError() }
-    func indexFaces(input: AWSRekognition.IndexFacesInput) async throws -> AWSRekognition.IndexFacesOutputResponse { fatalError() }
-    func listCollections(input: AWSRekognition.ListCollectionsInput) async throws -> AWSRekognition.ListCollectionsOutputResponse { fatalError() }
-    func listDatasetEntries(input: AWSRekognition.ListDatasetEntriesInput) async throws -> AWSRekognition.ListDatasetEntriesOutputResponse { fatalError() }
-    func listDatasetLabels(input: AWSRekognition.ListDatasetLabelsInput) async throws -> AWSRekognition.ListDatasetLabelsOutputResponse { fatalError() }
-    func listFaces(input: AWSRekognition.ListFacesInput) async throws -> AWSRekognition.ListFacesOutputResponse { fatalError() }
-    func listProjectPolicies(input: AWSRekognition.ListProjectPoliciesInput) async throws -> AWSRekognition.ListProjectPoliciesOutputResponse { fatalError() }
-    func listStreamProcessors(input: AWSRekognition.ListStreamProcessorsInput) async throws -> AWSRekognition.ListStreamProcessorsOutputResponse { fatalError() }
-    func listTagsForResource(input: AWSRekognition.ListTagsForResourceInput) async throws -> AWSRekognition.ListTagsForResourceOutputResponse { fatalError() }
-    func putProjectPolicy(input: AWSRekognition.PutProjectPolicyInput) async throws -> AWSRekognition.PutProjectPolicyOutputResponse { fatalError() }
-    func recognizeCelebrities(input: AWSRekognition.RecognizeCelebritiesInput) async throws -> AWSRekognition.RecognizeCelebritiesOutputResponse { fatalError() }
-    func searchFaces(input: AWSRekognition.SearchFacesInput) async throws -> AWSRekognition.SearchFacesOutputResponse { fatalError() }
-    func startCelebrityRecognition(input: AWSRekognition.StartCelebrityRecognitionInput) async throws -> AWSRekognition.StartCelebrityRecognitionOutputResponse { fatalError() }
-    func startContentModeration(input: AWSRekognition.StartContentModerationInput) async throws -> AWSRekognition.StartContentModerationOutputResponse { fatalError() }
-    func startFaceDetection(input: AWSRekognition.StartFaceDetectionInput) async throws -> AWSRekognition.StartFaceDetectionOutputResponse { fatalError() }
-    func startFaceSearch(input: AWSRekognition.StartFaceSearchInput) async throws -> AWSRekognition.StartFaceSearchOutputResponse { fatalError() }
-    func startLabelDetection(input: AWSRekognition.StartLabelDetectionInput) async throws -> AWSRekognition.StartLabelDetectionOutputResponse { fatalError() }
-    func startPersonTracking(input: AWSRekognition.StartPersonTrackingInput) async throws -> AWSRekognition.StartPersonTrackingOutputResponse { fatalError() }
-    func startProjectVersion(input: AWSRekognition.StartProjectVersionInput) async throws -> AWSRekognition.StartProjectVersionOutputResponse { fatalError() }
-    func startSegmentDetection(input: AWSRekognition.StartSegmentDetectionInput) async throws -> AWSRekognition.StartSegmentDetectionOutputResponse { fatalError() }
-    func startStreamProcessor(input: AWSRekognition.StartStreamProcessorInput) async throws -> AWSRekognition.StartStreamProcessorOutputResponse { fatalError() }
-    func startTextDetection(input: AWSRekognition.StartTextDetectionInput) async throws -> AWSRekognition.StartTextDetectionOutputResponse { fatalError() }
-    func stopProjectVersion(input: AWSRekognition.StopProjectVersionInput) async throws -> AWSRekognition.StopProjectVersionOutputResponse { fatalError() }
-    func stopStreamProcessor(input: AWSRekognition.StopStreamProcessorInput) async throws -> AWSRekognition.StopStreamProcessorOutputResponse { fatalError() }
-    func tagResource(input: AWSRekognition.TagResourceInput) async throws -> AWSRekognition.TagResourceOutputResponse { fatalError() }
-    func untagResource(input: AWSRekognition.UntagResourceInput) async throws -> AWSRekognition.UntagResourceOutputResponse { fatalError() }
-    func updateDatasetEntries(input: AWSRekognition.UpdateDatasetEntriesInput) async throws -> AWSRekognition.UpdateDatasetEntriesOutputResponse { fatalError() }
-    func updateStreamProcessor(input: AWSRekognition.UpdateStreamProcessorInput) async throws -> AWSRekognition.UpdateStreamProcessorOutputResponse { fatalError() }
-    func associateFaces(input: AWSRekognition.AssociateFacesInput) async throws -> AWSRekognition.AssociateFacesOutputResponse { fatalError() }
-    func createFaceLivenessSession(input: AWSRekognition.CreateFaceLivenessSessionInput) async throws -> AWSRekognition.CreateFaceLivenessSessionOutputResponse { fatalError() }
-    func createUser(input: AWSRekognition.CreateUserInput) async throws -> AWSRekognition.CreateUserOutputResponse { fatalError() }
-    func deleteUser(input: AWSRekognition.DeleteUserInput) async throws -> AWSRekognition.DeleteUserOutputResponse { fatalError() }
-    func disassociateFaces(input: AWSRekognition.DisassociateFacesInput) async throws -> AWSRekognition.DisassociateFacesOutputResponse { fatalError() }
-    func getFaceLivenessSessionResults(input: AWSRekognition.GetFaceLivenessSessionResultsInput) async throws -> AWSRekognition.GetFaceLivenessSessionResultsOutputResponse { fatalError() }
-    func listUsers(input: AWSRekognition.ListUsersInput) async throws -> AWSRekognition.ListUsersOutputResponse { fatalError() }
-    func searchUsers(input: AWSRekognition.SearchUsersInput) async throws -> AWSRekognition.SearchUsersOutputResponse { fatalError() }
-    func searchUsersByImage(input: AWSRekognition.SearchUsersByImageInput) async throws -> AWSRekognition.SearchUsersByImageOutputResponse { fatalError() }
+    func compareFaces(input: AWSRekognition.CompareFacesInput) async throws -> AWSRekognition.CompareFacesOutput { fatalError() }
+    func copyProjectVersion(input: AWSRekognition.CopyProjectVersionInput) async throws -> AWSRekognition.CopyProjectVersionOutput { fatalError() }
+    func createCollection(input: AWSRekognition.CreateCollectionInput) async throws -> AWSRekognition.CreateCollectionOutput { fatalError() }
+    func createDataset(input: AWSRekognition.CreateDatasetInput) async throws -> AWSRekognition.CreateDatasetOutput { fatalError() }
+    func createProject(input: AWSRekognition.CreateProjectInput) async throws -> AWSRekognition.CreateProjectOutput { fatalError() }
+    func createProjectVersion(input: AWSRekognition.CreateProjectVersionInput) async throws -> AWSRekognition.CreateProjectVersionOutput { fatalError() }
+    func createStreamProcessor(input: AWSRekognition.CreateStreamProcessorInput) async throws -> AWSRekognition.CreateStreamProcessorOutput { fatalError() }
+    func deleteCollection(input: AWSRekognition.DeleteCollectionInput) async throws -> AWSRekognition.DeleteCollectionOutput { fatalError() }
+    func deleteDataset(input: AWSRekognition.DeleteDatasetInput) async throws -> AWSRekognition.DeleteDatasetOutput { fatalError() }
+    func deleteFaces(input: AWSRekognition.DeleteFacesInput) async throws -> AWSRekognition.DeleteFacesOutput { fatalError() }
+    func deleteProject(input: AWSRekognition.DeleteProjectInput) async throws -> AWSRekognition.DeleteProjectOutput { fatalError() }
+    func deleteProjectPolicy(input: AWSRekognition.DeleteProjectPolicyInput) async throws -> AWSRekognition.DeleteProjectPolicyOutput { fatalError() }
+    func deleteProjectVersion(input: AWSRekognition.DeleteProjectVersionInput) async throws -> AWSRekognition.DeleteProjectVersionOutput { fatalError() }
+    func deleteStreamProcessor(input: AWSRekognition.DeleteStreamProcessorInput) async throws -> AWSRekognition.DeleteStreamProcessorOutput { fatalError() }
+    func describeCollection(input: AWSRekognition.DescribeCollectionInput) async throws -> AWSRekognition.DescribeCollectionOutput { fatalError() }
+    func describeDataset(input: AWSRekognition.DescribeDatasetInput) async throws -> AWSRekognition.DescribeDatasetOutput { fatalError() }
+    func describeProjects(input: AWSRekognition.DescribeProjectsInput) async throws -> AWSRekognition.DescribeProjectsOutput { fatalError() }
+    func describeProjectVersions(input: AWSRekognition.DescribeProjectVersionsInput) async throws -> AWSRekognition.DescribeProjectVersionsOutput { fatalError() }
+    func describeStreamProcessor(input: AWSRekognition.DescribeStreamProcessorInput) async throws -> AWSRekognition.DescribeStreamProcessorOutput { fatalError() }
+    func detectCustomLabels(input: AWSRekognition.DetectCustomLabelsInput) async throws -> AWSRekognition.DetectCustomLabelsOutput { fatalError() }
+    func detectProtectiveEquipment(input: AWSRekognition.DetectProtectiveEquipmentInput) async throws -> AWSRekognition.DetectProtectiveEquipmentOutput { fatalError() }
+    func distributeDatasetEntries(input: AWSRekognition.DistributeDatasetEntriesInput) async throws -> AWSRekognition.DistributeDatasetEntriesOutput { fatalError() }
+    func getCelebrityInfo(input: AWSRekognition.GetCelebrityInfoInput) async throws -> AWSRekognition.GetCelebrityInfoOutput { fatalError() }
+    func getCelebrityRecognition(input: AWSRekognition.GetCelebrityRecognitionInput) async throws -> AWSRekognition.GetCelebrityRecognitionOutput { fatalError() }
+    func getContentModeration(input: AWSRekognition.GetContentModerationInput) async throws -> AWSRekognition.GetContentModerationOutput { fatalError() }
+    func getFaceDetection(input: AWSRekognition.GetFaceDetectionInput) async throws -> AWSRekognition.GetFaceDetectionOutput { fatalError() }
+    func getFaceSearch(input: AWSRekognition.GetFaceSearchInput) async throws -> AWSRekognition.GetFaceSearchOutput { fatalError() }
+    func getLabelDetection(input: AWSRekognition.GetLabelDetectionInput) async throws -> AWSRekognition.GetLabelDetectionOutput { fatalError() }
+    func getPersonTracking(input: AWSRekognition.GetPersonTrackingInput) async throws -> AWSRekognition.GetPersonTrackingOutput { fatalError() }
+    func getSegmentDetection(input: AWSRekognition.GetSegmentDetectionInput) async throws -> AWSRekognition.GetSegmentDetectionOutput { fatalError() }
+    func getTextDetection(input: AWSRekognition.GetTextDetectionInput) async throws -> AWSRekognition.GetTextDetectionOutput { fatalError() }
+    func indexFaces(input: AWSRekognition.IndexFacesInput) async throws -> AWSRekognition.IndexFacesOutput { fatalError() }
+    func listCollections(input: AWSRekognition.ListCollectionsInput) async throws -> AWSRekognition.ListCollectionsOutput { fatalError() }
+    func listDatasetEntries(input: AWSRekognition.ListDatasetEntriesInput) async throws -> AWSRekognition.ListDatasetEntriesOutput { fatalError() }
+    func listDatasetLabels(input: AWSRekognition.ListDatasetLabelsInput) async throws -> AWSRekognition.ListDatasetLabelsOutput { fatalError() }
+    func listFaces(input: AWSRekognition.ListFacesInput) async throws -> AWSRekognition.ListFacesOutput { fatalError() }
+    func listProjectPolicies(input: AWSRekognition.ListProjectPoliciesInput) async throws -> AWSRekognition.ListProjectPoliciesOutput { fatalError() }
+    func listStreamProcessors(input: AWSRekognition.ListStreamProcessorsInput) async throws -> AWSRekognition.ListStreamProcessorsOutput { fatalError() }
+    func listTagsForResource(input: AWSRekognition.ListTagsForResourceInput) async throws -> AWSRekognition.ListTagsForResourceOutput { fatalError() }
+    func putProjectPolicy(input: AWSRekognition.PutProjectPolicyInput) async throws -> AWSRekognition.PutProjectPolicyOutput { fatalError() }
+    func recognizeCelebrities(input: AWSRekognition.RecognizeCelebritiesInput) async throws -> AWSRekognition.RecognizeCelebritiesOutput { fatalError() }
+    func searchFaces(input: AWSRekognition.SearchFacesInput) async throws -> AWSRekognition.SearchFacesOutput { fatalError() }
+    func startCelebrityRecognition(input: AWSRekognition.StartCelebrityRecognitionInput) async throws -> AWSRekognition.StartCelebrityRecognitionOutput { fatalError() }
+    func startContentModeration(input: AWSRekognition.StartContentModerationInput) async throws -> AWSRekognition.StartContentModerationOutput { fatalError() }
+    func startFaceDetection(input: AWSRekognition.StartFaceDetectionInput) async throws -> AWSRekognition.StartFaceDetectionOutput { fatalError() }
+    func startFaceSearch(input: AWSRekognition.StartFaceSearchInput) async throws -> AWSRekognition.StartFaceSearchOutput { fatalError() }
+    func startLabelDetection(input: AWSRekognition.StartLabelDetectionInput) async throws -> AWSRekognition.StartLabelDetectionOutput { fatalError() }
+    func startPersonTracking(input: AWSRekognition.StartPersonTrackingInput) async throws -> AWSRekognition.StartPersonTrackingOutput { fatalError() }
+    func startProjectVersion(input: AWSRekognition.StartProjectVersionInput) async throws -> AWSRekognition.StartProjectVersionOutput { fatalError() }
+    func startSegmentDetection(input: AWSRekognition.StartSegmentDetectionInput) async throws -> AWSRekognition.StartSegmentDetectionOutput { fatalError() }
+    func startStreamProcessor(input: AWSRekognition.StartStreamProcessorInput) async throws -> AWSRekognition.StartStreamProcessorOutput { fatalError() }
+    func startTextDetection(input: AWSRekognition.StartTextDetectionInput) async throws -> AWSRekognition.StartTextDetectionOutput { fatalError() }
+    func stopProjectVersion(input: AWSRekognition.StopProjectVersionInput) async throws -> AWSRekognition.StopProjectVersionOutput { fatalError() }
+    func stopStreamProcessor(input: AWSRekognition.StopStreamProcessorInput) async throws -> AWSRekognition.StopStreamProcessorOutput { fatalError() }
+    func tagResource(input: AWSRekognition.TagResourceInput) async throws -> AWSRekognition.TagResourceOutput { fatalError() }
+    func untagResource(input: AWSRekognition.UntagResourceInput) async throws -> AWSRekognition.UntagResourceOutput { fatalError() }
+    func updateDatasetEntries(input: AWSRekognition.UpdateDatasetEntriesInput) async throws -> AWSRekognition.UpdateDatasetEntriesOutput { fatalError() }
+    func updateStreamProcessor(input: AWSRekognition.UpdateStreamProcessorInput) async throws -> AWSRekognition.UpdateStreamProcessorOutput { fatalError() }
+    func associateFaces(input: AWSRekognition.AssociateFacesInput) async throws -> AWSRekognition.AssociateFacesOutput { fatalError() }
+    func createFaceLivenessSession(input: AWSRekognition.CreateFaceLivenessSessionInput) async throws -> AWSRekognition.CreateFaceLivenessSessionOutput { fatalError() }
+    func createUser(input: AWSRekognition.CreateUserInput) async throws -> AWSRekognition.CreateUserOutput { fatalError() }
+    func deleteUser(input: AWSRekognition.DeleteUserInput) async throws -> AWSRekognition.DeleteUserOutput { fatalError() }
+    func disassociateFaces(input: AWSRekognition.DisassociateFacesInput) async throws -> AWSRekognition.DisassociateFacesOutput { fatalError() }
+    func getFaceLivenessSessionResults(input: AWSRekognition.GetFaceLivenessSessionResultsInput) async throws -> AWSRekognition.GetFaceLivenessSessionResultsOutput { fatalError() }
+    func listUsers(input: AWSRekognition.ListUsersInput) async throws -> AWSRekognition.ListUsersOutput { fatalError() }
+    func searchUsers(input: AWSRekognition.SearchUsersInput) async throws -> AWSRekognition.SearchUsersOutput { fatalError() }
+    func searchUsersByImage(input: AWSRekognition.SearchUsersByImageInput) async throws -> AWSRekognition.SearchUsersByImageOutput { fatalError() }
+    func getMediaAnalysisJob(input: AWSRekognition.GetMediaAnalysisJobInput) async throws -> AWSRekognition.GetMediaAnalysisJobOutput {
+        fatalError()
+    }
+
+    func listMediaAnalysisJobs(input: AWSRekognition.ListMediaAnalysisJobsInput) async throws -> AWSRekognition.ListMediaAnalysisJobsOutput {
+        fatalError()
+    }
+
+    func startMediaAnalysisJob(input: AWSRekognition.StartMediaAnalysisJobInput) async throws -> AWSRekognition.StartMediaAnalysisJobOutput {
+        fatalError()
+    }
 }

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Mocks/Service/MockTextractBehavior.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Mocks/Service/MockTextractBehavior.swift
@@ -12,19 +12,19 @@ import AWSTextract
 struct MockBehaviorDefaultError: Error {}
 
 class MockTextractBehavior: TextractClientProtocol {
-    var analyzeDocumentResult: ((AnalyzeDocumentInput) async throws -> AnalyzeDocumentOutputResponse)? = nil
-    var detectDocumentTextResult: ((DetectDocumentTextInput) async throws -> DetectDocumentTextOutputResponse)? = nil
+    var analyzeDocumentResult: ((AnalyzeDocumentInput) async throws -> AnalyzeDocumentOutput)? = nil
+    var detectDocumentTextResult: ((DetectDocumentTextInput) async throws -> DetectDocumentTextOutput)? = nil
 
     func analyzeDocument(
         input: AnalyzeDocumentInput
-    ) async throws -> AnalyzeDocumentOutputResponse {
+    ) async throws -> AnalyzeDocumentOutput {
         guard let analyzeDocumentResult else { throw MockBehaviorDefaultError() }
         return try await analyzeDocumentResult(input)
     }
 
     func detectDocumentText(
         input: DetectDocumentTextInput
-    ) async throws -> DetectDocumentTextOutputResponse {
+    ) async throws -> DetectDocumentTextOutput {
         guard let detectDocumentTextResult else { throw MockBehaviorDefaultError() }
         return try await detectDocumentTextResult(input)
     }
@@ -35,15 +35,62 @@ class MockTextractBehavior: TextractClientProtocol {
 }
 
 extension MockTextractBehavior {
-    func analyzeExpense(input: AWSTextract.AnalyzeExpenseInput) async throws -> AWSTextract.AnalyzeExpenseOutputResponse { fatalError() }
-    func analyzeID(input: AWSTextract.AnalyzeIDInput) async throws -> AWSTextract.AnalyzeIDOutputResponse { fatalError() }
-    func getDocumentAnalysis(input: AWSTextract.GetDocumentAnalysisInput) async throws -> AWSTextract.GetDocumentAnalysisOutputResponse { fatalError() }
-    func getDocumentTextDetection(input: AWSTextract.GetDocumentTextDetectionInput) async throws -> AWSTextract.GetDocumentTextDetectionOutputResponse { fatalError() }
-    func getExpenseAnalysis(input: AWSTextract.GetExpenseAnalysisInput) async throws -> AWSTextract.GetExpenseAnalysisOutputResponse { fatalError() }
-    func getLendingAnalysis(input: AWSTextract.GetLendingAnalysisInput) async throws -> AWSTextract.GetLendingAnalysisOutputResponse { fatalError() }
-    func getLendingAnalysisSummary(input: AWSTextract.GetLendingAnalysisSummaryInput) async throws -> AWSTextract.GetLendingAnalysisSummaryOutputResponse { fatalError() }
-    func startDocumentAnalysis(input: AWSTextract.StartDocumentAnalysisInput) async throws -> AWSTextract.StartDocumentAnalysisOutputResponse { fatalError() }
-    func startDocumentTextDetection(input: AWSTextract.StartDocumentTextDetectionInput) async throws -> AWSTextract.StartDocumentTextDetectionOutputResponse { fatalError() }
-    func startExpenseAnalysis(input: AWSTextract.StartExpenseAnalysisInput) async throws -> AWSTextract.StartExpenseAnalysisOutputResponse { fatalError() }
-    func startLendingAnalysis(input: AWSTextract.StartLendingAnalysisInput) async throws -> AWSTextract.StartLendingAnalysisOutputResponse { fatalError() }
+    func analyzeExpense(input: AWSTextract.AnalyzeExpenseInput) async throws -> AWSTextract.AnalyzeExpenseOutput { fatalError() }
+    func analyzeID(input: AWSTextract.AnalyzeIDInput) async throws -> AWSTextract.AnalyzeIDOutput { fatalError() }
+    func getDocumentAnalysis(input: AWSTextract.GetDocumentAnalysisInput) async throws -> AWSTextract.GetDocumentAnalysisOutput { fatalError() }
+    func getDocumentTextDetection(input: AWSTextract.GetDocumentTextDetectionInput) async throws -> AWSTextract.GetDocumentTextDetectionOutput { fatalError() }
+    func getExpenseAnalysis(input: AWSTextract.GetExpenseAnalysisInput) async throws -> AWSTextract.GetExpenseAnalysisOutput { fatalError() }
+    func getLendingAnalysis(input: AWSTextract.GetLendingAnalysisInput) async throws -> AWSTextract.GetLendingAnalysisOutput { fatalError() }
+    func getLendingAnalysisSummary(input: AWSTextract.GetLendingAnalysisSummaryInput) async throws -> AWSTextract.GetLendingAnalysisSummaryOutput { fatalError() }
+    func startDocumentAnalysis(input: AWSTextract.StartDocumentAnalysisInput) async throws -> AWSTextract.StartDocumentAnalysisOutput { fatalError() }
+    func startDocumentTextDetection(input: AWSTextract.StartDocumentTextDetectionInput) async throws -> AWSTextract.StartDocumentTextDetectionOutput { fatalError() }
+    func startExpenseAnalysis(input: AWSTextract.StartExpenseAnalysisInput) async throws -> AWSTextract.StartExpenseAnalysisOutput { fatalError() }
+    func startLendingAnalysis(input: AWSTextract.StartLendingAnalysisInput) async throws -> AWSTextract.StartLendingAnalysisOutput { fatalError() }
+    func createAdapter(input: AWSTextract.CreateAdapterInput) async throws -> AWSTextract.CreateAdapterOutput {
+        fatalError()
+    }
+
+    func createAdapterVersion(input: AWSTextract.CreateAdapterVersionInput) async throws -> AWSTextract.CreateAdapterVersionOutput {
+        fatalError()
+    }
+
+    func deleteAdapter(input: AWSTextract.DeleteAdapterInput) async throws -> AWSTextract.DeleteAdapterOutput {
+        fatalError()
+    }
+
+    func deleteAdapterVersion(input: AWSTextract.DeleteAdapterVersionInput) async throws -> AWSTextract.DeleteAdapterVersionOutput {
+        fatalError()
+    }
+
+    func getAdapter(input: AWSTextract.GetAdapterInput) async throws -> AWSTextract.GetAdapterOutput {
+        fatalError()
+    }
+
+    func getAdapterVersion(input: AWSTextract.GetAdapterVersionInput) async throws -> AWSTextract.GetAdapterVersionOutput {
+        fatalError()
+    }
+
+    func listAdapters(input: AWSTextract.ListAdaptersInput) async throws -> AWSTextract.ListAdaptersOutput {
+        fatalError()
+    }
+
+    func listAdapterVersions(input: AWSTextract.ListAdapterVersionsInput) async throws -> AWSTextract.ListAdapterVersionsOutput {
+        fatalError()
+    }
+
+    func listTagsForResource(input: AWSTextract.ListTagsForResourceInput) async throws -> AWSTextract.ListTagsForResourceOutput {
+        fatalError()
+    }
+
+    func tagResource(input: AWSTextract.TagResourceInput) async throws -> AWSTextract.TagResourceOutput {
+        fatalError()
+    }
+
+    func untagResource(input: AWSTextract.UntagResourceInput) async throws -> AWSTextract.UntagResourceOutput {
+        fatalError()
+    }
+
+    func updateAdapter(input: AWSTextract.UpdateAdapterInput) async throws -> AWSTextract.UpdateAdapterOutput {
+        fatalError()
+    }
 }

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Mocks/Service/MockTranslateBehavior.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Mocks/Service/MockTranslateBehavior.swift
@@ -9,11 +9,11 @@ import AWSTranslate
 @testable import AWSPredictionsPlugin
 
 class MockTranslateBehavior: TranslateClientProtocol {
-    var translateTextResult: ((TranslateTextInput) async throws -> TranslateTextOutputResponse)? = nil
+    var translateTextResult: ((TranslateTextInput) async throws -> TranslateTextOutput)? = nil
 
     func translateText(
         input: TranslateTextInput
-    ) async throws -> TranslateTextOutputResponse {
+    ) async throws -> TranslateTextOutput {
         guard let translateTextResult else { throw MockBehaviorDefaultError() }
         return try await translateTextResult(input)
     }
@@ -24,22 +24,22 @@ class MockTranslateBehavior: TranslateClientProtocol {
 }
 
 extension MockTranslateBehavior {
-    func createParallelData(input: AWSTranslate.CreateParallelDataInput) async throws -> AWSTranslate.CreateParallelDataOutputResponse { fatalError() }
-    func deleteParallelData(input: AWSTranslate.DeleteParallelDataInput) async throws -> AWSTranslate.DeleteParallelDataOutputResponse { fatalError() }
-    func deleteTerminology(input: AWSTranslate.DeleteTerminologyInput) async throws -> AWSTranslate.DeleteTerminologyOutputResponse { fatalError() }
-    func describeTextTranslationJob(input: AWSTranslate.DescribeTextTranslationJobInput) async throws -> AWSTranslate.DescribeTextTranslationJobOutputResponse { fatalError() }
-    func getParallelData(input: AWSTranslate.GetParallelDataInput) async throws -> AWSTranslate.GetParallelDataOutputResponse { fatalError() }
-    func getTerminology(input: AWSTranslate.GetTerminologyInput) async throws -> AWSTranslate.GetTerminologyOutputResponse { fatalError() }
-    func importTerminology(input: AWSTranslate.ImportTerminologyInput) async throws -> AWSTranslate.ImportTerminologyOutputResponse { fatalError() }
-    func listLanguages(input: AWSTranslate.ListLanguagesInput) async throws -> AWSTranslate.ListLanguagesOutputResponse { fatalError() }
-    func listParallelData(input: AWSTranslate.ListParallelDataInput) async throws -> AWSTranslate.ListParallelDataOutputResponse { fatalError() }
-    func listTagsForResource(input: AWSTranslate.ListTagsForResourceInput) async throws -> AWSTranslate.ListTagsForResourceOutputResponse { fatalError() }
-    func listTerminologies(input: AWSTranslate.ListTerminologiesInput) async throws -> AWSTranslate.ListTerminologiesOutputResponse { fatalError() }
-    func listTextTranslationJobs(input: AWSTranslate.ListTextTranslationJobsInput) async throws -> AWSTranslate.ListTextTranslationJobsOutputResponse { fatalError() }
-    func startTextTranslationJob(input: AWSTranslate.StartTextTranslationJobInput) async throws -> AWSTranslate.StartTextTranslationJobOutputResponse { fatalError() }
-    func stopTextTranslationJob(input: AWSTranslate.StopTextTranslationJobInput) async throws -> AWSTranslate.StopTextTranslationJobOutputResponse { fatalError() }
-    func tagResource(input: AWSTranslate.TagResourceInput) async throws -> AWSTranslate.TagResourceOutputResponse { fatalError() }
-    func untagResource(input: AWSTranslate.UntagResourceInput) async throws -> AWSTranslate.UntagResourceOutputResponse { fatalError() }
-    func updateParallelData(input: AWSTranslate.UpdateParallelDataInput) async throws -> AWSTranslate.UpdateParallelDataOutputResponse { fatalError() }
-    func translateDocument(input: AWSTranslate.TranslateDocumentInput) async throws -> AWSTranslate.TranslateDocumentOutputResponse { fatalError() }
+    func createParallelData(input: AWSTranslate.CreateParallelDataInput) async throws -> AWSTranslate.CreateParallelDataOutput { fatalError() }
+    func deleteParallelData(input: AWSTranslate.DeleteParallelDataInput) async throws -> AWSTranslate.DeleteParallelDataOutput { fatalError() }
+    func deleteTerminology(input: AWSTranslate.DeleteTerminologyInput) async throws -> AWSTranslate.DeleteTerminologyOutput { fatalError() }
+    func describeTextTranslationJob(input: AWSTranslate.DescribeTextTranslationJobInput) async throws -> AWSTranslate.DescribeTextTranslationJobOutput { fatalError() }
+    func getParallelData(input: AWSTranslate.GetParallelDataInput) async throws -> AWSTranslate.GetParallelDataOutput { fatalError() }
+    func getTerminology(input: AWSTranslate.GetTerminologyInput) async throws -> AWSTranslate.GetTerminologyOutput { fatalError() }
+    func importTerminology(input: AWSTranslate.ImportTerminologyInput) async throws -> AWSTranslate.ImportTerminologyOutput { fatalError() }
+    func listLanguages(input: AWSTranslate.ListLanguagesInput) async throws -> AWSTranslate.ListLanguagesOutput { fatalError() }
+    func listParallelData(input: AWSTranslate.ListParallelDataInput) async throws -> AWSTranslate.ListParallelDataOutput { fatalError() }
+    func listTagsForResource(input: AWSTranslate.ListTagsForResourceInput) async throws -> AWSTranslate.ListTagsForResourceOutput { fatalError() }
+    func listTerminologies(input: AWSTranslate.ListTerminologiesInput) async throws -> AWSTranslate.ListTerminologiesOutput { fatalError() }
+    func listTextTranslationJobs(input: AWSTranslate.ListTextTranslationJobsInput) async throws -> AWSTranslate.ListTextTranslationJobsOutput { fatalError() }
+    func startTextTranslationJob(input: AWSTranslate.StartTextTranslationJobInput) async throws -> AWSTranslate.StartTextTranslationJobOutput { fatalError() }
+    func stopTextTranslationJob(input: AWSTranslate.StopTextTranslationJobInput) async throws -> AWSTranslate.StopTextTranslationJobOutput { fatalError() }
+    func tagResource(input: AWSTranslate.TagResourceInput) async throws -> AWSTranslate.TagResourceOutput { fatalError() }
+    func untagResource(input: AWSTranslate.UntagResourceInput) async throws -> AWSTranslate.UntagResourceOutput { fatalError() }
+    func updateParallelData(input: AWSTranslate.UpdateParallelDataInput) async throws -> AWSTranslate.UpdateParallelDataOutput { fatalError() }
+    func translateDocument(input: AWSTranslate.TranslateDocumentInput) async throws -> AWSTranslate.TranslateDocumentOutput { fatalError() }
 }

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceComprehendTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceComprehendTests.swift
@@ -52,7 +52,7 @@ class PredictionsServiceComprehendTests: XCTestCase {
     ///    - I should get back a result with dominant language
     ///
     func testWithOnlyLanguageResult() async throws {
-        let mockDominantLanguage = DetectDominantLanguageOutputResponse(
+        let mockDominantLanguage = DetectDominantLanguageOutput(
             languages: [.init(languageCode: "en", score: 0.5)]
         )
         mockComprehend.languageResponse = { _ in mockDominantLanguage }
@@ -78,7 +78,7 @@ class PredictionsServiceComprehendTests: XCTestCase {
         let english = ComprehendClientTypes.DominantLanguage(languageCode: "en", score: 0.1)
         let spanish = ComprehendClientTypes.DominantLanguage(languageCode: "es", score: 0.2)
         let italian = ComprehendClientTypes.DominantLanguage(languageCode: "it", score: 0.6)
-        let mockDominantLanguage = DetectDominantLanguageOutputResponse(
+        let mockDominantLanguage = DetectDominantLanguageOutput(
             languages: [english, spanish, italian]
         )
         mockComprehend.languageResponse = { _ in mockDominantLanguage }
@@ -101,7 +101,7 @@ class PredictionsServiceComprehendTests: XCTestCase {
     ///    - I should get an error
     ///
     func testWithEmptyLanguageResult() async throws {
-        let mockDominantLanguage = DetectDominantLanguageOutputResponse()
+        let mockDominantLanguage = DetectDominantLanguageOutput()
         mockComprehend.languageResponse = { _ in mockDominantLanguage }
 
         do {
@@ -152,7 +152,7 @@ class PredictionsServiceComprehendTests: XCTestCase {
     func testCompleteResult() async throws {
         let english = ComprehendClientTypes.DominantLanguage(languageCode: "en", score: 0.2)
         let spanish = ComprehendClientTypes.DominantLanguage(languageCode: "es", score: 0.7)
-        let mockDominantLanguage = DetectDominantLanguageOutputResponse(
+        let mockDominantLanguage = DetectDominantLanguageOutput(
             languages: [english, spanish]
         )
         mockComprehend.languageResponse = { _ in mockDominantLanguage }
@@ -164,10 +164,10 @@ class PredictionsServiceComprehendTests: XCTestCase {
             partOfSpeech: partOfSpeech
         )
         let unknownToken = ComprehendClientTypes.SyntaxToken(beginOffset: 0, endOffset: 2)
-        let mockSyntaxTokens = DetectSyntaxOutputResponse(syntaxTokens: [adjToken, unknownToken])
+        let mockSyntaxTokens = DetectSyntaxOutput(syntaxTokens: [adjToken, unknownToken])
         mockComprehend.syntaxResponse = { _ in mockSyntaxTokens }
 
-        let mockSentiment = DetectSentimentOutputResponse(sentiment: .positive)
+        let mockSentiment = DetectSentimentOutput(sentiment: .positive)
         mockComprehend.sentimentResponse = { _ in mockSentiment }
 
         let entity = ComprehendClientTypes.Entity(
@@ -176,7 +176,7 @@ class PredictionsServiceComprehendTests: XCTestCase {
             text: "some text",
             type: .commercialItem
         )
-        let mockEntities = DetectEntitiesOutputResponse(entities: [entity])
+        let mockEntities = DetectEntitiesOutput(entities: [entity])
         mockComprehend.entitiesResponse = { _ in mockEntities }
 
         let keyPhrase = ComprehendClientTypes.KeyPhrase(
@@ -185,7 +185,7 @@ class PredictionsServiceComprehendTests: XCTestCase {
             score: 0.8,
             text: "some text"
         )
-        let mockKeyPhrases = DetectKeyPhrasesOutputResponse(keyPhrases: [keyPhrase])
+        let mockKeyPhrases = DetectKeyPhrasesOutput(keyPhrases: [keyPhrase])
         mockComprehend.keyPhrasesResponse = { _ in mockKeyPhrases }
 
         let result = try await predictionsService.comprehend(text: inputForTest)

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceRekognitionTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceRekognitionTests.swift
@@ -88,7 +88,7 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyLabelsService() async throws {
         setUpAmplify()
-        let mockResponse = DetectLabelsOutputResponse(labels: [])
+        let mockResponse = DetectLabelsOutput(labels: [])
         mockRekognition.detectLabelsResponse = { _ in mockResponse }
         let url = try url("testImageLabels")
 
@@ -128,7 +128,7 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyModerationLabelsService() async throws {
         setUpAmplify()
-        let mockResponse = DetectModerationLabelsOutputResponse(moderationLabels: [])
+        let mockResponse = DetectModerationLabelsOutput(moderationLabels: [])
         mockRekognition.moderationLabelsResponse = { _ in mockResponse }
         let url = try url("testImageLabels")
 
@@ -172,8 +172,8 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyAllLabelsService() async throws {
         setUpAmplify()
-        let mockLabelsResponse = DetectLabelsOutputResponse(labels: [])
-        let mockModerationResponse = DetectModerationLabelsOutputResponse(moderationLabels: [])
+        let mockLabelsResponse = DetectLabelsOutput(labels: [])
+        let mockModerationResponse = DetectModerationLabelsOutput(moderationLabels: [])
         mockRekognition.detectLabelsResponse = { _ in mockLabelsResponse }
         mockRekognition.moderationLabelsResponse = { _ in mockModerationResponse }
         let url = try url("testImageLabels")
@@ -198,7 +198,7 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyAllLabelsServiceWithNilModerationResponse() async throws {
         setUpAmplify()
-        let mockLabelsResponse = DetectLabelsOutputResponse(labels: [])
+        let mockLabelsResponse = DetectLabelsOutput(labels: [])
         mockRekognition.detectLabelsResponse = { _ in mockLabelsResponse }
         let url = try url("testImageLabels")
 
@@ -241,7 +241,7 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyEntitiesService() async throws {
         setUpAmplify()
-        let mockResponse = DetectFacesOutputResponse(faceDetails: [])
+        let mockResponse = DetectFacesOutput(faceDetails: [])
         mockRekognition.facesResponse = { _ in mockResponse }
         let url = try url("testImageEntities")
 
@@ -285,7 +285,7 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyEntityMatchesService()  async throws {
         setUpAmplify(withCollection: true)
-        let mockResponse = SearchFacesByImageOutputResponse(faceMatches: [])
+        let mockResponse = SearchFacesByImageOutput(faceMatches: [])
         mockRekognition.facesFromCollectionResponse = { _ in mockResponse }
         let url = try url("testImageEntities")
         let collectionID = try XCTUnwrap(predictionsService.predictionsConfig.identify.identifyEntities?.collectionId)
@@ -325,7 +325,7 @@ class PredictionsServiceRekognitionTests: XCTestCase {
     ///
     func testIdentifyPlainTextService() async throws {
         setUpAmplify()
-        let mockResponse = DetectTextOutputResponse(textDetections: [])
+        let mockResponse = DetectTextOutput(textDetections: [])
         mockRekognition.detectTextResponse = { _ in mockResponse }
         let url = try url("testImageText")
         let result = try await predictionsService.detectPlainText(image: url)

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceTextractTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceTextractTests.swift
@@ -66,7 +66,7 @@ class PredictionsServiceTextractTests: XCTestCase {
     ///    - I should get back a result
     ///
     func testIdentifyTablesService() async throws {
-        let mockResponse = AnalyzeDocumentOutputResponse(blocks: [])
+        let mockResponse = AnalyzeDocumentOutput(blocks: [])
         mockTextract.analyzeDocumentResult = { _ in mockResponse }
         let url = try url("testImageText")
 
@@ -110,7 +110,7 @@ class PredictionsServiceTextractTests: XCTestCase {
     ///    - I should get back a result
     ///
     func testIdentifyFormsService() async throws {
-        let mockResponse = AnalyzeDocumentOutputResponse(blocks: [])
+        let mockResponse = AnalyzeDocumentOutput(blocks: [])
         mockTextract.analyzeDocumentResult = { _ in mockResponse }
         let url = try url("testImageText")
 
@@ -154,7 +154,7 @@ class PredictionsServiceTextractTests: XCTestCase {
     ///    - I should get back a result
     ///
     func testIdentifyAllTextService() async throws {
-        let mockResponse = AnalyzeDocumentOutputResponse(blocks: [])
+        let mockResponse = AnalyzeDocumentOutput(blocks: [])
         mockTextract.analyzeDocumentResult = { _ in mockResponse }
         let url = try url("testImageText")
 

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceTranslateTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceTranslateTests.swift
@@ -51,7 +51,7 @@ class PredictionsServiceTranslateTests: XCTestCase {
     ///    - I should get back a result
     ///
     func testTranslateService() async throws {
-        let mockResponse = TranslateTextOutputResponse(translatedText: "translated text here")
+        let mockResponse = TranslateTextOutput(translatedText: "translated text here")
         mockTranslate.translateTextResult = { _ in mockResponse }
 
         let result = try await predictionsService.translateText(
@@ -132,7 +132,7 @@ class PredictionsServiceTranslateTests: XCTestCase {
             XCTFail("Initialization of the text failed. \(error)")
         }
 
-        let mockResponse = TranslateTextOutputResponse(translatedText: "translated text here")
+        let mockResponse = TranslateTextOutput(translatedText: "translated text here")
         mockTranslate.translateTextResult = { _ in mockResponse }
 
         let result = try await predictionsService.translateText(
@@ -157,7 +157,7 @@ class PredictionsServiceTranslateTests: XCTestCase {
     ///    - I should get back an error
     ///
     func testNilSourceLanguageError() async throws {
-        let mockResponse = TranslateTextOutputResponse(translatedText: "translated text here")
+        let mockResponse = TranslateTextOutput(translatedText: "translated text here")
         mockTranslate.translateTextResult = { _ in mockResponse }
 
         do {
@@ -182,7 +182,7 @@ class PredictionsServiceTranslateTests: XCTestCase {
     ///    - I should get back an error
     ///
     func testNilTargetLanguageError() async throws {
-        let mockResponse = TranslateTextOutputResponse(translatedText: "translated text here")
+        let mockResponse = TranslateTextOutput(translatedText: "translated text here")
         mockTranslate.translateTextResult = { _ in mockResponse }
 
         do {
@@ -206,7 +206,7 @@ class PredictionsServiceTranslateTests: XCTestCase {
     ///    - I should get an error back
     ///
     func testNilTranslatedTextResult() async throws {
-        let mockResponse = TranslateTextOutputResponse()
+        let mockResponse = TranslateTextOutput()
         mockTranslate.translateTextResult = { _ in mockResponse }
 
         do {
@@ -230,7 +230,7 @@ class PredictionsServiceTranslateTests: XCTestCase {
     ///    - The target language should be set
     ///
     func testTargetLanguageTranslateService() async throws {
-        let mockResponse = TranslateTextOutputResponse(translatedText: "translated text here")
+        let mockResponse = TranslateTextOutput(translatedText: "translated text here")
         mockTranslate.translateTextResult = { _ in mockResponse }
 
         let result = try await predictionsService.translateText(

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3Behavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3Behavior.swift
@@ -26,7 +26,7 @@ protocol AWSS3Behavior {
     func createMultipartUpload(_ request: CreateMultipartUploadRequest, completion: @escaping (Result<AWSS3CreateMultipartUploadResponse, StorageError>) -> Void)
 
     // Get list of uploaded parts (supports development)
-    func listParts(bucket: String, key: String, uploadId: UploadID, completion: @escaping (Result<ListPartsOutputResponse, StorageError>) -> Void)
+    func listParts(bucket: String, key: String, uploadId: UploadID, completion: @escaping (Result<ListPartsOutput, StorageError>) -> Void)
 
     // Completes a Multipart Upload.
     func completeMultipartUpload(_ request: AWSS3CompleteMultipartUploadRequest, completion: @escaping (Result<AWSS3CompleteMultipartUploadResponse, StorageError>) -> Void)
@@ -40,7 +40,7 @@ protocol AWSS3Behavior {
 }
 
 extension AWSS3Behavior {
-    func listParts(bucket: String, key: String, uploadId: UploadID, completion: @escaping (Result<ListPartsOutputResponse, StorageError>) -> Void) {
+    func listParts(bucket: String, key: String, uploadId: UploadID, completion: @escaping (Result<ListPartsOutput, StorageError>) -> Void) {
         // do nothing
     }
 }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3ListUploadPartResponse.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3ListUploadPartResponse.swift
@@ -29,7 +29,7 @@ struct AWSS3ListUploadPartResponse {
 
 extension AWSS3ListUploadPartResponse {
 
-    init?(response: ListPartsOutputResponse) {
+    init?(response: ListPartsOutput) {
         guard let bucket = response.bucket,
               let key = response.key,
               let uploadId = response.uploadId,

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Dependency/AWSS3AdapterTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Dependency/AWSS3AdapterTests.swift
@@ -70,7 +70,7 @@ class AWSS3AdapterTests: XCTestCase {
     /// Then: A .success result is returned containing the corresponding list items
     func testListObjectsV2_withSuccess_shouldSucceed() {
         let listExpectation = expectation(description: "List Objects")
-        awsS3.listObjectsV2Result = .success(ListObjectsV2OutputResponse(
+        awsS3.listObjectsV2Result = .success(ListObjectsV2Output(
             contents: [
                 .init(eTag: "one", key: "prefix/key1", lastModified: .init()),
                 .init(eTag: "two", key: "prefix/key2", lastModified: .init())
@@ -363,392 +363,392 @@ class AWSS3AdapterTests: XCTestCase {
 
 private class S3ClientMock: S3ClientProtocol {
     var deleteObjectCount = 0
-    var deleteObjectResult: Result<DeleteObjectOutputResponse, Error> = .success(.init())
-    func deleteObject(input: AWSS3.DeleteObjectInput) async throws -> AWSS3.DeleteObjectOutputResponse {
+    var deleteObjectResult: Result<DeleteObjectOutput, Error> = .success(.init())
+    func deleteObject(input: AWSS3.DeleteObjectInput) async throws -> AWSS3.DeleteObjectOutput {
         deleteObjectCount += 1
         return try deleteObjectResult.get()
     }
     
     var listObjectsV2Count = 0
-    var listObjectsV2Result: Result<ListObjectsV2OutputResponse, Error> = .success(.init())
-    func listObjectsV2(input: AWSS3.ListObjectsV2Input) async throws -> AWSS3.ListObjectsV2OutputResponse {
+    var listObjectsV2Result: Result<ListObjectsV2Output, Error> = .success(.init())
+    func listObjectsV2(input: AWSS3.ListObjectsV2Input) async throws -> AWSS3.ListObjectsV2Output {
         listObjectsV2Count += 1
         return try listObjectsV2Result.get()
     }
     
     var createMultipartUploadCount = 0
-    var createMultipartUploadResult: Result<CreateMultipartUploadOutputResponse, Error> = .success(.init())
-    func createMultipartUpload(input: AWSS3.CreateMultipartUploadInput) async throws -> AWSS3.CreateMultipartUploadOutputResponse {
+    var createMultipartUploadResult: Result<CreateMultipartUploadOutput, Error> = .success(.init())
+    func createMultipartUpload(input: AWSS3.CreateMultipartUploadInput) async throws -> AWSS3.CreateMultipartUploadOutput {
         createMultipartUploadCount += 1
         return try createMultipartUploadResult.get()
     }
     
     var listPartsCount = 0
-    var listPartsResult: Result<ListPartsOutputResponse, Error> = .success(.init())
-    func listParts(input: AWSS3.ListPartsInput) async throws -> AWSS3.ListPartsOutputResponse {
+    var listPartsResult: Result<ListPartsOutput, Error> = .success(.init())
+    func listParts(input: AWSS3.ListPartsInput) async throws -> AWSS3.ListPartsOutput {
         listPartsCount += 1
         return try listPartsResult.get()
     }
     
     var completeMultipartUploadCount = 0
-    var completeMultipartUploadResult: Result<CompleteMultipartUploadOutputResponse, Error> = .success(.init())
-    func completeMultipartUpload(input: AWSS3.CompleteMultipartUploadInput) async throws -> AWSS3.CompleteMultipartUploadOutputResponse {
+    var completeMultipartUploadResult: Result<CompleteMultipartUploadOutput, Error> = .success(.init())
+    func completeMultipartUpload(input: AWSS3.CompleteMultipartUploadInput) async throws -> AWSS3.CompleteMultipartUploadOutput {
         completeMultipartUploadCount += 1
         return try completeMultipartUploadResult.get()
     }
     
     var abortMultipartUploadCount = 0
-    var abortMultipartUploadResult: Result<AbortMultipartUploadOutputResponse, Error> = .success(.init())
-    func abortMultipartUpload(input: AWSS3.AbortMultipartUploadInput) async throws -> AWSS3.AbortMultipartUploadOutputResponse {
+    var abortMultipartUploadResult: Result<AbortMultipartUploadOutput, Error> = .success(.init())
+    func abortMultipartUpload(input: AWSS3.AbortMultipartUploadInput) async throws -> AWSS3.AbortMultipartUploadOutput {
         abortMultipartUploadCount += 1
         return try abortMultipartUploadResult.get()
     }
     
-    func copyObject(input: AWSS3.CopyObjectInput) async throws -> AWSS3.CopyObjectOutputResponse {
+    func copyObject(input: AWSS3.CopyObjectInput) async throws -> AWSS3.CopyObjectOutput {
         fatalError("Not Implemented")
     }
     
-    func createBucket(input: AWSS3.CreateBucketInput) async throws -> AWSS3.CreateBucketOutputResponse {
+    func createBucket(input: AWSS3.CreateBucketInput) async throws -> AWSS3.CreateBucketOutput {
         fatalError("Not Implemented")
     }
     
-    func deleteBucket(input: AWSS3.DeleteBucketInput) async throws -> AWSS3.DeleteBucketOutputResponse {
+    func deleteBucket(input: AWSS3.DeleteBucketInput) async throws -> AWSS3.DeleteBucketOutput {
         fatalError("Not Implemented")
     }
     
-    func deleteBucketAnalyticsConfiguration(input: AWSS3.DeleteBucketAnalyticsConfigurationInput) async throws -> AWSS3.DeleteBucketAnalyticsConfigurationOutputResponse {
+    func deleteBucketAnalyticsConfiguration(input: AWSS3.DeleteBucketAnalyticsConfigurationInput) async throws -> AWSS3.DeleteBucketAnalyticsConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func deleteBucketCors(input: AWSS3.DeleteBucketCorsInput) async throws -> AWSS3.DeleteBucketCorsOutputResponse {
+    func deleteBucketCors(input: AWSS3.DeleteBucketCorsInput) async throws -> AWSS3.DeleteBucketCorsOutput {
         fatalError("Not Implemented")
     }
     
-    func deleteBucketEncryption(input: AWSS3.DeleteBucketEncryptionInput) async throws -> AWSS3.DeleteBucketEncryptionOutputResponse {
+    func deleteBucketEncryption(input: AWSS3.DeleteBucketEncryptionInput) async throws -> AWSS3.DeleteBucketEncryptionOutput {
         fatalError("Not Implemented")
     }
     
-    func deleteBucketIntelligentTieringConfiguration(input: AWSS3.DeleteBucketIntelligentTieringConfigurationInput) async throws -> AWSS3.DeleteBucketIntelligentTieringConfigurationOutputResponse {
+    func deleteBucketIntelligentTieringConfiguration(input: AWSS3.DeleteBucketIntelligentTieringConfigurationInput) async throws -> AWSS3.DeleteBucketIntelligentTieringConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func deleteBucketInventoryConfiguration(input: AWSS3.DeleteBucketInventoryConfigurationInput) async throws -> AWSS3.DeleteBucketInventoryConfigurationOutputResponse {
+    func deleteBucketInventoryConfiguration(input: AWSS3.DeleteBucketInventoryConfigurationInput) async throws -> AWSS3.DeleteBucketInventoryConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func deleteBucketLifecycle(input: AWSS3.DeleteBucketLifecycleInput) async throws -> AWSS3.DeleteBucketLifecycleOutputResponse {
+    func deleteBucketLifecycle(input: AWSS3.DeleteBucketLifecycleInput) async throws -> AWSS3.DeleteBucketLifecycleOutput {
         fatalError("Not Implemented")
     }
     
-    func deleteBucketMetricsConfiguration(input: AWSS3.DeleteBucketMetricsConfigurationInput) async throws -> AWSS3.DeleteBucketMetricsConfigurationOutputResponse {
+    func deleteBucketMetricsConfiguration(input: AWSS3.DeleteBucketMetricsConfigurationInput) async throws -> AWSS3.DeleteBucketMetricsConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func deleteBucketOwnershipControls(input: AWSS3.DeleteBucketOwnershipControlsInput) async throws -> AWSS3.DeleteBucketOwnershipControlsOutputResponse {
+    func deleteBucketOwnershipControls(input: AWSS3.DeleteBucketOwnershipControlsInput) async throws -> AWSS3.DeleteBucketOwnershipControlsOutput {
         fatalError("Not Implemented")
     }
     
-    func deleteBucketPolicy(input: AWSS3.DeleteBucketPolicyInput) async throws -> AWSS3.DeleteBucketPolicyOutputResponse {
+    func deleteBucketPolicy(input: AWSS3.DeleteBucketPolicyInput) async throws -> AWSS3.DeleteBucketPolicyOutput {
         fatalError("Not Implemented")
     }
     
-    func deleteBucketReplication(input: AWSS3.DeleteBucketReplicationInput) async throws -> AWSS3.DeleteBucketReplicationOutputResponse {
+    func deleteBucketReplication(input: AWSS3.DeleteBucketReplicationInput) async throws -> AWSS3.DeleteBucketReplicationOutput {
         fatalError("Not Implemented")
     }
     
-    func deleteBucketTagging(input: AWSS3.DeleteBucketTaggingInput) async throws -> AWSS3.DeleteBucketTaggingOutputResponse {
+    func deleteBucketTagging(input: AWSS3.DeleteBucketTaggingInput) async throws -> AWSS3.DeleteBucketTaggingOutput {
         fatalError("Not Implemented")
     }
     
-    func deleteBucketWebsite(input: AWSS3.DeleteBucketWebsiteInput) async throws -> AWSS3.DeleteBucketWebsiteOutputResponse {
+    func deleteBucketWebsite(input: AWSS3.DeleteBucketWebsiteInput) async throws -> AWSS3.DeleteBucketWebsiteOutput {
         fatalError("Not Implemented")
     }
     
-    func deleteObjects(input: AWSS3.DeleteObjectsInput) async throws -> AWSS3.DeleteObjectsOutputResponse {
+    func deleteObjects(input: AWSS3.DeleteObjectsInput) async throws -> AWSS3.DeleteObjectsOutput {
         fatalError("Not Implemented")
     }
     
-    func deleteObjectTagging(input: AWSS3.DeleteObjectTaggingInput) async throws -> AWSS3.DeleteObjectTaggingOutputResponse {
+    func deleteObjectTagging(input: AWSS3.DeleteObjectTaggingInput) async throws -> AWSS3.DeleteObjectTaggingOutput {
         fatalError("Not Implemented")
     }
     
-    func deletePublicAccessBlock(input: AWSS3.DeletePublicAccessBlockInput) async throws -> AWSS3.DeletePublicAccessBlockOutputResponse {
+    func deletePublicAccessBlock(input: AWSS3.DeletePublicAccessBlockInput) async throws -> AWSS3.DeletePublicAccessBlockOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketAccelerateConfiguration(input: AWSS3.GetBucketAccelerateConfigurationInput) async throws -> AWSS3.GetBucketAccelerateConfigurationOutputResponse {
+    func getBucketAccelerateConfiguration(input: AWSS3.GetBucketAccelerateConfigurationInput) async throws -> AWSS3.GetBucketAccelerateConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketAcl(input: AWSS3.GetBucketAclInput) async throws -> AWSS3.GetBucketAclOutputResponse {
+    func getBucketAcl(input: AWSS3.GetBucketAclInput) async throws -> AWSS3.GetBucketAclOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketAnalyticsConfiguration(input: AWSS3.GetBucketAnalyticsConfigurationInput) async throws -> AWSS3.GetBucketAnalyticsConfigurationOutputResponse {
+    func getBucketAnalyticsConfiguration(input: AWSS3.GetBucketAnalyticsConfigurationInput) async throws -> AWSS3.GetBucketAnalyticsConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketCors(input: AWSS3.GetBucketCorsInput) async throws -> AWSS3.GetBucketCorsOutputResponse {
+    func getBucketCors(input: AWSS3.GetBucketCorsInput) async throws -> AWSS3.GetBucketCorsOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketEncryption(input: AWSS3.GetBucketEncryptionInput) async throws -> AWSS3.GetBucketEncryptionOutputResponse {
+    func getBucketEncryption(input: AWSS3.GetBucketEncryptionInput) async throws -> AWSS3.GetBucketEncryptionOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketIntelligentTieringConfiguration(input: AWSS3.GetBucketIntelligentTieringConfigurationInput) async throws -> AWSS3.GetBucketIntelligentTieringConfigurationOutputResponse {
+    func getBucketIntelligentTieringConfiguration(input: AWSS3.GetBucketIntelligentTieringConfigurationInput) async throws -> AWSS3.GetBucketIntelligentTieringConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketInventoryConfiguration(input: AWSS3.GetBucketInventoryConfigurationInput) async throws -> AWSS3.GetBucketInventoryConfigurationOutputResponse {
+    func getBucketInventoryConfiguration(input: AWSS3.GetBucketInventoryConfigurationInput) async throws -> AWSS3.GetBucketInventoryConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketLifecycleConfiguration(input: AWSS3.GetBucketLifecycleConfigurationInput) async throws -> AWSS3.GetBucketLifecycleConfigurationOutputResponse {
+    func getBucketLifecycleConfiguration(input: AWSS3.GetBucketLifecycleConfigurationInput) async throws -> AWSS3.GetBucketLifecycleConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketLocation(input: AWSS3.GetBucketLocationInput) async throws -> AWSS3.GetBucketLocationOutputResponse {
+    func getBucketLocation(input: AWSS3.GetBucketLocationInput) async throws -> AWSS3.GetBucketLocationOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketLogging(input: AWSS3.GetBucketLoggingInput) async throws -> AWSS3.GetBucketLoggingOutputResponse {
+    func getBucketLogging(input: AWSS3.GetBucketLoggingInput) async throws -> AWSS3.GetBucketLoggingOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketMetricsConfiguration(input: AWSS3.GetBucketMetricsConfigurationInput) async throws -> AWSS3.GetBucketMetricsConfigurationOutputResponse {
+    func getBucketMetricsConfiguration(input: AWSS3.GetBucketMetricsConfigurationInput) async throws -> AWSS3.GetBucketMetricsConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketNotificationConfiguration(input: AWSS3.GetBucketNotificationConfigurationInput) async throws -> AWSS3.GetBucketNotificationConfigurationOutputResponse {
+    func getBucketNotificationConfiguration(input: AWSS3.GetBucketNotificationConfigurationInput) async throws -> AWSS3.GetBucketNotificationConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketOwnershipControls(input: AWSS3.GetBucketOwnershipControlsInput) async throws -> AWSS3.GetBucketOwnershipControlsOutputResponse {
+    func getBucketOwnershipControls(input: AWSS3.GetBucketOwnershipControlsInput) async throws -> AWSS3.GetBucketOwnershipControlsOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketPolicy(input: AWSS3.GetBucketPolicyInput) async throws -> AWSS3.GetBucketPolicyOutputResponse {
+    func getBucketPolicy(input: AWSS3.GetBucketPolicyInput) async throws -> AWSS3.GetBucketPolicyOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketPolicyStatus(input: AWSS3.GetBucketPolicyStatusInput) async throws -> AWSS3.GetBucketPolicyStatusOutputResponse {
+    func getBucketPolicyStatus(input: AWSS3.GetBucketPolicyStatusInput) async throws -> AWSS3.GetBucketPolicyStatusOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketReplication(input: AWSS3.GetBucketReplicationInput) async throws -> AWSS3.GetBucketReplicationOutputResponse {
+    func getBucketReplication(input: AWSS3.GetBucketReplicationInput) async throws -> AWSS3.GetBucketReplicationOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketRequestPayment(input: AWSS3.GetBucketRequestPaymentInput) async throws -> AWSS3.GetBucketRequestPaymentOutputResponse {
+    func getBucketRequestPayment(input: AWSS3.GetBucketRequestPaymentInput) async throws -> AWSS3.GetBucketRequestPaymentOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketTagging(input: AWSS3.GetBucketTaggingInput) async throws -> AWSS3.GetBucketTaggingOutputResponse {
+    func getBucketTagging(input: AWSS3.GetBucketTaggingInput) async throws -> AWSS3.GetBucketTaggingOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketVersioning(input: AWSS3.GetBucketVersioningInput) async throws -> AWSS3.GetBucketVersioningOutputResponse {
+    func getBucketVersioning(input: AWSS3.GetBucketVersioningInput) async throws -> AWSS3.GetBucketVersioningOutput {
         fatalError("Not Implemented")
     }
     
-    func getBucketWebsite(input: AWSS3.GetBucketWebsiteInput) async throws -> AWSS3.GetBucketWebsiteOutputResponse {
+    func getBucketWebsite(input: AWSS3.GetBucketWebsiteInput) async throws -> AWSS3.GetBucketWebsiteOutput {
         fatalError("Not Implemented")
     }
     
-    func getObject(input: AWSS3.GetObjectInput) async throws -> AWSS3.GetObjectOutputResponse {
+    func getObject(input: AWSS3.GetObjectInput) async throws -> AWSS3.GetObjectOutput {
         fatalError("Not Implemented")
     }
     
-    func getObjectAcl(input: AWSS3.GetObjectAclInput) async throws -> AWSS3.GetObjectAclOutputResponse {
+    func getObjectAcl(input: AWSS3.GetObjectAclInput) async throws -> AWSS3.GetObjectAclOutput {
         fatalError("Not Implemented")
     }
     
-    func getObjectAttributes(input: AWSS3.GetObjectAttributesInput) async throws -> AWSS3.GetObjectAttributesOutputResponse {
+    func getObjectAttributes(input: AWSS3.GetObjectAttributesInput) async throws -> AWSS3.GetObjectAttributesOutput {
         fatalError("Not Implemented")
     }
     
-    func getObjectLegalHold(input: AWSS3.GetObjectLegalHoldInput) async throws -> AWSS3.GetObjectLegalHoldOutputResponse {
+    func getObjectLegalHold(input: AWSS3.GetObjectLegalHoldInput) async throws -> AWSS3.GetObjectLegalHoldOutput {
         fatalError("Not Implemented")
     }
     
-    func getObjectLockConfiguration(input: AWSS3.GetObjectLockConfigurationInput) async throws -> AWSS3.GetObjectLockConfigurationOutputResponse {
+    func getObjectLockConfiguration(input: AWSS3.GetObjectLockConfigurationInput) async throws -> AWSS3.GetObjectLockConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func getObjectRetention(input: AWSS3.GetObjectRetentionInput) async throws -> AWSS3.GetObjectRetentionOutputResponse {
+    func getObjectRetention(input: AWSS3.GetObjectRetentionInput) async throws -> AWSS3.GetObjectRetentionOutput {
         fatalError("Not Implemented")
     }
     
-    func getObjectTagging(input: AWSS3.GetObjectTaggingInput) async throws -> AWSS3.GetObjectTaggingOutputResponse {
+    func getObjectTagging(input: AWSS3.GetObjectTaggingInput) async throws -> AWSS3.GetObjectTaggingOutput {
         fatalError("Not Implemented")
     }
     
-    func getObjectTorrent(input: AWSS3.GetObjectTorrentInput) async throws -> AWSS3.GetObjectTorrentOutputResponse {
+    func getObjectTorrent(input: AWSS3.GetObjectTorrentInput) async throws -> AWSS3.GetObjectTorrentOutput {
         fatalError("Not Implemented")
     }
     
-    func getPublicAccessBlock(input: AWSS3.GetPublicAccessBlockInput) async throws -> AWSS3.GetPublicAccessBlockOutputResponse {
+    func getPublicAccessBlock(input: AWSS3.GetPublicAccessBlockInput) async throws -> AWSS3.GetPublicAccessBlockOutput {
         fatalError("Not Implemented")
     }
     
-    func headBucket(input: AWSS3.HeadBucketInput) async throws -> AWSS3.HeadBucketOutputResponse {
+    func headBucket(input: AWSS3.HeadBucketInput) async throws -> AWSS3.HeadBucketOutput {
         fatalError("Not Implemented")
     }
     
-    func headObject(input: AWSS3.HeadObjectInput) async throws -> AWSS3.HeadObjectOutputResponse {
+    func headObject(input: AWSS3.HeadObjectInput) async throws -> AWSS3.HeadObjectOutput {
         fatalError("Not Implemented")
     }
     
-    func listBucketAnalyticsConfigurations(input: AWSS3.ListBucketAnalyticsConfigurationsInput) async throws -> AWSS3.ListBucketAnalyticsConfigurationsOutputResponse {
+    func listBucketAnalyticsConfigurations(input: AWSS3.ListBucketAnalyticsConfigurationsInput) async throws -> AWSS3.ListBucketAnalyticsConfigurationsOutput {
         fatalError("Not Implemented")
     }
     
-    func listBucketIntelligentTieringConfigurations(input: AWSS3.ListBucketIntelligentTieringConfigurationsInput) async throws -> AWSS3.ListBucketIntelligentTieringConfigurationsOutputResponse {
+    func listBucketIntelligentTieringConfigurations(input: AWSS3.ListBucketIntelligentTieringConfigurationsInput) async throws -> AWSS3.ListBucketIntelligentTieringConfigurationsOutput {
         fatalError("Not Implemented")
     }
     
-    func listBucketInventoryConfigurations(input: AWSS3.ListBucketInventoryConfigurationsInput) async throws -> AWSS3.ListBucketInventoryConfigurationsOutputResponse {
+    func listBucketInventoryConfigurations(input: AWSS3.ListBucketInventoryConfigurationsInput) async throws -> AWSS3.ListBucketInventoryConfigurationsOutput {
         fatalError("Not Implemented")
     }
     
-    func listBucketMetricsConfigurations(input: AWSS3.ListBucketMetricsConfigurationsInput) async throws -> AWSS3.ListBucketMetricsConfigurationsOutputResponse {
+    func listBucketMetricsConfigurations(input: AWSS3.ListBucketMetricsConfigurationsInput) async throws -> AWSS3.ListBucketMetricsConfigurationsOutput {
         fatalError("Not Implemented")
     }
     
-    func listBuckets(input: AWSS3.ListBucketsInput) async throws -> AWSS3.ListBucketsOutputResponse {
+    func listBuckets(input: AWSS3.ListBucketsInput) async throws -> AWSS3.ListBucketsOutput {
         fatalError("Not Implemented")
     }
     
-    func listMultipartUploads(input: AWSS3.ListMultipartUploadsInput) async throws -> AWSS3.ListMultipartUploadsOutputResponse {
+    func listMultipartUploads(input: AWSS3.ListMultipartUploadsInput) async throws -> AWSS3.ListMultipartUploadsOutput {
         fatalError("Not Implemented")
     }
     
-    func listObjects(input: AWSS3.ListObjectsInput) async throws -> AWSS3.ListObjectsOutputResponse {
+    func listObjects(input: AWSS3.ListObjectsInput) async throws -> AWSS3.ListObjectsOutput {
         fatalError("Not Implemented")
     }
     
-    func listObjectVersions(input: AWSS3.ListObjectVersionsInput) async throws -> AWSS3.ListObjectVersionsOutputResponse {
+    func listObjectVersions(input: AWSS3.ListObjectVersionsInput) async throws -> AWSS3.ListObjectVersionsOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketAccelerateConfiguration(input: AWSS3.PutBucketAccelerateConfigurationInput) async throws -> AWSS3.PutBucketAccelerateConfigurationOutputResponse {
+    func putBucketAccelerateConfiguration(input: AWSS3.PutBucketAccelerateConfigurationInput) async throws -> AWSS3.PutBucketAccelerateConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketAcl(input: AWSS3.PutBucketAclInput) async throws -> AWSS3.PutBucketAclOutputResponse {
+    func putBucketAcl(input: AWSS3.PutBucketAclInput) async throws -> AWSS3.PutBucketAclOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketAnalyticsConfiguration(input: AWSS3.PutBucketAnalyticsConfigurationInput) async throws -> AWSS3.PutBucketAnalyticsConfigurationOutputResponse {
+    func putBucketAnalyticsConfiguration(input: AWSS3.PutBucketAnalyticsConfigurationInput) async throws -> AWSS3.PutBucketAnalyticsConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketCors(input: AWSS3.PutBucketCorsInput) async throws -> AWSS3.PutBucketCorsOutputResponse {
+    func putBucketCors(input: AWSS3.PutBucketCorsInput) async throws -> AWSS3.PutBucketCorsOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketEncryption(input: AWSS3.PutBucketEncryptionInput) async throws -> AWSS3.PutBucketEncryptionOutputResponse {
+    func putBucketEncryption(input: AWSS3.PutBucketEncryptionInput) async throws -> AWSS3.PutBucketEncryptionOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketIntelligentTieringConfiguration(input: AWSS3.PutBucketIntelligentTieringConfigurationInput) async throws -> AWSS3.PutBucketIntelligentTieringConfigurationOutputResponse {
+    func putBucketIntelligentTieringConfiguration(input: AWSS3.PutBucketIntelligentTieringConfigurationInput) async throws -> AWSS3.PutBucketIntelligentTieringConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketInventoryConfiguration(input: AWSS3.PutBucketInventoryConfigurationInput) async throws -> AWSS3.PutBucketInventoryConfigurationOutputResponse {
+    func putBucketInventoryConfiguration(input: AWSS3.PutBucketInventoryConfigurationInput) async throws -> AWSS3.PutBucketInventoryConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketLifecycleConfiguration(input: AWSS3.PutBucketLifecycleConfigurationInput) async throws -> AWSS3.PutBucketLifecycleConfigurationOutputResponse {
+    func putBucketLifecycleConfiguration(input: AWSS3.PutBucketLifecycleConfigurationInput) async throws -> AWSS3.PutBucketLifecycleConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketLogging(input: AWSS3.PutBucketLoggingInput) async throws -> AWSS3.PutBucketLoggingOutputResponse {
+    func putBucketLogging(input: AWSS3.PutBucketLoggingInput) async throws -> AWSS3.PutBucketLoggingOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketMetricsConfiguration(input: AWSS3.PutBucketMetricsConfigurationInput) async throws -> AWSS3.PutBucketMetricsConfigurationOutputResponse {
+    func putBucketMetricsConfiguration(input: AWSS3.PutBucketMetricsConfigurationInput) async throws -> AWSS3.PutBucketMetricsConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketNotificationConfiguration(input: AWSS3.PutBucketNotificationConfigurationInput) async throws -> AWSS3.PutBucketNotificationConfigurationOutputResponse {
+    func putBucketNotificationConfiguration(input: AWSS3.PutBucketNotificationConfigurationInput) async throws -> AWSS3.PutBucketNotificationConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketOwnershipControls(input: AWSS3.PutBucketOwnershipControlsInput) async throws -> AWSS3.PutBucketOwnershipControlsOutputResponse {
+    func putBucketOwnershipControls(input: AWSS3.PutBucketOwnershipControlsInput) async throws -> AWSS3.PutBucketOwnershipControlsOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketPolicy(input: AWSS3.PutBucketPolicyInput) async throws -> AWSS3.PutBucketPolicyOutputResponse {
+    func putBucketPolicy(input: AWSS3.PutBucketPolicyInput) async throws -> AWSS3.PutBucketPolicyOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketReplication(input: AWSS3.PutBucketReplicationInput) async throws -> AWSS3.PutBucketReplicationOutputResponse {
+    func putBucketReplication(input: AWSS3.PutBucketReplicationInput) async throws -> AWSS3.PutBucketReplicationOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketRequestPayment(input: AWSS3.PutBucketRequestPaymentInput) async throws -> AWSS3.PutBucketRequestPaymentOutputResponse {
+    func putBucketRequestPayment(input: AWSS3.PutBucketRequestPaymentInput) async throws -> AWSS3.PutBucketRequestPaymentOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketTagging(input: AWSS3.PutBucketTaggingInput) async throws -> AWSS3.PutBucketTaggingOutputResponse {
+    func putBucketTagging(input: AWSS3.PutBucketTaggingInput) async throws -> AWSS3.PutBucketTaggingOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketVersioning(input: AWSS3.PutBucketVersioningInput) async throws -> AWSS3.PutBucketVersioningOutputResponse {
+    func putBucketVersioning(input: AWSS3.PutBucketVersioningInput) async throws -> AWSS3.PutBucketVersioningOutput {
         fatalError("Not Implemented")
     }
     
-    func putBucketWebsite(input: AWSS3.PutBucketWebsiteInput) async throws -> AWSS3.PutBucketWebsiteOutputResponse {
+    func putBucketWebsite(input: AWSS3.PutBucketWebsiteInput) async throws -> AWSS3.PutBucketWebsiteOutput {
         fatalError("Not Implemented")
     }
     
-    func putObject(input: AWSS3.PutObjectInput) async throws -> AWSS3.PutObjectOutputResponse {
+    func putObject(input: AWSS3.PutObjectInput) async throws -> AWSS3.PutObjectOutput {
         fatalError("Not Implemented")
     }
     
-    func putObjectAcl(input: AWSS3.PutObjectAclInput) async throws -> AWSS3.PutObjectAclOutputResponse {
+    func putObjectAcl(input: AWSS3.PutObjectAclInput) async throws -> AWSS3.PutObjectAclOutput {
         fatalError("Not Implemented")
     }
     
-    func putObjectLegalHold(input: AWSS3.PutObjectLegalHoldInput) async throws -> AWSS3.PutObjectLegalHoldOutputResponse {
+    func putObjectLegalHold(input: AWSS3.PutObjectLegalHoldInput) async throws -> AWSS3.PutObjectLegalHoldOutput {
         fatalError("Not Implemented")
     }
     
-    func putObjectLockConfiguration(input: AWSS3.PutObjectLockConfigurationInput) async throws -> AWSS3.PutObjectLockConfigurationOutputResponse {
+    func putObjectLockConfiguration(input: AWSS3.PutObjectLockConfigurationInput) async throws -> AWSS3.PutObjectLockConfigurationOutput {
         fatalError("Not Implemented")
     }
     
-    func putObjectRetention(input: AWSS3.PutObjectRetentionInput) async throws -> AWSS3.PutObjectRetentionOutputResponse {
+    func putObjectRetention(input: AWSS3.PutObjectRetentionInput) async throws -> AWSS3.PutObjectRetentionOutput {
         fatalError("Not Implemented")
     }
     
-    func putObjectTagging(input: AWSS3.PutObjectTaggingInput) async throws -> AWSS3.PutObjectTaggingOutputResponse {
+    func putObjectTagging(input: AWSS3.PutObjectTaggingInput) async throws -> AWSS3.PutObjectTaggingOutput {
         fatalError("Not Implemented")
     }
     
-    func putPublicAccessBlock(input: AWSS3.PutPublicAccessBlockInput) async throws -> AWSS3.PutPublicAccessBlockOutputResponse {
+    func putPublicAccessBlock(input: AWSS3.PutPublicAccessBlockInput) async throws -> AWSS3.PutPublicAccessBlockOutput {
         fatalError("Not Implemented")
     }
     
-    func restoreObject(input: AWSS3.RestoreObjectInput) async throws -> AWSS3.RestoreObjectOutputResponse {
+    func restoreObject(input: AWSS3.RestoreObjectInput) async throws -> AWSS3.RestoreObjectOutput {
         fatalError("Not Implemented")
     }
     
-    func selectObjectContent(input: AWSS3.SelectObjectContentInput) async throws -> AWSS3.SelectObjectContentOutputResponse {
+    func selectObjectContent(input: AWSS3.SelectObjectContentInput) async throws -> AWSS3.SelectObjectContentOutput {
         fatalError("Not Implemented")
     }
     
-    func uploadPart(input: AWSS3.UploadPartInput) async throws -> AWSS3.UploadPartOutputResponse {
+    func uploadPart(input: AWSS3.UploadPartInput) async throws -> AWSS3.UploadPartOutput {
         fatalError("Not Implemented")
     }
     
-    func uploadPartCopy(input: AWSS3.UploadPartCopyInput) async throws -> AWSS3.UploadPartCopyOutputResponse {
+    func uploadPartCopy(input: AWSS3.UploadPartCopyInput) async throws -> AWSS3.UploadPartCopyOutput {
         fatalError("Not Implemented")
     }
     
-    func writeGetObjectResponse(input: AWSS3.WriteGetObjectResponseInput) async throws -> AWSS3.WriteGetObjectResponseOutputResponse {
+    func writeGetObjectResponse(input: AWSS3.WriteGetObjectResponseInput) async throws -> AWSS3.WriteGetObjectResponseOutput {
         fatalError("Not Implemented")
     }
 }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockS3Client.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockS3Client.swift
@@ -24,385 +24,385 @@ final class MockS3Client {
     /// in order to extract results during each invocation.
     ///
     /// - Tag: MockS3Client.listObjectsV2Handler
-    var listObjectsV2Handler: (ListObjectsV2Input) async throws -> ListObjectsV2OutputResponse = { _ in throw ClientError.missingResult }
+    var listObjectsV2Handler: (ListObjectsV2Input) async throws -> ListObjectsV2Output = { _ in throw ClientError.missingResult }
 
-    var headObjectHandler: (HeadObjectInput) async throws -> HeadObjectOutputResponse = { _ in return HeadObjectOutputResponse() }
+    var headObjectHandler: (HeadObjectInput) async throws -> HeadObjectOutput = { _ in return HeadObjectOutput() }
 }
 
 extension MockS3Client: S3ClientProtocol {
 
     /// - Tag: MockS3Client.listObjectsV2
-    func listObjectsV2(input: AWSS3.ListObjectsV2Input) async throws -> AWSS3.ListObjectsV2OutputResponse {
+    func listObjectsV2(input: AWSS3.ListObjectsV2Input) async throws -> AWSS3.ListObjectsV2Output {
         interactions.append("\(#function) bucket: \(input.bucket ?? "nil") prefix: \(input.prefix ?? "nil") continuationToken: \(input.continuationToken ?? "nil")")
         return try await listObjectsV2Handler(input)
     }
 
-    func abortMultipartUpload(input: AWSS3.AbortMultipartUploadInput) async throws -> AWSS3.AbortMultipartUploadOutputResponse {
+    func abortMultipartUpload(input: AWSS3.AbortMultipartUploadInput) async throws -> AWSS3.AbortMultipartUploadOutput {
         throw ClientError.missingImplementation
     }
 
-    func completeMultipartUpload(input: AWSS3.CompleteMultipartUploadInput) async throws -> AWSS3.CompleteMultipartUploadOutputResponse {
+    func completeMultipartUpload(input: AWSS3.CompleteMultipartUploadInput) async throws -> AWSS3.CompleteMultipartUploadOutput {
         throw ClientError.missingImplementation
     }
 
-    func copyObject(input: AWSS3.CopyObjectInput) async throws -> AWSS3.CopyObjectOutputResponse {
+    func copyObject(input: AWSS3.CopyObjectInput) async throws -> AWSS3.CopyObjectOutput {
         throw ClientError.missingImplementation
     }
 
-    func createBucket(input: AWSS3.CreateBucketInput) async throws -> AWSS3.CreateBucketOutputResponse {
+    func createBucket(input: AWSS3.CreateBucketInput) async throws -> AWSS3.CreateBucketOutput {
         throw ClientError.missingImplementation
     }
 
-    func createMultipartUpload(input: AWSS3.CreateMultipartUploadInput) async throws -> AWSS3.CreateMultipartUploadOutputResponse {
+    func createMultipartUpload(input: AWSS3.CreateMultipartUploadInput) async throws -> AWSS3.CreateMultipartUploadOutput {
         throw ClientError.missingImplementation
     }
 
-    func deleteBucket(input: AWSS3.DeleteBucketInput) async throws -> AWSS3.DeleteBucketOutputResponse {
+    func deleteBucket(input: AWSS3.DeleteBucketInput) async throws -> AWSS3.DeleteBucketOutput {
         throw ClientError.missingImplementation
     }
 
-    func deleteBucketAnalyticsConfiguration(input: AWSS3.DeleteBucketAnalyticsConfigurationInput) async throws -> AWSS3.DeleteBucketAnalyticsConfigurationOutputResponse {
+    func deleteBucketAnalyticsConfiguration(input: AWSS3.DeleteBucketAnalyticsConfigurationInput) async throws -> AWSS3.DeleteBucketAnalyticsConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func deleteBucketCors(input: AWSS3.DeleteBucketCorsInput) async throws -> AWSS3.DeleteBucketCorsOutputResponse {
+    func deleteBucketCors(input: AWSS3.DeleteBucketCorsInput) async throws -> AWSS3.DeleteBucketCorsOutput {
         throw ClientError.missingImplementation
     }
 
-    func deleteBucketEncryption(input: AWSS3.DeleteBucketEncryptionInput) async throws -> AWSS3.DeleteBucketEncryptionOutputResponse {
+    func deleteBucketEncryption(input: AWSS3.DeleteBucketEncryptionInput) async throws -> AWSS3.DeleteBucketEncryptionOutput {
         throw ClientError.missingImplementation
     }
 
-    func deleteBucketIntelligentTieringConfiguration(input: AWSS3.DeleteBucketIntelligentTieringConfigurationInput) async throws -> AWSS3.DeleteBucketIntelligentTieringConfigurationOutputResponse {
+    func deleteBucketIntelligentTieringConfiguration(input: AWSS3.DeleteBucketIntelligentTieringConfigurationInput) async throws -> AWSS3.DeleteBucketIntelligentTieringConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func deleteBucketInventoryConfiguration(input: AWSS3.DeleteBucketInventoryConfigurationInput) async throws -> AWSS3.DeleteBucketInventoryConfigurationOutputResponse {
+    func deleteBucketInventoryConfiguration(input: AWSS3.DeleteBucketInventoryConfigurationInput) async throws -> AWSS3.DeleteBucketInventoryConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func deleteBucketLifecycle(input: AWSS3.DeleteBucketLifecycleInput) async throws -> AWSS3.DeleteBucketLifecycleOutputResponse {
+    func deleteBucketLifecycle(input: AWSS3.DeleteBucketLifecycleInput) async throws -> AWSS3.DeleteBucketLifecycleOutput {
         throw ClientError.missingImplementation
     }
 
-    func deleteBucketMetricsConfiguration(input: AWSS3.DeleteBucketMetricsConfigurationInput) async throws -> AWSS3.DeleteBucketMetricsConfigurationOutputResponse {
+    func deleteBucketMetricsConfiguration(input: AWSS3.DeleteBucketMetricsConfigurationInput) async throws -> AWSS3.DeleteBucketMetricsConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func deleteBucketOwnershipControls(input: AWSS3.DeleteBucketOwnershipControlsInput) async throws -> AWSS3.DeleteBucketOwnershipControlsOutputResponse {
+    func deleteBucketOwnershipControls(input: AWSS3.DeleteBucketOwnershipControlsInput) async throws -> AWSS3.DeleteBucketOwnershipControlsOutput {
         throw ClientError.missingImplementation
     }
 
-    func deleteBucketPolicy(input: AWSS3.DeleteBucketPolicyInput) async throws -> AWSS3.DeleteBucketPolicyOutputResponse {
+    func deleteBucketPolicy(input: AWSS3.DeleteBucketPolicyInput) async throws -> AWSS3.DeleteBucketPolicyOutput {
         throw ClientError.missingImplementation
     }
 
-    func deleteBucketReplication(input: AWSS3.DeleteBucketReplicationInput) async throws -> AWSS3.DeleteBucketReplicationOutputResponse {
+    func deleteBucketReplication(input: AWSS3.DeleteBucketReplicationInput) async throws -> AWSS3.DeleteBucketReplicationOutput {
         throw ClientError.missingImplementation
     }
 
-    func deleteBucketTagging(input: AWSS3.DeleteBucketTaggingInput) async throws -> AWSS3.DeleteBucketTaggingOutputResponse {
+    func deleteBucketTagging(input: AWSS3.DeleteBucketTaggingInput) async throws -> AWSS3.DeleteBucketTaggingOutput {
         throw ClientError.missingImplementation
     }
 
-    func deleteBucketWebsite(input: AWSS3.DeleteBucketWebsiteInput) async throws -> AWSS3.DeleteBucketWebsiteOutputResponse {
+    func deleteBucketWebsite(input: AWSS3.DeleteBucketWebsiteInput) async throws -> AWSS3.DeleteBucketWebsiteOutput {
         throw ClientError.missingImplementation
     }
 
-    func deleteObject(input: AWSS3.DeleteObjectInput) async throws -> AWSS3.DeleteObjectOutputResponse {
+    func deleteObject(input: AWSS3.DeleteObjectInput) async throws -> AWSS3.DeleteObjectOutput {
         throw ClientError.missingImplementation
     }
 
-    func deleteObjects(input: AWSS3.DeleteObjectsInput) async throws -> AWSS3.DeleteObjectsOutputResponse {
+    func deleteObjects(input: AWSS3.DeleteObjectsInput) async throws -> AWSS3.DeleteObjectsOutput {
         throw ClientError.missingImplementation
     }
 
-    func deleteObjectTagging(input: AWSS3.DeleteObjectTaggingInput) async throws -> AWSS3.DeleteObjectTaggingOutputResponse {
+    func deleteObjectTagging(input: AWSS3.DeleteObjectTaggingInput) async throws -> AWSS3.DeleteObjectTaggingOutput {
         throw ClientError.missingImplementation
     }
 
-    func deletePublicAccessBlock(input: AWSS3.DeletePublicAccessBlockInput) async throws -> AWSS3.DeletePublicAccessBlockOutputResponse {
+    func deletePublicAccessBlock(input: AWSS3.DeletePublicAccessBlockInput) async throws -> AWSS3.DeletePublicAccessBlockOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketAccelerateConfiguration(input: AWSS3.GetBucketAccelerateConfigurationInput) async throws -> AWSS3.GetBucketAccelerateConfigurationOutputResponse {
+    func getBucketAccelerateConfiguration(input: AWSS3.GetBucketAccelerateConfigurationInput) async throws -> AWSS3.GetBucketAccelerateConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketAcl(input: AWSS3.GetBucketAclInput) async throws -> AWSS3.GetBucketAclOutputResponse {
+    func getBucketAcl(input: AWSS3.GetBucketAclInput) async throws -> AWSS3.GetBucketAclOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketAnalyticsConfiguration(input: AWSS3.GetBucketAnalyticsConfigurationInput) async throws -> AWSS3.GetBucketAnalyticsConfigurationOutputResponse {
+    func getBucketAnalyticsConfiguration(input: AWSS3.GetBucketAnalyticsConfigurationInput) async throws -> AWSS3.GetBucketAnalyticsConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketCors(input: AWSS3.GetBucketCorsInput) async throws -> AWSS3.GetBucketCorsOutputResponse {
+    func getBucketCors(input: AWSS3.GetBucketCorsInput) async throws -> AWSS3.GetBucketCorsOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketEncryption(input: AWSS3.GetBucketEncryptionInput) async throws -> AWSS3.GetBucketEncryptionOutputResponse {
+    func getBucketEncryption(input: AWSS3.GetBucketEncryptionInput) async throws -> AWSS3.GetBucketEncryptionOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketIntelligentTieringConfiguration(input: AWSS3.GetBucketIntelligentTieringConfigurationInput) async throws -> AWSS3.GetBucketIntelligentTieringConfigurationOutputResponse {
+    func getBucketIntelligentTieringConfiguration(input: AWSS3.GetBucketIntelligentTieringConfigurationInput) async throws -> AWSS3.GetBucketIntelligentTieringConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketInventoryConfiguration(input: AWSS3.GetBucketInventoryConfigurationInput) async throws -> AWSS3.GetBucketInventoryConfigurationOutputResponse {
+    func getBucketInventoryConfiguration(input: AWSS3.GetBucketInventoryConfigurationInput) async throws -> AWSS3.GetBucketInventoryConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketLifecycleConfiguration(input: AWSS3.GetBucketLifecycleConfigurationInput) async throws -> AWSS3.GetBucketLifecycleConfigurationOutputResponse {
+    func getBucketLifecycleConfiguration(input: AWSS3.GetBucketLifecycleConfigurationInput) async throws -> AWSS3.GetBucketLifecycleConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketLocation(input: AWSS3.GetBucketLocationInput) async throws -> AWSS3.GetBucketLocationOutputResponse {
+    func getBucketLocation(input: AWSS3.GetBucketLocationInput) async throws -> AWSS3.GetBucketLocationOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketLogging(input: AWSS3.GetBucketLoggingInput) async throws -> AWSS3.GetBucketLoggingOutputResponse {
+    func getBucketLogging(input: AWSS3.GetBucketLoggingInput) async throws -> AWSS3.GetBucketLoggingOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketMetricsConfiguration(input: AWSS3.GetBucketMetricsConfigurationInput) async throws -> AWSS3.GetBucketMetricsConfigurationOutputResponse {
+    func getBucketMetricsConfiguration(input: AWSS3.GetBucketMetricsConfigurationInput) async throws -> AWSS3.GetBucketMetricsConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketNotificationConfiguration(input: AWSS3.GetBucketNotificationConfigurationInput) async throws -> AWSS3.GetBucketNotificationConfigurationOutputResponse {
+    func getBucketNotificationConfiguration(input: AWSS3.GetBucketNotificationConfigurationInput) async throws -> AWSS3.GetBucketNotificationConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketOwnershipControls(input: AWSS3.GetBucketOwnershipControlsInput) async throws -> AWSS3.GetBucketOwnershipControlsOutputResponse {
+    func getBucketOwnershipControls(input: AWSS3.GetBucketOwnershipControlsInput) async throws -> AWSS3.GetBucketOwnershipControlsOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketPolicy(input: AWSS3.GetBucketPolicyInput) async throws -> AWSS3.GetBucketPolicyOutputResponse {
+    func getBucketPolicy(input: AWSS3.GetBucketPolicyInput) async throws -> AWSS3.GetBucketPolicyOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketPolicyStatus(input: AWSS3.GetBucketPolicyStatusInput) async throws -> AWSS3.GetBucketPolicyStatusOutputResponse {
+    func getBucketPolicyStatus(input: AWSS3.GetBucketPolicyStatusInput) async throws -> AWSS3.GetBucketPolicyStatusOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketReplication(input: AWSS3.GetBucketReplicationInput) async throws -> AWSS3.GetBucketReplicationOutputResponse {
+    func getBucketReplication(input: AWSS3.GetBucketReplicationInput) async throws -> AWSS3.GetBucketReplicationOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketRequestPayment(input: AWSS3.GetBucketRequestPaymentInput) async throws -> AWSS3.GetBucketRequestPaymentOutputResponse {
+    func getBucketRequestPayment(input: AWSS3.GetBucketRequestPaymentInput) async throws -> AWSS3.GetBucketRequestPaymentOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketTagging(input: AWSS3.GetBucketTaggingInput) async throws -> AWSS3.GetBucketTaggingOutputResponse {
+    func getBucketTagging(input: AWSS3.GetBucketTaggingInput) async throws -> AWSS3.GetBucketTaggingOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketVersioning(input: AWSS3.GetBucketVersioningInput) async throws -> AWSS3.GetBucketVersioningOutputResponse {
+    func getBucketVersioning(input: AWSS3.GetBucketVersioningInput) async throws -> AWSS3.GetBucketVersioningOutput {
         throw ClientError.missingImplementation
     }
 
-    func getBucketWebsite(input: AWSS3.GetBucketWebsiteInput) async throws -> AWSS3.GetBucketWebsiteOutputResponse {
+    func getBucketWebsite(input: AWSS3.GetBucketWebsiteInput) async throws -> AWSS3.GetBucketWebsiteOutput {
         throw ClientError.missingImplementation
     }
 
-    func getObject(input: AWSS3.GetObjectInput) async throws -> AWSS3.GetObjectOutputResponse {
+    func getObject(input: AWSS3.GetObjectInput) async throws -> AWSS3.GetObjectOutput {
         throw ClientError.missingImplementation
     }
 
-    func getObjectAcl(input: AWSS3.GetObjectAclInput) async throws -> AWSS3.GetObjectAclOutputResponse {
+    func getObjectAcl(input: AWSS3.GetObjectAclInput) async throws -> AWSS3.GetObjectAclOutput {
         throw ClientError.missingImplementation
     }
 
-    func getObjectAttributes(input: AWSS3.GetObjectAttributesInput) async throws -> AWSS3.GetObjectAttributesOutputResponse {
+    func getObjectAttributes(input: AWSS3.GetObjectAttributesInput) async throws -> AWSS3.GetObjectAttributesOutput {
         throw ClientError.missingImplementation
     }
 
-    func getObjectLegalHold(input: AWSS3.GetObjectLegalHoldInput) async throws -> AWSS3.GetObjectLegalHoldOutputResponse {
+    func getObjectLegalHold(input: AWSS3.GetObjectLegalHoldInput) async throws -> AWSS3.GetObjectLegalHoldOutput {
         throw ClientError.missingImplementation
     }
 
-    func getObjectLockConfiguration(input: AWSS3.GetObjectLockConfigurationInput) async throws -> AWSS3.GetObjectLockConfigurationOutputResponse {
+    func getObjectLockConfiguration(input: AWSS3.GetObjectLockConfigurationInput) async throws -> AWSS3.GetObjectLockConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func getObjectRetention(input: AWSS3.GetObjectRetentionInput) async throws -> AWSS3.GetObjectRetentionOutputResponse {
+    func getObjectRetention(input: AWSS3.GetObjectRetentionInput) async throws -> AWSS3.GetObjectRetentionOutput {
         throw ClientError.missingImplementation
     }
 
-    func getObjectTagging(input: AWSS3.GetObjectTaggingInput) async throws -> AWSS3.GetObjectTaggingOutputResponse {
+    func getObjectTagging(input: AWSS3.GetObjectTaggingInput) async throws -> AWSS3.GetObjectTaggingOutput {
         throw ClientError.missingImplementation
     }
 
-    func getObjectTorrent(input: AWSS3.GetObjectTorrentInput) async throws -> AWSS3.GetObjectTorrentOutputResponse {
+    func getObjectTorrent(input: AWSS3.GetObjectTorrentInput) async throws -> AWSS3.GetObjectTorrentOutput {
         throw ClientError.missingImplementation
     }
 
-    func getPublicAccessBlock(input: AWSS3.GetPublicAccessBlockInput) async throws -> AWSS3.GetPublicAccessBlockOutputResponse {
+    func getPublicAccessBlock(input: AWSS3.GetPublicAccessBlockInput) async throws -> AWSS3.GetPublicAccessBlockOutput {
         throw ClientError.missingImplementation
     }
 
-    func headBucket(input: AWSS3.HeadBucketInput) async throws -> AWSS3.HeadBucketOutputResponse {
+    func headBucket(input: AWSS3.HeadBucketInput) async throws -> AWSS3.HeadBucketOutput {
         throw ClientError.missingImplementation
     }
 
-    func headObject(input: HeadObjectInput) async throws -> HeadObjectOutputResponse {
+    func headObject(input: HeadObjectInput) async throws -> HeadObjectOutput {
         interactions.append(#function)
         return try await headObjectHandler(input)
     }
 
-    func listBucketAnalyticsConfigurations(input: AWSS3.ListBucketAnalyticsConfigurationsInput) async throws -> AWSS3.ListBucketAnalyticsConfigurationsOutputResponse {
+    func listBucketAnalyticsConfigurations(input: AWSS3.ListBucketAnalyticsConfigurationsInput) async throws -> AWSS3.ListBucketAnalyticsConfigurationsOutput {
         throw ClientError.missingImplementation
     }
 
-    func listBucketIntelligentTieringConfigurations(input: AWSS3.ListBucketIntelligentTieringConfigurationsInput) async throws -> AWSS3.ListBucketIntelligentTieringConfigurationsOutputResponse {
+    func listBucketIntelligentTieringConfigurations(input: AWSS3.ListBucketIntelligentTieringConfigurationsInput) async throws -> AWSS3.ListBucketIntelligentTieringConfigurationsOutput {
         throw ClientError.missingImplementation
     }
 
-    func listBucketInventoryConfigurations(input: AWSS3.ListBucketInventoryConfigurationsInput) async throws -> AWSS3.ListBucketInventoryConfigurationsOutputResponse {
+    func listBucketInventoryConfigurations(input: AWSS3.ListBucketInventoryConfigurationsInput) async throws -> AWSS3.ListBucketInventoryConfigurationsOutput {
         throw ClientError.missingImplementation
     }
 
-    func listBucketMetricsConfigurations(input: AWSS3.ListBucketMetricsConfigurationsInput) async throws -> AWSS3.ListBucketMetricsConfigurationsOutputResponse {
+    func listBucketMetricsConfigurations(input: AWSS3.ListBucketMetricsConfigurationsInput) async throws -> AWSS3.ListBucketMetricsConfigurationsOutput {
         throw ClientError.missingImplementation
     }
 
-    func listBuckets(input: AWSS3.ListBucketsInput) async throws -> AWSS3.ListBucketsOutputResponse {
+    func listBuckets(input: AWSS3.ListBucketsInput) async throws -> AWSS3.ListBucketsOutput {
         throw ClientError.missingImplementation
     }
 
-    func listMultipartUploads(input: AWSS3.ListMultipartUploadsInput) async throws -> AWSS3.ListMultipartUploadsOutputResponse {
+    func listMultipartUploads(input: AWSS3.ListMultipartUploadsInput) async throws -> AWSS3.ListMultipartUploadsOutput {
         throw ClientError.missingImplementation
     }
 
-    func listObjects(input: AWSS3.ListObjectsInput) async throws -> AWSS3.ListObjectsOutputResponse {
+    func listObjects(input: AWSS3.ListObjectsInput) async throws -> AWSS3.ListObjectsOutput {
         throw ClientError.missingImplementation
     }
 
-    func listObjectVersions(input: AWSS3.ListObjectVersionsInput) async throws -> AWSS3.ListObjectVersionsOutputResponse {
+    func listObjectVersions(input: AWSS3.ListObjectVersionsInput) async throws -> AWSS3.ListObjectVersionsOutput {
         throw ClientError.missingImplementation
     }
 
-    func listParts(input: AWSS3.ListPartsInput) async throws -> AWSS3.ListPartsOutputResponse {
+    func listParts(input: AWSS3.ListPartsInput) async throws -> AWSS3.ListPartsOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketAccelerateConfiguration(input: AWSS3.PutBucketAccelerateConfigurationInput) async throws -> AWSS3.PutBucketAccelerateConfigurationOutputResponse {
+    func putBucketAccelerateConfiguration(input: AWSS3.PutBucketAccelerateConfigurationInput) async throws -> AWSS3.PutBucketAccelerateConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketAcl(input: AWSS3.PutBucketAclInput) async throws -> AWSS3.PutBucketAclOutputResponse {
+    func putBucketAcl(input: AWSS3.PutBucketAclInput) async throws -> AWSS3.PutBucketAclOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketAnalyticsConfiguration(input: AWSS3.PutBucketAnalyticsConfigurationInput) async throws -> AWSS3.PutBucketAnalyticsConfigurationOutputResponse {
+    func putBucketAnalyticsConfiguration(input: AWSS3.PutBucketAnalyticsConfigurationInput) async throws -> AWSS3.PutBucketAnalyticsConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketCors(input: AWSS3.PutBucketCorsInput) async throws -> AWSS3.PutBucketCorsOutputResponse {
+    func putBucketCors(input: AWSS3.PutBucketCorsInput) async throws -> AWSS3.PutBucketCorsOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketEncryption(input: AWSS3.PutBucketEncryptionInput) async throws -> AWSS3.PutBucketEncryptionOutputResponse {
+    func putBucketEncryption(input: AWSS3.PutBucketEncryptionInput) async throws -> AWSS3.PutBucketEncryptionOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketIntelligentTieringConfiguration(input: AWSS3.PutBucketIntelligentTieringConfigurationInput) async throws -> AWSS3.PutBucketIntelligentTieringConfigurationOutputResponse {
+    func putBucketIntelligentTieringConfiguration(input: AWSS3.PutBucketIntelligentTieringConfigurationInput) async throws -> AWSS3.PutBucketIntelligentTieringConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketInventoryConfiguration(input: AWSS3.PutBucketInventoryConfigurationInput) async throws -> AWSS3.PutBucketInventoryConfigurationOutputResponse {
+    func putBucketInventoryConfiguration(input: AWSS3.PutBucketInventoryConfigurationInput) async throws -> AWSS3.PutBucketInventoryConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketLifecycleConfiguration(input: AWSS3.PutBucketLifecycleConfigurationInput) async throws -> AWSS3.PutBucketLifecycleConfigurationOutputResponse {
+    func putBucketLifecycleConfiguration(input: AWSS3.PutBucketLifecycleConfigurationInput) async throws -> AWSS3.PutBucketLifecycleConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketLogging(input: AWSS3.PutBucketLoggingInput) async throws -> AWSS3.PutBucketLoggingOutputResponse {
+    func putBucketLogging(input: AWSS3.PutBucketLoggingInput) async throws -> AWSS3.PutBucketLoggingOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketMetricsConfiguration(input: AWSS3.PutBucketMetricsConfigurationInput) async throws -> AWSS3.PutBucketMetricsConfigurationOutputResponse {
+    func putBucketMetricsConfiguration(input: AWSS3.PutBucketMetricsConfigurationInput) async throws -> AWSS3.PutBucketMetricsConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketNotificationConfiguration(input: AWSS3.PutBucketNotificationConfigurationInput) async throws -> AWSS3.PutBucketNotificationConfigurationOutputResponse {
+    func putBucketNotificationConfiguration(input: AWSS3.PutBucketNotificationConfigurationInput) async throws -> AWSS3.PutBucketNotificationConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketOwnershipControls(input: AWSS3.PutBucketOwnershipControlsInput) async throws -> AWSS3.PutBucketOwnershipControlsOutputResponse {
+    func putBucketOwnershipControls(input: AWSS3.PutBucketOwnershipControlsInput) async throws -> AWSS3.PutBucketOwnershipControlsOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketPolicy(input: AWSS3.PutBucketPolicyInput) async throws -> AWSS3.PutBucketPolicyOutputResponse {
+    func putBucketPolicy(input: AWSS3.PutBucketPolicyInput) async throws -> AWSS3.PutBucketPolicyOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketReplication(input: AWSS3.PutBucketReplicationInput) async throws -> AWSS3.PutBucketReplicationOutputResponse {
+    func putBucketReplication(input: AWSS3.PutBucketReplicationInput) async throws -> AWSS3.PutBucketReplicationOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketRequestPayment(input: AWSS3.PutBucketRequestPaymentInput) async throws -> AWSS3.PutBucketRequestPaymentOutputResponse {
+    func putBucketRequestPayment(input: AWSS3.PutBucketRequestPaymentInput) async throws -> AWSS3.PutBucketRequestPaymentOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketTagging(input: AWSS3.PutBucketTaggingInput) async throws -> AWSS3.PutBucketTaggingOutputResponse {
+    func putBucketTagging(input: AWSS3.PutBucketTaggingInput) async throws -> AWSS3.PutBucketTaggingOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketVersioning(input: AWSS3.PutBucketVersioningInput) async throws -> AWSS3.PutBucketVersioningOutputResponse {
+    func putBucketVersioning(input: AWSS3.PutBucketVersioningInput) async throws -> AWSS3.PutBucketVersioningOutput {
         throw ClientError.missingImplementation
     }
 
-    func putBucketWebsite(input: AWSS3.PutBucketWebsiteInput) async throws -> AWSS3.PutBucketWebsiteOutputResponse {
+    func putBucketWebsite(input: AWSS3.PutBucketWebsiteInput) async throws -> AWSS3.PutBucketWebsiteOutput {
         throw ClientError.missingImplementation
     }
 
-    func putObject(input: AWSS3.PutObjectInput) async throws -> AWSS3.PutObjectOutputResponse {
+    func putObject(input: AWSS3.PutObjectInput) async throws -> AWSS3.PutObjectOutput {
         throw ClientError.missingImplementation
     }
 
-    func putObjectAcl(input: AWSS3.PutObjectAclInput) async throws -> AWSS3.PutObjectAclOutputResponse {
+    func putObjectAcl(input: AWSS3.PutObjectAclInput) async throws -> AWSS3.PutObjectAclOutput {
         throw ClientError.missingImplementation
     }
 
-    func putObjectLegalHold(input: AWSS3.PutObjectLegalHoldInput) async throws -> AWSS3.PutObjectLegalHoldOutputResponse {
+    func putObjectLegalHold(input: AWSS3.PutObjectLegalHoldInput) async throws -> AWSS3.PutObjectLegalHoldOutput {
         throw ClientError.missingImplementation
     }
 
-    func putObjectLockConfiguration(input: AWSS3.PutObjectLockConfigurationInput) async throws -> AWSS3.PutObjectLockConfigurationOutputResponse {
+    func putObjectLockConfiguration(input: AWSS3.PutObjectLockConfigurationInput) async throws -> AWSS3.PutObjectLockConfigurationOutput {
         throw ClientError.missingImplementation
     }
 
-    func putObjectRetention(input: AWSS3.PutObjectRetentionInput) async throws -> AWSS3.PutObjectRetentionOutputResponse {
+    func putObjectRetention(input: AWSS3.PutObjectRetentionInput) async throws -> AWSS3.PutObjectRetentionOutput {
         throw ClientError.missingImplementation
     }
 
-    func putObjectTagging(input: AWSS3.PutObjectTaggingInput) async throws -> AWSS3.PutObjectTaggingOutputResponse {
+    func putObjectTagging(input: AWSS3.PutObjectTaggingInput) async throws -> AWSS3.PutObjectTaggingOutput {
         throw ClientError.missingImplementation
     }
 
-    func putPublicAccessBlock(input: AWSS3.PutPublicAccessBlockInput) async throws -> AWSS3.PutPublicAccessBlockOutputResponse {
+    func putPublicAccessBlock(input: AWSS3.PutPublicAccessBlockInput) async throws -> AWSS3.PutPublicAccessBlockOutput {
         throw ClientError.missingImplementation
     }
 
-    func restoreObject(input: AWSS3.RestoreObjectInput) async throws -> AWSS3.RestoreObjectOutputResponse {
+    func restoreObject(input: AWSS3.RestoreObjectInput) async throws -> AWSS3.RestoreObjectOutput {
         throw ClientError.missingImplementation
     }
 
-    func selectObjectContent(input: AWSS3.SelectObjectContentInput) async throws -> AWSS3.SelectObjectContentOutputResponse {
+    func selectObjectContent(input: AWSS3.SelectObjectContentInput) async throws -> AWSS3.SelectObjectContentOutput {
         throw ClientError.missingImplementation
     }
 
-    func uploadPart(input: AWSS3.UploadPartInput) async throws -> AWSS3.UploadPartOutputResponse {
+    func uploadPart(input: AWSS3.UploadPartInput) async throws -> AWSS3.UploadPartOutput {
         throw ClientError.missingImplementation
     }
 
-    func uploadPartCopy(input: AWSS3.UploadPartCopyInput) async throws -> AWSS3.UploadPartCopyOutputResponse {
+    func uploadPartCopy(input: AWSS3.UploadPartCopyInput) async throws -> AWSS3.UploadPartCopyOutput {
         throw ClientError.missingImplementation
     }
 
-    func writeGetObjectResponse(input: AWSS3.WriteGetObjectResponseInput) async throws -> AWSS3.WriteGetObjectResponseOutputResponse {
+    func writeGetObjectResponse(input: AWSS3.WriteGetObjectResponseInput) async throws -> AWSS3.WriteGetObjectResponseOutput {
         throw ClientError.missingImplementation
     }
 }

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginUploadMetadataTestCase.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginUploadMetadataTestCase.swift
@@ -231,7 +231,7 @@ class AWSS3StoragePluginUploadMetadataTestCase: AWSS3StoragePluginTestBase {
         return fileURL
     }
 
-    private func headObject(key: String) async throws -> HeadObjectOutputResponse {
+    private func headObject(key: String) async throws -> HeadObjectOutput {
         let plugin = try Amplify.Storage.getPlugin(for: "awsS3StoragePlugin")
         let storagePlugin = try XCTUnwrap(
             plugin as? AWSS3StoragePlugin,


### PR DESCRIPTION
## Description
Renames SDK response types from *OutputResponse to *Output.

See base branch staging PR for more information:
- https://github.com/aws-amplify/amplify-swift/pull/3346

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [ ] ~Build succeeds with all target using Swift Package Manager~
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
