### PR TITLE
chore: add Amplify.xcworkspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Thumbs.db
 
 *.xcworkspace/
 !.swiftpm/xcode/package.xcworkspace
+!Amplify.xcworkspace
 Amplify.xcodeproj/xcuserdata
 Amplify.xcworkspace/xcuserdata
 xcuserdata

--- a/Amplify.xcworkspace/contents.xcworkspacedata
+++ b/Amplify.xcworkspace/contents.xcworkspacedata
@@ -1713,6 +1713,9 @@
    <Group
       location = "group:AmplifyPlugins"
       name = "AmplifyPlugins">
+      <FileRef
+         location = "group:../HostApp/AmplifyHostApp/AmplifyHostApp.xcodeproj">
+      </FileRef>
       <Group
          location = "group:Core"
          name = "Core">
@@ -12699,6 +12702,9 @@
          </Group>
       </Group>
    </Group>
+   <FileRef
+      location = "group:HostApp/AmplifyHostApp/AmplifyHostApp.xcodeproj">
+   </FileRef>
    <FileRef
       location = "group:AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj">
    </FileRef>

--- a/Amplify.xcworkspace/contents.xcworkspacedata
+++ b/Amplify.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,12732 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <Group
+      location = "group:Amplify"
+      name = "Amplify">
+      <Group
+         location = "group:Core"
+         name = "Core">
+         <Group
+            location = "group:Configuration"
+            name = "Configuration">
+            <FileRef
+               location = "group:CategoryConfiguration.swift">
+            </FileRef>
+            <Group
+               location = "group:Internal"
+               name = "Internal">
+               <FileRef
+                  location = "group:AmplifyConfigurationInitialization.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Category+Configuration.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Amplify+Reset.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:CategoryConfigurable.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Amplify+Resolve.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:ConfigurationError.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AmplifyConfiguration.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Category"
+            name = "Category">
+            <FileRef
+               location = "group:CategoryType.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Category+Logging.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Category.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Plugin"
+            name = "Plugin">
+            <FileRef
+               location = "group:PluginError.swift">
+            </FileRef>
+            <Group
+               location = "group:Internal"
+               name = "Internal">
+               <FileRef
+                  location = "group:Resettable.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Plugin+Resettable.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:Plugin.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Internal"
+            name = "Internal">
+            <FileRef
+               location = "group:Foundation+Utils.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Support"
+            name = "Support">
+            <FileRef
+               location = "group:Array+Extensions.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AmplifyTask+OperationTaskAdapters.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AtomicValue+Numeric.swift">
+            </FileRef>
+            <FileRef
+               location = "group:RequestIdentifier.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Task+Seconds.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AmplifyTesting.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AmplifyTask.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AmplifyInProcessReportingOperation+Combine.swift">
+            </FileRef>
+            <FileRef
+               location = "group:JSONValue.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AmplifyOperation+Hub.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Operations+Combine.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AmplifyOperationContext.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Optional+Extension.swift">
+            </FileRef>
+            <FileRef
+               location = "group:JSONValue+Subscript.swift">
+            </FileRef>
+            <FileRef
+               location = "group:String+Extensions.swift">
+            </FileRef>
+            <FileRef
+               location = "group:BasicClosure.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Amplify+Publisher.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AtomicValue.swift">
+            </FileRef>
+            <FileRef
+               location = "group:BufferingSequence.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AmplifyErrorMessages.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Fatal.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AsyncSequence+forEach.swift">
+            </FileRef>
+            <Group
+               location = "group:Internal"
+               name = "Internal">
+               <FileRef
+                  location = "group:NSLocking+Execute.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:InternalTask.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:InternalTask+AsyncSequence.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:InternalTask+Hub.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:InternalTask+Result.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:Resumable.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AccessLevel.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AmplifyOperation+Combine.swift">
+            </FileRef>
+            <FileRef
+               location = "group:WeakRef.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AmplifyError.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Cancellable.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Encodable+AnyEncodable.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AmplifyInProcessReportingOperation.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Tree.swift">
+            </FileRef>
+            <FileRef
+               location = "group:TimeInterval+Helper.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AsychronousOperation.swift">
+            </FileRef>
+            <FileRef
+               location = "group:OperationCancelledError.swift">
+            </FileRef>
+            <FileRef
+               location = "group:ChildTask.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AtomicValue+Bool.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AmplifyAsyncThrowingSequence.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AtomicValue+RangeReplaceableCollection.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AtomicDictionary.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AmplifyTaskGateway.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Result+Void.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DeviceInfo.swift">
+            </FileRef>
+            <FileRef
+               location = "group:TaskQueue.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DispatchSource+MakeOneOff.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Amplify+HubPayloadEventName.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AmplifyOperation.swift">
+            </FileRef>
+            <FileRef
+               location = "group:JSONValue+KeyPath.swift">
+            </FileRef>
+            <FileRef
+               location = "group:InstanceFactory.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AmplifyAsyncSequence.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Model"
+            name = "Model">
+            <FileRef
+               location = "group:UserProfile.swift">
+            </FileRef>
+            <FileRef
+               location = "group:BasicUserProfile.swift">
+            </FileRef>
+            <FileRef
+               location = "group:UserProfilePropertyValue.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Error"
+            name = "Error">
+            <FileRef
+               location = "group:CoreError.swift">
+            </FileRef>
+         </Group>
+      </Group>
+      <FileRef
+         location = "group:Amplify.swift">
+      </FileRef>
+      <Group
+         location = "group:DevMenu"
+         name = "DevMenu">
+         <Group
+            location = "group:Trigger"
+            name = "Trigger">
+            <FileRef
+               location = "group:TriggerDelegate.swift">
+            </FileRef>
+            <FileRef
+               location = "group:TriggerRecognizer.swift">
+            </FileRef>
+            <FileRef
+               location = "group:LongPressGestureRecognizer.swift">
+            </FileRef>
+         </Group>
+         <FileRef
+            location = "group:Amplify+DevMenu.swift">
+         </FileRef>
+         <FileRef
+            location = "group:AmplifyVersionable.swift">
+         </FileRef>
+         <FileRef
+            location = "group:DevMenuStringConstants.swift">
+         </FileRef>
+         <FileRef
+            location = "group:AmplifyDevMenu.swift">
+         </FileRef>
+         <FileRef
+            location = "group:DevMenuPresentationContextProvider.swift">
+         </FileRef>
+         <Group
+            location = "group:View"
+            name = "View">
+            <FileRef
+               location = "group:IssueReporter.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DevMenuList.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DeviceInfoDetailView.swift">
+            </FileRef>
+            <FileRef
+               location = "group:LogEntryRow.swift">
+            </FileRef>
+            <FileRef
+               location = "group:EnvironmentInfoDetailView.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DevMenuRow.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DetailViewFactory.swift">
+            </FileRef>
+            <FileRef
+               location = "group:InfoRow.swift">
+            </FileRef>
+            <FileRef
+               location = "group:LogViewer.swift">
+            </FileRef>
+         </Group>
+         <FileRef
+            location = "group:DevEnvironmentInfo.swift">
+         </FileRef>
+         <Group
+            location = "group:Data"
+            name = "Data">
+            <FileRef
+               location = "group:DeviceInfoHelper.swift">
+            </FileRef>
+            <FileRef
+               location = "group:PluginInfoHelper.swift">
+            </FileRef>
+            <FileRef
+               location = "group:EnvironmentInfoItemType.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DeviceInfoItemType.swift">
+            </FileRef>
+            <FileRef
+               location = "group:PluginInfoItem.swift">
+            </FileRef>
+            <FileRef
+               location = "group:LogEntryHelper.swift">
+            </FileRef>
+            <FileRef
+               location = "group:InfoItemProvider.swift">
+            </FileRef>
+            <FileRef
+               location = "group:EnvironmentInfoHelper.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DevMenuItemType.swift">
+            </FileRef>
+            <FileRef
+               location = "group:IssueInfo.swift">
+            </FileRef>
+            <FileRef
+               location = "group:IssueInfoHelper.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DevMenuItem.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DeviceInfoItem.swift">
+            </FileRef>
+            <FileRef
+               location = "group:EnvironmentInfoItem.swift">
+            </FileRef>
+            <FileRef
+               location = "group:LogEntryItem.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Logging"
+            name = "Logging">
+            <FileRef
+               location = "group:PersistentLoggingPlugin.swift">
+            </FileRef>
+            <FileRef
+               location = "group:PersistentLogWrapper.swift">
+            </FileRef>
+         </Group>
+         <FileRef
+            location = "group:DevMenuBehavior.swift">
+         </FileRef>
+      </Group>
+      <Group
+         location = "group:DefaultPlugins"
+         name = "DefaultPlugins">
+         <Group
+            location = "group:AWSHubPlugin"
+            name = "AWSHubPlugin">
+            <Group
+               location = "group:Internal"
+               name = "Internal">
+               <FileRef
+                  location = "group:FilteredListener.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:HubChannelDispatcher.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SerialDispatcher.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:ConcurrentDispatcher.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:AWSHubPlugin.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:AWSUnifiedLoggingPlugin"
+            name = "AWSUnifiedLoggingPlugin">
+            <FileRef
+               location = "group:AWSUnifiedLoggingPlugin.swift">
+            </FileRef>
+            <Group
+               location = "group:Internal"
+               name = "Internal">
+               <FileRef
+                  location = "group:OSLogWrapper.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:ConsoleLoggingConfiguration.swift">
+               </FileRef>
+            </Group>
+         </Group>
+      </Group>
+      <Group
+         location = "group:Categories"
+         name = "Categories">
+         <Group
+            location = "group:Auth"
+            name = "Auth">
+            <FileRef
+               location = "group:AuthCategoryBehavior.swift">
+            </FileRef>
+            <Group
+               location = "group:Result"
+               name = "Result">
+               <FileRef
+                  location = "group:AuthSignOutResult.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthUpdateAttributeResult.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthSignUpResult.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthResetPasswordResult.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthSignInResult.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:AuthCategory+DeviceBehavior.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AuthCategoryDeviceBehavior.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AuthCategory+UserBehavior.swift">
+            </FileRef>
+            <Group
+               location = "group:Internal"
+               name = "Internal">
+               <FileRef
+                  location = "group:AuthCategory+Resettable.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthCategory+CategoryConfigurable.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:AuthCategoryConfiguration.swift">
+            </FileRef>
+            <Group
+               location = "group:Models"
+               name = "Models">
+               <FileRef
+                  location = "group:AuthProvider.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthCodeDeliveryDetails.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:DeliveryDestination.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthUserAttribute.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthUpdateAttributeStep.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthEventName.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthSession.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthSignInStep.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:MFAType.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthSignUpStep.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:TOTPSetupDetails.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthUser.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthDevice.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:AuthCategoryPlugin.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AuthCategory+ClientBehavior.swift">
+            </FileRef>
+            <Group
+               location = "group:Request"
+               name = "Request">
+               <FileRef
+                  location = "group:AuthConfirmUserAttributeRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthConfirmSignInRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthUpdateUserAttributesRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthWebUISignInRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthResendSignUpCodeRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthFetchDevicesRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthConfirmSignUpRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthResetPasswordRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthForgetDeviceRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthSignInRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthChangePasswordRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthConfirmResetPasswordRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthRememberDeviceRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthAttributeResendConfirmationCodeRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthFetchUserAttributesRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthUpdateUserAttributeRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:VerifyTOTPSetupRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthSignUpRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthSignOutRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AuthFetchSessionRequest.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:AuthCategory+HubPayloadEventName.swift">
+            </FileRef>
+            <Group
+               location = "group:Error"
+               name = "Error">
+               <FileRef
+                  location = "group:AuthError.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:AuthCategoryUserBehavior.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AuthCategory.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Geo"
+            name = "Geo">
+            <Group
+               location = "group:Types"
+               name = "Types">
+               <FileRef
+                  location = "group:Geo+BoundingBox.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Geo+ResultsHandler.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Geo+Error.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:CLocationCoordinate2D+Geo.Coordinates.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Geo+SearchArea.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Geo+SearchOptions.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Geo+Place.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Geo+Country.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Geo.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Geo+Coordinates.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Geo+MapStyle.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:GeoCategory+HubPayloadEventName.swift">
+            </FileRef>
+            <Group
+               location = "group:Internal"
+               name = "Internal">
+               <FileRef
+                  location = "group:GeoCategory+CategoryConfigurable.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:GeoCategory+Resettable.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:GeoCategoryConfiguration.swift">
+            </FileRef>
+            <FileRef
+               location = "group:GeoCategoryPlugin.swift">
+            </FileRef>
+            <FileRef
+               location = "group:GeoCategory.swift">
+            </FileRef>
+            <FileRef
+               location = "group:GeoCategory+ClientBehavior.swift">
+            </FileRef>
+            <FileRef
+               location = "group:GeoCategoryBehavior.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Storage"
+            name = "Storage">
+            <Group
+               location = "group:Operation"
+               name = "Operation">
+               <FileRef
+                  location = "group:StorageListOperation.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:StorageGetURLOperation.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:StorageUploadDataOperation.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:StorageUploadFileOperation.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:StorageDownloadDataOperation.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:StorageDownloadFileOperation.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:StorageRemoveOperation.swift">
+               </FileRef>
+               <Group
+                  location = "group:Request"
+                  name = "Request">
+                  <FileRef
+                     location = "group:StorageGetURLRequest.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageRemoveRequest.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageUploadDataRequest.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageListRequest.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageDownloadFileRequest.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageDownloadDataRequest.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageUploadFileRequest.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+            <Group
+               location = "group:Result"
+               name = "Result">
+               <FileRef
+                  location = "group:StorageListResult.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:ProgressListener.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:StorageAccessLevel.swift">
+            </FileRef>
+            <FileRef
+               location = "group:StorageCategoryBehavior.swift">
+            </FileRef>
+            <FileRef
+               location = "group:StorageCategory+ClientBehavior.swift">
+            </FileRef>
+            <FileRef
+               location = "group:StorageCategory+HubPayloadEventName.swift">
+            </FileRef>
+            <Group
+               location = "group:Internal"
+               name = "Internal">
+               <FileRef
+                  location = "group:StorageCategory+Resettable.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:StorageCategory+CategoryConfigurable.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:StorageCategoryConfiguration.swift">
+            </FileRef>
+            <FileRef
+               location = "group:StorageCategoryPlugin.swift">
+            </FileRef>
+            <FileRef
+               location = "group:StorageCategory.swift">
+            </FileRef>
+            <Group
+               location = "group:Error"
+               name = "Error">
+               <FileRef
+                  location = "group:StorageError.swift">
+               </FileRef>
+            </Group>
+         </Group>
+         <Group
+            location = "group:DataStore"
+            name = "DataStore">
+            <FileRef
+               location = "group:DataStoreError.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DataStoreConflict.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DataStoreCallback.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DataStoreCategoryConfiguration.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DataStoreCategory.swift">
+            </FileRef>
+            <Group
+               location = "group:Internal"
+               name = "Internal">
+               <FileRef
+                  location = "group:DataStoreCategory+Resettable.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:DataStoreCategory+Configurable.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:DataStoreCategoryPlugin.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DataStoreCategoryBehavior.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DataStoreCallback+Combine.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DataStoreCategory+HubPayloadEventName.swift">
+            </FileRef>
+            <Group
+               location = "group:Subscribe"
+               name = "Subscribe">
+               <FileRef
+                  location = "group:MutationEvent+MutationType.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:MutationEvent+Schema.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:DataStoreCategory+Subscribe.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:MutationEvent.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:DataStoreQuerySnapshot.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:MutationEvent+Model.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:DataStoreCategory+Behavior.swift">
+            </FileRef>
+            <Group
+               location = "group:GraphQL"
+               name = "GraphQL">
+               <FileRef
+                  location = "group:GraphQLMutationType.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:GraphQLQueryType.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:GraphQLSubscriptionType.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Model"
+               name = "Model">
+               <Group
+                  location = "group:Temporal"
+                  name = "Temporal">
+                  <FileRef
+                     location = "group:SpecBasedDateConverting.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Date.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Temporal+Hashable.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Time.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Temporal+Comparable.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Date+Operation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Temporal+Codable.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Temporal.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:TemporalFormat.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DataStoreError+Temporal.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:TemporalOperation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Time+Operation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Temporal+Cache.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DateTime.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:TemporalUnit.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:Model+ModelName.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Model.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:PropertyPath.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AmplifyModelRegistration.swift">
+               </FileRef>
+               <Group
+                  location = "group:Internal"
+                  name = "Internal">
+                  <FileRef
+                     location = "group:Model+Subscript.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ModelProviderDecoder.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ModelRegistry.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Model+Enum.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ModelListProvider.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ModelProvider.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Schema"
+                     name = "Schema">
+                     <FileRef
+                        location = "group:ModelSchema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthRule.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelValueConverter.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelSchema+Identifiers.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelSchema+Definition.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Model+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelSchema+AuthRulesByOperation.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelPrimaryKey.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelField+Association.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelSchema+Attributes.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:ModelRegistry+Syncable.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Model+Array.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Persistable.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Embedded.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ModelListDecoder.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Model+Codable.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Model+DateFormatting.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:ModelIdentifiable.swift">
+               </FileRef>
+               <Group
+                  location = "group:Lazy"
+                  name = "Lazy">
+                  <FileRef
+                     location = "group:List+Pagination.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:List+LazyLoad.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LazyReference.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:List+Combine.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:List+Model.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DefaultModelProvider.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ArrayLiteralListProvider.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:JSONHelper"
+                  name = "JSONHelper">
+                  <FileRef
+                     location = "group:JSONValueHolder.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+            <Group
+               location = "group:Query"
+               name = "Query">
+               <FileRef
+                  location = "group:Evaluable.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:ModelKey.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryPaginationInput.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryOperator.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryPredicate.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryField.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QuerySortInput.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryOperator+Equatable.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryPredicate+Equatable.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:DataStoreStatement.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:API"
+            name = "API">
+            <Group
+               location = "group:Operation"
+               name = "Operation">
+               <FileRef
+                  location = "group:GraphQLOperation.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:RetryableGraphQLOperation.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:RESTOperation.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AmplifyOperation+APIPublishers.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Response"
+               name = "Response">
+               <FileRef
+                  location = "group:GraphQLResponse.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SubscriptionEvent.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:GraphQLError.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SubscriptionConnectionState.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:APICategoryConfiguration.swift">
+            </FileRef>
+            <FileRef
+               location = "group:APICategory+HubPayloadEventName.swift">
+            </FileRef>
+            <Group
+               location = "group:Internal"
+               name = "Internal">
+               <FileRef
+                  location = "group:APICategory+Resettable.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:APICategory+CategoryConfigurable.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:ClientBehavior"
+               name = "ClientBehavior">
+               <FileRef
+                  location = "group:APICategory+RESTBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:APICategory+ReachabilityBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:APICategory+AuthProviderFactoryBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:APICategoryAuthProviderFactoryBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:APICategoryRESTBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:APICategoryGraphQLBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:APICategoryBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:APICategory+InterceptorBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:APICategoryReachabilityBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:APICategory+GraphQLBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:APICategoryInterceptorBehavior.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:APICategory.swift">
+            </FileRef>
+            <Group
+               location = "group:Reachability"
+               name = "Reachability">
+               <FileRef
+                  location = "group:ReachabilityUpdate.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Request"
+               name = "Request">
+               <FileRef
+                  location = "group:RESTRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:GraphQLOperationRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:RESTOperationRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:GraphQLOperationType.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:GraphQLRequest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:RESTOperationType.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Error"
+               name = "Error">
+               <FileRef
+                  location = "group:APIError.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Interceptor"
+               name = "Interceptor">
+               <FileRef
+                  location = "group:URLRequestInterceptor.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:AuthProvider"
+               name = "AuthProvider">
+               <FileRef
+                  location = "group:APIAuthProviderFactory.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:APICategoryPlugin.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Hub"
+            name = "Hub">
+            <FileRef
+               location = "group:HubFilter.swift">
+            </FileRef>
+            <FileRef
+               location = "group:HubCategoryBehavior+Combine.swift">
+            </FileRef>
+            <FileRef
+               location = "group:HubPayload.swift">
+            </FileRef>
+            <FileRef
+               location = "group:HubCategory.swift">
+            </FileRef>
+            <FileRef
+               location = "group:HubCategoryPlugin.swift">
+            </FileRef>
+            <FileRef
+               location = "group:UnsubscribeToken.swift">
+            </FileRef>
+            <Group
+               location = "group:Internal"
+               name = "Internal">
+               <FileRef
+                  location = "group:HubCategory+CategoryConfigurable.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:HubCategory+Resettable.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:HubError.swift">
+            </FileRef>
+            <FileRef
+               location = "group:HubPayloadEventName.swift">
+            </FileRef>
+            <FileRef
+               location = "group:HubCategoryConfiguration.swift">
+            </FileRef>
+            <FileRef
+               location = "group:HubChannel.swift">
+            </FileRef>
+            <FileRef
+               location = "group:HubCategoryBehavior.swift">
+            </FileRef>
+            <FileRef
+               location = "group:HubCategory+ClientBehavior.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Logging"
+            name = "Logging">
+            <FileRef
+               location = "group:LoggingCategory+Logger.swift">
+            </FileRef>
+            <FileRef
+               location = "group:LoggingCategory.swift">
+            </FileRef>
+            <FileRef
+               location = "group:LoggingCategory+ClientBehavior.swift">
+            </FileRef>
+            <FileRef
+               location = "group:LoggingCategory+HubPayloadEventName.swift">
+            </FileRef>
+            <FileRef
+               location = "group:LoggingCategoryConfiguration.swift">
+            </FileRef>
+            <FileRef
+               location = "group:DefaultLogger.swift">
+            </FileRef>
+            <Group
+               location = "group:Internal"
+               name = "Internal">
+               <FileRef
+                  location = "group:LoggingCategory+CategoryConfigurable.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:BroadcastLogger.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:LoggingCategory+Resettable.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:LoggingError.swift">
+            </FileRef>
+            <FileRef
+               location = "group:LogLevel.swift">
+            </FileRef>
+            <FileRef
+               location = "group:LoggingCategoryPlugin.swift">
+            </FileRef>
+            <FileRef
+               location = "group:LoggingCategoryClientBehavior.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Notifications"
+            name = "Notifications">
+            <FileRef
+               location = "group:NotificationsCategory+HubPayloadEventName.swift">
+            </FileRef>
+            <FileRef
+               location = "group:NotificationsCategory.swift">
+            </FileRef>
+            <FileRef
+               location = "group:NotificationsSubcategoryBehaviour.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Notifications.swift">
+            </FileRef>
+            <FileRef
+               location = "group:NotificationsCategoryConfiguration.swift">
+            </FileRef>
+            <Group
+               location = "group:PushNotifications"
+               name = "PushNotifications">
+               <FileRef
+                  location = "group:PushNotificationsCategory+HubPayloadEventName.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:PushNotificationsCategory.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:PushNotificationsCategory+ClientBehaviour.swift">
+               </FileRef>
+               <Group
+                  location = "group:Types"
+                  name = "Types">
+                  <FileRef
+                     location = "group:PushNotificationsCategory+Types.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PushNotificationsCategory+UserInfo.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:PushNotificationsCategoryPlugin.swift">
+               </FileRef>
+               <Group
+                  location = "group:Internal"
+                  name = "Internal">
+                  <FileRef
+                     location = "group:PushNotificationsCategory+CategoryConfigurable.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PushNotificationsCategory+Resettable.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:PushNotificationsCategoryBehaviour.swift">
+               </FileRef>
+               <Group
+                  location = "group:Error"
+                  name = "Error">
+                  <FileRef
+                     location = "group:PushNotificationsError.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+         </Group>
+         <Group
+            location = "group:Predictions"
+            name = "Predictions">
+            <FileRef
+               location = "group:PredictionsCategory.swift">
+            </FileRef>
+            <Group
+               location = "group:Internal"
+               name = "Internal">
+               <FileRef
+                  location = "group:PredictionsCategory+Resettable.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:DefaultNetworkPolicy.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:PredictionsCategory+CategoryConfigurable.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Models"
+               name = "Models">
+               <FileRef
+                  location = "group:IdentifiedWord.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Gender.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Language.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:TextFormatType.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SyntaxToken.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:BoundedKeyValue.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:IdentifiedText.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Entity.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Sentiment.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Emotion+Kind.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:GenderAttribute.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Celebrity.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Pose.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Table.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:IdentifiedLine.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:PartOfSpeech.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Entity+DetectionResult.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:LabelType.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Entity+Match.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:KeyPhrase.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Entity+Metadata.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Language+DetectionResult.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Emotion.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Polygon.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Selection.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Entity+Kind.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Voice.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Celebrity+Metadata.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Sentiment+Kind.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Attribute.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:PartOfSpeech+DetectionResult.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Landmark.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:PredictionsCategoryBehavior.swift">
+            </FileRef>
+            <FileRef
+               location = "group:PredictionsCategoryConfiguration.swift">
+            </FileRef>
+            <FileRef
+               location = "group:PredictionsCategory+ClientBehavior.swift">
+            </FileRef>
+            <Group
+               location = "group:Request"
+               name = "Request">
+               <Group
+                  location = "group:Identify"
+                  name = "Identify">
+                  <FileRef
+                     location = "group:Identify+DocumentText+Result.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Identify+Entities.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Identify+Lift.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Identify+Celebrities.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Identify+Labels.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Identify+EntityMatches+Result.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Identify.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Identify+Celebrities+Result.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Identify+Text+Result.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Identify+Labels+Result.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Identify+Document.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Identify+Text.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Identify+Entities+Result.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Identify+EntityMatches.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Interpret"
+                  name = "Interpret">
+                  <FileRef
+                     location = "group:Interpret.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Interpret+Result.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Convert"
+                  name = "Convert">
+                  <FileRef
+                     location = "group:Convert+SpeechToText+Result.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Convert+TextToSpeech.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Convert+TextToSpeech+Result.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Convert+SpeechToText+Options.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Convert+SpeechToText.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Convert+TranslateText+Options.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Convert+Lift.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Convert+TextToSpeech+Request.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Convert.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Convert+TranslateText+Result.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Convert+TranslateText.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Convert+TextToSpeech+Options.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Convert+SpeechToText+Request.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Convert+TranslateText+Request.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+            <FileRef
+               location = "group:PredictionsCategory+HubPayloadEventName.swift">
+            </FileRef>
+            <Group
+               location = "group:Error"
+               name = "Error">
+               <FileRef
+                  location = "group:PredictionsError+ClientError.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:PredictionsError+ServiceError.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:PredictionsError.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:PredictionsCategoryPlugin.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Analytics"
+            name = "Analytics">
+            <FileRef
+               location = "group:AnalyticsPropertyValue.swift">
+            </FileRef>
+            <Group
+               location = "group:Internal"
+               name = "Internal">
+               <FileRef
+                  location = "group:AnalyticsCategory+CategoryConfigurable.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AnalyticsCategory+Resettable.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:AnalyticsCategoryBehavior.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AnalyticsCategoryConfiguration.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AnalyticsCategoryPlugin.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AnalyticsProfile.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AnalyticsCategory.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AnalyticsCategory+ClientBehavior.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AnalyticsCategory+HubPayloadEventName.swift">
+            </FileRef>
+            <Group
+               location = "group:Error"
+               name = "Error">
+               <FileRef
+                  location = "group:AnalyticsError.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Event"
+               name = "Event">
+               <FileRef
+                  location = "group:BasicAnalyticsEvent.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AnalyticsEvent.swift">
+               </FileRef>
+            </Group>
+         </Group>
+      </Group>
+      <FileRef
+         location = "group:Info.plist">
+      </FileRef>
+   </Group>
+   <Group
+      location = "group:AmplifyPlugins"
+      name = "AmplifyPlugins">
+      <Group
+         location = "group:Core"
+         name = "Core">
+         <Group
+            location = "group:AWSPluginsTestCommon"
+            name = "AWSPluginsTestCommon">
+            <FileRef
+               location = "group:MockAWSSignatureV4Signer.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AWSPluginsTestCommon.h">
+            </FileRef>
+            <FileRef
+               location = "group:MockAWSAuthService.swift">
+            </FileRef>
+            <FileRef
+               location = "group:MockHttpResponse.swift">
+            </FileRef>
+            <FileRef
+               location = "group:Info.plist">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:AWSPluginsCoreTests"
+            name = "AWSPluginsCoreTests">
+            <Group
+               location = "group:Auth"
+               name = "Auth">
+               <FileRef
+                  location = "group:AuthModeStrategyTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAuthServiceTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAuthorizationTypeTests.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Utils"
+               name = "Utils">
+               <FileRef
+                  location = "group:UserAgentSuffixAppenderTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:UserAgentSettingClientEngineTests.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Keychain"
+               name = "Keychain">
+               <FileRef
+                  location = "group:KeychainStoreAttributesTests.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Model"
+               name = "Model">
+               <Group
+                  location = "group:GraphQLDocument"
+                  name = "GraphQLDocument">
+                  <FileRef
+                     location = "group:GraphQLSubscriptionTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLListQueryTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLUpdateMutationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLSyncQueryTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLCreateMutationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLDeleteMutationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLGetQueryTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Decorator"
+                  name = "Decorator">
+                  <Group
+                     location = "group:AuthRuleDecorator"
+                     name = "AuthRuleDecorator">
+                     <FileRef
+                        location = "group:ModelMultipleOwnerAuthRuleTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelWithOwnerAuthAndGroupWithGroupClaim.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelWithOwnerFieldAuthRuleTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelReadUpdateAuthRuleTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelWithOwnerAuthAndMultiGroup.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:IncludeAssociationDecoratorTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:GraphQLRequest"
+                  name = "GraphQLRequest">
+                  <FileRef
+                     location = "group:GraphQLRequestAnyModelWithSyncTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLRequestAuthRuleTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLRequestSyncCustomPrimaryKeyWithMultipleFieldsTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLRequestOwnerAndGroupTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLRequestEmbeddableTypeTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLRequestEmbeddableTypeJSONTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLRequestModelTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLRequestSyncCustomPrimaryKeyTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLRequestAuthIdentityClaimTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockAWSAuthUser.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLRequestOptionalAssociationTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Support"
+                  name = "Support">
+                  <FileRef
+                     location = "group:ModelSchemaGraphQLTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ModelGraphQLTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AuthRuleExtensionTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:QueryPredicateGraphQLTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AnyModel"
+                  name = "AnyModel">
+                  <FileRef
+                     location = "group:AnyModelTester.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AnyModelTests.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+            <Group
+               location = "group:API"
+               name = "API">
+               <FileRef
+                  location = "group:AppSyncErrorTypeTests.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Sync"
+               name = "Sync">
+               <FileRef
+                  location = "group:PaginatedListTests.swift">
+               </FileRef>
+               <Group
+                  location = "group:MutationSync"
+                  name = "MutationSync">
+                  <FileRef
+                     location = "group:MutationSyncMetadataTests.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+            <Group
+               location = "group:Query"
+               name = "Query">
+               <FileRef
+                  location = "group:QueryPredicateEvaluateGeneratedTimeTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryPredicateEvaluateGeneratedIntDoubleTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryPredicateEvaluateGeneratedDateTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryPredicateEvaluateGeneratedDoubleTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryPredicateEvaluateGeneratedBoolTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryPredicateEvaluateGeneratedDoubleIntTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryPredicateEvaluateGenerator.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryPredicateEvaluateGeneratedDateTimeTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryPredicateEvaluateGeneratedIntTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryPredicateEvaluateGeneratedEnumTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryPredicateEvaluateTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:QueryPredicateEvaluateGeneratedStringTests.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:Info.plist">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:AWSPluginsCore"
+            name = "AWSPluginsCore">
+            <FileRef
+               location = "group:AWSPluginOptions.swift">
+            </FileRef>
+            <Group
+               location = "group:Auth"
+               name = "Auth">
+               <Group
+                  location = "group:Configuration"
+                  name = "Configuration">
+                  <FileRef
+                     location = "group:AWSIAMConfiguration.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:APIKeyConfiguration.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAuthorizationConfiguration.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:OIDCConfiguration.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CognitoUserPoolsConfiguration.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSLambdaAuthConfiguration.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSAuthServiceBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAuthorizationType.swift">
+               </FileRef>
+               <Group
+                  location = "group:AuthPluginBehavior"
+                  name = "AuthPluginBehavior">
+                  <FileRef
+                     location = "group:AuthInvalidateCredentialBehavior.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Provider"
+                  name = "Provider">
+                  <FileRef
+                     location = "group:AuthAWSCredentialsProvider.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AuthTokenProvider.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AuthCognitoIdentityProvider.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:IAMCredentialProvider.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AuthCognitoTokensProvider.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:APIKeyProvider.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AmplifyAWSSignatureV4Signer.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AmplifyAWSCredentialsProvider.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSAuthSessionBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAuthModeStrategy.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAuthService.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Utils"
+               name = "Utils">
+               <FileRef
+                  location = "group:AWSPluginExtension.swift">
+               </FileRef>
+               <Group
+                  location = "group:CustomHttpClientEngine"
+                  name = "CustomHttpClientEngine">
+                  <FileRef
+                     location = "group:UserAgentSettingClientEngine.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:UserAgentSuffixAppender.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PluginClientEngine.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FoundationClientEngineError.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SdkHttpRequest+updatingUserAgent.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FoundationClientEngine.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ClientRuntimeFoundationBridge.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+            <Group
+               location = "group:ServiceConfiguration"
+               name = "ServiceConfiguration">
+               <FileRef
+                  location = "group:AmplifyAWSServiceConfiguration+Platform.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AmplifyAWSServiceConfiguration.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Keychain"
+               name = "Keychain">
+               <FileRef
+                  location = "group:KeychainStoreError.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:KeychainStoreAttributes.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:KeychainStore.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:AWSPluginsCore.h">
+            </FileRef>
+            <Group
+               location = "group:Model"
+               name = "Model">
+               <Group
+                  location = "group:GraphQLDocument"
+                  name = "GraphQLDocument">
+                  <FileRef
+                     location = "group:GraphQLMutation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SingleDirectiveGraphQLDocument.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLQuery.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLSubscription.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ModelBasedGraphQLDocumentBuilder.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Decorator"
+                  name = "Decorator">
+                  <FileRef
+                     location = "group:DirectiveNameDecorator.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AuthRuleDecorator.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ModelIdDecorator.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ModelDecorator.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PaginationDecorator.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ModelBasedGraphQLDocumentDecorator.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:IncludeAssociationDecorator.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FilterDecorator.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ConflictResolutionDecorator.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:GraphQLRequest"
+                  name = "GraphQLRequest">
+                  <FileRef
+                     location = "group:GraphQLRequest+AnyModelWithSync.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLRequest+Model.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Support"
+                  name = "Support">
+                  <FileRef
+                     location = "group:SelectionSet.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLDocumentInput.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:QueryPredicate+GraphQL.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Model+GraphQL.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AuthRule+Extension.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ModelField+GraphQL.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLDocumentInputValue.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ModelSchema+GraphQL.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AnyModel"
+                  name = "AnyModel">
+                  <FileRef
+                     location = "group:AnyModel+Subscript.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AnyModel+Schema.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AnyModel.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Model+AnyModel.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AnyModel+Codable.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+            <Group
+               location = "group:API"
+               name = "API">
+               <FileRef
+                  location = "group:AppSyncErrorType.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:APICategoryGraphQLBehaviorExtended.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAPIAuthInformation.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Sync"
+               name = "Sync">
+               <Group
+                  location = "group:MutationSync"
+                  name = "MutationSync">
+                  <FileRef
+                     location = "group:MutationSyncMetadata+Schema.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MutationSync.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MutationSyncMetadata.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:PaginatedList.swift">
+               </FileRef>
+               <Group
+                  location = "group:ModelSync"
+                  name = "ModelSync">
+                  <FileRef
+                     location = "group:ModelSyncMetadata+Schema.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ModelSyncMetadata.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+            <FileRef
+               location = "group:Info.plist">
+            </FileRef>
+         </Group>
+      </Group>
+      <Group
+         location = "group:Auth"
+         name = "Auth">
+         <Group
+            location = "group:Tests"
+            name = "Tests">
+            <Group
+               location = "group:AWSCognitoAuthPluginUnitTests"
+               name = "AWSCognitoAuthPluginUnitTests">
+               <Group
+                  location = "group:TestHarness"
+                  name = "TestHarness">
+                  <Group
+                     location = "group:Mocks"
+                     name = "Mocks">
+                     <FileRef
+                        location = "group:AuthTestHarnessInput+MockIdentity.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockedAuthCognitoPlugin.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthTestHarnessInput+MockIdentityProvider.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AuthTestHarnessInput.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:CognitoAPIDecoding"
+                     name = "CognitoAPIDecoding">
+                     <FileRef
+                        location = "group:CognitoAPIDecodingHelper.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AuthTestHarnessConstants.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:CodableStates"
+                     name = "CodableStates">
+                     <FileRef
+                        location = "group:AuthState+Codable.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:CodableStates.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthorizationState+Codable.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthenticationState+Codable.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignInState+Codable.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignInChallengeState+Codable.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AuthTestHarness.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:AuthCodableImplementations"
+                     name = "AuthCodableImplementations">
+                     <Group
+                        location = "group:Cognito"
+                        name = "Cognito">
+                        <Group
+                           location = "group:Response"
+                           name = "Response">
+                           <FileRef
+                              location = "group:DeleteUserOutputResponse+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:GetIdOutputResponse+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:RevokeTokenOutputResponse+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:ForgotPasswordOutputResponse+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:HttpResponse+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:ChangePasswordOutputResponse+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:ConfirmDeviceOutputResponse+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:GlobalSignOutOutputResponse+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:GetCredentialsForIdentityOutputResponse+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:SignUpOutputResponse+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:RespondToAuthChallengeOutputResponse+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:InitiateAuthOutputResponse+Codable.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:Input"
+                           name = "Input">
+                           <FileRef
+                              location = "group:InitiateAuthInput+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:ChangePasswordInput+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:GetCredentialsForIdentityInput+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:ForgotPasswordInput+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:DeleteUserInput+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:RespondToAuthChallengeInput+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:GlobalSignOutInput+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:SignUpInput+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:RevokeTokenInput+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:GetIdInput+Codable.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:ConfirmDeviceInput+Codable.swift">
+                           </FileRef>
+                        </Group>
+                     </Group>
+                     <Group
+                        location = "group:Results"
+                        name = "Results">
+                        <FileRef
+                           location = "group:AuthSignUpResult+Codable.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSCognitoSignOutResult+Codable.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthResetPasswordResult+Codable.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSAuthCognitoSession+Codable.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthSignInResult+Codable.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:Errors"
+                        name = "Errors">
+                        <FileRef
+                           location = "group:AuthError+Codable.swift">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <FileRef
+                     location = "group:FeatureSpecification.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:AmplifyAPIDecoding"
+                     name = "AmplifyAPIDecoding">
+                     <FileRef
+                        location = "group:TestHarnessAPIDecoder.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AmplifyAuthCognitoPluginTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Helpers"
+                     name = "Helpers">
+                     <FileRef
+                        location = "group:AmplifyConfigurationInitializationInTest.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:BundleLoader.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:Mocks"
+                  name = "Mocks">
+                  <Group
+                     location = "group:MockData"
+                     name = "MockData">
+                     <FileRef
+                        location = "group:GlobalSignOutOutputResponse+Mock.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSCognitoUserPoolTokens+Mock.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignedInData+Mock.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:RevokeTokenOutputResponse+Mock.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:MockRandomStringGenerator.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockHostedUISession.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockURLProtocol.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockAnalyticsHandler.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockAuthHubEventBehavior.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:ConfigurationTests"
+                  name = "ConfigurationTests">
+                  <FileRef
+                     location = "group:AWSCognitoAuthPluginConfigTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ClientSecretConfigurationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:EscapeHatchTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:CognitoASFTests"
+                  name = "CognitoASFTests">
+                  <FileRef
+                     location = "group:ASFCognitoTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ASFDeviceInfoTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:ClientBehaviorTests"
+                  name = "ClientBehaviorTests">
+                  <FileRef
+                     location = "group:AuthGetCurrentUserTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:CredentialStore"
+                  name = "CredentialStore">
+                  <FileRef
+                     location = "group:CredentialStoreOperationClientTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:ResolverTests"
+                  name = "ResolverTests">
+                  <FileRef
+                     location = "group:AuthTestData.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:SignOutState"
+                     name = "SignOutState">
+                     <FileRef
+                        location = "group:SignOutStateSigningOutGloballyTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignOutStateResolverTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignOutStateTestData.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignOutStateSigningOutLocallyTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignOutStateRevokingTokenTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignOutStateNotStartedTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:AuthState"
+                     name = "AuthState">
+                     <FileRef
+                        location = "group:AuthStateConfiguringAuthorization.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthStateNotConfiguredTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthStateTestData.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthStateConfiguringTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthStateConfiguringAuthentication.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:SRPSignInState"
+                     name = "SRPSignInState">
+                     <FileRef
+                        location = "group:InitiatingAuthTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SRPTestData.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:NotStartedTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SRPSignInStateTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:CredentialStoreState"
+                     name = "CredentialStoreState">
+                     <FileRef
+                        location = "group:CredentialStoreStateResolverTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:SignUpState"
+                     name = "SignUpState">
+                     <FileRef
+                        location = "group:SignUpInputTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:RespondToAuthInputTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ConfirmSignUpInputTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:StateTransitionTests"
+                     name = "StateTransitionTests">
+                     <FileRef
+                        location = "group:SignedOutTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ConfiguredTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UnconfiguredTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:AuthorizationState"
+                     name = "AuthorizationState">
+                     <FileRef
+                        location = "group:AuthorizationStateResolverTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthorizationTestData.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:FetchAuthSessionStateResolverTests.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AuthenticationStateResolverTests.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:XCTestManifests.swift">
+               </FileRef>
+               <Group
+                  location = "group:ActionTests"
+                  name = "ActionTests">
+                  <Group
+                     location = "group:VerifySignInChallenge"
+                     name = "VerifySignInChallenge">
+                     <FileRef
+                        location = "group:VerifySignInChallengeTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:CredentialStore"
+                     name = "CredentialStore">
+                     <FileRef
+                        location = "group:MockAmplifyCredentialStoreBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:LoadCredentialsTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockCredentialStoreBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ClearCredentialsTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StoreCredentialTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MigrateLegacyCredentialStoreTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:SignOut"
+                     name = "SignOut">
+                     <FileRef
+                        location = "group:RevokeTokenTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignOutGloballyTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:FetchAuthSession"
+                     name = "FetchAuthSession">
+                     <Group
+                        location = "group:FetchUserPoolTokens"
+                        name = "FetchUserPoolTokens">
+                        <FileRef
+                           location = "group:RefreshUserPoolTokensTests.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:InitializeFetchAuthSessionTests.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:FetchAWSCredentials"
+                        name = "FetchAWSCredentials">
+                        <FileRef
+                           location = "group:FetchAuthAWSCredentialsTests.swift">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <Group
+                     location = "group:InitiateAuthSRP"
+                     name = "InitiateAuthSRP">
+                     <FileRef
+                        location = "group:VerifyPasswordSRPTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InitiateAuthSRPTests.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:Support"
+                  name = "Support">
+                  <FileRef
+                     location = "group:MockDispatcher.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CognitoAuthTestHelper.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockIdentity.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:HostedUIRequestHelperTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:CustomEndpoint"
+                     name = "CustomEndpoint">
+                     <FileRef
+                        location = "group:EndpointResolvingTestCase.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:EndpointResolving+ValidationStepTestCase.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:CustomEndpoint+AuthConfigurationJSONTestCase.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:StateSequence.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DefaultConfig.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAuthCognitoSessionTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockIdentityProvider.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:hierarchical-state-machine-swiftTests"
+                  name = "hierarchical-state-machine-swiftTests">
+                  <FileRef
+                     location = "group:CombinedStateTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StateMachineTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Support"
+                     name = "Support">
+                     <FileRef
+                        location = "group:ColorCounter.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Counter+Event.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Counter.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Counter+Resolver.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Color.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:StateMachineListenerTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:HubEventTests"
+                  name = "HubEventTests">
+                  <FileRef
+                     location = "group:AuthHubEventHandlerTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:TestResources"
+                  name = "TestResources">
+                  <Group
+                     location = "group:configuration"
+                     name = "configuration">
+                     <FileRef
+                        location = "group:authconfiguration.json">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:testSuites"
+                     name = "testSuites">
+                     <Group
+                        location = "group:signUp"
+                        name = "signUp">
+                        <FileRef
+                           location = "group:Test_that_signup_invokes_proper_cognito_request_and_returns_success.json">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:confirmSignIn"
+                        name = "confirmSignIn">
+                        <FileRef
+                           location = "group:Test_that_SignIn_with_SMS_challenge_invokes_proper_cognito_request_and_returns_success.json">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:deleteUser"
+                        name = "deleteUser">
+                        <FileRef
+                           location = "group:Test_that_Cognito_is_called_with_given_payload_and_returns_successful_data.json">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Nothing_is_returned_when_delete_user_succeeds.json">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthException_is_thrown_when_deleteUser_API_call_fails.json">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:signOut"
+                        name = "signOut">
+                        <FileRef
+                           location = "group:Test_that_signOut_while_signed_in_returns_complete_with_success.json">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Test_that_signOut_returns_partial_success_with_revoke_token_error.json">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Test_that_signOut_while_already_signed_out_returns_complete_with_success.json">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Test_that_global_signOut_while_signed_in_returns_complete_with_success.json">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Test_that_globalSignOut_returns_partial_success_with_revoke_token_error.json">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Test_that_global_signOut_error_returns_partial_success_with_global_sign_out_error.json">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:signIn"
+                        name = "signIn">
+                        <FileRef
+                           location = "group:Test_that_SRP_signIn_invokes_proper_cognito_request_and_returns_success.json">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Test_that_Device_SRP_signIn_invokes_proper_cognito_request_and_returns_success.json">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Test_that_SRP_signIn_invokes_proper_cognito_request_and_returns_SMS_challenge.json">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:fetchAuthSession"
+                        name = "fetchAuthSession">
+                        <FileRef
+                           location = "group:Test_that_API_is_called_with_given_payload_and_returns_successful_data.json">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:resetPassword"
+                        name = "resetPassword">
+                        <FileRef
+                           location = "group:AuthException_is_thrown_when_forgotPassword_API_call_fails.json">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthResetPasswordResult_object_is_returned_when_reset_password_succeeds.json">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <Group
+                     location = "group:states"
+                     name = "states">
+                     <FileRef
+                        location = "group:SignedIn_SessionEstablished.json">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SigningIn_SigningIn.json">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignedOut_Configured.json">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:SRPTests"
+                  name = "SRPTests">
+                  <FileRef
+                     location = "group:HKDFTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SRPClientTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:TaskTests"
+                  name = "TaskTests">
+                  <Group
+                     location = "group:UserBehaviourTests"
+                     name = "UserBehaviourTests">
+                     <FileRef
+                        location = "group:UserBehaviorChangePasswordTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:BasePluginTest.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UserBehaviorFetchAttributeTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UserBehaviorConfirmAttributeTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSCognitoAuthUserBehaviorTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UserBehaviorResendCodeTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UserBehaviorUpdateAttributeTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:ClientBehaviorTests"
+                     name = "ClientBehaviorTests">
+                     <Group
+                        location = "group:SignUp"
+                        name = "SignUp">
+                        <FileRef
+                           location = "group:AWSAuthSignUpTaskTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSAuthSignUpAPITests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSAuthConfirmSignUpAPITests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSAuthResendSignUpCodeAPITests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSAuthConfirmSignUpTaskTests.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:ClientBehaviorResetPasswordTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthenticationProviderDeleteUserTests.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:MFA"
+                        name = "MFA">
+                        <FileRef
+                           location = "group:FetchMFAPreferenceTaskTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:VerifyTOTPSetupTaskTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SetUpTOTPTaskTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:UpdateMFAPreferenceTaskTests.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:AWSCognitoAuthClientBehaviorTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthSignOutTaskTests.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:SignIn"
+                        name = "SignIn">
+                        <FileRef
+                           location = "group:AWSAuthConfirmSignInTaskTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSAuthMigrationSignInTaskTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSAuthSignInPluginTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ConfirmSignInWithSetUpMFATaskTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ConfirmSignInTOTPTaskTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SignInSetUpTOTPTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSAuthSignInOptionsTestCase.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ConfirmSignInWithMFASelectionTaskTests.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:ClientBehaviorConfirmResetPasswordTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:DeviceBehaviorTests"
+                     name = "DeviceBehaviorTests">
+                     <FileRef
+                        location = "group:DeviceBehaviorFetchDevicesTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DeviceBehaviorRememberDeviceTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DeviceBehaviorForgetDeviceTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:HostedUITests"
+                     name = "HostedUITests">
+                     <FileRef
+                        location = "group:AWSAuthHostedUISignInTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:AuthorizationTests"
+                     name = "AuthorizationTests">
+                     <FileRef
+                        location = "group:AWSAuthFetchSignInSessionOperationTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthFederationToIdentityPoolTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:BaseAuthorizationTests.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+            </Group>
+            <Group
+               location = "group:AmplifyBigIntegerUnitTests"
+               name = "AmplifyBigIntegerUnitTests">
+               <FileRef
+                  location = "group:AmplifyBigIntegerHelperTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AmplifyBigIntDecimalTests.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:AuthHostApp"
+               name = "AuthHostApp">
+               <FileRef
+                  location = "group:AuthHostApp.xcodeproj">
+               </FileRef>
+               <Group
+                  location = "group:AuthStressTests"
+                  name = "AuthStressTests">
+                  <FileRef
+                     location = "group:AuthStressTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AuthStressBaseTest.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AuthHostApp"
+                  name = "AuthHostApp">
+                  <Group
+                     location = "group:Assets.xcassets"
+                     name = "Assets.xcassets">
+                     <Group
+                        location = "group:AppIcon.appiconset"
+                        name = "AppIcon.appiconset">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:AccentColor.colorset"
+                        name = "AccentColor.colorset">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:Contents.json">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Preview Content"
+                     name = "Preview Content">
+                     <Group
+                        location = "group:Preview Assets.xcassets"
+                        name = "Preview Assets.xcassets">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <FileRef
+                     location = "group:AuthHostAppApp.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ContentView.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AuthIntegrationTests"
+                  name = "AuthIntegrationTests">
+                  <Group
+                     location = "group:AuthDeleteUserTests"
+                     name = "AuthDeleteUserTests">
+                     <FileRef
+                        location = "group:AuthDeleteUserTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:SignOutTests"
+                     name = "SignOutTests">
+                     <FileRef
+                        location = "group:AuthSignOutTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:ResetPasswordTests"
+                     name = "ResetPasswordTests">
+                     <FileRef
+                        location = "group:AuthConfirmResetPasswordTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthResetPasswordTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:CredentialStore"
+                     name = "CredentialStore">
+                     <FileRef
+                        location = "group:CredentialStoreConfigurationTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:AuthEventTests"
+                     name = "AuthEventTests">
+                     <FileRef
+                        location = "group:AuthEventIntegrationTests.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <Group
+                     location = "group:SessionTests"
+                     name = "SessionTests">
+                     <FileRef
+                        location = "group:GetCurrentUserTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignedOutAuthSessionTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignedInAuthSessionTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:FederatedSessionTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:SignInTests"
+                     name = "SignInTests">
+                     <FileRef
+                        location = "group:AuthCustomSignInTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthSRPSignInTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:SignUpTests"
+                     name = "SignUpTests">
+                     <FileRef
+                        location = "group:AuthSignUpTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthConfirmSignUpTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthResendSignUpCodeTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:MFATests"
+                     name = "MFATests">
+                     <FileRef
+                        location = "group:MFASignInTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MFAPreferenceTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TOTPSetupWhenAuthenticatedTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TOTPSetupWhenUnauthenticatedTests.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AWSAuthBaseTest.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Helpers"
+                     name = "Helpers">
+                     <FileRef
+                        location = "group:TOTPHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthEnvironmentHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthSignInHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthSessionHelper.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:AuthUserAttributesTests"
+                     name = "AuthUserAttributesTests">
+                     <FileRef
+                        location = "group:AuthUserAttributesTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:DeviceTests"
+                     name = "DeviceTests">
+                     <FileRef
+                        location = "group:AuthForgetDeviceTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthRememberDeviceTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthFetchDeviceTests.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+            </Group>
+            <Group
+               location = "group:AuthHostedUIApp"
+               name = "AuthHostedUIApp">
+               <FileRef
+                  location = "group:AuthHostedUIApp.xcodeproj">
+               </FileRef>
+               <Group
+                  location = "group:AuthHostedUIAppUITests"
+                  name = "AuthHostedUIAppUITests">
+                  <Group
+                     location = "group:AuthenticationTest"
+                     name = "AuthenticationTest">
+                     <FileRef
+                        location = "group:HostedUISignInTests.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:UITestCase.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Screen"
+                     name = "Screen">
+                     <FileRef
+                        location = "group:SignUpScreen.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthenticatedScreen.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignInScreen.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:AuthHostedUIApp"
+                  name = "AuthHostedUIApp">
+                  <Group
+                     location = "group:Assets.xcassets"
+                     name = "Assets.xcassets">
+                     <Group
+                        location = "group:AppIcon.appiconset"
+                        name = "AppIcon.appiconset">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:AccentColor.colorset"
+                        name = "AccentColor.colorset">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:Contents.json">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Utils"
+                     name = "Utils">
+                     <FileRef
+                        location = "group:AuthError+Info.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ConfigurationHelper.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Preview Content"
+                     name = "Preview Content">
+                     <Group
+                        location = "group:Preview Assets.xcassets"
+                        name = "Preview Assets.xcassets">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <Group
+                     location = "group:Views"
+                     name = "Views">
+                     <FileRef
+                        location = "group:SignedOutView.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignUpView.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignedInView.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:ContentView.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Info.plist">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AuthHostedUIAppApp.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+         </Group>
+         <Group
+            location = "group:Sources"
+            name = "Sources">
+            <Group
+               location = "group:AmplifyBigInteger"
+               name = "AmplifyBigInteger">
+               <FileRef
+                  location = "group:AmplifyBigInt+Bytes.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AmplifyBigIntHelper.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AmplifyBigInt.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AmplifyBigInt+Sign.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AmplifyBigInt+Integer.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AmplifyBigInt+Comparable.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AmplifyBigInt+Operations.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:AWSCognitoAuthPlugin"
+               name = "AWSCognitoAuthPlugin">
+               <FileRef
+                  location = "group:AWSCognitoAuthPlugin.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSCognitoAuthPlugin+Configure.swift">
+               </FileRef>
+               <Group
+                  location = "group:HubEvents"
+                  name = "HubEvents">
+                  <FileRef
+                     location = "group:AuthHubEventHandler.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AuthHubEventBehavior.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSCognitoAuthPlugin+PluginExtension.swift">
+               </FileRef>
+               <Group
+                  location = "group:StateMachine"
+                  name = "StateMachine">
+                  <Group
+                     location = "group:hierarchical-state-machine-swift"
+                     name = "hierarchical-state-machine-swift">
+                     <FileRef
+                        location = "group:StateAsyncSequence.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StateResolution.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Environment.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StateMachineResolver.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AtomicValue.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StateMachine.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:Internal"
+                        name = "Internal">
+                        <FileRef
+                           location = "group:NSLocking+Execute.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:BasicClosure.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:State.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Builder.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StateMachineEvent.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DebugSupport.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ConcurrentEffectExecutor.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:LoggingStateMachineResolver.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:EffectExecutor.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Action.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:EventDispatcher.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:CodeGen"
+                     name = "CodeGen">
+                     <Group
+                        location = "group:States"
+                        name = "States">
+                        <FileRef
+                           location = "group:SignInState.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CredentialStoreState.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:DeleteUserState.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthenticationState.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthState.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:DeviceSRPState.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SignOutState.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CustomSignInState.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:FetchAuthSessionState.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:HostedUISignInState.swift">
+                        </FileRef>
+                        <Group
+                           location = "group:DebugInfo"
+                           name = "DebugInfo">
+                           <FileRef
+                              location = "group:SignOutState+Debug.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:MigrateSignInState+Debug.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:DeleteUserState+Debug.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:SignInState+Debug.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:CredentialStoreState+Debug.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:AuthorizationState+Debug.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:CustomSignInState+Debug.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:SRPSignInState+Debug.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:FetchAuthSessionState+Debug.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:SignInTOTPSetupState+Debug.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:RefreshSessionState+Debug.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:SignInChallengeState+Debug.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:AuthenticationState+Debug.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:HostedUISignInState+Debug.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:AuthState+Debug.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:DeviceSRPState+Debug.swift">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:SignInChallengeState.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:MigrateSignInState.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthorizationState.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SRPSignInState.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SignInTOTPSetupState.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:RefreshSessionState.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:Errors"
+                        name = "Errors">
+                        <FileRef
+                           location = "group:SignUpError.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthenticationError.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SignInError.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:FetchSessionError.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthorizationError.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SignOutError.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:HostedUIError.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:Events"
+                        name = "Events">
+                        <FileRef
+                           location = "group:DeleteUserEvent.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CredentialStoreEvent.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthenticationEvent.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SignInEvent.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SetUpTOTPEvent.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:RefreshSessionEvent.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthEvents.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthorizationEvent.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:FetchAuthSessionEvent.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:HostedUIEvent.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SignOutEvent.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SignInChallengeEvent.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:Data"
+                        name = "Data">
+                        <FileRef
+                           location = "group:HostedUIConfigurationData.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SignOutEventData.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:LoginsMapProvider.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthConfiguration.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:HostedUIResult.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:IdentityPoolConfigurationData.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:FederatedToken.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SignedOutData.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:HostedUIProviderInfo.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:HostedUIOptions.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:UserPoolConfigurationData.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SignInMethod.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SignInTOTPSetupData.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ConfirmSignInEventData.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SignInEventData.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:RespondToAuthChallenge.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SignedInData.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:DeviceMetadata.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthenticationConfiguration.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SRPStateData.swift">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <Group
+                     location = "group:ErrorMapping"
+                     name = "ErrorMapping">
+                     <FileRef
+                        location = "group:SignInError+Helper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignUpError+Helper.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Resolvers"
+                     name = "Resolvers">
+                     <Group
+                        location = "group:CustomAuth"
+                        name = "CustomAuth">
+                        <FileRef
+                           location = "group:CustomSignInState+Resolver.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:AuthState"
+                        name = "AuthState">
+                        <FileRef
+                           location = "group:AuthState+Resolver.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:CredentialStore"
+                        name = "CredentialStore">
+                        <FileRef
+                           location = "group:CredentialStoreState+Resolver.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:RefreshSession"
+                        name = "RefreshSession">
+                        <FileRef
+                           location = "group:RefreshSessionState+Resolver.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:TOTPSetup"
+                        name = "TOTPSetup">
+                        <FileRef
+                           location = "group:SignInTOTPSetupState+Resolver.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:MigrateAuth"
+                        name = "MigrateAuth">
+                        <FileRef
+                           location = "group:MigrateSignInState+Resolver.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:DeleteUser"
+                        name = "DeleteUser">
+                        <FileRef
+                           location = "group:DeleteUserState+Resolver.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:SignOut"
+                        name = "SignOut">
+                        <FileRef
+                           location = "group:SignOutState+Resolver.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:SignIn"
+                        name = "SignIn">
+                        <FileRef
+                           location = "group:SignInState+Resolver.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:HostedUISignInState+Resolver.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SignInChallengeState+Resolver.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:FetchAuthSession"
+                        name = "FetchAuthSession">
+                        <FileRef
+                           location = "group:FetchAuthSessionState+Resolver.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:Authorization"
+                        name = "Authorization">
+                        <FileRef
+                           location = "group:AuthorizationState+Resolver.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:Authentication"
+                        name = "Authentication">
+                        <FileRef
+                           location = "group:AuthenticationState+Resolver.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:SRP"
+                        name = "SRP">
+                        <FileRef
+                           location = "group:DeviceSRPState+Resolver.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SRPSignInState+Resolver.swift">
+                        </FileRef>
+                     </Group>
+                  </Group>
+               </Group>
+               <FileRef
+                  location = "group:AWSCognitoAuthPlugin+EscapeHatch.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSCognitoAuthPluginBehavior.swift">
+               </FileRef>
+               <Group
+                  location = "group:Models"
+                  name = "Models">
+                  <Group
+                     location = "group:Options"
+                     name = "Options">
+                     <FileRef
+                        location = "group:AWSAuthResendSignUpCodeOptions.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAttributeResendConfirmationCodeOptions.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthConfirmSignInOptions.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:VerifyTOTPSetupOptions.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthUpdateUserAttributesOptions.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthConfirmSignUpOptions.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthResetPasswordOptions.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthUpdateUserAttributeOptions.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthSignInOptions.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthSignUpOptions.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthWebUISignInOptions.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthConfirmResetPasswordOptions.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AWSCognitoUserPoolTokens.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAuthDevice.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSCognitoAuthService.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AuthAWSCognitoCredentials.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAuthUser.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:UserMFAPreference.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MFATypeExtension.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSCognitoSignOutResult.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FederateToIdentityPoolResult.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AuthFlowType.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MFAPreference.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAuthCognitoSession.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Errors"
+                     name = "Errors">
+                     <FileRef
+                        location = "group:AWSCognitoAuthError.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AuthChallengeType.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Operations"
+                  name = "Operations">
+                  <FileRef
+                     location = "group:AuthConfigureOperation.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Helpers"
+                     name = "Helpers">
+                     <FileRef
+                        location = "group:ClearFederationOperationHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UpdateAttributesOperationHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:HostedUISignInHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:FetchAuthSessionOperationHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AmplifyOperationHelper.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:ClientBehavior"
+                  name = "ClientBehavior">
+                  <FileRef
+                     location = "group:AWSCognitoAuthPlugin+ClientBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSCognitoAuthPlugin+DeviceBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSCognitoAuthPlugin+UserBehavior.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Support"
+                  name = "Support">
+                  <Group
+                     location = "group:CustomEndpoint"
+                     name = "CustomEndpoint">
+                     <FileRef
+                        location = "group:AWSEndpointResolving.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:EndpointResolving+ValidationStep.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:EndpointResolving.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Constants"
+                     name = "Constants">
+                     <FileRef
+                        location = "group:AuthPluginErrorConstants.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthPluginConstants.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Utils"
+                     name = "Utils">
+                     <FileRef
+                        location = "group:HttpClientEngineProxy.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignUpInput+Amplify.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Date+UTC.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthUserAttributeKey+RawValue.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:RespondToAuthChallengeInput+Amplify.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ConfirmSignUpInput+Amplify.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InitiateAuthInput+Amplify.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Request"
+                     name = "Request">
+                     <FileRef
+                        location = "group:AuthConfirmSignUpRequest+Validation.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthConfirmSignInRequest+Validation.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthResetPasswordRequest+Validation.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthSignUpRequest+Validation.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthResendSignUpCodeRequest+Validation.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthConfirmResetPasswordRequest+Validation.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:HostedUI"
+                     name = "HostedUI">
+                     <FileRef
+                        location = "group:RandomStringBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:HostedUIRequestHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:RandomStringGenerator.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:HostedUISessionBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthUIPresentationAnchorPlaceholder.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:HostedUIASWebAuthenticationSession.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:StateMachineSupport"
+                     name = "StateMachineSupport">
+                     <FileRef
+                        location = "group:AWSCognitoAuthPlugin+StateMachine.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StateMachineEvent+Type.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Environment+Type.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Helpers"
+                     name = "Helpers">
+                     <FileRef
+                        location = "group:String+Mask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UserPoolSignInHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TokenParserHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DeviceMetadataHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ConfigurationHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ClientSecretHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthCognitoTokens+Validation.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthAWSCognitoCredentials+Validation.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthCognitoSignedInSessionHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthCognitoSignedOutSessionHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthProvider+Cognito.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Logging"
+                     name = "Logging">
+                     <FileRef
+                        location = "group:AWSCognitoAuthPlugin+Log.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:Task"
+                  name = "Task">
+                  <FileRef
+                     location = "group:AWSAuthSignUpTask.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAuthChangePasswordTask.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAuthSignInTask.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SetUpTOTPTask.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAuthDeleteUserTask.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAuthResetPasswordTask.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:UserTasks"
+                     name = "UserTasks">
+                     <FileRef
+                        location = "group:AWSAuthUpdateUserAttributesTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthConfirmUserAttributeTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthUpdateUserAttributeTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthFetchUserAttributeTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthAttributeResendConfirmationCodeTask.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AWSAuthResendSignUpCodeTask.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAuthFederateToIdentityPoolTask.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAuthWebUISignInTask.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAuthConfirmSignInTask.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAuthFetchSessionTask.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:DeviceTasks"
+                     name = "DeviceTasks">
+                     <FileRef
+                        location = "group:AWSAuthForgetDeviceTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthFetchDevicesTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSAuthRememberDeviceTask.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AWSAuthClearFederationToIdentityPoolTask.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FetchMFAPreferenceTask.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAuthConfirmResetPasswordTask.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAuthConfirmSignUpTask.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Protocols"
+                     name = "Protocols">
+                     <FileRef
+                        location = "group:AuthConfirmSignUpTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthResendSignUpCodeTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthDeleteUserTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthVerifyTOTPSetupTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthChangePasswordTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AmplifyAuthTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthWebUISignInTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthConfirmSignInTask.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:UserTasks"
+                        name = "UserTasks">
+                        <FileRef
+                           location = "group:AuthFetchUserAttributeTask.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthUpdateUserAttributeTask.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthConfirmUserAttributeTask.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthUpdateUserAttributesTask.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthAttributeResendConfirmationCodeTask.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:AmplifyAuthTaskNonThrowing.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthFetchSessionTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthConfirmResetPasswordTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthSignUpTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthResetPasswordTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthSetUpTOTPTask.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:DeviceTasks"
+                        name = "DeviceTasks">
+                        <FileRef
+                           location = "group:AuthFetchDevicesTask.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthForgetDeviceTask.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AuthRememberDeviceTask.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:AuthSignOutTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthSocialWebUISignInTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthSignInTask.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Helpers"
+                     name = "Helpers">
+                     <FileRef
+                        location = "group:AWSAuthTaskHelper.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:UpdateMFAPreferenceTask.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:VerifyTOTPSetupTask.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAuthSignOutTask.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Actions"
+                  name = "Actions">
+                  <Group
+                     location = "group:Configuration"
+                     name = "Configuration">
+                     <FileRef
+                        location = "group:InitializeAuthenticationConfiguration.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ValidateCredentialsAndConfiguration.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InitializeAuthorizationConfiguration.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InitializeAuthConfiguration.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:CredentialStore"
+                     name = "CredentialStore">
+                     <FileRef
+                        location = "group:ClearCredentialStore.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StoreCredentials.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MigrateLegacyCredentialStore.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:IdleCredentialStore.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:LoadCredentialStore.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:DeleteUser"
+                     name = "DeleteUser">
+                     <FileRef
+                        location = "group:InformUserDeletedAndSignedOut.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DeleteUser.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:SignOut"
+                     name = "SignOut">
+                     <FileRef
+                        location = "group:SignOutLocally.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:BuildRevokeTokenError.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ShowHostedUISignOut.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InitiateSignOut.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:CancelSignOut.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:RevokeToken.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignOutGlobally.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InitiateGuestSignOut.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:SignIn"
+                     name = "SignIn">
+                     <FileRef
+                        location = "group:VerifySignInChallenge.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InitializeResolveChallenge.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:SRPAuth"
+                        name = "SRPAuth">
+                        <FileRef
+                           location = "group:VerifyPasswordSRP+ChallengeParameters.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:InitiateAuthSRP.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ThrowSignInError.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SRPSignInHelper.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:VerifyPasswordSRP+Calculations.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CancelSignIn.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:VerifyPasswordSRP.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:StartSRPFlow.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:MigrateAuth"
+                        name = "MigrateAuth">
+                        <FileRef
+                           location = "group:StartMigrateAuthFlow.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:InitiateMigrateAuth.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:CustomSignIn"
+                        name = "CustomSignIn">
+                        <FileRef
+                           location = "group:InitiateCustomAuth.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:StartCustomSignInFlow.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:DeviceSRPAuth"
+                        name = "DeviceSRPAuth">
+                        <FileRef
+                           location = "group:StartDeviceSRPFlow.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:VerifyDevicePasswordSRP+ChallengeParameters.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:InitiateAuthDeviceSRP.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:VerifyDevicePasswordSRP+Calculations.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:VerifyDevicePasswordSRP.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:HostedUI"
+                        name = "HostedUI">
+                        <FileRef
+                           location = "group:ShowHostedUISignIn.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:InitializeHostedUISignIn.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:FetchHostedUISignInToken.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:SoftwareTokenSetup"
+                        name = "SoftwareTokenSetup">
+                        <FileRef
+                           location = "group:InitializeTOTPSetup.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CompleteTOTPSetup.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:VerifyTOTPSetup.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SetUpTOTP.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:ConfirmDevice.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:IntializeSignInFlow.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:RefreshAuthorizationSession"
+                     name = "RefreshAuthorizationSession">
+                     <FileRef
+                        location = "group:InformSessionRefreshed.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InitializeRefreshSession.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:UserPool"
+                        name = "UserPool">
+                        <FileRef
+                           location = "group:RefreshHostedUITokens.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:RefreshUserPoolTokens.swift">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <Group
+                     location = "group:Federation"
+                     name = "Federation">
+                     <FileRef
+                        location = "group:InitializeFederationToIdentityPool.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ClearFederationToIdentityPool.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Persistence"
+                     name = "Persistence">
+                     <FileRef
+                        location = "group:ConfigureAuthorization.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ConfigureAuthentication.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:FetchAuthorizationSession"
+                     name = "FetchAuthorizationSession">
+                     <FileRef
+                        location = "group:InformSessionFetched.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InitializeFetchAuthSessionWithUserPool.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:FetchIdentity"
+                        name = "FetchIdentity">
+                        <FileRef
+                           location = "group:FetchAuthIdentityId.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:AWSCredentials"
+                        name = "AWSCredentials">
+                        <FileRef
+                           location = "group:FetchAuthAWSCredentials.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:PersistCredentials.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InitializeFetchUnAuthSession.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InformSessionError.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:Action+Logging.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Authentication"
+                     name = "Authentication">
+                     <FileRef
+                        location = "group:SignInComplete.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:ASF"
+                  name = "ASF">
+                  <FileRef
+                     location = "group:ASFDeviceInfo.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ASFAppInfo.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CognitoUserPoolASF+KeyChain.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CognitoUserPoolASF.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AdvancedSecurityBehavior.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Environment"
+                  name = "Environment">
+                  <FileRef
+                     location = "group:IDFactory.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SRPAuthEnvironment.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AuthorizationEnvironment.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:UserPoolEnvironment.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CredentialStoreEnvironment.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:HostedUIEnvironemt.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AuthenticationEnvironment.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SRPSignInEnvironment.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AuthEnvironment.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Request"
+                  name = "Request">
+                  <FileRef
+                     location = "group:AuthClearFederationToIdentityPoolRequest.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AuthFederateToIdentityPoolRequest.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSCognitoAuthPlugin+PluginSpecificAPI.swift">
+               </FileRef>
+               <Group
+                  location = "group:Service"
+                  name = "Service">
+                  <FileRef
+                     location = "group:CognitoIdentityBehavior.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:UserPoolAnalytics"
+                     name = "UserPoolAnalytics">
+                     <FileRef
+                        location = "group:UserPoolAnalytics.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UserPoolAnalyticsBehavior.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:CognitoUserPoolBehavior.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:ErrorMapping"
+                     name = "ErrorMapping">
+                     <FileRef
+                        location = "group:AWSCongnitoIdentityProvider+AuthErrorConvertible.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ClientError+AuthErrorConvertible.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthErrorConvertible.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:CommonRunTimeError+AuthErrorConvertible.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSCognitoIdentity+AuthErrorConvertible.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:SdkTypealiases.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Helpers"
+                     name = "Helpers">
+                     <FileRef
+                        location = "group:SignUpOutputResponse+Helper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SignInResponseBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthUserAttribute+Helper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ListDevicesOutputResponse+Helper.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:CredentialStorage"
+                  name = "CredentialStorage">
+                  <FileRef
+                     location = "group:AWSCognitoAuthCredentialStore.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AmplifyAuthCredentialStoreBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CredentialStoreOperationClient.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AmplifyCredentials+CognitoSession.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AmplifyCredentials.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:SRP"
+                  name = "SRP">
+                  <FileRef
+                     location = "group:SRPClientBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SRPKeys.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AmplifySRPClient.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+            <Group
+               location = "group:libtommath"
+               name = "libtommath">
+               <FileRef
+                  location = "group:amplify_bn_mp_mod_2d.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_cutoffs.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_mod.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_set_ll.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_2expt.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_signed_rsh.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_init_multi.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_sqr.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_karatsuba_sqr.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_get_ll.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_or.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_prime_strong_lucas_selfridge.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_prime_tab.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_reduce_2k_setup_l.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_set_u32.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_root_u32.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_set_double.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_neg.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_rand.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_prime_fermat.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_init_u64.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_expt_u32.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_exptmod.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_set.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_dr_reduce.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_shrink.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_init_size.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_init_ull.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_xor.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_exch.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_mul_digs.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_div.c">
+               </FileRef>
+               <FileRef
+                  location = "group:LICENSE">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_from_ubin.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_div_2.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_set_ul.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_is_square.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_get_bit.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_sqr.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_init.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_fwrite.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_tommath_cutoffs.h">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_tommath_private.h">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_kronecker.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_init_i32.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_mul_d.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_reduce_is_2k_l.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_get_i64.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_zero.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_cmp_d.c">
+               </FileRef>
+               <Group
+                  location = "group:include"
+                  name = "include">
+                  <FileRef
+                     location = "group:libtommathAmplify.h">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:amplify_bn_mp_reduce_2k_setup.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_get_l.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_gcd.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_mul.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_balance_mul.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_sqr_fast.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_error_to_string.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_karatsuba_mul.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_prime_next_prime.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_decr.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_from_sbin.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_copy.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_rand_jenkins.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_prime_miller_rabin.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_invmod_fast.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_radix_size.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_mod_d.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_reduce_is_2k.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_dr_is_modulus.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_submod.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_montgomery_calc_normalization.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_get_mag_ull.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_count_bits.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_exptmod_fast.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_dr_setup.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_montgomery_setup.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_set_i64.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_prime_frobenius_underwood.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_get_mag_u64.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_invmod.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_pack_count.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_get_double.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_add.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_reduce_2k.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_cmp.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_clear_multi.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_init_set.c">
+               </FileRef>
+               <FileRef
+                  location = "group:README.md">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_pack.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_complement.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_sqrt.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_sub.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_exptmod.c">
+               </FileRef>
+               <FileRef
+                  location = "group:changes.txt">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_reduce_2k_l.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_clamp.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_tommath_superclass.h">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_cmp_mag.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_fread.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_incr.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_init_u32.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_reduce.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_cnt_lsb.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_prime_is_divisible.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_prime_rabin_miller_trials.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_div_d.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_lshd.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_mul_high_digs_fast.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_set_u64.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_set_ull.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_addmod.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_montgomery_reduce.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_to_sbin.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_prime_is_prime.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_abs.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_iseven.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_toom_sqr.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_reverse.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_reduce_setup.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_div_2d.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_add.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_clear.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_rand_platform.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_sub.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_tommath.h">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_lcm.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_mul_high_digs.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_radix_smap.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_and.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_invmod_slow.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_log_u32.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_set_i32.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_get_mag_u32.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_sub_d.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_grow.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_init_ul.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_rshd.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_init_copy.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_to_radix.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_read_radix.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_exteuclid.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_mul_2d.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_ubin_size.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_deprecated.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_toom_mul.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_montgomery_reduce_fast.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_unpack.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_sqrtmod_prime.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_mul_2.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_set_l.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_sqrmod.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_tommath_class.h">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_s_mp_mul_digs_fast.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_isodd.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_init_ll.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_add_d.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_div_3.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_get_mag_ul.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_sbin_size.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_mulmod.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_init_i64.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_init_l.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_prime_rand.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_to_ubin.c">
+               </FileRef>
+               <FileRef
+                  location = "group:amplify_bn_mp_get_i32.c">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:AmplifySRP"
+               name = "AmplifySRP">
+               <FileRef
+                  location = "group:HKDF.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SRPClientState.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SRPServerResponse.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SRPCommonState.swift">
+               </FileRef>
+            </Group>
+         </Group>
+      </Group>
+      <Group
+         location = "group:Geo"
+         name = "Geo">
+         <Group
+            location = "group:Tests"
+            name = "Tests">
+            <Group
+               location = "group:GeoHostApp"
+               name = "GeoHostApp">
+               <Group
+                  location = "group:GeoHostApp"
+                  name = "GeoHostApp">
+                  <FileRef
+                     location = "group:GeoHostAppApp.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Assets.xcassets"
+                     name = "Assets.xcassets">
+                     <Group
+                        location = "group:AppIcon.appiconset"
+                        name = "AppIcon.appiconset">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:AccentColor.colorset"
+                        name = "AccentColor.colorset">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:Contents.json">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Preview Content"
+                     name = "Preview Content">
+                     <Group
+                        location = "group:Preview Assets.xcassets"
+                        name = "Preview Assets.xcassets">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <FileRef
+                     location = "group:ContentView.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AWSLocationGeoPluginIntegrationTests"
+                  name = "AWSLocationGeoPluginIntegrationTests">
+                  <FileRef
+                     location = "group:TestConfigHelper.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSLocationGeoPluginIntegrationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:GeoStressTests"
+                  name = "GeoStressTests">
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GeoStressTests.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:GeoHostApp.xcodeproj">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:AWSLocationGeoPluginTests"
+               name = "AWSLocationGeoPluginTests">
+               <Group
+                  location = "group:Mocks"
+                  name = "Mocks">
+                  <FileRef
+                     location = "group:MockAWSLocation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockAWSLocation+ClientBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockAWSClientConfiguration.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Configuration"
+                  name = "Configuration">
+                  <FileRef
+                     location = "group:AWSLocationGeoPluginConfigurationTests.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSLocationGeoPluginAmplifyVersionableTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSLocationGeoPluginConfigureTests.swift">
+               </FileRef>
+               <Group
+                  location = "group:Resources"
+                  name = "Resources">
+                  <FileRef
+                     location = "group:Info.plist">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Support"
+                  name = "Support">
+                  <Group
+                     location = "group:Constants"
+                     name = "Constants">
+                     <FileRef
+                        location = "group:GeoPluginTestConfig.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <FileRef
+                  location = "group:AWSLocationGeoPluginClientBehaviorTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSLocationGeoPluginTestBase.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSLocationGeoPluginResetTests.swift">
+               </FileRef>
+            </Group>
+         </Group>
+         <Group
+            location = "group:Sources"
+            name = "Sources">
+            <Group
+               location = "group:AWSLocationGeoPlugin"
+               name = "AWSLocationGeoPlugin">
+               <Group
+                  location = "group:Options"
+                  name = "Options">
+                  <FileRef
+                     location = "group:AWSLocationGeoPluginSearchOptions.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Configuration"
+                  name = "Configuration">
+                  <FileRef
+                     location = "group:GeoPluginConfigError.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSLocationGeoPluginConfiguration+Keys.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSLocationGeoPluginConfiguration.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSLocationGeoPlugin+Configure.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSLocationGeoPlugin+Reset.swift">
+               </FileRef>
+               <Group
+                  location = "group:Resources"
+                  name = "Resources">
+                  <FileRef
+                     location = "group:Info.plist">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSLocationGeoPlugin+ClientBehavior.swift">
+               </FileRef>
+               <Group
+                  location = "group:Dependency"
+                  name = "Dependency">
+                  <FileRef
+                     location = "group:AWSLocationAdapter.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSLocationBehavior.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSLocationGeoPlugin.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSLocationGeoPlugin+DefaultLogger.swift">
+               </FileRef>
+               <Group
+                  location = "group:Support"
+                  name = "Support">
+                  <Group
+                     location = "group:Constants"
+                     name = "Constants">
+                     <FileRef
+                        location = "group:GeoPluginErrorConstants.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Utils"
+                     name = "Utils">
+                     <FileRef
+                        location = "group:GeoErrorConvertible.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+            </Group>
+         </Group>
+      </Group>
+      <Group
+         location = "group:Internal"
+         name = "Internal">
+         <Group
+            location = "group:Tests"
+            name = "Tests">
+            <Group
+               location = "group:InternalAWSPinpointUnitTests"
+               name = "InternalAWSPinpointUnitTests">
+               <Group
+                  location = "group:Mocks"
+                  name = "Mocks">
+                  <FileRef
+                     location = "group:MockUserDefaults.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockAnalyticsClient.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockPinpointClient.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockKeychainStore.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockSQLiteLocalStorageAdapter.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockProvisioningProfileReader.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockEndpointClient.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockEventRecorder.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockArchiver.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockAnalyticsEventStorage.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockActivityTracker.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockFileManager.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:SessionClientTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSPinpointFactoryTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AwsPinpointAnalyticsKeychainMigrationTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:PinpointRequestsRegistryTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:ActivityTrackerTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:EndpointClientTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SQLiteLocalStorageAdapterTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:EventRecorderTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AnalyticsClientTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AnalyticsEventStorageTests.swift">
+               </FileRef>
+            </Group>
+         </Group>
+         <Group
+            location = "group:Sources"
+            name = "Sources">
+            <Group
+               location = "group:InternalAWSPinpoint"
+               name = "InternalAWSPinpoint">
+               <Group
+                  location = "group:Configuration"
+                  name = "Configuration">
+                  <FileRef
+                     location = "group:AWSPinpointPluginConfiguration.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Context"
+                  name = "Context">
+                  <FileRef
+                     location = "group:PinpointContext+AWSPinpointBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PinpointContext.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPinpointFactory.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSPinpointBehavior.swift">
+               </FileRef>
+               <Group
+                  location = "group:Models"
+                  name = "Models">
+                  <FileRef
+                     location = "group:PinpointUserProfile.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Extensions"
+                  name = "Extensions">
+                  <FileRef
+                     location = "group:SDKModels+AmplifyStringConvertible.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PinpointClient+CredentialsProvider.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Date+Formatting.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Data+HexString.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CommonRunTimeError+isConnectivityError.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Support"
+                  name = "Support">
+                  <Group
+                     location = "group:Constants"
+                     name = "Constants">
+                     <FileRef
+                        location = "group:AWSPinpointErrorConstants.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSPinpointAnalyticsConstants.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Utils"
+                     name = "Utils">
+                     <FileRef
+                        location = "group:ProvisioningProfileReader.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AmplifyArchiver.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PinpointRequestsRegistry.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:RepeatingTimer.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:RemoteNotificationsHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AmplifyStringConvertible.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AnalyticsPropertiesModel.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:ModeledErrorDescribable.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Endpoint"
+                  name = "Endpoint">
+                  <FileRef
+                     location = "group:EndpointLocation+UserProfileLocation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:EndpointInformation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PinpointEndpointProfile.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:EndpointClient.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Analytics"
+                  name = "Analytics">
+                  <FileRef
+                     location = "group:PinpointEvent.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:EventRecorder.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AnalyticsClient.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ClientError+IsRetryable.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PinpointEvent+PinpointClientTypes.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:LocalStorage"
+                     name = "LocalStorage">
+                     <FileRef
+                        location = "group:LocalStorageError.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AnalyticsEventSQLStorage.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SQLiteLocalStorageAdapter.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SQLStorageProtocol.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AnalyticsEventStorage.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PinpointEvent+Bindings.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:Session"
+                  name = "Session">
+                  <FileRef
+                     location = "group:SessionClient.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PinpointSession.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:ActivityTracking"
+                     name = "ActivityTracking">
+                     <FileRef
+                        location = "group:StateMachine.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ActivityTracker.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+            </Group>
+         </Group>
+      </Group>
+      <Group
+         location = "group:Storage"
+         name = "Storage">
+         <Group
+            location = "group:Tests"
+            name = "Tests">
+            <Group
+               location = "group:StorageHostApp"
+               name = "StorageHostApp">
+               <Group
+                  location = "group:Configuration"
+                  name = "Configuration">
+                  <FileRef
+                     location = "group:Tests.xcconfig">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Base.xcconfig">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:StorageHostApp.xcodeproj">
+               </FileRef>
+               <Group
+                  location = "group:StorageHostApp"
+                  name = "StorageHostApp">
+                  <Group
+                     location = "group:AppIcon.xcassets"
+                     name = "AppIcon.xcassets">
+                     <Group
+                        location = "group:AppIcon.appiconset"
+                        name = "AppIcon.appiconset">
+                        <FileRef
+                           location = "group:spotlight120.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ipad76.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:notification40.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:settings87.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:spotlight80.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:mac16.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:mac64.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ipadPro167.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ipad152.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:mac256.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ipadSettings29.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:mac1024.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:mac128.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:iphone120.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ipadNotification20.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:mac512.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ipadSpotlight40.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:mac32.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:notification60.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ipadSpotlight80.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:settings58.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:iphone180.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:appstore1024.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ipadSettings58.png">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ipadNotification40.png">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:Contents.json">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:StorageHostAppApp.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ContentView.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Info.plist">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageWatchApp.entitlements">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageHostApp.entitlements">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:copy_configuration.sh">
+               </FileRef>
+               <Group
+                  location = "group:StorageStressTests"
+                  name = "StorageStressTests">
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageStressTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AWSS3StoragePluginIntegrationTests"
+                  name = "AWSS3StoragePluginIntegrationTests">
+                  <FileRef
+                     location = "group:AWSS3StoragePluginAccelerateIntegrationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StoragePluginTestBase.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StoragePluginPrefixKeyResolverTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StoragePluginConfigurationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StoragePluginOptionsUsabilityTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StoragePluginNegativeTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StoragePluginBasicIntegrationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StoragePluginAccessLevelTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:ResumabilityTests"
+                     name = "ResumabilityTests">
+                     <FileRef
+                        location = "group:AWSS3StoragePluginPutDataResumabilityTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StoragePluginDownloadFileResumabilityTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StoragePluginUploadFileResumabilityTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StoragePluginGetDataResumabilityTests.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AWSS3StoragePluginProgressTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StoragePluginRequestRecorder.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Helpers"
+                     name = "Helpers">
+                     <FileRef
+                        location = "group:TestConfigHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthSignInHelper.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:Info.plist">
+                  </FileRef>
+               </Group>
+            </Group>
+            <Group
+               location = "group:AWSS3StoragePluginTests"
+               name = "AWSS3StoragePluginTests">
+               <Group
+                  location = "group:Mocks"
+                  name = "Mocks">
+                  <FileRef
+                     location = "group:MockS3Client.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockAWSS3TransferUtility.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockAWSS3.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockOperationQueue.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockAWSS3StorageService.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockAWSS3PreSignedURLBuilder.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Operation"
+                  name = "Operation">
+                  <FileRef
+                     location = "group:AWSS3StorageRemoveOperationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StorageUploadFileOperationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StorageGetDataOperationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StorageDownloadFileOperationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StorageOperationTestBase.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StorageUploadFileOperationTests2.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StoragePutDataOperationTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Configuration"
+                  name = "Configuration">
+                  <FileRef
+                     location = "group:S3ClientConfigurationProxyTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StoragePluginConfigurationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3PluginPrefixResolverTests.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSS3StoragePluginTestBase.swift">
+               </FileRef>
+               <Group
+                  location = "group:Resources"
+                  name = "Resources">
+                  <FileRef
+                     location = "group:Info.plist">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSS3StoragePluginResetTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSS3StoragePluginBaseConfigTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSS3StoragePluginAsyncBehaviorTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSS3StoragePluginConfigureTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSS3StoragePluginGetPresignedUrlTests.swift">
+               </FileRef>
+               <Group
+                  location = "group:Support"
+                  name = "Support">
+                  <Group
+                     location = "group:Internal"
+                     name = "Internal">
+                     <FileRef
+                        location = "group:MockStorageTransferDatabase.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AttemptTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageTransferDatabaseTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageUploadPartSizeTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UploadSourceTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageBackgroundEventsRegistryTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockMultipartUploadClient.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:BytesTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:FatalTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StoragePersistableTransferTaskTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:FileSystemTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageMultipartUploadSessionTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageUploadPartTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UploadFileTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Utils"
+                     name = "Utils">
+                     <FileRef
+                        location = "group:StorageRequestUtilsValidatorTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageRequestUtilsGetterTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageRequestUtilsTests.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <FileRef
+                  location = "group:AWSS3StoragePluginAmplifyVersionableTests.swift">
+               </FileRef>
+               <Group
+                  location = "group:Request"
+                  name = "Request">
+                  <FileRef
+                     location = "group:AWSS3StorageGetURLRequestTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StorageRemoveRequestTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StorageUploadFileRequestTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StorageGetDataRequestTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StorageDownloadFileRequestTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StoragePutDataRequestTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StorageListRequestTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Service"
+                  name = "Service">
+                  <Group
+                     location = "group:Storage"
+                     name = "Storage">
+                     <FileRef
+                        location = "group:AWSS3StorageServiceConfigureTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageServiceGetPreSignedURLBehaviorTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageServiceListTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageServiceDeleteBehaviorTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageServiceUploadBehaviorTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageServiceListBehaviorTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3MultipartUploadRequestCompletedPartTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageServiceDownloadBehaviorTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageServiceTestBase.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageServiceEscapeHatchBehaviorTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageServiceMultiPartUploadBehaviorTests.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+            </Group>
+         </Group>
+         <Group
+            location = "group:Sources"
+            name = "Sources">
+            <Group
+               location = "group:AWSS3StoragePlugin"
+               name = "AWSS3StoragePlugin">
+               <Group
+                  location = "group:Operation"
+                  name = "Operation">
+                  <FileRef
+                     location = "group:AWSS3StorageUploadDataOperation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StorageUploadFileOperation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StorageDownloadFileOperation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StorageDownloadDataOperation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StorageRemoveOperation.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Configuration"
+                  name = "Configuration">
+                  <FileRef
+                     location = "group:AWSS3PluginPrefixResolver.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3PluginOptions.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3StoragePluginConfiguration.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSS3StoragePlugin+Reset.swift">
+               </FileRef>
+               <Group
+                  location = "group:Resources"
+                  name = "Resources">
+                  <FileRef
+                     location = "group:Info.plist">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Dependency"
+                  name = "Dependency">
+                  <FileRef
+                     location = "group:AWSS3ListObjectsV2Request.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:S3ClientConfiguration+withAccelerate.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3ListUploadPartResponse.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3DeleteObjectRequest.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3Adapter.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3CompleteMultipartUploadResponse.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3AbortMultipartUploadRequest.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:S3ClientConfigurationProtocol+Endpoint.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SdkTypealiases.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3Behavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3SigningOperation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:UploadPartInput+presignURL.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3CompleteMultipartUploadRequest.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3MultipartUploadRequestCompletedPart.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3PreSignedURLBuilderBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3CreateMultipartUploadResponse.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3PreSignedURLBuilderAdapter.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSS3StoragePlugin.swift">
+               </FileRef>
+               <Group
+                  location = "group:Support"
+                  name = "Support">
+                  <Group
+                     location = "group:Constants"
+                     name = "Constants">
+                     <FileRef
+                        location = "group:StorageErrorConstants.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PluginConstants.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PluginErrorConstants.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Internal"
+                     name = "Internal">
+                     <FileRef
+                        location = "group:StorageUploadPart.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageMultipartUploadSession.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageTransferStatus.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageBackgroundEventsRegistry.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageUploadPartEvent.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UploadFile.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageLogger.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:URLSessionTask+eTag.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageSessionTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Attempt.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StoragePersistableTransferTask.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:FileSystem.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageTransferType.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DefaultStorageTransferDatabase.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:CreateMultipartUploadRequest.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageURLSession.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageServiceProxy.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageTransferDatabase.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageTransferTaskPair.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UploadSource.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TypeAliases.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageTransferResponse.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageMultipartUploadClient.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageOperationReference.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageMultipartUpload.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageEvent.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageConfiguration.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageServiceSessionDelegate.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageMultipartUploadEvent.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Bytes.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageTransferTask.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Utils"
+                     name = "Utils">
+                     <FileRef
+                        location = "group:StorageRequestUtils.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:HttpClientEngineProxy.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageRequestUtils+Validator.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageRequestUtils+Getter.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SdkError+Properties.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:URLRequestDelegate.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <FileRef
+                  location = "group:AWSS3StoragePlugin+ClientBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSS3StoragePlugin+Configure.swift">
+               </FileRef>
+               <Group
+                  location = "group:Request"
+                  name = "Request">
+                  <FileRef
+                     location = "group:StorageDownloadFileRequest+Validate.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageDownloadDataRequest+Validate.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageUploadFileRequest+Validate.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageUploadDataRequest+Validate.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageListRequest+Validate.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageRemoveRequest+Validate.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:GetURL"
+                     name = "GetURL">
+                     <FileRef
+                        location = "group:AWSStorageGetURLOptions.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageGetURLRequest+Validate.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:Service"
+                  name = "Service">
+                  <Group
+                     location = "group:Storage"
+                     name = "Storage">
+                     <FileRef
+                        location = "group:AWSS3StorageService+UploadBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageService+DeleteBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageService+EscapeHatchBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageService+GetPreSignedURLBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageService+MultiPartUploadBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageServiceBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageService+DownloadBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageService+ListBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSS3StorageService.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <FileRef
+                  location = "group:AWSS3StoragePlugin+AsyncClientBehavior.swift">
+               </FileRef>
+               <Group
+                  location = "group:Error"
+                  name = "Error">
+                  <FileRef
+                     location = "group:StorageErrorConvertible.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSS3+StorageErrorConvertible.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+         </Group>
+      </Group>
+      <Group
+         location = "group:DataStore"
+         name = "DataStore">
+         <Group
+            location = "group:Tests"
+            name = "Tests">
+            <Group
+               location = "group:DataStoreHostApp"
+               name = "DataStoreHostApp">
+               <Group
+                  location = "group:DataStoreStressTests"
+                  name = "DataStoreStressTests">
+                  <FileRef
+                     location = "group:DataStoreStressBaseTest.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DataStoreStressTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Models"
+                     name = "Models">
+                     <FileRef
+                        location = "group:AmplifyModels.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostStatus.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AWSDataStorePluginV2Tests"
+                  name = "AWSDataStorePluginV2Tests">
+                  <Group
+                     location = "group:TestSupport"
+                     name = "TestSupport">
+                     <FileRef
+                        location = "group:DataStoreTestBase.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreInternal.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SyncEngineIntegrationV2TestBase.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TestModelV2Registration.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:TransformerV2"
+                     name = "TransformerV2">
+                     <FileRef
+                        location = "group:schema.graphql">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreSchemaDriftTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario8V2Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreModelWithSecondaryIndexTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionOptionalAssociations.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario5V2Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario2V2Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario3V2Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario4V2Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario6V2Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario1V2Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:README.md">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreModelWithCustomTimestampTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario7V2Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreModelWithDefaultValueTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario3aV2Tests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Models"
+                     name = "Models">
+                     <Group
+                        location = "group:TransformerV2"
+                        name = "TransformerV2">
+                        <FileRef
+                           location = "group:CustomerMultipleSecondaryIndexV2+Schema.swift">
+                        </FileRef>
+                        <Group
+                           location = "group:3V2"
+                           name = "3V2">
+                           <FileRef
+                              location = "group:Comment3V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post3V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post3V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment3V2+Schema.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:4bV2"
+                           name = "4bV2">
+                           <FileRef
+                              location = "group:Project4bV2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team4bV2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Project4bV2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team4bV2.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:7V2"
+                           name = "7V2">
+                           <FileRef
+                              location = "group:Post7V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post7V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Blog7V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Blog7V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment7V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment7V2.swift">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:TodoCustomTimestampV2+Schema.swift">
+                        </FileRef>
+                        <Group
+                           location = "group:4aV2"
+                           name = "4aV2">
+                           <FileRef
+                              location = "group:Team4aV2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Project4aV2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Project4aV2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team4aV2.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:4V2"
+                           name = "4V2">
+                           <FileRef
+                              location = "group:Post4V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post4V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment4V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment4V2+Schema.swift">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:CustomerSecondaryIndexV2.swift">
+                        </FileRef>
+                        <Group
+                           location = "group:OptionalAssociations"
+                           name = "OptionalAssociations">
+                           <FileRef
+                              location = "group:MyNestedModel8+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Blog8+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment8+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post8+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment8.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:MyCustomModel8.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:MyNestedModel8.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:MyCustomModel8+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Blog8.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post8.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:1V2"
+                           name = "1V2">
+                           <FileRef
+                              location = "group:Project1V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team1V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Project1V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team1V2.swift">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:TodoWithDefaultValueV2.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Priority.swift">
+                        </FileRef>
+                        <Group
+                           location = "group:5V2"
+                           name = "5V2">
+                           <FileRef
+                              location = "group:Post5V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post5V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:User5V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:PostEditor5V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:User5V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:PostEditor5V2+Schema.swift">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:CustomerWithMultipleFieldsinPK.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CustomerSecondaryIndexV2+Schema.swift">
+                        </FileRef>
+                        <Group
+                           location = "group:3aV2"
+                           name = "3aV2">
+                           <FileRef
+                              location = "group:Post3aV2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment3aV2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post3aV2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment3aV2+Schema.swift">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:TodoCustomTimestampV2.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CustomerMultipleSecondaryIndexV2.swift">
+                        </FileRef>
+                        <Group
+                           location = "group:SchemaDrift"
+                           name = "SchemaDrift">
+                           <FileRef
+                              location = "group:SchemaDrift.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:EnumDrift.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:SchemaDrift+Schema.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:8V2"
+                           name = "8V2">
+                           <FileRef
+                              location = "group:Meeting8V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Attendee8V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Registration8V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Meeting8V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Registration8V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Attendee8V2+Schema.swift">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:CustomerWithMultipleFieldsinPK+Schema.swift">
+                        </FileRef>
+                        <Group
+                           location = "group:2V2"
+                           name = "2V2">
+                           <FileRef
+                              location = "group:Project2V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team2V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Project2V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team2V2+Schema.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:6V2"
+                           name = "6V2">
+                           <FileRef
+                              location = "group:Post6V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post6V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment6V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Blog6V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Blog6V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment6V2.swift">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:TodoWithDefaultValueV2+Schema.swift">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <Group
+                     location = "group:Base"
+                     name = "Base">
+                     <FileRef
+                        location = "group:TestConfigHelper.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:AWSDataStorePluginAuthCognitoTests"
+                  name = "AWSDataStorePluginAuthCognitoTests">
+                  <FileRef
+                     location = "group:AWSDataStoreCategoryPluginAuthIntegrationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSDataStoreCategoryPluginAuthIntegrationTests+Support.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:TestConfigHelper.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Models"
+                     name = "Models">
+                     <FileRef
+                        location = "group:TodoImplicitOwnerField+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TodoCognitoPrivate.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TodoCognitoPrivate+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TodoCognitoMultiOwner+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TodoExplicitOwnerField.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TodoCognitoMultiOwner.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TodoImplicitOwnerField.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TodoExplicitOwnerField+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TodoCustomOwnerExplicit+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TodoCustomOwnerImplicit.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TodoCustomOwnerImplicit+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TodoCustomOwnerExplicit.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSDataStoreCategoryPluginAuthOwnerIntegrationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:singleauth-cognito-schema.graphql">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSDataStoreAuthBaseTest.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AWSDataStorePluginCPKTests"
+                  name = "AWSDataStorePluginCPKTests">
+                  <Group
+                     location = "group:Models"
+                     name = "Models">
+                     <FileRef
+                        location = "group:PostTagsWithCompositeKey.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project2+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment8+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelCompositeIntPk.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostWithCompositeKeyAndIndex.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post4.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team6+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post8+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelImplicitDefaultPk+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:CommentWithCompositeKeyAndIndex+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelCompositeMultiplePk+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelExplicitCustomPk.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostWithTagsCompositeKey+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelExplicitDefaultPk+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TagWithCompositeKey.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelExplicitCustomPk+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment8.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostWithTagsCompositeKey.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:CommentWithCompositeKeyUnidirectional.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelCustomPKDefined.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostWithCompositeKeyUnidirectional.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:CommentWithCompositeKeyAndIndex.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post4+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment4+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelCompositePkWithAssociation.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelCompositePk.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post7.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelCompositeIntPk+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team6.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment4.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelCompositePkWithAssociation+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelCompositeMultiplePk.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelCompositePk+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post7+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostWithCompositeKeyUnidirectional+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelCustomPkDefined+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:CommentWithCompositeKeyUnidirectional+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostWithCompositeKeyAndIndex+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment7+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelImplicitDefaultPk.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post8.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project6+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment7.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TagWithCompositeKey+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelCompositePkBelongsTo.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelCompositePkBelongsTo+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project6.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team2+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelExplicitDefaultPk.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostTagsWithCompositeKey+Schema.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:PrimaryKey"
+                     name = "PrimaryKey">
+                     <FileRef
+                        location = "group:primarykey_schema.graphql">
+                     </FileRef>
+                     <Group
+                        location = "group:20"
+                        name = "20">
+                        <FileRef
+                           location = "group:Post20+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSDataStoreAWSTimestampSortKeyTest.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post20.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:18"
+                        name = "18">
+                        <FileRef
+                           location = "group:AWSDataStoreAWSPhoneSortKeyTest.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post18.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post18+Schema.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:9"
+                        name = "9">
+                        <FileRef
+                           location = "group:AWSDataStoreCompositeSortKeyIdentifierTest.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Comment9+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post9+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Comment9.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post9.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:11"
+                        name = "11">
+                        <FileRef
+                           location = "group:Post11+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSDataStoreIntSortKeyTest.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post11.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:7"
+                        name = "7">
+                        <FileRef
+                           location = "group:CommentWithCompositeKey.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:PostWithCompositeKey+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSDataStorePrimaryKeyPostCommentCompositeKeyTest.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CommentWithCompositeKey+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:PostWithCompositeKey.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:16"
+                        name = "16">
+                        <FileRef
+                           location = "group:Post16+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSDataStoreAWSURLSortKeyTest.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post16.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:AWSDataStoreSortKeyBaseTest.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:17"
+                        name = "17">
+                        <FileRef
+                           location = "group:Post17+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post17.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSDataStoreAWSEmailSortKeyTest.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:10"
+                        name = "10">
+                        <FileRef
+                           location = "group:Post4V2.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post4V2+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSDataStorePrimaryKeyPostComment4V2Test.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Comment4V2.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Comment4V2+Schema.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:19"
+                        name = "19">
+                        <FileRef
+                           location = "group:AWSDataStoreAWSIPAddressSortKeyTest.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post19.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post19+Schema.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:README.md">
+                     </FileRef>
+                     <Group
+                        location = "group:15"
+                        name = "15">
+                        <FileRef
+                           location = "group:AWSDataStoreTimeSortKeyTest.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post15.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post15+Schema.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:12"
+                        name = "12">
+                        <FileRef
+                           location = "group:AWSDataStoreFloatSortKeyTest.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post12+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post12.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:AWSDataStorePrimaryKeyTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStorePrimaryKeyBaseTest.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:13"
+                        name = "13">
+                        <FileRef
+                           location = "group:AWSDataStoreDateTimeSortKeyTest.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post13.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post13+Schema.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:14"
+                        name = "14">
+                        <FileRef
+                           location = "group:AWSDataStoreDateSortKeyTest.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post14.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post14+Schema.swift">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <Group
+                     location = "group:Base"
+                     name = "Base">
+                     <FileRef
+                        location = "group:TestConfigHelper.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:DataStoreHostApp"
+                  name = "DataStoreHostApp">
+                  <FileRef
+                     location = "group:DataStoreHostAppApp.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AmplifyURLSessionFactory.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Assets.xcassets"
+                     name = "Assets.xcassets">
+                     <Group
+                        location = "group:AppIcon.appiconset"
+                        name = "AppIcon.appiconset">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:AccentColor.colorset"
+                        name = "AccentColor.colorset">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:Contents.json">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Preview Content"
+                     name = "Preview Content">
+                     <Group
+                        location = "group:Preview Assets.xcassets"
+                        name = "Preview Assets.xcassets">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <FileRef
+                     location = "group:HubListenerTestUtilities.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DataStoreHubEvent.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AmplifyURLSession.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ContentView.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Info.plist">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AWSDataStorePluginAuthIAMTests"
+                  name = "AWSDataStorePluginAuthIAMTests">
+                  <FileRef
+                     location = "group:TestConfigHelper.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Models"
+                     name = "Models">
+                     <FileRef
+                        location = "group:TodoIAMPublic+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TodoIAMPrivate+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TodoIAMPrivate.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TodoIAMPublic.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:singleauth-iam-schema.graphql">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSDataStoreAuthBaseTest.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSDataStoreCategoryPluginIAMAuthIntegrationTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AWSDataStorePluginIntegrationTests"
+                  name = "AWSDataStorePluginIntegrationTests">
+                  <FileRef
+                     location = "group:DataStoreCustomPrimaryKeyTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:TestSupport"
+                     name = "TestSupport">
+                     <FileRef
+                        location = "group:TestModelRegistration.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SyncEngineIntegrationTestBase.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreTestBase.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreInternal.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:HubEventsIntegrationTestBase.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TestModelV2Registration.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:DataStoreConfigurationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSDataStorePluginConfigurationTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Connection"
+                     name = "Connection">
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario5Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario2Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario4Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario1Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario6Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario3Tests.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:DataStoreHubEventsTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Models"
+                     name = "Models">
+                     <Group
+                        location = "group:TeamProject"
+                        name = "TeamProject">
+                        <FileRef
+                           location = "group:Project+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:schema.graphql">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Team.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Project.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Team+Schema.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:Restaurant"
+                        name = "Restaurant">
+                        <FileRef
+                           location = "group:schema.graphql">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Dish.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:MenuType.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Menu+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Restaurant+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Menu.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Dish+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Restaurant.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:Associations"
+                        name = "Associations">
+                        <FileRef
+                           location = "group:Book+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:BookAuthor.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Author.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:UserProfile.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:UserProfile+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Book.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:BookAuthor+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:UserAccount+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:UserAccount.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Author+Schema.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:Collection"
+                        name = "Collection">
+                        <Group
+                           location = "group:6"
+                           name = "6">
+                           <FileRef
+                              location = "group:Blog6.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post6.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment6.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post6+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment6+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Blog6+Schema.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:1"
+                           name = "1">
+                           <FileRef
+                              location = "group:Team1+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Project1.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Project1+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team1.swift">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:connection-schema.graphql">
+                        </FileRef>
+                        <Group
+                           location = "group:4"
+                           name = "4">
+                           <FileRef
+                              location = "group:Post4.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post4+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment4+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment4.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:3"
+                           name = "3">
+                           <FileRef
+                              location = "group:Post3.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post3+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment3+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment3.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:2"
+                           name = "2">
+                           <FileRef
+                              location = "group:Project2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Project2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team2+Schema.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:5"
+                           name = "5">
+                           <FileRef
+                              location = "group:PostEditor5.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:User5.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:PostEditor5+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:User5+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post5+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post5.swift">
+                           </FileRef>
+                        </Group>
+                     </Group>
+                     <FileRef
+                        location = "group:QPredGen.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:schema.graphql">
+                     </FileRef>
+                     <FileRef
+                        location = "group:CustomerOrder+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AmplifyModels.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostCommentModelRegistration.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ScenarioATest6Post.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:User+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post+Schema.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:M2MPostEditorUser"
+                        name = "M2MPostEditorUser">
+                        <FileRef
+                           location = "group:M2MPost.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:schema.graphql">
+                        </FileRef>
+                        <FileRef
+                           location = "group:M2MPostEditor+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:M2MUser.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:M2MUser+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:M2MPost+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:M2MPostEditor.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:User.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:TransformerV2"
+                        name = "TransformerV2">
+                        <FileRef
+                           location = "group:CustomerMultipleSecondaryIndexV2+Schema.swift">
+                        </FileRef>
+                        <Group
+                           location = "group:3V2"
+                           name = "3V2">
+                           <FileRef
+                              location = "group:Comment3V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post3V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post3V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment3V2+Schema.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:4bV2"
+                           name = "4bV2">
+                           <FileRef
+                              location = "group:Project4bV2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team4bV2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Project4bV2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team4bV2.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:7V2"
+                           name = "7V2">
+                           <FileRef
+                              location = "group:Post7V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post7V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Blog7V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Blog7V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment7V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment7V2.swift">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:TodoCustomTimestampV2+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:schema.graphql">
+                        </FileRef>
+                        <Group
+                           location = "group:4aV2"
+                           name = "4aV2">
+                           <FileRef
+                              location = "group:Team4aV2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Project4aV2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Project4aV2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team4aV2.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:4V2"
+                           name = "4V2">
+                           <FileRef
+                              location = "group:Post4V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post4V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment4V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment4V2+Schema.swift">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:CustomerSecondaryIndexV2.swift">
+                        </FileRef>
+                        <Group
+                           location = "group:OptionalAssociations"
+                           name = "OptionalAssociations">
+                           <FileRef
+                              location = "group:MyNestedModel8+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Blog8+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment8+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post8+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment8.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:MyCustomModel8.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:MyNestedModel8.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:MyCustomModel8+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Blog8.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post8.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:1V2"
+                           name = "1V2">
+                           <FileRef
+                              location = "group:Project1V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team1V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Project1V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team1V2.swift">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:TodoWithDefaultValueV2.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Priority.swift">
+                        </FileRef>
+                        <Group
+                           location = "group:5V2"
+                           name = "5V2">
+                           <FileRef
+                              location = "group:Post5V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post5V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:User5V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:PostEditor5V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:User5V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:PostEditor5V2+Schema.swift">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:CustomerWithMultipleFieldsinPK.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CustomerSecondaryIndexV2+Schema.swift">
+                        </FileRef>
+                        <Group
+                           location = "group:3aV2"
+                           name = "3aV2">
+                           <FileRef
+                              location = "group:Post3aV2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment3aV2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post3aV2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment3aV2+Schema.swift">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:TodoCustomTimestampV2.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CustomerMultipleSecondaryIndexV2.swift">
+                        </FileRef>
+                        <Group
+                           location = "group:SchemaDrift"
+                           name = "SchemaDrift">
+                           <FileRef
+                              location = "group:SchemaDrift.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:EnumDrift.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:SchemaDrift+Schema.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:8V2"
+                           name = "8V2">
+                           <FileRef
+                              location = "group:Meeting8V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Attendee8V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Registration8V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Meeting8V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Registration8V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Attendee8V2+Schema.swift">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:CustomerWithMultipleFieldsinPK+Schema.swift">
+                        </FileRef>
+                        <Group
+                           location = "group:2V2"
+                           name = "2V2">
+                           <FileRef
+                              location = "group:Project2V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team2V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Project2V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Team2V2+Schema.swift">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:6V2"
+                           name = "6V2">
+                           <FileRef
+                              location = "group:Post6V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Post6V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment6V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Blog6V2.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Blog6V2+Schema.swift">
+                           </FileRef>
+                           <FileRef
+                              location = "group:Comment6V2.swift">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:TodoWithDefaultValueV2+Schema.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:ScenarioATest6Post+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:QPredGen+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OGCScenarioBMGroupPost+Schema.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:NonModel"
+                        name = "NonModel">
+                        <FileRef
+                           location = "group:DynamicEmbedded.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:DynamicModel.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Section.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Category.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Todo.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Todo+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Color.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:MockModels.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UserFollowers.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostStatus.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UserFollowing+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:RecordCover.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UserFollowing.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:ReservedWords"
+                        name = "ReservedWords">
+                        <FileRef
+                           location = "group:Row+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Group.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Group+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Transaction.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Row.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Transaction+Schema.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:OGCScenarioBPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:RecordCover+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Record.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Article.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:CustomerOrder.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UserFollowers+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Article+Schema.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:Scalar"
+                        name = "Scalar">
+                        <FileRef
+                           location = "group:ListStringContainer.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ListStringContainer+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:EnumTestModel.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Scalar+Equatable.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Nested.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ScalarContainer.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:EnumTestModel+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Nested+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:TestEnum.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ScalarContainer+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:NestedTypeTestModel+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:NestedTypeTestModel.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ListIntContainer+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ListIntContainer.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:Record+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OGCScenarioBMGroupPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OGCScenarioBPost.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:Deprecated"
+                        name = "Deprecated">
+                        <FileRef
+                           location = "group:DeprecatedTodo.swift">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <FileRef
+                     location = "group:SubscriptionEndToEndTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DataStoreScalarTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DataStoreEndToEndTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DataStoreObserveQueryTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DataStoreConsecutiveUpdatesTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Base"
+                     name = "Base">
+                     <FileRef
+                        location = "group:TestConfigHelper.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <FileRef
+                  location = "group:DataStoreHostApp.xcodeproj">
+               </FileRef>
+               <Group
+                  location = "group:AWSDataStorePluginLazyLoadTests"
+                  name = "AWSDataStorePluginLazyLoadTests">
+                  <Group
+                     location = "group:LL13"
+                     name = "LL13">
+                     <FileRef
+                        location = "group:Person+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PhoneCall.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Transcript.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Person.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadPhoneCallSnapshotTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PhoneCall+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadPhoneCallTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Transcript+Schema.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL14"
+                     name = "LL14">
+                     <FileRef
+                        location = "group:Comment14.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadUserPostCommentSnapshotTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:User14.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment14+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UserSettings14+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadUserPostCommentTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostStatus.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UserSettings14.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:User14+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post14.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post14+Schema.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL15"
+                     name = "LL15">
+                     <FileRef
+                        location = "group:ListStringContainer.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ListStringContainer+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:EnumTestModel.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Nested.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ScalarContainer.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:EnumTestModel+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Nested+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TestEnum.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ScalarContainer+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:NestedTypeTestModel+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:NestedTypeTestModel.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ListIntContainer+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ListIntContainer.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL12"
+                     name = "LL12">
+                     <Group
+                        location = "group:CompositePK"
+                        name = "CompositePK">
+                        <FileRef
+                           location = "group:ChildSansBelongsTo+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ImplicitChild.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:StrangeExplicitChild.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSDataStoreLazyLoadCompositePKImplicitTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CompositePKParent+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSDataStoreLazyLoadCompositePKSnapshotTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSDataStoreLazyLoadCompositePKChildTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ChildSansBelongsTo.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSDataStoreLazyLoadCompositePKTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSDataStoreLazyLoadCompositePKChildSansTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CompositePKParent.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:StrangeExplicitChild+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSDataStoreLazyLoadCompositePKStrangeExplicitTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ImplicitChild+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CompositePKChild.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CompositePKChild+Schema.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:DefaultPK"
+                        name = "DefaultPK">
+                        <FileRef
+                           location = "group:DefaultPKParent.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:DefaultPKParent+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSDataStoreLazyLoadDefaultPKSnapshotTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:DefaultPKChild.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:DefaultPKChild+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSDataStoreLazyLoadDefaultPKTests.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:HasOneParentChild"
+                        name = "HasOneParentChild">
+                        <FileRef
+                           location = "group:HasOneChild+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:HasOneParent.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:HasOneParent+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:HasOneChild.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSDataStoreLazyLoadHasOneSnapshotTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSDataStoreLazyLoadHasOneTests.swift">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <Group
+                     location = "group:LL3"
+                     name = "LL3">
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadPostCommentWithCompositeKeySnapshotTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:CommentWithCompositeKey.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostWithCompositeKey+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:CommentWithCompositeKey+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadPostCommentWithCompositeKeyTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostWithCompositeKey.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL4"
+                     name = "LL4">
+                     <FileRef
+                        location = "group:PostTagsWithCompositeKey.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadPostTagTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostWithTagsCompositeKey+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TagWithCompositeKey.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostWithTagsCompositeKey.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadPostTagSnapshotTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TagWithCompositeKey+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostTagsWithCompositeKey+Schema.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL5"
+                     name = "LL5">
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadProjectTeam1Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team1+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadProjectTeam1SnapshotTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project1.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project1+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team1.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL2"
+                     name = "LL2">
+                     <FileRef
+                        location = "group:MyNestedModel8+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post8V2+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Blog8V2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment8V2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MyCustomModel8.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadBlogPostComment8V2Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Blog8V2+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MyNestedModel8.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MyCustomModel8+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadingBlogPostCmment8V2SnapshotTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post8V2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment8V2+Schema.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LazyLoadBase"
+                     name = "LazyLoadBase">
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadBaseTest.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TestConfigHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AmplifyModels.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:lazyload-schema.graphql">
+                     </FileRef>
+                     <FileRef
+                        location = "group:README.md">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL10"
+                     name = "LL10">
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadPostComment7SnapshotTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post7.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post7+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadPostComment7Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment7+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment7.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL11"
+                     name = "LL11">
+                     <FileRef
+                        location = "group:Comment8+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post8+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment8.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post8.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadPostComment8SnapshotTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadPostComment8Tests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL9"
+                     name = "LL9">
+                     <FileRef
+                        location = "group:Team6+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadProjectTeam6Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team6.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project6+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project6.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadProjectTeam6SnapshotTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL7"
+                     name = "LL7">
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadPostComment4SnapshotTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post4.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadPostComment4Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post4+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment4+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment4.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL1"
+                     name = "LL1">
+                     <FileRef
+                        location = "group:Post4V2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post4V2+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment4V2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadPostComment4V2SnapshotTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment4V2+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadPostComment4V2Tests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL6"
+                     name = "LL6">
+                     <FileRef
+                        location = "group:Project2+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadProjectTeam2SnapshotTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadProjectTeam2Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team2+Schema.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL8"
+                     name = "LL8">
+                     <FileRef
+                        location = "group:Project5+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadProjectTeam5Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project5.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSDataStoreLazyLoadProjectTeam5SnapshotTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team5.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team5+Schema.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AWSDataStoreLazyLoadPostComment4V2.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AWSDataStorePluginMultiAuthTests"
+                  name = "AWSDataStorePluginMultiAuthTests">
+                  <FileRef
+                     location = "group:TestConfigHelper.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSDataStoreMultiAuthSingleRuleTests+Models.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSDataStoreMultiAuthSingleRuleTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:multiauth-schema.graphql">
+                  </FileRef>
+                  <Group
+                     location = "group:Models"
+                     name = "Models">
+                     <FileRef
+                        location = "group:PrivatePublicUPAPIPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivateUPPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePublicComboAPIPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GroupUPPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePublicComboUPPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OwnerUPPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PublicIAMPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePrivatePublicUPIAMIAMPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OwnerPrivatePublicUPIAMAPIPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivateIAMPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GroupPrivatePublicUPIAMAPIPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePrivatePublicUPIAMIAMPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GroupPublicUPAPIPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GroupUPPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OwnerPrivateUPIAMPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OwnerPublicUPAPIPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GroupPrivateUPIAMPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PublicIAMPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePublicComboAPIPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GroupPublicUPIAMPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePrivatePublicUPIAMAPIPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PublicAPIPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePublicComboUPPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PublicPublicIAMAPIPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GroupPublicUPIAMPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GroupPublicUPAPIPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePublicIAMAPIPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OwnerPublicOIDAPIPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PublicAPIPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivateUPPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivateIAMPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePublicPublicUPAPIIAMPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OwnerPublicUPIAMPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePublicUPIAMPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePublicIAMAPIPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PublicPublicIAMAPIPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GroupPrivateUPIAMPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OwnerPublicUPIAMPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OwnerOIDCPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OwnerPrivatePublicUPIAMAPIPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OwnerUPPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePublicPublicUPAPIIAMPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePrivatePublicUPIAMAPIPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OwnerPrivateUPIAMPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OwnerPublicUPAPIPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GroupPrivatePublicUPIAMAPIPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OwnerPublicOIDAPIPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePublicUPAPIPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePrivateUPIAMPost.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OwnerOIDCPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePrivateUPIAMPost+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PrivatePublicUPIAMPost+Schema.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AWSDataStoreMultiAuthThreeRulesTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSDataStoreAuthBaseTest.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSDataStoreMultiAuthTwoRulesTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSDataStoreMultiAuthThreeRulesTests+Models.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSDataStoreMultiAuthCombinationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSDataStoreMultiAuthTwoRulesTests+Models.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AWSDataStorePluginFlutterTests"
+                  name = "AWSDataStorePluginFlutterTests">
+                  <Group
+                     location = "group:TestSupport"
+                     name = "TestSupport">
+                     <FileRef
+                        location = "group:SyncEngineFlutterIntegrationTestBase.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:SerializedModelWrappers"
+                        name = "SerializedModelWrappers">
+                        <FileRef
+                           location = "group:Post5Wrapper.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Comment4Wrapper.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Comment3Wrapper.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post3Wrapper.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:PostWrapper.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post4Wrapper.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Project2Wrapper.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:PostEditor5Wrapper.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:User5Wrapper.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Project1Wrapper.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:TeamWrapper.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Comment6Wrapper.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Post6Wrapper.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:Blog6Wrapper.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:TestFlutterModelRegistration.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:AmplifyFlutterHelpers"
+                        name = "AmplifyFlutterHelpers">
+                        <FileRef
+                           location = "group:FlutterSerializedModel.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:FlutterDataStoreRequestUtils.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:FlutterTemporal.swift">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <Group
+                     location = "group:Connection"
+                     name = "Connection">
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario3FlutterTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario6FlutterTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario2FlutterTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario1FlutterTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario4FlutterTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreConnectionScenario5FlutterTests.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:DataStoreFlutterEndToEndTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSDataStoreCategoryPluginFlutterIntegrationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DataStoreFlutterConsecutiveUpdatesTests.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+            <Group
+               location = "group:AWSDataStorePluginTests"
+               name = "AWSDataStorePluginTests">
+               <Group
+                  location = "group:TestSupport"
+                  name = "TestSupport">
+                  <Group
+                     location = "group:Mocks"
+                     name = "Mocks">
+                     <FileRef
+                        location = "group:NoOpInitialSyncOrchestrator.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TestModelRegistration.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:NoOpMutationQueue.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockAWSInitialSyncOrchestrator.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockRemoteSyncEngine.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockOutgoingMutationQueue.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockRequestRetryablePolicy.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockStateMachine.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockAWSIncomingEventReconciliationQueue.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockFileManager.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockReconciliationQueue.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:XCTest+AmplifyExtensions.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LocalStoreIntegrationTestBase.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:BaseDataStoreTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Foundation+TestExtensions.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SyncEngineTestBase.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Core"
+                  name = "Core">
+                  <FileRef
+                     location = "group:DataStoreListProviderFunctionalTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DataStoreListDecoderTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SQLiteStorageEngineAdapterJsonTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SQLiteStorageEngineAdapterTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DataStoreCategoryConfigurationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageAdapterMutationSyncTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:QueryPredicateTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSDataStorePluginAmplifyVersionableTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StateMachineTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ConfigurationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSDataStorePluginTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CodableDateFormatTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DataStoreListProviderTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SQLStatementTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SortByDependencyOrderTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:QuerySortDescriptorTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ListTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:QueryPaginationInputTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Models"
+                  name = "Models">
+                  <FileRef
+                     location = "group:DynamicModel.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ExampleWithEveryType.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SQLModelValueConverterTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ExampleWithEveryType+Schema.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSDataStorePluginBaseBehaviorTests.swift">
+               </FileRef>
+               <Group
+                  location = "group:Storage"
+                  name = "Storage">
+                  <FileRef
+                     location = "group:StorageEngineTestsDelete.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageEngineTestsOptionalAssociation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CascadeDeleteOperationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageEngineTestsHasOne.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageEnginePublisherTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:SQLite"
+                     name = "SQLite">
+                     <FileRef
+                        location = "group:StatementModelTests.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:StorageEngineTestsManyToMany.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageEngineTestsPostComment4V2Tests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageEngineTestsSQLiteIndex.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageEngineTestsLazyPostComment4V2Tests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageEngineTestsHasMany.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageEngineTestsBase.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Subscribe"
+                  name = "Subscribe">
+                  <FileRef
+                     location = "group:ObserveTaskRunnerTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Support"
+                     name = "Support">
+                     <FileRef
+                        location = "group:SortedListTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelSortTests.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:ObserveQueryTaskRunnerTests.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSDataStorePluginSubscribeBehaviorTests.swift">
+               </FileRef>
+               <Group
+                  location = "group:Sync"
+                  name = "Sync">
+                  <FileRef
+                     location = "group:LocalSubscriptionTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:APICategoryDependencyTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DataStoreHubTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:RemoteSyncEngineTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:SubscriptionSync"
+                     name = "SubscriptionSync">
+                     <FileRef
+                        location = "group:ReconcileAndSaveQueueTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelReconciliationDeleteTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:RemoteSyncReconcilerTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSIncomingEventReconciliationQueueTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ReconcileAndLocalSaveOperationTests.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:Support"
+                        name = "Support">
+                        <FileRef
+                           location = "group:ReconciliationQueueTestBase.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:MockSQLiteStorageEngineAdapterResponders.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:MockModelReconciliationQueue.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:EquatableExtensions.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:MockSQLiteStorageEngineAdapter.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:ModelReconciliationQueueBehaviorTests.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:LocalSubscriptionWithJSONModelTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Support"
+                     name = "Support">
+                     <FileRef
+                        location = "group:ModelCompareTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MutationEventQueryTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StopwatchTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MutationEventExtensionsTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:MutationQueue"
+                     name = "MutationQueue">
+                     <FileRef
+                        location = "group:MutationEventClearStateTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OutgoingMutationQueueTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSMutationDatabaseAdapterTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OutgoingMutationQueueTestsWithMockStateMachine.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ProcessMutationErrorFromCloudOperationTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OutgoingMutationQueueNetworkTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSMutationEventIngesterTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SyncMutationToCloudOperationTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MutationIngesterConflictResolutionTests.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:RequestRetryablePolicyTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageEngineSyncRequirementsTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:RemoteSync"
+                     name = "RemoteSync">
+                     <FileRef
+                        location = "group:RemoteSyncAPIInvocationTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:InitialSync"
+                     name = "InitialSync">
+                     <FileRef
+                        location = "group:SyncEventEmitterTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InitialSyncOperationSyncExpressionTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelSyncedEventEmitterTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ReadyEventEmitterTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InitialSyncOperationTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SyncEngineStartupTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InitialSyncOrchestratorTests.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:Migration"
+                  name = "Migration">
+                  <FileRef
+                     location = "group:MutationSyncMetadataMigrationTestBase.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MutationSyncMetadataMigrationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockMutationSyncMigrationDelegate.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SQLiteMutationSyncMetadataMigrationValidationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SQLiteMutationSyncMetadataMigrationDelegateTests.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:Info.plist">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSDataStoreLocalStoreTests.swift">
+               </FileRef>
+            </Group>
+         </Group>
+         <Group
+            location = "group:Sources"
+            name = "Sources">
+            <Group
+               location = "group:AWSDataStorePlugin"
+               name = "AWSDataStorePlugin">
+               <Group
+                  location = "group:Configuration"
+                  name = "Configuration">
+                  <FileRef
+                     location = "group:DataStoreConfiguration+Helper.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:InternalDatastoreConfiguration.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DataStoreConfiguration.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Core"
+                  name = "Core">
+                  <FileRef
+                     location = "group:DataStoreModelDecoder.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DataStoreModelProvider.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DataStoreListProvider.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DataStoreListDecoder.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:DataStoreSyncExpression.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSDataStorePlugin+DataStoreBaseBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSDataStorePlugin.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSDataStorePlugin+DataStoreSubscribeBehavior.swift">
+               </FileRef>
+               <Group
+                  location = "group:Storage"
+                  name = "Storage">
+                  <FileRef
+                     location = "group:StorageEngineBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageEngineAdapter.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CascadeDeleteOperation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageEngine+SyncRequirement.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:StorageEngine.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ModelStorageBehavior.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:SQLite"
+                     name = "SQLite">
+                     <FileRef
+                        location = "group:StorageEngineAdapter+UntypedModel.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SQLStatement.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SQLStatement+AlterTable.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SQLStatement+Insert.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelSchema+SQLite.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:QuerySortDescriptor.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageEngineMigrationAdapter+SQLite.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Model+SQLite.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SQLStatement+Select.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SQLStatement+DropTable.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Statement+AnyModel.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SQLStatement+Update.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SQLStatement+CreateTable.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SQLStatement+Delete.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelValueConverter+SQLite.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:QueryPredicate+SQLite.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:QueryPaginationInput+SQLite.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SQLStatement+CreateIndex.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StorageEngineAdapter+SQLite.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SQLStatement+Condition.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:QuerySort+SQLite.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Statement+Model.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:Subscribe"
+                  name = "Subscribe">
+                  <FileRef
+                     location = "group:DataStorePublisher.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ObserveTaskRunner.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Support"
+                     name = "Support">
+                     <FileRef
+                        location = "group:Model+Sort.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SortedList.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:DataStoreObserveQueryOperation.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSDataStorePlugin+DefaultLogger.swift">
+               </FileRef>
+               <Group
+                  location = "group:Sync"
+                  name = "Sync">
+                  <FileRef
+                     location = "group:RequestRetryable.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:RemoteSyncEngine+Retryable.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:RemoteSyncEngineBehavior.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:SubscriptionSync"
+                     name = "SubscriptionSync">
+                     <FileRef
+                        location = "group:IncomingEventReconciliationQueue.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:IncomingAsyncSubscriptionEventToAnyModelMapper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSIncomingSubscriptionEventPublisher.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:IncomingAsyncSubscriptionEventPublisher.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:IncomingSubscriptionEventPublisher.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:ReconcileAndLocalSave"
+                        name = "ReconcileAndLocalSave">
+                        <FileRef
+                           location = "group:ReconcileAndLocalSaveOperation+Action.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSModelReconciliationQueue.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ReconcileAndLocalSaveOperation+Resolver.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ReconcileAndLocalSaveOperation+State.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:RemoteSyncReconciler.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ModelReconciliationQueue.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ReconcileAndLocalSaveOperation.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ReconcileAndLocalSaveQueue.swift">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:AWSIncomingEventReconciliationQueue.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:RemoteSyncEngine+Resolver.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:RemoteSyncEngine.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:RemoteSyncEngine+IncomingEventReconciliationQueueEvent.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:MutationSync"
+                     name = "MutationSync">
+                     <Group
+                        location = "group:OutgoingMutationQueue"
+                        name = "OutgoingMutationQueue">
+                        <FileRef
+                           location = "group:OutgoingMutationQueue+State.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ProcessMutationErrorFromCloudOperation.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:MutationRetryNotifier.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:OutgoingMutationQueue+Action.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:OutgoingMutationQueue+Resolver.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SyncMutationToCloudOperation.mmd">
+                        </FileRef>
+                        <FileRef
+                           location = "group:OutgoingMutationQueue.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:SyncMutationToCloudOperation.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:AWSMutationDatabaseAdapter"
+                        name = "AWSMutationDatabaseAdapter">
+                        <FileRef
+                           location = "group:AWSMutationDatabaseAdapter+MutationEventSource.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSMutationDatabaseAdapter.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSMutationDatabaseAdapter+MutationEventIngester.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:MutationEvent"
+                        name = "MutationEvent">
+                        <FileRef
+                           location = "group:MutationEventClearState.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:MutationEventSource.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:MutationEventSubscription.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:MutationEventIngester.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:AWSMutationEventPublisher.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:MutationEventPublisher.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:MutationEventSubscriber.swift">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <Group
+                     location = "group:Support"
+                     name = "Support">
+                     <FileRef
+                        location = "group:CancelAwareBlockOperation.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:DataStoreError+Plugin.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:StateMachine.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SQLiteResultError.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Model+Compare.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Stopwatch.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MutationEvent+Query.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MutationEvent+Extensions.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:RemoteSyncEngine+State.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Events"
+                     name = "Events">
+                     <FileRef
+                        location = "group:ModelSyncedEvent.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:NetworkStatusEvent.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OutboxMutationEvent.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OutboxStatusEvent.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SyncQueriesStartedEvent.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:RequestRetryablePolicy.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:RemoteSyncEngine+Action.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:RemoteSyncEngine+AuthModeStrategyDelegate.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:InitialSync"
+                     name = "InitialSync">
+                     <FileRef
+                        location = "group:ReadyEventEmitter.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InitialSyncOperationEvent.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InitialSyncOperation.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ModelSyncedEventEmitter.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:InitialSyncOrchestrator.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:SyncEventEmitter.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:Migration"
+                  name = "Migration">
+                  <FileRef
+                     location = "group:MutationSyncMetadataMigrationDelegate+SQLiteValidation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MutationSyncMetadataMigrationDelegate+SQLite.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MutationSyncMetadataCopy.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MutationSyncMetadataMigration.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MutationSyncMetadataMigrationDelegate.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ModelMigrations.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:Info.plist">
+               </FileRef>
+            </Group>
+         </Group>
+      </Group>
+      <Group
+         location = "group:API"
+         name = "API">
+         <Group
+            location = "group:Tests"
+            name = "Tests">
+            <Group
+               location = "group:APIHostApp"
+               name = "APIHostApp">
+               <Group
+                  location = "group:AWSAPIPluginGraphQLLambdaAuthTests"
+                  name = "AWSAPIPluginGraphQLLambdaAuthTests">
+                  <FileRef
+                     location = "group:GraphQLWithLambdaAuthIntegrationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Todo.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Base"
+                     name = "Base">
+                     <FileRef
+                        location = "group:TestConfigHelper.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:APIHostApp"
+                  name = "APIHostApp">
+                  <Group
+                     location = "group:Assets.xcassets"
+                     name = "Assets.xcassets">
+                     <Group
+                        location = "group:AppIcon.appiconset"
+                        name = "AppIcon.appiconset">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:AccentColor.colorset"
+                        name = "AccentColor.colorset">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:Contents.json">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Preview Content"
+                     name = "Preview Content">
+                     <Group
+                        location = "group:Preview Assets.xcassets"
+                        name = "Preview Assets.xcassets">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <FileRef
+                     location = "group:APIHostAppApp.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SubscriptionView.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ContentView.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Info.plist">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AWSAPIPluginRESTIAMTests"
+                  name = "AWSAPIPluginRESTIAMTests">
+                  <FileRef
+                     location = "group:RESTWithIAMIntegrationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <Group
+                     location = "group:Base"
+                     name = "Base">
+                     <FileRef
+                        location = "group:TestConfigHelper.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:AWSAPIPluginLazyLoadTests"
+                  name = "AWSAPIPluginLazyLoadTests">
+                  <Group
+                     location = "group:LL14"
+                     name = "LL14">
+                     <FileRef
+                        location = "group:GraphQLLazyLoadUserPostCommentTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment14.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:User14.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment14+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UserSettings14+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostStatus.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:UserSettings14.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:User14+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post14.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post14+Schema.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL15"
+                     name = "LL15">
+                     <FileRef
+                        location = "group:ListStringContainer.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ListStringContainer+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:EnumTestModel.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Nested.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ScalarContainer.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:EnumTestModel+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Nested+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TestEnum.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ScalarContainer+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:NestedTypeTestModel+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:NestedTypeTestModel.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ListIntContainer+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ListIntContainer.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL12"
+                     name = "LL12">
+                     <Group
+                        location = "group:CompositePK"
+                        name = "CompositePK">
+                        <FileRef
+                           location = "group:ChildSansBelongsTo+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ImplicitChild.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:StrangeExplicitChild.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CompositePKParent+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ChildSansBelongsTo.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:GraphQLLazyLoadCompositePKChildTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CompositePKParent.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:StrangeExplicitChild+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:GraphQLLazyLoadCompositePKImplicitTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:GraphQLLazyLoadCompositePKChildSansTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:GraphQLLazyLoadCompositePKStrangeExplicitTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:ImplicitChild+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:GraphQLLazyLoadCompositePKTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CompositePKChild.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:CompositePKChild+Schema.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:DefaultPK"
+                        name = "DefaultPK">
+                        <FileRef
+                           location = "group:DefaultPKParent.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:DefaultPKParent+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:DefaultPKChild.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:DefaultPKChild+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:GraphQLLazyLoadDefaultPKTests.swift">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:HasOneParentChild"
+                        name = "HasOneParentChild">
+                        <FileRef
+                           location = "group:HasOneChild+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:HasOneParent.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:HasOneParent+Schema.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:GraphQLLazyLoadHasOneTests.swift">
+                        </FileRef>
+                        <FileRef
+                           location = "group:HasOneChild.swift">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <Group
+                     location = "group:LL3"
+                     name = "LL3">
+                     <FileRef
+                        location = "group:CommentWithCompositeKey.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLLazyLoadPostCommentWithCompositeKeyTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostWithCompositeKey+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:CommentWithCompositeKey+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostWithCompositeKey.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL4"
+                     name = "LL4">
+                     <FileRef
+                        location = "group:PostTagsWithCompositeKey.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLLazyLoadPostTagTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostWithTagsCompositeKey+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TagWithCompositeKey.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostWithTagsCompositeKey.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TagWithCompositeKey+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostTagsWithCompositeKey+Schema.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL5"
+                     name = "LL5">
+                     <FileRef
+                        location = "group:Team1+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project1.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project1+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team1.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLLazyLoadProjectTeam1Tests.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:TestConfigHelper.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLLazyLoadBaseTest.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:LL2"
+                     name = "LL2">
+                     <FileRef
+                        location = "group:MyNestedModel8+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post8V2+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Blog8V2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment8V2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MyCustomModel8.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Blog8V2+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MyNestedModel8.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MyCustomModel8+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLLazyLoadBlogPostComment8V2Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post8V2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment8V2+Schema.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:lazyload-schema.graphql">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <Group
+                     location = "group:LL10"
+                     name = "LL10">
+                     <FileRef
+                        location = "group:GraphQLLazyLoadPostComment7Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post7.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post7+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment7+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment7.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL11"
+                     name = "LL11">
+                     <FileRef
+                        location = "group:GraphQLLazyLoadPostComment8Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment8+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post8+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment8.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post8.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:L13"
+                     name = "L13">
+                     <FileRef
+                        location = "group:Person+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PhoneCall.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Transcript.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Person.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PhoneCall+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLLazyLoadPhoneCallTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Transcript+Schema.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL9"
+                     name = "LL9">
+                     <FileRef
+                        location = "group:Team6+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team6.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLLazyLoadProjectTeam6Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project6+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project6.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL7"
+                     name = "LL7">
+                     <FileRef
+                        location = "group:Post4.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post4+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment4+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment4.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLLazyLoadPostComment4Tests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL1"
+                     name = "LL1">
+                     <FileRef
+                        location = "group:GraphQLLazyLoadPostComment4V2Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post4V2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post4V2+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment4V2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment4V2+Schema.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL6"
+                     name = "LL6">
+                     <FileRef
+                        location = "group:GraphQLLazyLoadProjectTeam2Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project2+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team2+Schema.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:LL8"
+                     name = "LL8">
+                     <FileRef
+                        location = "group:Project5+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLLazyLoadProjectTeam5Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project5.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team5.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team5+Schema.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:AWSAPIPluginFunctionalTests"
+                  name = "AWSAPIPluginFunctionalTests">
+                  <FileRef
+                     location = "group:GraphQLScalarTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AnyModelIntegrationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLConnectionScenario5Tests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLTestBase.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLConnectionScenario1APISwiftTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLConnectionScenario2Tests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLConnectionScenario3Tests+List.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Models"
+                     name = "Models">
+                     <FileRef
+                        location = "group:PostEditor5.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:User5.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostEditor5+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ListStringContainer.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ListStringContainer+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:EnumTestModel.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project2+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Blog6.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:User5+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post6.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post4.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team1+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AmplifyModels.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post5+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post3.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Nested.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ScalarContainer.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post5.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:EnumTestModel+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post3+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post4+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment4+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment3+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Nested+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment6.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project1.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post6+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TestEnum.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ScalarContainer+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment6+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostStatus.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment4.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:NestedTypeTestModel+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Blog6+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project2.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:NestedTypeTestModel.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Project1+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ListIntContainer+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team1.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comment3.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ListIntContainer.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Team2+Schema.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLConnectionScenario4Tests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLScalarAPISwiftTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLModelBasedTests+List.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLConnectionScenario1Tests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:API.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Todo.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLConnectionScenario6Tests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:GraphQLSyncBased"
+                     name = "GraphQLSyncBased">
+                     <FileRef
+                        location = "group:GraphQLSyncBasedTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:README.md">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLSyncCustomPrimaryKeyTests.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:GraphQLConnectionScenario3Tests+Subscribe.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLModelBasedTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Info.plist">
+                  </FileRef>
+                  <Group
+                     location = "group:Base"
+                     name = "Base">
+                     <FileRef
+                        location = "group:TestConfigHelper.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:GraphQLConnectionScenario3Tests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLConnectionScenario3APISwiftTests+Subscribe.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLConnectionScenario3Tests+Helpers.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AWSAPIPluginIGraphQLAuthDirectiveTests"
+                  name = "AWSAPIPluginIGraphQLAuthDirectiveTests">
+                  <FileRef
+                     location = "group:SocialNote.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLAuthDirectiveIntegrationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <Group
+                     location = "group:Base"
+                     name = "Base">
+                     <FileRef
+                        location = "group:TestConfigHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthSignInHelper.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:AWSAPIPluginGraphQLIAMTests"
+                  name = "AWSAPIPluginGraphQLIAMTests">
+                  <FileRef
+                     location = "group:GraphQLWithIAMIntegrationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLWithIAMIntegrationAPISwiftTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:API.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Todo.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Base"
+                     name = "Base">
+                     <FileRef
+                        location = "group:TestConfigHelper.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:AWSAPIPluginGraphQLUserPoolTests"
+                  name = "AWSAPIPluginGraphQLUserPoolTests">
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLWithUserPoolIntegrationAPISwiftTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:API.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Todo.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLWithUserPoolIntegrationTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Base"
+                     name = "Base">
+                     <FileRef
+                        location = "group:TestConfigHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AsyncExpectation.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:GraphQLAPIStressTests"
+                  name = "GraphQLAPIStressTests">
+                  <Group
+                     location = "group:Models"
+                     name = "Models">
+                     <FileRef
+                        location = "group:AmplifyModels.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post+Schema.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PostStatus.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Post.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLAPIStressTests.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:APIHostApp.xcodeproj">
+               </FileRef>
+               <Group
+                  location = "group:AWSAPIPluginRESTUserPoolTests"
+                  name = "AWSAPIPluginRESTUserPoolTests">
+                  <FileRef
+                     location = "group:RESTWithUserPoolIntegrationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <Group
+                     location = "group:Base"
+                     name = "Base">
+                     <FileRef
+                        location = "group:TestConfigHelper.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+            </Group>
+            <Group
+               location = "group:AWSAPIPluginTestCommon"
+               name = "AWSAPIPluginTestCommon">
+               <Group
+                  location = "group:Model"
+                  name = "Model">
+                  <FileRef
+                     location = "group:Todo.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:Info.plist">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:AWSAPIPluginTests"
+               name = "AWSAPIPluginTests">
+               <Group
+                  location = "group:Mocks"
+                  name = "Mocks">
+                  <FileRef
+                     location = "group:MockSubscription.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockSessionFactory.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockURLSessionTask.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockURLSession.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockReachability.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Operation"
+                  name = "Operation">
+                  <FileRef
+                     location = "group:AWSGraphQLOperationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSGraphQLSubscriptionTaskRunnerCancelTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSRESTOperationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLQueryCombineTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLMutateCombineTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSGraphQLSubscriptionOperationCancelTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:RESTCombineTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLSubscribeTaskTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLSubscribeTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLSubscribeCombineTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:OperationTestBase.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSHTTPURLResponseTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Configuration"
+                  name = "Configuration">
+                  <FileRef
+                     location = "group:AWSAPICategoryPluginConfigurationEndpointConfigTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAPICategoryPluginConfigurationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAPIEndpointInterceptorsTests.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSAPICategoryPlugin+InterceptorBehaviorTests.swift">
+               </FileRef>
+               <Group
+                  location = "group:Core"
+                  name = "Core">
+                  <FileRef
+                     location = "group:AppSyncListPayloadTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AppSyncListResponseTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AppSyncListDecoderTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AppSyncListProviderTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AppSyncModelMetadataTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AppSyncListProviderPaginationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ListTests.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSAPICategoryPlugin+RESTClientBehaviorTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:APIError+UnauthorizedTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAPICategoryPluginAmplifyVersionableTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAPICategoryPluginTestBase.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAPICategoryPlugin+GraphQLBehaviorTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAPICategoryPlugin+AuthInformationTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAPICategoryPlugin+ReachabilityTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAPICategoryPlugin+ResetTests.swift">
+               </FileRef>
+               <Group
+                  location = "group:Support"
+                  name = "Support">
+                  <Group
+                     location = "group:Internal"
+                     name = "Internal">
+                     <FileRef
+                        location = "group:AWSAppSyncGrpahQLResponseTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Utils"
+                     name = "Utils">
+                     <FileRef
+                        location = "group:Result+AsyncTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLRequestUtils+ValidatorTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:RESTRequestUtilsTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLRequestToListQueryTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLRequestUtilsTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:XCTestExpectation+ShouldTrigger.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:RESTRequestUtils+ValidatorTests.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Decode"
+                     name = "Decode">
+                     <FileRef
+                        location = "group:GraphQLResponseDecoder+DecodeDataTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLResponseDecoderTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLErrorDecoderTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLResponseDecoderLazyPostComment4V2Tests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLResponseDecoderPostComment4V2Tests.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:Reachability"
+                  name = "Reachability">
+                  <FileRef
+                     location = "group:NetworkReachabilityNotifierTests.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSAPICategoryPlugin+URLSessionBehaviorDelegateTests.swift">
+               </FileRef>
+               <Group
+                  location = "group:Request"
+                  name = "Request">
+                  <FileRef
+                     location = "group:RESTOperationRequestValidateTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLOperationRequestValidateTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GraphQLOperationRequestUtilsTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:APISwiftCompatibility"
+                  name = "APISwiftCompatibility">
+                  <FileRef
+                     location = "group:APISwiftTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:API.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Interceptor"
+                  name = "Interceptor">
+                  <FileRef
+                     location = "group:APIKeyURLRequestInterceptorTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:IAMURLRequestInterceptorTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AuthTokenURLRequestInterceptorTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:SubscriptionInterceptor"
+                     name = "SubscriptionInterceptor">
+                     <FileRef
+                        location = "group:AuthenticationTokenAuthInterceptorTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:IAMAuthInterceptorTests.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <FileRef
+                  location = "group:Info.plist">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAPICategoryPlugin+ConfigureTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAPICategoryPlugin+URLSessionDelegateTests.swift">
+               </FileRef>
+            </Group>
+         </Group>
+         <Group
+            location = "group:Sources"
+            name = "Sources">
+            <Group
+               location = "group:AWSAPIPlugin"
+               name = "AWSAPIPlugin">
+               <FileRef
+                  location = "group:AWSAPIPlugin+Log.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAPIPlugin+URLSessionDelegate.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAPIPlugin+Configure.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAPIPlugin+Resettable.swift">
+               </FileRef>
+               <Group
+                  location = "group:Operation"
+                  name = "Operation">
+                  <FileRef
+                     location = "group:AWSGraphQLOperation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSRESTOperation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAPIOperation+APIOperation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSGraphQLOperation+APIOperation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:APIOperation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSGraphQLSubscriptionTaskRunner.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSHTTPURLResponse.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:APIOperationResponse.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Configuration"
+                  name = "Configuration">
+                  <FileRef
+                     location = "group:AWSAPICategoryPluginEndpointType.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAPIEndpointInterceptors.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAPICategoryPluginConfiguration.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSAPICategoryPluginConfiguration+EndpointConfig.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSAPIPlugin+GraphQLBehavior.swift">
+               </FileRef>
+               <Group
+                  location = "group:Core"
+                  name = "Core">
+                  <FileRef
+                     location = "group:AppSyncModelDecoder.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AppSyncModelProvider.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AppSyncListDecoder.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AppSyncListProvider.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AppSyncModelMetadata.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AppSyncListPayload.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AppSyncListResponse.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSAPIPlugin+Reachability.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAPIPlugin+AuthInformation.swift">
+               </FileRef>
+               <Group
+                  location = "group:SubscriptionFactory"
+                  name = "SubscriptionFactory">
+                  <FileRef
+                     location = "group:SubscriptionConnectionFactory.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSSubscriptionConnectionFactory.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSOIDCAuthProvider.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:APIError+Unauthorized.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAPIPlugin+RESTBehavior.swift">
+               </FileRef>
+               <Group
+                  location = "group:URLSessionBehavior"
+                  name = "URLSessionBehavior">
+                  <FileRef
+                     location = "group:URLSessionFactory.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:URLSession+URLSessionBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:URLSessionDataTaskBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:URLSessionBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:URLSessionTask+URLSessionTaskBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:OperationTaskMapper.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:URLSessionBehaviorDelegate.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSAPIPlugin+InterceptorBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAPIPlugin.swift">
+               </FileRef>
+               <Group
+                  location = "group:Support"
+                  name = "Support">
+                  <Group
+                     location = "group:Constants"
+                     name = "Constants">
+                     <FileRef
+                        location = "group:URLRequestConstants.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Internal"
+                     name = "Internal">
+                     <FileRef
+                        location = "group:AWSAppSyncGraphQLResponse.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Utils"
+                     name = "Utils">
+                     <FileRef
+                        location = "group:RESTOperationRequestUtils.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AppSyncJSONValue+toJSONValue.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:APIError+DecodingError.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:RESTOperationRequest+RESTRequest.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLOperationRequestUtils.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLOperationRequestUtils+Validator.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLOperationRequest+Validate.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLRequest+toListQuery.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:RESTOperationRequest+Validate.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:RESTOperationRequestUtils+Validator.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLRequest+toOperationRequest.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Result+Async.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AnyModel+JSONInit.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Decode"
+                     name = "Decode">
+                     <FileRef
+                        location = "group:GraphQLResponseDecoder+DecodeData.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLResponseDecoder.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:GraphQLErrorDecoder.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <FileRef
+                  location = "group:AWSAPIPlugin+URLSessionBehaviorDelegate.swift">
+               </FileRef>
+               <Group
+                  location = "group:Reachability"
+                  name = "Reachability">
+                  <FileRef
+                     location = "group:AmplifyReachability.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AmplifyRechability+watchOS.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:NetworkReachabilityNotifier.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:NetworkReachability.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSAPIPlugin+APIAuthProviderFactoryBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSAPIPlugin.md">
+               </FileRef>
+               <Group
+                  location = "group:Interceptor"
+                  name = "Interceptor">
+                  <Group
+                     location = "group:RequestInterceptor"
+                     name = "RequestInterceptor">
+                     <FileRef
+                        location = "group:APIKeyURLRequestInterceptor.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthTokenProviderWrapper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:IAMURLRequestInterceptor.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthTokenURLRequestInterceptor.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AWSAPICategoryPluginError.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:SubscriptionInterceptor"
+                     name = "SubscriptionInterceptor">
+                     <FileRef
+                        location = "group:IAMAuthInterceptor.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:OIDCAuthProviderWrapper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AuthenticationTokenAuthInterceptor.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <FileRef
+                  location = "group:Info.plist">
+               </FileRef>
+            </Group>
+         </Group>
+      </Group>
+      <Group
+         location = "group:Logging"
+         name = "Logging">
+         <Group
+            location = "group:Tests"
+            name = "Tests">
+            <Group
+               location = "group:AWSCloudWatchLoggingPluginTests"
+               name = "AWSCloudWatchLoggingPluginTests">
+               <FileRef
+                  location = "group:LoggingConstraintsLocalStoreTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSCloudWatchLoggingSessionControllerTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:LogEntryTestExtensions.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:BroadcastLoggerTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSCloudWatchLoggingPluginConfigurationTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:MockLogger.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:DefaultRemoteConfigurationTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:MockCloudWatchLogsClient.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSCloudWatchLoggingPluginTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSCloudWatchLoggingMonitorTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSCloudWatchingLoggingFilterTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:CloudWatchLogConsumerTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:RotatingLogBatchTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:LoggingNetworkMonitorTests.swift">
+               </FileRef>
+               <Group
+                  location = "group:TestResources"
+                  name = "TestResources">
+                  <FileRef
+                     location = "group:remoteloggingconstraints.json">
+                  </FileRef>
+                  <FileRef
+                     location = "group:amplifyconfiguration_logging.json">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:LogRotationTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:RotatingLoggerTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:LogActorTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:LogFileTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:LogEntryTests.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:AWSCloudWatchLoggingPluginHostApp"
+               name = "AWSCloudWatchLoggingPluginHostApp">
+               <FileRef
+                  location = "group:CloudWatchLoggingHostApp.xcodeproj">
+               </FileRef>
+               <Group
+                  location = "group:CloudWatchLoggingHostApp"
+                  name = "CloudWatchLoggingHostApp">
+                  <FileRef
+                     location = "group:CloudWatchLoggingApp.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Assets.xcassets"
+                     name = "Assets.xcassets">
+                     <Group
+                        location = "group:AppIcon.appiconset"
+                        name = "AppIcon.appiconset">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:AccentColor.colorset"
+                        name = "AccentColor.colorset">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:Contents.json">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Preview Content"
+                     name = "Preview Content">
+                     <Group
+                        location = "group:Preview Assets.xcassets"
+                        name = "Preview Assets.xcassets">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <FileRef
+                     location = "group:ContentView.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AWSCloudWatchLoggingPluginIntegrationTests"
+                  name = "AWSCloudWatchLoggingPluginIntegrationTests">
+                  <FileRef
+                     location = "group:TestConfigHelper.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSCloudWatchLoggingPluginIntegrationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSCloudWatchClientHelper.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+               </Group>
+            </Group>
+         </Group>
+         <Group
+            location = "group:Sources"
+            name = "Sources">
+            <Group
+               location = "group:AWSCloudWatchLoggingPlugin"
+               name = "AWSCloudWatchLoggingPlugin">
+               <Group
+                  location = "group:Configuration"
+                  name = "Configuration">
+                  <FileRef
+                     location = "group:LoggingConstraints.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSCloudWatchLoggingPluginConfiguration.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:RemoteLoggingConstraintsProviderBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:UserLogLevel.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DefaultRemoteConfiguration.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DefaultRemoteLoggingConstraintsProvider.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AmplifyConfigurationLogging.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Producer"
+                  name = "Producer">
+                  <FileRef
+                     location = "group:RotatingLogBatch.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:RotatingLogger.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSCloudWatchLoggingSessionController.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSCloudWatchLoggingError.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSCloudWatchLoggingPlugin.swift">
+               </FileRef>
+               <Group
+                  location = "group:Support"
+                  name = "Support">
+                  <Group
+                     location = "group:Constants"
+                     name = "Constants">
+                     <FileRef
+                        location = "group:AWSCloudWatchConstants.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PluginConstants.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PluginErrorConstants.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AWSCloudWatchLoggingMonitor.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSCloudWatchLoggingConstraintsResolver.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LoggingConstraintsLocalStore.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSCloudWatchLoggingFilterBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSCloudWatchLoggingFilter.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LoggingNetworkMonitor.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Persistence"
+                  name = "Persistence">
+                  <FileRef
+                     location = "group:LogFile.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LogActor.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LogEntryCodec.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LogRotation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LogEntry.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSCloudWatchLoggingCategoryClient.swift">
+               </FileRef>
+               <Group
+                  location = "group:Consumer"
+                  name = "Consumer">
+                  <FileRef
+                     location = "group:CloudWatchLoggingStreamNameFormatter.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CloudWatchLoggingConsumer.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CloudWatchLoggingEntryFormatter.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Domain"
+                  name = "Domain">
+                  <FileRef
+                     location = "group:LogBatchConsumer.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LogBatchProducer.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LogBatch.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LoggerKey.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSCloudWatchLoggingSession.swift">
+               </FileRef>
+            </Group>
+         </Group>
+      </Group>
+      <Group
+         location = "group:Notifications"
+         name = "Notifications">
+         <Group
+            location = "group:Push"
+            name = "Push">
+            <Group
+               location = "group:Tests"
+               name = "Tests">
+               <Group
+                  location = "group:PushNotificationHostApp"
+                  name = "PushNotificationHostApp">
+                  <FileRef
+                     location = "group:PushNotificationsWatchApp-Info.plist">
+                  </FileRef>
+                  <Group
+                     location = "group:PushNotificationHostApp"
+                     name = "PushNotificationHostApp">
+                     <FileRef
+                        location = "group:PushNotificationHostAppApp.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:TestConfigHelper.swift">
+                     </FileRef>
+                     <Group
+                        location = "group:Assets.xcassets"
+                        name = "Assets.xcassets">
+                        <Group
+                           location = "group:AppIcon.appiconset"
+                           name = "AppIcon.appiconset">
+                           <FileRef
+                              location = "group:Contents.json">
+                           </FileRef>
+                        </Group>
+                        <Group
+                           location = "group:AccentColor.colorset"
+                           name = "AccentColor.colorset">
+                           <FileRef
+                              location = "group:Contents.json">
+                           </FileRef>
+                        </Group>
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:Preview Content"
+                        name = "Preview Content">
+                        <Group
+                           location = "group:Preview Assets.xcassets"
+                           name = "Preview Assets.xcassets">
+                           <FileRef
+                              location = "group:Contents.json">
+                           </FileRef>
+                        </Group>
+                     </Group>
+                     <FileRef
+                        location = "group:PushNotificationHostApp.entitlements">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ContentView.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Info.plist">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:PushNotificationHostApp.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PushNotificationWatchTests.xctestplan">
+                  </FileRef>
+                  <Group
+                     location = "group:LocalServer"
+                     name = "LocalServer">
+                     <FileRef
+                        location = "group:package-lock.json">
+                     </FileRef>
+                     <FileRef
+                        location = "group:package.json">
+                     </FileRef>
+                     <FileRef
+                        location = "group:index.mjs">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:PushNotificationHostAppUITests"
+                     name = "PushNotificationHostAppUITests">
+                     <FileRef
+                        location = "group:LocalServer.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:README.md">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Notification.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PushNotificationHostAppUITests.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:PushNotificationsWatchApp.entitlements">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AWSPinpointPushNotificationsPluginUnitTests"
+                  name = "AWSPinpointPushNotificationsPluginUnitTests">
+                  <Group
+                     location = "group:Mocks"
+                     name = "Mocks">
+                     <FileRef
+                        location = "group:MockAWSPinpoint.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockRemoteNotifications.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AWSPinpointPushNotificationsPluginClientBehaviourTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPinpointPushNotificationsPluginConfigureTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPinpointPushNotificationsPluginResetTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPinpointPushNotificationsPluginTestBase.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPinpointPushNotificationsPluginAmplifyVersionableTests.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+            <Group
+               location = "group:Sources"
+               name = "Sources">
+               <Group
+                  location = "group:AWSPinpointPushNotificationsPlugin"
+                  name = "AWSPinpointPushNotificationsPlugin">
+                  <FileRef
+                     location = "group:AWSPinpointPushNotificationsPlugin.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Models"
+                     name = "Models">
+                     <FileRef
+                        location = "group:PushNotification.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PinpointUserProfile.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:ApplicationState.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AWSPinpointPushNotificationsPlugin+Types.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Extensions"
+                     name = "Extensions">
+                     <FileRef
+                        location = "group:Error+PushNotifications.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:HubCategory+PushNotifications.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PushNotificationUserInfo+Pinpoint.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Support"
+                     name = "Support">
+                     <Group
+                        location = "group:Constants"
+                        name = "Constants">
+                        <FileRef
+                           location = "group:PushNotificationsPluginErrorConstants.swift">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <FileRef
+                     location = "group:AWSPinpointPushNotificationsPlugin+Configure.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPinpointPushNotificationsPlugin+DefaultLogger.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Error"
+                     name = "Error">
+                     <FileRef
+                        location = "group:Pinpoint+PushNotificationsErrorConvertible.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:CommonRunTimeError+PushNotificationsErrorConvertible.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PushNotificationsErrorConvertible.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AWSPinpointPushNotificationsPlugin+ClientBehaviour.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPinpointPushNotificationsPlugin+Reset.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+         </Group>
+      </Group>
+      <Group
+         location = "group:Predictions"
+         name = "Predictions">
+         <Group
+            location = "group:AWSPredictionsPlugin"
+            name = "AWSPredictionsPlugin">
+            <Group
+               location = "group:Configuration"
+               name = "Configuration">
+               <FileRef
+                  location = "group:InterpretConfiguration.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:ConvertConfiguration.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:PredictionsPluginConfiguration.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:IdentifyConfiguration.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Signing"
+               name = "Signing">
+               <FileRef
+                  location = "group:SigV4Signer+Credential.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:HexDigest.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SigV4Signer+HTTPMethod.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SigV4Signer+HashedEmptyBody.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SigV4Signer+PercentEncoding.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SigV4Signer.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SigV4Signer+PayloadSigning.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:URL+Signing.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:SigV4Signer+RequestBody.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:AWSPredictionsPlugin.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AWSPredictionsPlugin+Convert.swift">
+            </FileRef>
+            <Group
+               location = "group:Liveness"
+               name = "Liveness">
+               <Group
+                  location = "group:ServiceModel"
+                  name = "ServiceModel">
+                  <FileRef
+                     location = "group:FreshnessColor.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:OvalParameters.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:DisconnectEvent.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:BoundingBox.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ServerChallenge.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ColorSequence.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FaceMovementAndLightClientChallenge.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ColorDisplayed.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ClientSessionInformationEvent.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:VideoEvent.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:TargetFace.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:InitialFace.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ServerSessionInformationEvent.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ChallengeConfig.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FaceMovementAndLightServerChallenge.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SessionInformation.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ClientChallenge.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:SPI"
+                  name = "SPI">
+                  <FileRef
+                     location = "group:LivenessCredentials.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPredictionsPlugin+Liveness.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LivenessStreamingURL.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Model"
+                  name = "Model">
+                  <FileRef
+                     location = "group:DTOMapping.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FaceLivenessSession+BoundingBox.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FaceLivenessSession+SessionConfiguration.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FaceLivenessSession+OvalMatchChallenge.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FaceLivenessSession+ColorChallenge.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Service"
+                  name = "Service">
+                  <FileRef
+                     location = "group:FaceLivenessSessionRepresentable.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ServerDisconnection.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FaceLivenessSession.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:WebSocketSession.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Events"
+                  name = "Events">
+                  <FileRef
+                     location = "group:LivenessFaceDetectionEvent.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Date+EpochMillis.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LivenessVideoEvent.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LivenessEvent.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LivenessFreshnessEvent.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LivenessCompletedEvent.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LivenessFinalCientEvent.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LivenessInitialClientEvent.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+            <FileRef
+               location = "group:AWSPredictionsPlugin+Reset.swift">
+            </FileRef>
+            <Group
+               location = "group:Dependency"
+               name = "Dependency">
+               <FileRef
+                  location = "group:AWSTranscribeStreamingBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSTranscribeStreamingAdapter.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Streaming"
+               name = "Streaming">
+               <FileRef
+                  location = "group:EventStream+Decoder.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:EventStream+Header.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:EventStream.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:EventStream+Encoder+HeaderValue.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:EventStream+Encoder.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:Data+Bytes.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:EventStream+Message.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Support"
+               name = "Support">
+               <FileRef
+                  location = "group:Voice+AWSExtension.swift">
+               </FileRef>
+               <Group
+                  location = "group:Internal"
+                  name = "Internal">
+                  <FileRef
+                     location = "group:AWSComprehendEntityTypeExtension.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:LanguageTypeExtension.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:ErrorHandling"
+                     name = "ErrorHandling">
+                     <FileRef
+                        location = "group:Polly+PredictionsErrorConvertible.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PluginErrorMessage.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Rekognition+PredictionsErrorConvertible.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Translate+PredictionsErrorConvertible.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PredictionsError+Service.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Comprehend+PredictionsErrorConvertible.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:Textract+PredictionsErrorConvertible.swift">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:AWSComprehendSentimentTypeExtension.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FormatType+AWSExtension.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSComprehendPartOfSpeechTagTypeExtension.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FetchDominantLanguageEvent.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Utils"
+                  name = "Utils">
+                  <FileRef
+                     location = "group:IdentifyTextResultTransformers+Tables.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:IdentifyTextResultTransformers.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:IdentifyCelebritiesResultTransformers.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:IdentifyLabelsResultTransformers.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:IdentifyResultTransformers.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:IdentifyTextResultTransformers+KeyValueSet.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:IdentifyEntitiesResultTransformers.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:PredictionsAWSServices.swift">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:AWSPredictionsPlugin+Identify.swift">
+            </FileRef>
+            <FileRef
+               location = "group:AWSPredictionsPlugin+Interpret.swift">
+            </FileRef>
+            <Group
+               location = "group:Service"
+               name = "Service">
+               <Group
+                  location = "group:MultiService"
+                  name = "MultiService">
+                  <FileRef
+                     location = "group:IdentifyMultiService.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:InterpretTextMultiService.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MultiServiceBehavior.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:CoreML"
+                  name = "CoreML">
+                  <FileRef
+                     location = "group:CoreMLPredictionBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CoreMLPredictionService.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Predictions"
+                  name = "Predictions">
+                  <FileRef
+                     location = "group:AWSTranslateServiceBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSComprehendServiceBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPollyServiceBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPredictionsService+Transcribe.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPredictionsService.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSTextractServiceBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPredictionsService+Comprehend.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSRekognitionServiceBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPredictionsService+Textract.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPredictionsService+Rekognition.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPredictionsService+Polly.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPredictionsService+Translate.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSTranscribeStreamingServiceBehavior.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPredictionsService+Resettable.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+            <FileRef
+               location = "group:AWSPredictionsPlugin+Configure.swift">
+            </FileRef>
+         </Group>
+         <Group
+            location = "group:Tests"
+            name = "Tests">
+            <Group
+               location = "group:AWSPredictionsPluginUnitTests"
+               name = "AWSPredictionsPluginUnitTests">
+               <Group
+                  location = "group:Mocks"
+                  name = "Mocks">
+                  <Group
+                     location = "group:Service"
+                     name = "Service">
+                     <FileRef
+                        location = "group:MockRekognitionBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockTextractBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockPollyBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockComprehendBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockTranscribeStreamingBehavior.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:MockTranslateBehavior.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <Group
+                  location = "group:EventStreamCodingTests"
+                  name = "EventStreamCodingTests">
+                  <FileRef
+                     location = "group:EventStreamCoderTestCase.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:ConfigurationTests"
+                  name = "ConfigurationTests">
+                  <FileRef
+                     location = "group:PredictionsPluginConfigurationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPredictionsPluginAmplifyVersionableTests.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:SigV4SignerTests"
+                  name = "SigV4SignerTests">
+                  <FileRef
+                     location = "group:SigV4URLSigningTestCase.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:PredictionsPluginInit.swift">
+               </FileRef>
+               <Group
+                  location = "group:ErrorMapping"
+                  name = "ErrorMapping">
+                  <FileRef
+                     location = "group:PollyErrorMappingTestCase.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:TextractErrorMappingTestCase.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:TestResources"
+                  name = "TestResources">
+                  <Group
+                     location = "group:TestImages"
+                     name = "TestImages">
+                     <FileRef
+                        location = "group:testImageText.jpg">
+                     </FileRef>
+                     <FileRef
+                        location = "group:testImageLabels.jpg">
+                     </FileRef>
+                     <FileRef
+                        location = "group:testImageEntities.jpg">
+                     </FileRef>
+                     <FileRef
+                        location = "group:testImageCeleb.jpg">
+                     </FileRef>
+                     <FileRef
+                        location = "group:audio.wav">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Info.plist">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Signing+EncodingTests"
+                  name = "Signing+EncodingTests">
+                  <FileRef
+                     location = "group:Signing+EncodingTestCase.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Service"
+                  name = "Service">
+                  <Group
+                     location = "group:PredictionsTest"
+                     name = "PredictionsTest">
+                     <FileRef
+                        location = "group:PredictionsServiceRekognitionTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PredictionsServiceComprehendTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PredictionsServiceTranscribeTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PredictionsServiceTextractTests.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PredictionsServiceTranslateTests.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+            </Group>
+            <Group
+               location = "group:CoreMLPredictionsPluginUnitTests"
+               name = "CoreMLPredictionsPluginUnitTests">
+               <Group
+                  location = "group:Mocks"
+                  name = "Mocks">
+                  <FileRef
+                     location = "group:MockCoreMLSpeechAdapter.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockOperationQueue.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockCoreMLVisionAdapter.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockCoreMLNaturalLanguageAdapter.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:README.md">
+               </FileRef>
+               <FileRef
+                  location = "group:CoreMLPredictionsPluginConfigTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:CoreMLPredictionsPluginAmplifyVersionableTests.swift">
+               </FileRef>
+               <Group
+                  location = "group:TestResources"
+                  name = "TestResources">
+                  <Group
+                     location = "group:TestImages"
+                     name = "TestImages">
+                     <FileRef
+                        location = "group:vehicles.jpg">
+                     </FileRef>
+                     <FileRef
+                        location = "group:screenshotWithText.png">
+                     </FileRef>
+                     <FileRef
+                        location = "group:people.jpg">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:audio.wav">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Info.plist">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:DependencyTests"
+                  name = "DependencyTests">
+                  <FileRef
+                     location = "group:CoreMLNaturalLanguageAdapterTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CoreMLVisionAdapterTests.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:CoreMLPredictionsPluginClientBehaviorTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:CoreMLPredictionsPluginTestBase.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:PredictionsHostApp"
+               name = "PredictionsHostApp">
+               <Group
+                  location = "group:CoreMLPredictionsPluginIntegrationTests"
+                  name = "CoreMLPredictionsPluginIntegrationTests">
+                  <Group
+                     location = "group:Resources"
+                     name = "Resources">
+                     <FileRef
+                        location = "group:audio.wav">
+                     </FileRef>
+                     <FileRef
+                        location = "group:people.jpg">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:CoreMLPredictionsPluginIntegrationTest.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:CoreMLPredictionsPluginTestBase.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AWSPredictionsPluginIntegrationTests"
+                  name = "AWSPredictionsPluginIntegrationTests">
+                  <FileRef
+                     location = "group:ConvertBasicIntegrationTests.swift">
+                  </FileRef>
+                  <Group
+                     location = "group:Resources"
+                     name = "Resources">
+                     <Group
+                        location = "group:TestImages"
+                        name = "TestImages">
+                        <FileRef
+                           location = "group:testImageText.jpg">
+                        </FileRef>
+                        <FileRef
+                           location = "group:testImageLabels.jpg">
+                        </FileRef>
+                        <FileRef
+                           location = "group:testImageTextWithTables.jpg">
+                        </FileRef>
+                        <FileRef
+                           location = "group:testImageTextAll.jpg">
+                        </FileRef>
+                        <FileRef
+                           location = "group:testImageEntities.jpg">
+                        </FileRef>
+                        <FileRef
+                           location = "group:testImageCeleb.jpg">
+                        </FileRef>
+                        <FileRef
+                           location = "group:testImageTextForms.jpg">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:audio.wav">
+                     </FileRef>
+                  </Group>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPredictionsPluginTestBase.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:InterpretBasicIntegrationTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:IdentifyBasicIntegrationTests.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:PredictionsHostApp.xcodeproj">
+               </FileRef>
+               <Group
+                  location = "group:PredictionsHostApp"
+                  name = "PredictionsHostApp">
+                  <Group
+                     location = "group:Assets.xcassets"
+                     name = "Assets.xcassets">
+                     <Group
+                        location = "group:AppIcon.appiconset"
+                        name = "AppIcon.appiconset">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                     <Group
+                        location = "group:AccentColor.colorset"
+                        name = "AccentColor.colorset">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                     <FileRef
+                        location = "group:Contents.json">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Preview Content"
+                     name = "Preview Content">
+                     <Group
+                        location = "group:Preview Assets.xcassets"
+                        name = "Preview Assets.xcassets">
+                        <FileRef
+                           location = "group:Contents.json">
+                        </FileRef>
+                     </Group>
+                  </Group>
+                  <FileRef
+                     location = "group:PredictionsHostAppApp.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:PredictionsHostApp.entitlements">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ContentView.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+         </Group>
+         <Group
+            location = "group:CoreMLPredictionsPlugin"
+            name = "CoreMLPredictionsPlugin">
+            <FileRef
+               location = "group:CoreMLPredictionsPlugin+Configure.swift">
+            </FileRef>
+            <Group
+               location = "group:Resources"
+               name = "Resources">
+               <FileRef
+                  location = "group:Info.plist">
+               </FileRef>
+            </Group>
+            <FileRef
+               location = "group:CoreMLPredictionsPlugin+ClientBehavior.swift">
+            </FileRef>
+            <Group
+               location = "group:Dependency"
+               name = "Dependency">
+               <FileRef
+                  location = "group:CoreMLVisionBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:CoreMLNaturalLanguageBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:CoreMLNaturalLanguageAdapter.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:CoreMLSpeechAdapter.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:CoreMLVisionAdapter.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:CoreMLSpeechBehavior.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:Support"
+               name = "Support">
+               <Group
+                  location = "group:Constants"
+                  name = "Constants">
+                  <FileRef
+                     location = "group:CoreMLPluginErrorString.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+            <FileRef
+               location = "group:CoreMLPredictionsPlugin+Reset.swift">
+            </FileRef>
+            <FileRef
+               location = "group:CoreMLPredictionsPlugin.swift">
+            </FileRef>
+         </Group>
+      </Group>
+      <Group
+         location = "group:Analytics"
+         name = "Analytics">
+         <Group
+            location = "group:Tests"
+            name = "Tests">
+            <Group
+               location = "group:AWSPinpointAnalyticsPluginUnitTests"
+               name = "AWSPinpointAnalyticsPluginUnitTests">
+               <Group
+                  location = "group:Mocks"
+                  name = "Mocks">
+                  <FileRef
+                     location = "group:MockAWSPinpoint+Targeting.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockAWSPinpoint.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockAWSPinpoint+Analytics.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:MockNetworkMonitor.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:Configuration"
+                  name = "Configuration">
+                  <FileRef
+                     location = "group:AWSPinpointAnalyticsPluginConfigurationTests.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSPinpointAnalyticsPluginConfigureTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSPinpointAnalyticsPluginResetTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSPinpointAnalyticsPluginAmplifyVersionableTests.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSPinpointAnalyticsPluginTestBase.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSPinpointAnalyticsPluginClientBehaviorTests.swift">
+               </FileRef>
+            </Group>
+            <Group
+               location = "group:AnalyticsHostApp"
+               name = "AnalyticsHostApp">
+               <FileRef
+                  location = "group:AnalyticsHostApp.xcodeproj">
+               </FileRef>
+               <Group
+                  location = "group:AnalyticsHostApp"
+                  name = "AnalyticsHostApp">
+                  <FileRef
+                     location = "group:AnalyticsHostAppApp.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ContentView.swift">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AnalyticsStressTests"
+                  name = "AnalyticsStressTests">
+                  <FileRef
+                     location = "group:AnalyticsStressTests.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+               </Group>
+               <Group
+                  location = "group:AWSPinpointAnalyticsPluginIntegrationTests"
+                  name = "AWSPinpointAnalyticsPluginIntegrationTests">
+                  <FileRef
+                     location = "group:TestConfigHelper.swift">
+                  </FileRef>
+                  <FileRef
+                     location = "group:README.md">
+                  </FileRef>
+                  <FileRef
+                     location = "group:AWSPinpointAnalyticsPluginIntegrationTests.swift">
+                  </FileRef>
+               </Group>
+            </Group>
+         </Group>
+         <Group
+            location = "group:Sources"
+            name = "Sources">
+            <Group
+               location = "group:AWSPinpointAnalyticsPlugin"
+               name = "AWSPinpointAnalyticsPlugin">
+               <FileRef
+                  location = "group:AWSPinpointAnalyticsPlugin+Reset.swift">
+               </FileRef>
+               <Group
+                  location = "group:Configuration"
+                  name = "Configuration">
+                  <FileRef
+                     location = "group:AWSPinpointAnalyticsPluginConfiguration.swift">
+                  </FileRef>
+               </Group>
+               <FileRef
+                  location = "group:AWSPinpointAnalyticsPlugin+ClientBehavior.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSPinpointAnalyticsPlugin.swift">
+               </FileRef>
+               <Group
+                  location = "group:Support"
+                  name = "Support">
+                  <Group
+                     location = "group:Constants"
+                     name = "Constants">
+                     <FileRef
+                        location = "group:AnalyticsErrorConstants.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Utils"
+                     name = "Utils">
+                     <FileRef
+                        location = "group:AnalyticsErrorConvertible.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:CommonRunTimeError+AnalyticsErrorConvertible.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AnalyticsErrorHelper.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:NetworkMonitor.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:AWSPinpoint+AnalyticsErrorConvertible.swift">
+                     </FileRef>
+                  </Group>
+                  <Group
+                     location = "group:Extensions"
+                     name = "Extensions">
+                     <FileRef
+                        location = "group:AWSPinpointAnalyticsPlugin+HubCategory.swift">
+                     </FileRef>
+                     <FileRef
+                        location = "group:PinpointEvent+AnalyticsEvent.swift">
+                     </FileRef>
+                  </Group>
+               </Group>
+               <FileRef
+                  location = "group:AWSPinpointAnalyticsPlugin+Configure.swift">
+               </FileRef>
+               <FileRef
+                  location = "group:AWSPinpointAnalyticsPlugin+DefaultLogger.swift">
+               </FileRef>
+            </Group>
+         </Group>
+      </Group>
+   </Group>
+   <FileRef
+      location = "group:AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:AmplifyPlugins/Predictions/Tests/PredictionsHostApp/PredictionsHostApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp/PushNotificationHostApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginHostApp/CloudWatchLoggingHostApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:AmplifyPlugins/Geo/Tests/GeoHostApp/GeoHostApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AnalyticsHostApp.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Amplify.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/Amplify.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>FILEHEADER</key>
+  <string>
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//</string>
+</dict>
+</plist>

