### PR TITLE
chore(workflows): Fixing release workflows depth

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -10,9 +10,68 @@ permissions:
   actions: write
 
 jobs:
-  release-stable:
-    uses: ./.github/workflows/deploy_package.yml
+  build-amplify-swift:
+    name: Build Amplify package
+    uses: ./.github/workflows/build_amplify_swift_platforms.yml
     with:
-      type: release
-    secrets: inherit
+      identifier: 'workflow-call-build-amplify-swift'
+  
+  unit-tests:
+    name: Run Plugins Unit Tests
+    uses: ./.github/workflows/unit_test.yml
+    with:
+      identifier: 'workflow-call-unit-test'
 
+  fortify:
+    name: Run Fortify Scan
+    uses: ./.github/workflows/fortify_scan.yml
+    secrets: inherit
+    with:
+      identifier: 'workflow-call-fortify'
+
+  release:
+    environment: Release
+    name: Release new release version
+    needs: [unit-tests, fortify, build-amplify-swift]
+    runs-on: macos-latest
+    env:
+      GITHUB_EMAIL: aws-amplify-ops@amazon.com
+      GITHUB_USER: aws-amplify-ops
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 #v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ format('{0}.release', github.run_id) }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - id: retrieve-token
+        name: Retrieve Token
+        env:
+          DEPLOY_SECRET_ARN: ${{ secrets.DEPLOY_SECRET_ARN }}
+        run: |
+          PAT=$(aws secretsmanager get-secret-value \
+          --secret-id "$DEPLOY_SECRET_ARN" \
+          | jq -r ".SecretString | fromjson | .Credential")
+          echo "token=$PAT" >> $GITHUB_OUTPUT
+
+      - name: Checkout repo
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          fetch-depth: 100
+          token: ${{steps.retrieve-token.outputs.token}}
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+        with:
+          ruby-version: '3.2.1'
+          bundler-cache: true
+
+      - name:  Release Package
+        run: bundle exec fastlane release
+
+      - name: Release docs
+        working-directory: ${{ github.workspace }}
+        run: |
+          git checkout -B gh-pages
+          bash ./CircleciScripts/jazzy_doc_gen.sh

--- a/.github/workflows/deploy_unstable.yml
+++ b/.github/workflows/deploy_unstable.yml
@@ -10,8 +10,62 @@ permissions:
   actions: write
 
 jobs:
-  release-unstable:
-    uses: ./.github/workflows/deploy_package.yml
+  build-amplify-swift:
+    name: Build Amplify package
+    uses: ./.github/workflows/build_amplify_swift_platforms.yml
     with:
-      type: unstable
+      identifier: 'workflow-call-build-amplify-swift'
+  
+  unit-tests:
+    name: Run Plugins Unit Tests
+    uses: ./.github/workflows/unit_test.yml
+    with:
+      identifier: 'workflow-call-unit-test'
+
+  fortify:
+    name: Run Fortify Scan
+    uses: ./.github/workflows/fortify_scan.yml
     secrets: inherit
+    with:
+      identifier: 'workflow-call-fortify'
+
+  release:
+    environment: Release
+    name: Release new unstable version
+    needs: [unit-tests, fortify, build-amplify-swift]
+    runs-on: macos-latest
+    env:
+      GITHUB_EMAIL: aws-amplify-ops@amazon.com
+      GITHUB_USER: aws-amplify-ops
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 #v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ format('{0}.release', github.run_id) }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - id: retrieve-token
+        name: Retrieve Token
+        env:
+          DEPLOY_SECRET_ARN: ${{ secrets.DEPLOY_SECRET_ARN }}
+        run: |
+          PAT=$(aws secretsmanager get-secret-value \
+          --secret-id "$DEPLOY_SECRET_ARN" \
+          | jq -r ".SecretString | fromjson | .Credential")
+          echo "token=$PAT" >> $GITHUB_OUTPUT
+
+      - name: Checkout repo
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          fetch-depth: 100
+          token: ${{steps.retrieve-token.outputs.token}}
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+        with:
+          ruby-version: '3.2.1'
+          bundler-cache: true
+
+      - name:  Release Package
+        run: bundle exec fastlane unstable


### PR DESCRIPTION
## Description
GitHub Actions have a limit of 3 reusable workflow depth. Unfortunately we've exceeded that limit during the release workflows, with the recent introduction of `run_unit_tests_paltforms`:
- deploy_unstable -> deploy_package -> run_unit_tests_platforms -> run_unit_tests
- deploy_stable -> deploy_package -> run_unit_tests_platforms -> run_unit_tests

So to unblock us quickly I'm just adding the required jobs and steps to the `deploy_unstable` and `deploy_stable` workflows, so they don't need to call `deploy_package`.
I will explore better options in a follow up PR, such as either using composite actions for releases, or tweaking the test workflows further.

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
