### PR TITLE
test: update mfa e2e tests to prevent concurrent run user collisions

### DIFF
--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AWSAuthBaseTest.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AWSAuthBaseTest.swift
@@ -16,6 +16,16 @@ class AWSAuthBaseTest: XCTestCase {
     var defaultTestEmail = "test-\(UUID().uuidString)@amazon.com"
     var defaultTestPassword = UUID().uuidString
 
+    var randomEmail: String {
+        "test-\(UUID().uuidString)@amazon.com"
+    }
+
+    var randomPhoneNumber: String {
+        "+1" + (1...10)
+            .map { _ in String(Int.random(in: 0...9)) }
+            .joined()
+    }
+
     var amplifyConfigurationFile = "testconfiguration/AWSCognitoAuthPluginIntegrationTests-amplifyconfiguration"
     let credentialsFile = "testconfiguration/AWSCognitoAuthPluginIntegrationTests-credentials"
 

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/MFATests/MFASignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/MFATests/MFASignInTests.swift
@@ -45,7 +45,8 @@ class MFASignInTests: AWSAuthBaseTest {
         let didSucceed = try await AuthSignInHelper.registerAndSignInUser(
             username: username,
             password: password,
-            email: defaultTestEmail)
+            email: randomEmail
+        )
 
         XCTAssertTrue(didSucceed, "Signup and sign in should succeed")
 
@@ -115,8 +116,9 @@ class MFASignInTests: AWSAuthBaseTest {
         let didSucceed = try await AuthSignInHelper.registerAndSignInUser(
             username: username,
             password: password,
-            email: defaultTestEmail,
-            phoneNumber: "+16135550116")
+            email: randomEmail,
+            phoneNumber: randomPhoneNumber
+        )
 
         XCTAssertTrue(didSucceed, "Signup and sign in should succeed")
 
@@ -175,8 +177,8 @@ class MFASignInTests: AWSAuthBaseTest {
         let didSucceed = try await AuthSignInHelper.registerAndSignInUser(
             username: username,
             password: password,
-            email: defaultTestEmail,
-            phoneNumber: "+16135550116")
+            email: randomEmail,
+            phoneNumber: randomPhoneNumber)
 
         XCTAssertTrue(didSucceed, "Signup and sign in should succeed")
 
@@ -254,8 +256,9 @@ class MFASignInTests: AWSAuthBaseTest {
         let didSucceed = try await AuthSignInHelper.registerAndSignInUser(
             username: username,
             password: password,
-            email: defaultTestEmail,
-            phoneNumber: "+16135550116")
+            email: randomEmail,
+            phoneNumber: randomPhoneNumber
+        )
 
         XCTAssertTrue(didSucceed, "Signup and sign in should succeed")
 

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/MFATests/TOTPSetupWhenAuthenticatedTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/MFATests/TOTPSetupWhenAuthenticatedTests.swift
@@ -21,7 +21,8 @@ class TOTPSetupWhenAuthenticatedTests: AWSAuthBaseTest {
         let didSucceed = try await AuthSignInHelper.registerAndSignInUser(
             username: username,
             password: password,
-            email: defaultTestEmail)
+            email: randomEmail
+        )
 
         XCTAssertTrue(didSucceed, "Signup and sign in should succeed")
     }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/MFATests/TOTPSetupWhenUnauthenticatedTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/MFATests/TOTPSetupWhenUnauthenticatedTests.swift
@@ -42,7 +42,8 @@ class TOTPSetupWhenUnauthenticatedTests: AWSAuthBaseTest {
         let didSucceed = try await AuthSignInHelper.signUpUser(
             username: username,
             password: password,
-            email: defaultTestEmail)
+            email: randomEmail
+        )
 
         XCTAssertTrue(didSucceed, "Signup should succeed")
 
@@ -82,8 +83,9 @@ class TOTPSetupWhenUnauthenticatedTests: AWSAuthBaseTest {
         let didSucceed = try await AuthSignInHelper.signUpUser(
             username: username,
             password: password,
-            email: defaultTestEmail,
-            phoneNumber: "+16135550116")
+            email: randomEmail,
+            phoneNumber: randomPhoneNumber
+        )
 
         XCTAssertTrue(didSucceed, "Signup should succeed")
 
@@ -132,7 +134,8 @@ class TOTPSetupWhenUnauthenticatedTests: AWSAuthBaseTest {
         let didSucceed = try await AuthSignInHelper.signUpUser(
             username: username,
             password: password,
-            email: defaultTestEmail)
+            email: randomEmail
+        )
 
         XCTAssertTrue(didSucceed, "Signup should succeed")
 
@@ -179,7 +182,8 @@ class TOTPSetupWhenUnauthenticatedTests: AWSAuthBaseTest {
         let didSucceed = try await AuthSignInHelper.signUpUser(
             username: username,
             password: password,
-            email: defaultTestEmail)
+            email: randomEmail
+        )
 
         XCTAssertTrue(didSucceed, "Signup should succeed")
 
@@ -246,7 +250,8 @@ class TOTPSetupWhenUnauthenticatedTests: AWSAuthBaseTest {
         let didSucceed = try await AuthSignInHelper.signUpUser(
             username: username,
             password: password,
-            email: defaultTestEmail)
+            email: randomEmail
+        )
 
         XCTAssertTrue(didSucceed, "Signup should succeed")
 


### PR DESCRIPTION
## Description
Some of the MFA integration tests are reusing the same email address or telephone number. This leads to intermittent test failures when tests suites are running concurrently -- either on different platforms in the same test run, or concurrent test runs.

This change addresses this by using random emails and telephone numbers where applicable to prevent collisions.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