--- a/Amplify.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Amplify.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Amplify.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Amplify.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,113 @@
+{
+  "pins" : [
+    {
+      "identity" : "amplify-swift-utils-notifications",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/aws-amplify/amplify-swift-utils-notifications.git",
+      "state" : {
+        "revision" : "f970384ad1035732f99259255cd2f97564807e41",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "aws-appsync-realtime-client-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
+      "state" : {
+        "revision" : "c7ec93dcbbcd8abc90c74203937f207a7fcaa611",
+        "version" : "3.1.1"
+      }
+    },
+    {
+      "identity" : "aws-crt-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/awslabs/aws-crt-swift",
+      "state" : {
+        "revision" : "fd1756b6e5c9fd1a906edfb743f7cb64c2c98639",
+        "version" : "0.17.0"
+      }
+    },
+    {
+      "identity" : "aws-sdk-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/awslabs/aws-sdk-swift.git",
+      "state" : {
+        "revision" : "4ecdba6927ff4be92e53c1834284ad1de60f8899",
+        "version" : "0.26.1"
+      }
+    },
+    {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
+        "version" : "2.1.2"
+      }
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "a23ded2c91df9156628a6996ab4f347526f17b6b",
+        "version" : "2.1.2"
+      }
+    },
+    {
+      "identity" : "smithy-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/smithy-lang/smithy-swift",
+      "state" : {
+        "revision" : "d580ddb8c2929b380a665a884935901b5ad808cc",
+        "version" : "0.30.1"
+      }
+    },
+    {
+      "identity" : "sqlite.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stephencelis/SQLite.swift.git",
+      "state" : {
+        "revision" : "5f5ad81ac0d0a0f3e56e39e646e8423c617df523",
+        "version" : "0.13.2"
+      }
+    },
+    {
+      "identity" : "starscream",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/daltoniam/Starscream",
+      "state" : {
+        "revision" : "df8d82047f6654d8e4b655d1b1525c64e1059d21",
+        "version" : "4.0.4"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "a902f1823a7ff3c9ab2fba0f992396b948eda307",
+        "version" : "1.0.5"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "532d8b529501fb73a2455b179e0bbb6d49b652ed",
+        "version" : "1.5.3"
+      }
+    },
+    {
+      "identity" : "xmlcoder",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/MaxDesiatov/XMLCoder.git",
+      "state" : {
+        "revision" : "80b4a1646399b8e4e0ce80711653476a85bd5e37",
+        "version" : "0.17.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/HostApp/AmplifyHostApp/AmplifyHostApp.xcodeproj/project.pbxproj
+++ b/HostApp/AmplifyHostApp/AmplifyHostApp.xcodeproj/project.pbxproj
@@ -1,0 +1,733 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		901BF6AB2AF98BF3007FC4D7 /* AmplifyHostAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901BF6AA2AF98BF3007FC4D7 /* AmplifyHostAppApp.swift */; };
+		901BF6AD2AF98BF3007FC4D7 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901BF6AC2AF98BF3007FC4D7 /* ContentView.swift */; };
+		901BF6AF2AF98BF4007FC4D7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 901BF6AE2AF98BF4007FC4D7 /* Assets.xcassets */; };
+		901BF6B32AF98BF4007FC4D7 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 901BF6B22AF98BF4007FC4D7 /* Preview Assets.xcassets */; };
+		901BF6BD2AF98BF5007FC4D7 /* AmplifyHostAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901BF6BC2AF98BF5007FC4D7 /* AmplifyHostAppTests.swift */; };
+		901BF6C72AF98BF5007FC4D7 /* AmplifyHostAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901BF6C62AF98BF5007FC4D7 /* AmplifyHostAppUITests.swift */; };
+		901BF6C92AF98BF5007FC4D7 /* AmplifyHostAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901BF6C82AF98BF5007FC4D7 /* AmplifyHostAppUITestsLaunchTests.swift */; };
+		901BF6D92AF98CCF007FC4D7 /* Amplify in Frameworks */ = {isa = PBXBuildFile; productRef = 901BF6D82AF98CCF007FC4D7 /* Amplify */; };
+		901BF6DB2AF98CCF007FC4D7 /* AWSAPIPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 901BF6DA2AF98CCF007FC4D7 /* AWSAPIPlugin */; };
+		901BF6DD2AF98CCF007FC4D7 /* AWSCloudWatchLoggingPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 901BF6DC2AF98CCF007FC4D7 /* AWSCloudWatchLoggingPlugin */; };
+		901BF6DF2AF98CCF007FC4D7 /* AWSCognitoAuthPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 901BF6DE2AF98CCF007FC4D7 /* AWSCognitoAuthPlugin */; };
+		901BF6E12AF98CCF007FC4D7 /* AWSDataStorePlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 901BF6E02AF98CCF007FC4D7 /* AWSDataStorePlugin */; };
+		901BF6E32AF98CCF007FC4D7 /* AWSLocationGeoPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 901BF6E22AF98CCF007FC4D7 /* AWSLocationGeoPlugin */; };
+		901BF6E52AF98CCF007FC4D7 /* AWSPinpointAnalyticsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 901BF6E42AF98CCF007FC4D7 /* AWSPinpointAnalyticsPlugin */; };
+		901BF6E72AF98CCF007FC4D7 /* AWSPinpointPushNotificationsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 901BF6E62AF98CCF007FC4D7 /* AWSPinpointPushNotificationsPlugin */; };
+		901BF6E92AF98CCF007FC4D7 /* AWSPluginsCore in Frameworks */ = {isa = PBXBuildFile; productRef = 901BF6E82AF98CCF007FC4D7 /* AWSPluginsCore */; };
+		901BF6EB2AF98CCF007FC4D7 /* AWSPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 901BF6EA2AF98CCF007FC4D7 /* AWSPredictionsPlugin */; };
+		901BF6ED2AF98CCF007FC4D7 /* AWSS3StoragePlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 901BF6EC2AF98CCF007FC4D7 /* AWSS3StoragePlugin */; };
+		901BF6EF2AF98CCF007FC4D7 /* CoreMLPredictionsPlugin in Frameworks */ = {isa = PBXBuildFile; productRef = 901BF6EE2AF98CCF007FC4D7 /* CoreMLPredictionsPlugin */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		901BF6B92AF98BF5007FC4D7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 901BF69F2AF98BF3007FC4D7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 901BF6A62AF98BF3007FC4D7;
+			remoteInfo = AmplifyHostApp;
+		};
+		901BF6C32AF98BF5007FC4D7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 901BF69F2AF98BF3007FC4D7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 901BF6A62AF98BF3007FC4D7;
+			remoteInfo = AmplifyHostApp;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		901BF6A72AF98BF3007FC4D7 /* AmplifyHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AmplifyHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		901BF6AA2AF98BF3007FC4D7 /* AmplifyHostAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplifyHostAppApp.swift; sourceTree = "<group>"; };
+		901BF6AC2AF98BF3007FC4D7 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		901BF6AE2AF98BF4007FC4D7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		901BF6B02AF98BF4007FC4D7 /* AmplifyHostApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AmplifyHostApp.entitlements; sourceTree = "<group>"; };
+		901BF6B22AF98BF4007FC4D7 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		901BF6B82AF98BF5007FC4D7 /* AmplifyHostAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AmplifyHostAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		901BF6BC2AF98BF5007FC4D7 /* AmplifyHostAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplifyHostAppTests.swift; sourceTree = "<group>"; };
+		901BF6C22AF98BF5007FC4D7 /* AmplifyHostAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AmplifyHostAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		901BF6C62AF98BF5007FC4D7 /* AmplifyHostAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplifyHostAppUITests.swift; sourceTree = "<group>"; };
+		901BF6C82AF98BF5007FC4D7 /* AmplifyHostAppUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplifyHostAppUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		901BF6D62AF98C5C007FC4D7 /* amplify-swift */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-swift"; path = ../../..; sourceTree = "<group>"; };
+		901BF6F02AF98CFF007FC4D7 /* Playground_macOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; name = Playground_macOS.playground; path = ../Playground_macOS.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		901BF6F12AF98D1D007FC4D7 /* Playground_iOS.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; name = Playground_iOS.playground; path = ../Playground_iOS.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		901BF6A42AF98BF3007FC4D7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				901BF6EB2AF98CCF007FC4D7 /* AWSPredictionsPlugin in Frameworks */,
+				901BF6E32AF98CCF007FC4D7 /* AWSLocationGeoPlugin in Frameworks */,
+				901BF6DB2AF98CCF007FC4D7 /* AWSAPIPlugin in Frameworks */,
+				901BF6E92AF98CCF007FC4D7 /* AWSPluginsCore in Frameworks */,
+				901BF6D92AF98CCF007FC4D7 /* Amplify in Frameworks */,
+				901BF6E72AF98CCF007FC4D7 /* AWSPinpointPushNotificationsPlugin in Frameworks */,
+				901BF6ED2AF98CCF007FC4D7 /* AWSS3StoragePlugin in Frameworks */,
+				901BF6DD2AF98CCF007FC4D7 /* AWSCloudWatchLoggingPlugin in Frameworks */,
+				901BF6EF2AF98CCF007FC4D7 /* CoreMLPredictionsPlugin in Frameworks */,
+				901BF6E12AF98CCF007FC4D7 /* AWSDataStorePlugin in Frameworks */,
+				901BF6DF2AF98CCF007FC4D7 /* AWSCognitoAuthPlugin in Frameworks */,
+				901BF6E52AF98CCF007FC4D7 /* AWSPinpointAnalyticsPlugin in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		901BF6B52AF98BF5007FC4D7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		901BF6BF2AF98BF5007FC4D7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		901BF69E2AF98BF3007FC4D7 = {
+			isa = PBXGroup;
+			children = (
+				901BF6F12AF98D1D007FC4D7 /* Playground_iOS.playground */,
+				901BF6F02AF98CFF007FC4D7 /* Playground_macOS.playground */,
+				901BF6D52AF98C23007FC4D7 /* Packages */,
+				901BF6A92AF98BF3007FC4D7 /* AmplifyHostApp */,
+				901BF6BB2AF98BF5007FC4D7 /* AmplifyHostAppTests */,
+				901BF6C52AF98BF5007FC4D7 /* AmplifyHostAppUITests */,
+				901BF6A82AF98BF3007FC4D7 /* Products */,
+				901BF6D72AF98CCF007FC4D7 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		901BF6A82AF98BF3007FC4D7 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				901BF6A72AF98BF3007FC4D7 /* AmplifyHostApp.app */,
+				901BF6B82AF98BF5007FC4D7 /* AmplifyHostAppTests.xctest */,
+				901BF6C22AF98BF5007FC4D7 /* AmplifyHostAppUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		901BF6A92AF98BF3007FC4D7 /* AmplifyHostApp */ = {
+			isa = PBXGroup;
+			children = (
+				901BF6AA2AF98BF3007FC4D7 /* AmplifyHostAppApp.swift */,
+				901BF6AC2AF98BF3007FC4D7 /* ContentView.swift */,
+				901BF6AE2AF98BF4007FC4D7 /* Assets.xcassets */,
+				901BF6B02AF98BF4007FC4D7 /* AmplifyHostApp.entitlements */,
+				901BF6B12AF98BF4007FC4D7 /* Preview Content */,
+			);
+			path = AmplifyHostApp;
+			sourceTree = "<group>";
+		};
+		901BF6B12AF98BF4007FC4D7 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				901BF6B22AF98BF4007FC4D7 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		901BF6BB2AF98BF5007FC4D7 /* AmplifyHostAppTests */ = {
+			isa = PBXGroup;
+			children = (
+				901BF6BC2AF98BF5007FC4D7 /* AmplifyHostAppTests.swift */,
+			);
+			path = AmplifyHostAppTests;
+			sourceTree = "<group>";
+		};
+		901BF6C52AF98BF5007FC4D7 /* AmplifyHostAppUITests */ = {
+			isa = PBXGroup;
+			children = (
+				901BF6C62AF98BF5007FC4D7 /* AmplifyHostAppUITests.swift */,
+				901BF6C82AF98BF5007FC4D7 /* AmplifyHostAppUITestsLaunchTests.swift */,
+			);
+			path = AmplifyHostAppUITests;
+			sourceTree = "<group>";
+		};
+		901BF6D52AF98C23007FC4D7 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				901BF6D62AF98C5C007FC4D7 /* amplify-swift */,
+			);
+			path = Packages;
+			sourceTree = "<group>";
+		};
+		901BF6D72AF98CCF007FC4D7 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		901BF6A62AF98BF3007FC4D7 /* AmplifyHostApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 901BF6CC2AF98BF5007FC4D7 /* Build configuration list for PBXNativeTarget "AmplifyHostApp" */;
+			buildPhases = (
+				901BF6A32AF98BF3007FC4D7 /* Sources */,
+				901BF6A42AF98BF3007FC4D7 /* Frameworks */,
+				901BF6A52AF98BF3007FC4D7 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AmplifyHostApp;
+			packageProductDependencies = (
+				901BF6D82AF98CCF007FC4D7 /* Amplify */,
+				901BF6DA2AF98CCF007FC4D7 /* AWSAPIPlugin */,
+				901BF6DC2AF98CCF007FC4D7 /* AWSCloudWatchLoggingPlugin */,
+				901BF6DE2AF98CCF007FC4D7 /* AWSCognitoAuthPlugin */,
+				901BF6E02AF98CCF007FC4D7 /* AWSDataStorePlugin */,
+				901BF6E22AF98CCF007FC4D7 /* AWSLocationGeoPlugin */,
+				901BF6E42AF98CCF007FC4D7 /* AWSPinpointAnalyticsPlugin */,
+				901BF6E62AF98CCF007FC4D7 /* AWSPinpointPushNotificationsPlugin */,
+				901BF6E82AF98CCF007FC4D7 /* AWSPluginsCore */,
+				901BF6EA2AF98CCF007FC4D7 /* AWSPredictionsPlugin */,
+				901BF6EC2AF98CCF007FC4D7 /* AWSS3StoragePlugin */,
+				901BF6EE2AF98CCF007FC4D7 /* CoreMLPredictionsPlugin */,
+			);
+			productName = AmplifyHostApp;
+			productReference = 901BF6A72AF98BF3007FC4D7 /* AmplifyHostApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+		901BF6B72AF98BF5007FC4D7 /* AmplifyHostAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 901BF6CF2AF98BF5007FC4D7 /* Build configuration list for PBXNativeTarget "AmplifyHostAppTests" */;
+			buildPhases = (
+				901BF6B42AF98BF5007FC4D7 /* Sources */,
+				901BF6B52AF98BF5007FC4D7 /* Frameworks */,
+				901BF6B62AF98BF5007FC4D7 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				901BF6BA2AF98BF5007FC4D7 /* PBXTargetDependency */,
+			);
+			name = AmplifyHostAppTests;
+			productName = AmplifyHostAppTests;
+			productReference = 901BF6B82AF98BF5007FC4D7 /* AmplifyHostAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		901BF6C12AF98BF5007FC4D7 /* AmplifyHostAppUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 901BF6D22AF98BF5007FC4D7 /* Build configuration list for PBXNativeTarget "AmplifyHostAppUITests" */;
+			buildPhases = (
+				901BF6BE2AF98BF5007FC4D7 /* Sources */,
+				901BF6BF2AF98BF5007FC4D7 /* Frameworks */,
+				901BF6C02AF98BF5007FC4D7 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				901BF6C42AF98BF5007FC4D7 /* PBXTargetDependency */,
+			);
+			name = AmplifyHostAppUITests;
+			productName = AmplifyHostAppUITests;
+			productReference = 901BF6C22AF98BF5007FC4D7 /* AmplifyHostAppUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		901BF69F2AF98BF3007FC4D7 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					901BF6A62AF98BF3007FC4D7 = {
+						CreatedOnToolsVersion = 15.0.1;
+					};
+					901BF6B72AF98BF5007FC4D7 = {
+						CreatedOnToolsVersion = 15.0.1;
+						TestTargetID = 901BF6A62AF98BF3007FC4D7;
+					};
+					901BF6C12AF98BF5007FC4D7 = {
+						CreatedOnToolsVersion = 15.0.1;
+						TestTargetID = 901BF6A62AF98BF3007FC4D7;
+					};
+				};
+			};
+			buildConfigurationList = 901BF6A22AF98BF3007FC4D7 /* Build configuration list for PBXProject "AmplifyHostApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 901BF69E2AF98BF3007FC4D7;
+			productRefGroup = 901BF6A82AF98BF3007FC4D7 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				901BF6A62AF98BF3007FC4D7 /* AmplifyHostApp */,
+				901BF6B72AF98BF5007FC4D7 /* AmplifyHostAppTests */,
+				901BF6C12AF98BF5007FC4D7 /* AmplifyHostAppUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		901BF6A52AF98BF3007FC4D7 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				901BF6B32AF98BF4007FC4D7 /* Preview Assets.xcassets in Resources */,
+				901BF6AF2AF98BF4007FC4D7 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		901BF6B62AF98BF5007FC4D7 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		901BF6C02AF98BF5007FC4D7 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		901BF6A32AF98BF3007FC4D7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				901BF6AD2AF98BF3007FC4D7 /* ContentView.swift in Sources */,
+				901BF6AB2AF98BF3007FC4D7 /* AmplifyHostAppApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		901BF6B42AF98BF5007FC4D7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				901BF6BD2AF98BF5007FC4D7 /* AmplifyHostAppTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		901BF6BE2AF98BF5007FC4D7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				901BF6C72AF98BF5007FC4D7 /* AmplifyHostAppUITests.swift in Sources */,
+				901BF6C92AF98BF5007FC4D7 /* AmplifyHostAppUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		901BF6BA2AF98BF5007FC4D7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 901BF6A62AF98BF3007FC4D7 /* AmplifyHostApp */;
+			targetProxy = 901BF6B92AF98BF5007FC4D7 /* PBXContainerItemProxy */;
+		};
+		901BF6C42AF98BF5007FC4D7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 901BF6A62AF98BF3007FC4D7 /* AmplifyHostApp */;
+			targetProxy = 901BF6C32AF98BF5007FC4D7 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		901BF6CA2AF98BF5007FC4D7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		901BF6CB2AF98BF5007FC4D7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		901BF6CD2AF98BF5007FC4D7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = AmplifyHostApp/AmplifyHostApp.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"AmplifyHostApp/Preview Content\"";
+				DEVELOPMENT_TEAM = W3DRXD72QU;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.aws.amplify.AmplifyHostApp.AmplifyHostApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		901BF6CE2AF98BF5007FC4D7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = AmplifyHostApp/AmplifyHostApp.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"AmplifyHostApp/Preview Content\"";
+				DEVELOPMENT_TEAM = W3DRXD72QU;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.aws.amplify.AmplifyHostApp.AmplifyHostApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		901BF6D02AF98BF5007FC4D7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = W3DRXD72QU;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.aws.amplify.AmplifyHostApp.AmplifyHostAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AmplifyHostApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/AmplifyHostApp";
+			};
+			name = Debug;
+		};
+		901BF6D12AF98BF5007FC4D7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = W3DRXD72QU;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.aws.amplify.AmplifyHostApp.AmplifyHostAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AmplifyHostApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/AmplifyHostApp";
+			};
+			name = Release;
+		};
+		901BF6D32AF98BF5007FC4D7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = W3DRXD72QU;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.aws.amplify.AmplifyHostApp.AmplifyHostAppUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = AmplifyHostApp;
+			};
+			name = Debug;
+		};
+		901BF6D42AF98BF5007FC4D7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = W3DRXD72QU;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.aws.amplify.AmplifyHostApp.AmplifyHostAppUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = AmplifyHostApp;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		901BF6A22AF98BF3007FC4D7 /* Build configuration list for PBXProject "AmplifyHostApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				901BF6CA2AF98BF5007FC4D7 /* Debug */,
+				901BF6CB2AF98BF5007FC4D7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		901BF6CC2AF98BF5007FC4D7 /* Build configuration list for PBXNativeTarget "AmplifyHostApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				901BF6CD2AF98BF5007FC4D7 /* Debug */,
+				901BF6CE2AF98BF5007FC4D7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		901BF6CF2AF98BF5007FC4D7 /* Build configuration list for PBXNativeTarget "AmplifyHostAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				901BF6D02AF98BF5007FC4D7 /* Debug */,
+				901BF6D12AF98BF5007FC4D7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		901BF6D22AF98BF5007FC4D7 /* Build configuration list for PBXNativeTarget "AmplifyHostAppUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				901BF6D32AF98BF5007FC4D7 /* Debug */,
+				901BF6D42AF98BF5007FC4D7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		901BF6D82AF98CCF007FC4D7 /* Amplify */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Amplify;
+		};
+		901BF6DA2AF98CCF007FC4D7 /* AWSAPIPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSAPIPlugin;
+		};
+		901BF6DC2AF98CCF007FC4D7 /* AWSCloudWatchLoggingPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSCloudWatchLoggingPlugin;
+		};
+		901BF6DE2AF98CCF007FC4D7 /* AWSCognitoAuthPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSCognitoAuthPlugin;
+		};
+		901BF6E02AF98CCF007FC4D7 /* AWSDataStorePlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSDataStorePlugin;
+		};
+		901BF6E22AF98CCF007FC4D7 /* AWSLocationGeoPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSLocationGeoPlugin;
+		};
+		901BF6E42AF98CCF007FC4D7 /* AWSPinpointAnalyticsPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSPinpointAnalyticsPlugin;
+		};
+		901BF6E62AF98CCF007FC4D7 /* AWSPinpointPushNotificationsPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSPinpointPushNotificationsPlugin;
+		};
+		901BF6E82AF98CCF007FC4D7 /* AWSPluginsCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSPluginsCore;
+		};
+		901BF6EA2AF98CCF007FC4D7 /* AWSPredictionsPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSPredictionsPlugin;
+		};
+		901BF6EC2AF98CCF007FC4D7 /* AWSS3StoragePlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AWSS3StoragePlugin;
+		};
+		901BF6EE2AF98CCF007FC4D7 /* CoreMLPredictionsPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = CoreMLPredictionsPlugin;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 901BF69F2AF98BF3007FC4D7 /* Project object */;
+}

