### PR TITLE
fix(DataStore): Store larger than 32-bit values in Int64 over Int

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -14,6 +14,7 @@ public enum ModelFieldType {
 
     case string
     case int
+    case int64
     case double
     case date
     case dateTime

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
@@ -15,12 +15,12 @@ import Foundation
 public struct ConflictResolutionDecorator: ModelBasedGraphQLDocumentDecorator {
 
     private let version: Int?
-    private let lastSync: Int?
+    private let lastSync: Int64?
     private let graphQLType: GraphQLOperationType
     private var primaryKeysOnly: Bool
     
     public init(version: Int? = nil,
-                lastSync: Int? = nil,
+                lastSync: Int64? = nil,
                 graphQLType: GraphQLOperationType,
                 primaryKeysOnly: Bool = true) {
         self.version = version

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -49,7 +49,7 @@ protocol ModelSyncGraphQLRequestFactory {
                           where predicate: QueryPredicate?,
                           limit: Int?,
                           nextToken: String?,
-                          lastSync: Int?,
+                          lastSync: Int64?,
                           authType: AWSAuthorizationType?) -> GraphQLRequest<SyncQueryResult>
 
 }
@@ -110,7 +110,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                  where predicate: QueryPredicate? = nil,
                                  limit: Int? = nil,
                                  nextToken: String? = nil,
-                                 lastSync: Int? = nil,
+                                 lastSync: Int64? = nil,
                                  authType: AWSAuthorizationType? = nil) -> GraphQLRequest<SyncQueryResult> {
         syncQuery(modelSchema: modelType.schema,
                          where: predicate,
@@ -215,7 +215,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                  where predicate: QueryPredicate? = nil,
                                  limit: Int? = nil,
                                  nextToken: String? = nil,
-                                 lastSync: Int? = nil,
+                                 lastSync: Int64? = nil,
                                  authType: AWSAuthorizationType? = nil) -> GraphQLRequest<SyncQueryResult> {
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelSchema,
                                                                operationType: .query,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/GraphQLDocumentInputValue.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/GraphQLDocumentInputValue.swift
@@ -37,6 +37,16 @@ extension Int: GraphQLDocumentValueRepresentable {
     }
 }
 
+extension Int64: GraphQLDocumentValueRepresentable {
+    public var graphQLDocumentValue: String {
+        return "\(self)"
+    }
+
+    public var graphQLInlineValue: String {
+        return "\(self)"
+    }
+}
+
 extension String: GraphQLDocumentValueRepresentable {
     public var graphQLDocumentValue: String {
         return self

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -103,7 +103,7 @@ extension Model {
                         return Fatal.preconditionFailure("Could not turn into json object from \(value)")
                     }
                 }
-            case .string, .int, .double, .timestamp, .bool:
+            case .string, .int, .int64, .double, .timestamp, .bool:
                 input[name] = value
             }
         }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata+Schema.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata+Schema.swift
@@ -27,7 +27,7 @@ extension ModelSyncMetadata {
 
         definition.fields(
             .id(),
-            .field(keys.lastSync, is: .optional, ofType: .int)
+            .field(keys.lastSync, is: .optional, ofType: .int64)
         )
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata.swift
@@ -12,10 +12,10 @@ public struct ModelSyncMetadata: Model {
     public let id: String
 
     /// The timestamp (in Unix seconds) at which the last sync was started, as reported by the service
-    public var lastSync: Int?
+    public var lastSync: Int64?
 
     public init(id: String,
-                lastSync: Int?) {
+                lastSync: Int64?) {
         self.id = id
         self.lastSync = lastSync
     }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSync.swift
@@ -87,7 +87,7 @@ public struct MutationSync<ModelType: Model>: Decodable {
         self.syncMetadata = MutationSyncMetadata(modelId: modelIdentifier,
                                                  modelName: resolvedModelName,
                                                  deleted: deleted,
-                                                 lastChangedAt: Int(lastChangedAt),
+                                                 lastChangedAt: Int64(lastChangedAt),
                                                  version: Int(version))
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata+Schema.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata+Schema.swift
@@ -31,7 +31,7 @@ extension MutationSyncMetadata {
         definition.fields(
             .id(),
             .field(sync.deleted, is: .required, ofType: .bool),
-            .field(sync.lastChangedAt, is: .required, ofType: .int),
+            .field(sync.lastChangedAt, is: .required, ofType: .int64),
             .field(sync.version, is: .required, ofType: .int)
         )
     }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata.swift
@@ -14,7 +14,7 @@ public struct MutationSyncMetadata: Model {
 
     public let id: MutationSyncIdentifier
     public var deleted: Bool
-    public var lastChangedAt: Int
+    public var lastChangedAt: Int64
     public var version: Int
 
     static let deliminator = "|"
@@ -30,14 +30,14 @@ public struct MutationSyncMetadata: Model {
         The format of the `id` has changed to support unique ids across mutiple model types.
         Use init(modelId:modelName:deleted:lastChangedAt) to pass in the `modelName`.
     """)
-    public init(id: MutationSyncIdentifier, deleted: Bool, lastChangedAt: Int, version: Int) {
+    public init(id: MutationSyncIdentifier, deleted: Bool, lastChangedAt: Int64, version: Int) {
         self.id = id
         self.deleted = deleted
         self.lastChangedAt = lastChangedAt
         self.version = version
     }
 
-    public init(modelId: ModelId, modelName: String, deleted: Bool, lastChangedAt: Int, version: Int) {
+    public init(modelId: ModelId, modelName: String, deleted: Bool, lastChangedAt: Int64, version: Int) {
         self.id = Self.identifier(modelName: modelName, modelId: modelId)
         self.deleted = deleted
         self.lastChangedAt = lastChangedAt

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/PaginatedList.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/PaginatedList.swift
@@ -11,5 +11,5 @@ import Foundation
 public struct PaginatedList<ModelType: Model>: Decodable {
     public let items: [MutationSync<ModelType>]
     public let nextToken: String?
-    public let startedAt: Int?
+    public let startedAt: Int64?
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSyncQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSyncQueryTests.swift
@@ -77,7 +77,7 @@ class GraphQLSyncQueryTests: XCTestCase {
         XCTAssertEqual(variables["nextToken"] as? String, "token")
         XCTAssertNotNil(variables["filter"])
         XCTAssertNotNil(variables["lastSync"])
-        XCTAssertEqual(variables["lastSync"] as? Int, 123)
+        XCTAssertEqual(variables["lastSync"] as? Int64, 123)
     }
 
     func testSyncGraphQLQueryForComment() {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAnyModelWithSyncTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAnyModelWithSyncTests.swift
@@ -228,7 +228,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
         let modelType = Post.self as Model.Type
         let nextToken = "nextToken"
         let limit = 100
-        let lastSync = 123
+        let lastSync: Int64 = 123
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .sync))
         documentBuilder.add(decorator: PaginationDecorator(limit: limit, nextToken: nextToken))
@@ -274,14 +274,14 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
         XCTAssertNotNil(variables["nextToken"])
         XCTAssertEqual(variables["nextToken"] as? String, nextToken)
         XCTAssertNotNil(variables["lastSync"])
-        XCTAssertEqual(variables["lastSync"] as? Int, lastSync)
+        XCTAssertEqual(variables["lastSync"] as? Int64, lastSync)
     }
 
     func testOptimizedSyncQueryGraphQLRequestWithFilter() {
         let modelType = Post.self as Model.Type
         let nextToken = "nextToken"
         let limit = 100
-        let lastSync = 123
+        let lastSync: Int64 = 123
         let postId = "123"
         let predicate = Post.CodingKeys.id.eq(postId)
         let request = GraphQLRequest<SyncQueryResult>.syncQuery(
@@ -310,7 +310,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
         let modelType = Post.self as Model.Type
         let nextToken = "nextToken"
         let limit = 100
-        let lastSync = 123
+        let lastSync: Int64 = 123
         let postId = "123"
         let altPostId = "456"
         let predicate = Post.CodingKeys.id.eq(postId) || Post.CodingKeys.id.eq(altPostId)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthRuleTests.swift
@@ -303,7 +303,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
         let modelType = Article.self as Model.Type
         let nextToken = "nextToken"
         let limit = 100
-        let lastSync = 123
+        let lastSync: Int64 = 123
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .sync))
         documentBuilder.add(decorator: PaginationDecorator(limit: limit, nextToken: nextToken))
@@ -347,6 +347,6 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
         XCTAssertNotNil(variables["nextToken"])
         XCTAssertEqual(variables["nextToken"] as? String, nextToken)
         XCTAssertNotNil(variables["lastSync"])
-        XCTAssertEqual(variables["lastSync"] as? Int, lastSync)
+        XCTAssertEqual(variables["lastSync"] as? Int64, lastSync)
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestSyncCustomPrimaryKeyWithMultipleFieldsTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestSyncCustomPrimaryKeyWithMultipleFieldsTests.swift
@@ -137,7 +137,7 @@ class GraphQLRequestSyncCustomPrimaryKeyWithMultipleFieldsTests: XCTestCase {
     func testSyncQueryGraphQLRequestWithDateInPK() throws {
         let nextToken = "nextToken"
         let limit = 100
-        let lastSync = 123
+        let lastSync: Int64 = 123
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: CustomerWithMultipleFieldsinPK.modelName,
                                                                operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .sync))
@@ -188,7 +188,7 @@ class GraphQLRequestSyncCustomPrimaryKeyWithMultipleFieldsTests: XCTestCase {
         XCTAssertNotNil(variables["nextToken"])
         XCTAssertEqual(variables["nextToken"] as? String, nextToken)
         XCTAssertNotNil(variables["lastSync"])
-        XCTAssertEqual(variables["lastSync"] as? Int, lastSync)
+        XCTAssertEqual(variables["lastSync"] as? Int64, lastSync)
     }
 
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Migration/MutationSyncMetadataCopy.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Migration/MutationSyncMetadataCopy.swift
@@ -12,7 +12,7 @@ extension MutationSyncMetadataMigration {
     public struct MutationSyncMetadataCopy: Model {
         public let id: String
         public var deleted: Bool
-        public var lastChangedAt: Int
+        public var lastChangedAt: Int64
         public var version: Int
 
         // MARK: - CodingKeys
@@ -36,7 +36,7 @@ extension MutationSyncMetadataMigration {
             definition.fields(
                 .id(),
                 .field(sync.deleted, is: .required, ofType: .bool),
-                .field(sync.lastChangedAt, is: .required, ofType: .int),
+                .field(sync.lastChangedAt, is: .required, ofType: .int64),
                 .field(sync.version, is: .required, ofType: .int)
             )
         }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/ModelSchema+SQLite.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/ModelSchema+SQLite.swift
@@ -92,7 +92,7 @@ extension ModelField: SQLColumn {
         switch type {
         case .string, .enum, .date, .dateTime, .time, .model:
             return .text
-        case .int, .bool, .timestamp:
+        case .int, .int64, .bool, .timestamp:
             return .integer
         case .double:
             return .real

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/ModelValueConverter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/ModelValueConverter+SQLite.swift
@@ -32,6 +32,8 @@ public struct SQLiteModelValueConverter: ModelValueConverter {
             return value as? String
         case .int:
             return value as? Int
+        case .int64:
+            return value as? Int64
         case .double:
             return value as? Double
         case .date, .dateTime, .time:
@@ -68,7 +70,7 @@ public struct SQLiteModelValueConverter: ModelValueConverter {
         switch fieldType {
         case .string, .date, .dateTime, .time:
             return value as? String
-        case .int:
+        case .int, .int64:
             return value as? Int64
         case .double:
             return value as? Double

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/Support/Model+Sort.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/Support/Model+Sort.swift
@@ -109,7 +109,13 @@ extension ModelSchema {
             return ModelValueCompare(value1Optional: value1Optional,
                                      value2Optional: value2Optional)
                 .sortComparator(sortOrder: sortOrder)
-
+        case .int64:
+            guard let value1Optional = value1 as? Int64?, let value2Optional = value2 as? Int64? else {
+                return false
+            }
+            return ModelValueCompare(value1Optional: value1Optional,
+                                     value2Optional: value2Optional)
+                .sortComparator(sortOrder: sortOrder)
         case .double:
             guard let value1Optional = value1 as? Double?, let value2Optional = value2 as? Double? else {
                 return false

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Events/OutboxMutationEvent.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Events/OutboxMutationEvent.swift
@@ -36,7 +36,7 @@ public struct OutboxMutationEvent {
     public struct OutboxMutationEventElement {
         public let model: Model
         public var version: Int?
-        public var lastChangedAt: Int?
+        public var lastChangedAt: Int64?
         public var deleted: Bool?
     }
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -67,7 +67,7 @@ final class InitialSyncOperation: AsynchronousOperation {
         }
     }
 
-    private func getLastSyncTime() -> Int? {
+    private func getLastSyncTime() -> Int64? {
         guard !isCancelled else {
             finish(result: .successfulVoid)
             return nil
@@ -109,7 +109,7 @@ final class InitialSyncOperation: AsynchronousOperation {
         }
     }
 
-    private func query(lastSyncTime: Int?, nextToken: String? = nil) async {
+    private func query(lastSyncTime: Int64?, nextToken: String? = nil) async {
         guard !isCancelled else {
             finish(result: .successfulVoid)
             return
@@ -160,7 +160,7 @@ final class InitialSyncOperation: AsynchronousOperation {
 
     /// Disposes of the query results: Stops if error, reconciles results if success, and kick off a new query if there
     /// is a next token
-    private func handleQueryResults(lastSyncTime: Int?,
+    private func handleQueryResults(lastSyncTime: Int64?,
                                     graphQLResult: Result<SyncQueryResult, GraphQLResponseError<SyncQueryResult>>) {
         guard !isCancelled else {
             finish(result: .successfulVoid)
@@ -198,7 +198,7 @@ final class InitialSyncOperation: AsynchronousOperation {
         }
     }
 
-    private func updateModelSyncMetadata(lastSyncTime: Int?) {
+    private func updateModelSyncMetadata(lastSyncTime: Int64?) {
         guard !isCancelled else {
             finish(result: .successfulVoid)
             return

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Support/Model+Compare.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Support/Model+Compare.swift
@@ -62,6 +62,13 @@ extension ModelSchema {
                 if !compare(value1Optional, value2Optional) {
                     return false
                 }
+            case .int64:
+                guard let value1Optional = value1 as? Int64?, let value2Optional = value2 as? Int64? else {
+                    return false
+                }
+                if !compare(value1Optional, value2Optional) {
+                    return false
+                }
             case .double:
                 guard let value1Optional = value1 as? Double?, let value2Optional = value2 as? Double? else {
                     return false

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -676,7 +676,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
         let metadata = MutationSyncMetadata(modelId: modelId,
                                             modelName: modelName,
                                             deleted: false,
-                                            lastChangedAt: Int(Date().timeIntervalSince1970),
+                                            lastChangedAt: Int64(Date().timeIntervalSince1970),
                                             version: 1)
 
         storageAdapter.save(metadata) { result in
@@ -700,12 +700,12 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
         let metadata1 = MutationSyncMetadata(modelId: UUID().uuidString,
                                              modelName: modelName,
                                              deleted: false,
-                                             lastChangedAt: Int(Date().timeIntervalSince1970),
+                                             lastChangedAt: Int64(Date().timeIntervalSince1970),
                                              version: 1)
         let metadata2 = MutationSyncMetadata(modelId: UUID().uuidString,
                                              modelName: modelName,
                                              deleted: false,
-                                             lastChangedAt: Int(Date().timeIntervalSince1970),
+                                             lastChangedAt: Int64(Date().timeIntervalSince1970),
                                              version: 1)
 
         let saveMetadata1 = expectation(description: "save metadata1 success")

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/StorageAdapterMutationSyncTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/StorageAdapterMutationSyncTests.swift
@@ -32,7 +32,7 @@ class StorageAdapterMutationSyncTests: BaseDataStoreTests {
             MutationSyncMetadata(modelId: $0.id,
                                  modelName: Post.modelName,
                                  deleted: false,
-                                 lastChangedAt: Int(Date().timeIntervalSince1970),
+                                 lastChangedAt: Int64(Date().timeIntervalSince1970),
                                  version: 1)
         }
         populateData(syncMetadataList)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -29,7 +29,7 @@ class InitialSyncOperationTests: XCTestCase {
     ///    - It reads sync metadata from storage
     func testReadsMetadata() {
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
-            let startDateMilliseconds = Int(Date().timeIntervalSince1970) * 1_000
+            let startDateMilliseconds = Int64(Date().timeIntervalSince1970) * 1_000
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: startDateMilliseconds)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
             listener?(event)
@@ -90,7 +90,7 @@ class InitialSyncOperationTests: XCTestCase {
     func testQueriesAPI() {
         let apiWasQueried = expectation(description: "API was queried for a PaginatedList of AnyModel")
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
-            let startDateMilliseconds = Int(Date().timeIntervalSince1970) * 1_000
+            let startDateMilliseconds = Int64(Date().timeIntervalSince1970) * 1_000
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: startDateMilliseconds)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
             listener?(event)
@@ -148,7 +148,7 @@ class InitialSyncOperationTests: XCTestCase {
     ///    - The method invokes a completion callback when complete
     func testInvokesPublisherCompletion() {
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
-            let startDateMilliseconds = Int(Date().timeIntervalSince1970) * 1_000
+            let startDateMilliseconds = Int64(Date().timeIntervalSince1970) * 1_000
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: startDateMilliseconds)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
             listener?(event)
@@ -203,7 +203,7 @@ class InitialSyncOperationTests: XCTestCase {
         var nextTokens = ["token1", "token2"]
 
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
-            let startedAt = Int(Date().timeIntervalSince1970)
+            let startedAt = Int64(Date().timeIntervalSince1970)
             let nextToken = nextTokens.isEmpty ? nil : nextTokens.removeFirst()
             let list = PaginatedList<AnyModel>(items: [], nextToken: nextToken, startedAt: startedAt)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
@@ -254,13 +254,13 @@ class InitialSyncOperationTests: XCTestCase {
     /// - Then:
     ///    - The method submits the returned data to the reconciliation queue
     func testSubmitsToReconciliationQueue() {
-        let startedAtMilliseconds = Int(Date().timeIntervalSince1970) * 1_000
+        let startedAtMilliseconds = Int64(Date().timeIntervalSince1970) * 1_000
         let model = MockSynced(id: "1")
         let anyModel = AnyModel(model)
         let metadata = MutationSyncMetadata(modelId: "1",
                                             modelName: MockSynced.modelName,
                                             deleted: false,
-                                            lastChangedAt: Int(Date().timeIntervalSince1970),
+                                            lastChangedAt: Int64(Date().timeIntervalSince1970),
                                             version: 1)
         let mutationSync = MutationSync(model: anyModel, syncMetadata: metadata)
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
@@ -331,7 +331,7 @@ class InitialSyncOperationTests: XCTestCase {
     /// - Then:
     ///    - The method submits the returned data to the reconciliation queue
     func testUpdatesSyncMetadata() throws {
-        let startDateMilliseconds = Int(Date().timeIntervalSince1970) * 1_000
+        let startDateMilliseconds = Int64(Date().timeIntervalSince1970) * 1_000
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
             let startedAt = startDateMilliseconds
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: startedAt)
@@ -477,7 +477,7 @@ class InitialSyncOperationTests: XCTestCase {
     ///    - It performs a sync query against the API category with a "lastSync" time from the last start time of
     ///      the stored metadata
     func testQueriesFromLastSync() throws {
-        let startDateMilliseconds = (Int(Date().timeIntervalSince1970) - 100) * 1_000
+        let startDateMilliseconds = (Int64(Date().timeIntervalSince1970) - 100) * 1_000
 
         let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
         try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas + [MockSynced.schema])
@@ -496,7 +496,7 @@ class InitialSyncOperationTests: XCTestCase {
 
         let apiWasQueried = expectation(description: "API was queried for a PaginatedList of AnyModel")
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { request, listener in
-            let lastSync = request.variables?["lastSync"] as? Int
+            let lastSync = request.variables?["lastSync"] as? Int64
             XCTAssertEqual(lastSync, startDateMilliseconds)
 
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: nil)
@@ -548,7 +548,7 @@ class InitialSyncOperationTests: XCTestCase {
 
     func testBaseQueryWhenExpiredLastSync() throws {
         // Set start date to 100 seconds in the past
-        let startDateMilliSeconds = (Int(Date().timeIntervalSince1970) - 100) * 1_000
+        let startDateMilliSeconds = (Int64(Date().timeIntervalSince1970) - 100) * 1_000
 
         let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
         try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas + [MockSynced.schema])

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
@@ -28,7 +28,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
         ModelRegistry.reset()
         PostCommentModelRegistration().registerModels(registry: ModelRegistry.self)
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
-            let startedAt = Int(Date().timeIntervalSince1970)
+            let startedAt = Int64(Date().timeIntervalSince1970)
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: startedAt)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
             listener?(event)
@@ -126,7 +126,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
                     .failure(APIError.operationError("", "", nil))
                 listener?(event)
             } else if request.document.contains("SyncComments") {
-                let startedAt = Int(Date().timeIntervalSince1970)
+                let startedAt = Int64(Date().timeIntervalSince1970)
                 let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: startedAt)
                 let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
                 listener?(event)
@@ -239,7 +239,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
         TestModelsWithNoAssociations().registerModels(registry: ModelRegistry.self)
 
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
-            let startedAt = Int(Date().timeIntervalSince1970)
+            let startedAt = Int64(Date().timeIntervalSince1970)
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: startedAt)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
             listener?(event)
@@ -306,7 +306,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
                 commentWasQueried.fulfill()
             }
 
-            let startedAt = Int(Date().timeIntervalSince1970)
+            let startedAt = Int64(Date().timeIntervalSince1970)
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: startedAt)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
             listener?(event)
@@ -380,7 +380,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
                 commentWasQueried.fulfill()
             }
 
-            let startedAt = Int(Date().timeIntervalSince1970)
+            let startedAt = Int64(Date().timeIntervalSince1970)
             let nextToken = nextTokens.isEmpty ? nil : nextTokens.removeFirst()
             let list = PaginatedList<AnyModel>(items: [], nextToken: nextToken, startedAt: startedAt)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/ModelSyncedEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/ModelSyncedEventEmitterTests.swift
@@ -49,7 +49,7 @@ class ModelSyncedEventEmitterTests: XCTestCase {
         let anyPostMetadata = MutationSyncMetadata(modelId: "1",
                                                    modelName: Post.modelName,
                                                    deleted: false,
-                                                   lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                   lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                    version: 1)
         let testPost = Post(id: "1", title: "post1", content: "content", createdAt: .now())
         let anyPost = AnyModel(testPost)
@@ -129,7 +129,7 @@ class ModelSyncedEventEmitterTests: XCTestCase {
         let anyPostMetadata = MutationSyncMetadata(modelId: "1",
                                                    modelName: "",
                                                    deleted: false,
-                                                   lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                   lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                    version: 1)
         let testPost = Post(id: "1", title: "post1", content: "content", createdAt: .now())
         let anyPost = AnyModel(testPost)
@@ -202,7 +202,7 @@ class ModelSyncedEventEmitterTests: XCTestCase {
         let anyPostMetadata = MutationSyncMetadata(modelId: "1",
                                                    modelName: Post.modelName,
                                                    deleted: false,
-                                                   lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                   lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                    version: 1)
         let testPost = Post(id: "1", title: "post1", content: "content", createdAt: .now())
         let anyPost = AnyModel(testPost)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
@@ -45,7 +45,7 @@ class SyncEventEmitterTests: XCTestCase {
         let anyPostMetadata = MutationSyncMetadata(modelId: "1",
                                                    modelName: Post.modelName,
                                                    deleted: false,
-                                                   lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                   lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                    version: 1)
         let anyPostMutationSync = MutationSync<AnyModel>(model: anyPost, syncMetadata: anyPostMetadata)
         let postMutationEvent = try MutationEvent(untypedModel: testPost, mutationType: .create)
@@ -196,7 +196,7 @@ class SyncEventEmitterTests: XCTestCase {
         let anyPostMetadata = MutationSyncMetadata(modelId: "1",
                                                    modelName: Post.modelName,
                                                    deleted: false,
-                                                   lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                   lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                    version: 1)
         let anyPostMutationSync = MutationSync<AnyModel>(model: anyPost, syncMetadata: anyPostMetadata)
 
@@ -207,7 +207,7 @@ class SyncEventEmitterTests: XCTestCase {
         let anyCommentMetadata = MutationSyncMetadata(modelId: "1",
                                                       modelName: Comment.modelName,
                                                       deleted: true,
-                                                      lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                      lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                       version: 2)
         let anyCommentMutationSync = MutationSync<AnyModel>(model: anyComment, syncMetadata: anyCommentMetadata)
         let commentMutationEvent = try MutationEvent(untypedModel: testComment, mutationType: .delete)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -39,7 +39,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         anyPostMetadata = MutationSyncMetadata(modelId: "1",
                                                modelName: testPost.modelName,
                                                deleted: false,
-                                               lastChangedAt: Int(Date().timeIntervalSince1970),
+                                               lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                version: 1)
         anyPostMutationSync = MutationSync<AnyModel>(model: anyPost, syncMetadata: anyPostMetadata)
 
@@ -48,7 +48,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         let anyPostDeleteMetadata = MutationSyncMetadata(modelId: "2",
                                                          modelName: testPost.modelName,
                                                          deleted: true,
-                                                         lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                         lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                          version: 2)
         anyPostDeletedMutationSync = MutationSync<AnyModel>(model: anyPostDelete, syncMetadata: anyPostDeleteMetadata)
         anyPostMutationEvent = MutationEvent(id: "1",
@@ -338,12 +338,12 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         let metadata1 = MutationSyncMetadata(modelId: model1.id,
                                              modelName: model1.modelName,
                                              deleted: false,
-                                             lastChangedAt: Int(Date().timeIntervalSince1970),
+                                             lastChangedAt: Int64(Date().timeIntervalSince1970),
                                              version: 1)
         let metadata2 = MutationSyncMetadata(modelId: model2.id,
                                              modelName: model2.modelName,
                                              deleted: false,
-                                             lastChangedAt: Int(Date().timeIntervalSince1970),
+                                             lastChangedAt: Int64(Date().timeIntervalSince1970),
                                              version: 1)
         let remoteModel1 = MutationSync<AnyModel>(model: model1, syncMetadata: metadata1)
         let remoteModel2 = MutationSync<AnyModel>(model: model2, syncMetadata: metadata2)
@@ -491,12 +491,12 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         let metadata1 = MutationSyncMetadata(modelId: model1.id,
                                              modelName: model1.modelName,
                                              deleted: false,
-                                             lastChangedAt: Int(Date().timeIntervalSince1970),
+                                             lastChangedAt: Int64(Date().timeIntervalSince1970),
                                              version: 1)
         let metadata2 = MutationSyncMetadata(modelId: model2.id,
                                              modelName: model2.modelName,
                                              deleted: false,
-                                             lastChangedAt: Int(Date().timeIntervalSince1970),
+                                             lastChangedAt: Int64(Date().timeIntervalSince1970),
                                              version: 1)
         let remoteModel1 = MutationSync<AnyModel>(model: model1, syncMetadata: metadata1)
         let remoteModel2 = MutationSync<AnyModel>(model: model2, syncMetadata: metadata2)
@@ -504,12 +504,12 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         let localMetadata1 = MutationSyncMetadata(modelId: model1.id,
                                                   modelName: model1.modelName,
                                                   deleted: false,
-                                                  lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                  lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                   version: 3)
         let localMetadata2 = MutationSyncMetadata(modelId: model2.id,
                                                   modelName: model2.modelName,
                                                   deleted: false,
-                                                  lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                  lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                   version: 4)
         operation.publisher
             .sink { completion in

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ReconcileAndSaveQueueTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ReconcileAndSaveQueueTests.swift
@@ -23,7 +23,7 @@ class ReconcileAndSaveQueueTests: XCTestCase {
         anyPostMetadata = MutationSyncMetadata(modelId: "1",
                                                modelName: testPost.modelName,
                                                deleted: false,
-                                               lastChangedAt: Int(Date().timeIntervalSince1970),
+                                               lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                version: 1)
         anyPostMutationSync = MutationSync<AnyModel>(model: anyPost, syncMetadata: anyPostMetadata)
         anyPostMutationSync = MutationSync<AnyModel>(model: anyPost, syncMetadata: anyPostMetadata)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/MutationEventExtensionsTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/MutationEventExtensionsTests.swift
@@ -361,7 +361,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         let metadata = MutationSyncMetadata(modelId: model.identifier(schema: MutationEvent.schema).stringValue,
                                             modelName: model.modelName,
                                             deleted: false,
-                                            lastChangedAt: Int(Date().timeIntervalSince1970),
+                                            lastChangedAt: Int64(Date().timeIntervalSince1970),
                                             version: version)
         return MutationSync(model: AnyModel(model), syncMetadata: metadata)
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Foundation+TestExtensions.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Foundation+TestExtensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Date {
-    var unixSeconds: Int {
-        Int(timeIntervalSince1970)
+    var unixSeconds: Int64 {
+        Int64(timeIntervalSince1970)
     }
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/3220

## Description
<!-- Why is this change required? What problem does it solve? -->

This PR is one of the changes necessary get DataStore working on watchOS. Currently, there are two issues with running DataStore on watchOS: 

1. It is observed that **Int** type is of size 32-bit on a physical watch device. When storing a value that's greater than 32-bits, it will crash with the error:
```
Swift/arm64_32-apple-watchos.swiftinterface:34421: Fatal error: Double value cannot be converted to Int because the result would be greater than Int.max
```

2. DataStore does not transition to an active sync state as it is stalled on connecting to the websocket endpoint. More to come regarding this issue in the next PR.

This PR addresses the first issue, as a pre-requisite to the second issue. We do this change first to make sure there are no regressions with existing use cases, and gives us a clean slate to work with. As well, it should be easier to get this change through the pipeline as it only involves internal implementation details of DataStore and have no customer impacting changes.

**Int** is replaced with **Int64** when we know that the values we are storing are larger than 32-bit. In **DataStore**, **ModelMetadata** and **MutationSyncMetadata** tables have columns storing `lastSync` and `lastChangedAt`. The values are, for example, 1,699,631,281,107 which is much larger than the largest 32-bit value of 2,147,483,647.

DataStore uses a local SQLite database, and have no changes to the local table generation, continue to store the values as **integer**, which supports 4B (32 bit) or 8B (64 bits).

> INTEGER. The value is a signed integer, stored in 0, 1, 2, 3, 4, 6, or 8 bytes depending on the magnitude of the value.

https://www.sqlite.org/datatype3.html

When creating a new watchOS app, the Architecture is set with “Standard Architectures (arm64, arm7k, arm64_32)”. (Xcode 15+).
 
> arm64_32 is a variant of arm64 with 32-bit pointer sizes, used on Apple Watch Series 4 and later.

https://stackoverflow.com/questions/67042548/watchos-multiple-build-targets-any-watchos-device-vs-armv7k-arm64-32

While the issue seems counter to the statement:

> On 32-bit platforms, Int is the same size as Int32, and on 64-bit platforms, Int is the same size as Int64.

https://developer.apple.com/documentation/swift/int

Setting things up with the latest Xcode (15.1), Apple Watch Series 9 running watchOS 10.1, the `Int` type is observed to be 32-bit size, crashing on the error above.


## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