--- a/HostApp/AmplifyHostApp/AmplifyHostApp/AmplifyHostApp.entitlements
+++ b/HostApp/AmplifyHostApp/AmplifyHostApp/AmplifyHostApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/HostApp/AmplifyHostApp/AmplifyHostApp/AmplifyHostAppApp.swift
+++ b/HostApp/AmplifyHostApp/AmplifyHostApp/AmplifyHostAppApp.swift
@@ -1,0 +1,17 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import SwiftUI
+
+@main
+struct AmplifyHostAppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/HostApp/AmplifyHostApp/AmplifyHostApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/HostApp/AmplifyHostApp/AmplifyHostApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HostApp/AmplifyHostApp/AmplifyHostApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/HostApp/AmplifyHostApp/AmplifyHostApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,63 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HostApp/AmplifyHostApp/AmplifyHostApp/Assets.xcassets/Contents.json
+++ b/HostApp/AmplifyHostApp/AmplifyHostApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HostApp/AmplifyHostApp/AmplifyHostApp/ContentView.swift
+++ b/HostApp/AmplifyHostApp/AmplifyHostApp/ContentView.swift
@@ -1,0 +1,24 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/HostApp/AmplifyHostApp/AmplifyHostApp/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/HostApp/AmplifyHostApp/AmplifyHostApp/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HostApp/AmplifyHostApp/AmplifyHostAppTests/AmplifyHostAppTests.swift
+++ b/HostApp/AmplifyHostApp/AmplifyHostAppTests/AmplifyHostAppTests.swift
@@ -1,0 +1,35 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+final class AmplifyHostAppTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/HostApp/AmplifyHostApp/AmplifyHostAppUITests/AmplifyHostAppUITests.swift
+++ b/HostApp/AmplifyHostApp/AmplifyHostAppUITests/AmplifyHostAppUITests.swift
@@ -1,0 +1,41 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+final class AmplifyHostAppUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/HostApp/AmplifyHostApp/AmplifyHostAppUITests/AmplifyHostAppUITestsLaunchTests.swift
+++ b/HostApp/AmplifyHostApp/AmplifyHostAppUITests/AmplifyHostAppUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+final class AmplifyHostAppUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/HostApp/Playground_iOS.playground/Contents.swift
+++ b/HostApp/Playground_iOS.playground/Contents.swift
@@ -1,0 +1,4 @@
+import Foundation
+import Amplify
+
+

--- a/HostApp/Playground_iOS.playground/contents.xcplayground
+++ b/HostApp/Playground_iOS.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='ios' buildActiveScheme='true' importAppTypes='true'>
+    <timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/HostApp/Playground_macOS.playground/Contents.swift
+++ b/HostApp/Playground_macOS.playground/Contents.swift
@@ -1,0 +1,2 @@
+import Foundation
+import Amplify

--- a/HostApp/Playground_macOS.playground/contents.xcplayground
+++ b/HostApp/Playground_macOS.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='macos' buildActiveScheme='true' importAppTypes='true'>
+    <timeline fileName='timeline.xctimeline'/>
+</playground>


### PR DESCRIPTION
## Description
Running integration tests across multiple host apps is a pain today. It requires opening the `AmplifyPlugins/<plugin>/Tests/<plugin>HostApp/<plugin>HostApp.xcodeproj` that you want to work with in that moment. But if you open a second one, Xcode will throw a tantrum because you have the local Amplify package open in multiple projects. To make this flow a bit more ergonomic (and less frustrating), this PR adds an xcworkspace containing each xcodeproj. 

- Adds an exception to `.gitignore` for Amplify.xcworkspace.
- Adds Amplify.xcworkspace with `.xcodeproj`'s for each of the integration test host apps.

| projects | schemes
| --- | ---
| ![project_overview](https://github.com/aws-amplify/amplify-swift/assets/52051793/61d4511e-dc36-4d37-a697-7f3fd67b8b2d) | ![schemes](https://github.com/aws-amplify/amplify-swift/assets/52051793/4520265b-61db-4539-a250-7a079cbbe728)

- Adds AmplifyHostApp project (linking all Amplify targets), as well as iOS and macOS playgrounds.
![playground_example](https://github.com/aws-amplify/amplify-swift/assets/52051793/47f980c8-7611-4ddb-8f77-babe6f515c89)


- Adds `IDETemplateMacros.plist` to new xcworkspace to use correct header when creating new files.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
