### PR TITLE
feat(DataStore): DisableSubscriptions flag for watchOS

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/AWSCloudWatchLoggingPlugin.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AWSCloudWatchLoggingPlugin.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1430"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -14,6 +14,7 @@ public enum ModelFieldType {
 
     case string
     case int
+    case int64
     case double
     case date
     case dateTime

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -14,7 +14,6 @@ public enum ModelFieldType {
 
     case string
     case int
-    case int64
     case double
     case date
     case dateTime

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Decorator/ConflictResolutionDecorator.swift
@@ -15,12 +15,12 @@ import Foundation
 public struct ConflictResolutionDecorator: ModelBasedGraphQLDocumentDecorator {
 
     private let version: Int?
-    private let lastSync: Int?
+    private let lastSync: Int64?
     private let graphQLType: GraphQLOperationType
     private var primaryKeysOnly: Bool
     
     public init(version: Int? = nil,
-                lastSync: Int? = nil,
+                lastSync: Int64? = nil,
                 graphQLType: GraphQLOperationType,
                 primaryKeysOnly: Bool = true) {
         self.version = version

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+AnyModelWithSync.swift
@@ -49,7 +49,7 @@ protocol ModelSyncGraphQLRequestFactory {
                           where predicate: QueryPredicate?,
                           limit: Int?,
                           nextToken: String?,
-                          lastSync: Int?,
+                          lastSync: Int64?,
                           authType: AWSAuthorizationType?) -> GraphQLRequest<SyncQueryResult>
 
 }
@@ -110,7 +110,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                  where predicate: QueryPredicate? = nil,
                                  limit: Int? = nil,
                                  nextToken: String? = nil,
-                                 lastSync: Int? = nil,
+                                 lastSync: Int64? = nil,
                                  authType: AWSAuthorizationType? = nil) -> GraphQLRequest<SyncQueryResult> {
         syncQuery(modelSchema: modelType.schema,
                          where: predicate,
@@ -215,7 +215,7 @@ extension GraphQLRequest: ModelSyncGraphQLRequestFactory {
                                  where predicate: QueryPredicate? = nil,
                                  limit: Int? = nil,
                                  nextToken: String? = nil,
-                                 lastSync: Int? = nil,
+                                 lastSync: Int64? = nil,
                                  authType: AWSAuthorizationType? = nil) -> GraphQLRequest<SyncQueryResult> {
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelSchema,
                                                                operationType: .query,

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/GraphQLDocumentInputValue.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/GraphQLDocumentInputValue.swift
@@ -37,6 +37,16 @@ extension Int: GraphQLDocumentValueRepresentable {
     }
 }
 
+extension Int64: GraphQLDocumentValueRepresentable {
+    public var graphQLDocumentValue: String {
+        return "\(self)"
+    }
+
+    public var graphQLInlineValue: String {
+        return "\(self)"
+    }
+}
+
 extension String: GraphQLDocumentValueRepresentable {
     public var graphQLDocumentValue: String {
         return self

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -103,7 +103,7 @@ extension Model {
                         return Fatal.preconditionFailure("Could not turn into json object from \(value)")
                     }
                 }
-            case .string, .int, .double, .timestamp, .bool:
+            case .string, .int, .int64, .double, .timestamp, .bool:
                 input[name] = value
             }
         }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/Model+GraphQL.swift
@@ -103,7 +103,7 @@ extension Model {
                         return Fatal.preconditionFailure("Could not turn into json object from \(value)")
                     }
                 }
-            case .string, .int, .int64, .double, .timestamp, .bool:
+            case .string, .int, .double, .timestamp, .bool:
                 input[name] = value
             }
         }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata+Schema.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata+Schema.swift
@@ -27,7 +27,7 @@ extension ModelSyncMetadata {
 
         definition.fields(
             .id(),
-            .field(keys.lastSync, is: .optional, ofType: .int64)
+            .field(keys.lastSync, is: .optional, ofType: .int)
         )
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata+Schema.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata+Schema.swift
@@ -27,7 +27,7 @@ extension ModelSyncMetadata {
 
         definition.fields(
             .id(),
-            .field(keys.lastSync, is: .optional, ofType: .int)
+            .field(keys.lastSync, is: .optional, ofType: .int64)
         )
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/ModelSync/ModelSyncMetadata.swift
@@ -12,10 +12,10 @@ public struct ModelSyncMetadata: Model {
     public let id: String
 
     /// The timestamp (in Unix seconds) at which the last sync was started, as reported by the service
-    public var lastSync: Int?
+    public var lastSync: Int64?
 
     public init(id: String,
-                lastSync: Int?) {
+                lastSync: Int64?) {
         self.id = id
         self.lastSync = lastSync
     }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSync.swift
@@ -87,7 +87,7 @@ public struct MutationSync<ModelType: Model>: Decodable {
         self.syncMetadata = MutationSyncMetadata(modelId: modelIdentifier,
                                                  modelName: resolvedModelName,
                                                  deleted: deleted,
-                                                 lastChangedAt: Int(lastChangedAt),
+                                                 lastChangedAt: Int64(lastChangedAt),
                                                  version: Int(version))
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata+Schema.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata+Schema.swift
@@ -31,7 +31,7 @@ extension MutationSyncMetadata {
         definition.fields(
             .id(),
             .field(sync.deleted, is: .required, ofType: .bool),
-            .field(sync.lastChangedAt, is: .required, ofType: .int),
+            .field(sync.lastChangedAt, is: .required, ofType: .int64),
             .field(sync.version, is: .required, ofType: .int)
         )
     }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata+Schema.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata+Schema.swift
@@ -31,7 +31,7 @@ extension MutationSyncMetadata {
         definition.fields(
             .id(),
             .field(sync.deleted, is: .required, ofType: .bool),
-            .field(sync.lastChangedAt, is: .required, ofType: .int64),
+            .field(sync.lastChangedAt, is: .required, ofType: .int),
             .field(sync.version, is: .required, ofType: .int)
         )
     }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSyncMetadata.swift
@@ -14,7 +14,7 @@ public struct MutationSyncMetadata: Model {
 
     public let id: MutationSyncIdentifier
     public var deleted: Bool
-    public var lastChangedAt: Int
+    public var lastChangedAt: Int64
     public var version: Int
 
     static let deliminator = "|"
@@ -30,14 +30,14 @@ public struct MutationSyncMetadata: Model {
         The format of the `id` has changed to support unique ids across mutiple model types.
         Use init(modelId:modelName:deleted:lastChangedAt) to pass in the `modelName`.
     """)
-    public init(id: MutationSyncIdentifier, deleted: Bool, lastChangedAt: Int, version: Int) {
+    public init(id: MutationSyncIdentifier, deleted: Bool, lastChangedAt: Int64, version: Int) {
         self.id = id
         self.deleted = deleted
         self.lastChangedAt = lastChangedAt
         self.version = version
     }
 
-    public init(modelId: ModelId, modelName: String, deleted: Bool, lastChangedAt: Int, version: Int) {
+    public init(modelId: ModelId, modelName: String, deleted: Bool, lastChangedAt: Int64, version: Int) {
         self.id = Self.identifier(modelName: modelName, modelId: modelId)
         self.deleted = deleted
         self.lastChangedAt = lastChangedAt

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/PaginatedList.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/PaginatedList.swift
@@ -11,5 +11,5 @@ import Foundation
 public struct PaginatedList<ModelType: Model>: Decodable {
     public let items: [MutationSync<ModelType>]
     public let nextToken: String?
-    public let startedAt: Int?
+    public let startedAt: Int64?
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSyncQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSyncQueryTests.swift
@@ -77,7 +77,7 @@ class GraphQLSyncQueryTests: XCTestCase {
         XCTAssertEqual(variables["nextToken"] as? String, "token")
         XCTAssertNotNil(variables["filter"])
         XCTAssertNotNil(variables["lastSync"])
-        XCTAssertEqual(variables["lastSync"] as? Int, 123)
+        XCTAssertEqual(variables["lastSync"] as? Int64, 123)
     }
 
     func testSyncGraphQLQueryForComment() {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAnyModelWithSyncTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAnyModelWithSyncTests.swift
@@ -228,7 +228,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
         let modelType = Post.self as Model.Type
         let nextToken = "nextToken"
         let limit = 100
-        let lastSync = 123
+        let lastSync: Int64 = 123
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .sync))
         documentBuilder.add(decorator: PaginationDecorator(limit: limit, nextToken: nextToken))
@@ -274,14 +274,14 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
         XCTAssertNotNil(variables["nextToken"])
         XCTAssertEqual(variables["nextToken"] as? String, nextToken)
         XCTAssertNotNil(variables["lastSync"])
-        XCTAssertEqual(variables["lastSync"] as? Int, lastSync)
+        XCTAssertEqual(variables["lastSync"] as? Int64, lastSync)
     }
 
     func testOptimizedSyncQueryGraphQLRequestWithFilter() {
         let modelType = Post.self as Model.Type
         let nextToken = "nextToken"
         let limit = 100
-        let lastSync = 123
+        let lastSync: Int64 = 123
         let postId = "123"
         let predicate = Post.CodingKeys.id.eq(postId)
         let request = GraphQLRequest<SyncQueryResult>.syncQuery(
@@ -310,7 +310,7 @@ class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
         let modelType = Post.self as Model.Type
         let nextToken = "nextToken"
         let limit = 100
-        let lastSync = 123
+        let lastSync: Int64 = 123
         let postId = "123"
         let altPostId = "456"
         let predicate = Post.CodingKeys.id.eq(postId) || Post.CodingKeys.id.eq(altPostId)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthRuleTests.swift
@@ -303,7 +303,7 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
         let modelType = Article.self as Model.Type
         let nextToken = "nextToken"
         let limit = 100
-        let lastSync = 123
+        let lastSync: Int64 = 123
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema, operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .sync))
         documentBuilder.add(decorator: PaginationDecorator(limit: limit, nextToken: nextToken))
@@ -347,6 +347,6 @@ class GraphQLRequestAuthRuleTests: XCTestCase {
         XCTAssertNotNil(variables["nextToken"])
         XCTAssertEqual(variables["nextToken"] as? String, nextToken)
         XCTAssertNotNil(variables["lastSync"])
-        XCTAssertEqual(variables["lastSync"] as? Int, lastSync)
+        XCTAssertEqual(variables["lastSync"] as? Int64, lastSync)
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestSyncCustomPrimaryKeyWithMultipleFieldsTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestSyncCustomPrimaryKeyWithMultipleFieldsTests.swift
@@ -137,7 +137,7 @@ class GraphQLRequestSyncCustomPrimaryKeyWithMultipleFieldsTests: XCTestCase {
     func testSyncQueryGraphQLRequestWithDateInPK() throws {
         let nextToken = "nextToken"
         let limit = 100
-        let lastSync = 123
+        let lastSync: Int64 = 123
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelName: CustomerWithMultipleFieldsinPK.modelName,
                                                                operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .sync))
@@ -188,7 +188,7 @@ class GraphQLRequestSyncCustomPrimaryKeyWithMultipleFieldsTests: XCTestCase {
         XCTAssertNotNil(variables["nextToken"])
         XCTAssertEqual(variables["nextToken"] as? String, nextToken)
         XCTAssertNotNil(variables["lastSync"])
-        XCTAssertEqual(variables["lastSync"] as? Int, lastSync)
+        XCTAssertEqual(variables["lastSync"] as? Int64, lastSync)
     }
 
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin.swift
@@ -56,7 +56,10 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
     }
 
     #if os(watchOS)
-    /// No-argument init that uses defaults for all providers
+    /// Initializer
+    /// - Parameters:
+    ///   - modelRegistration: Register DataStore models.
+    ///   - dataStoreConfiguration: Configuration object for DataStore
     public init(modelRegistration: AmplifyModelRegistration,
                 configuration dataStoreConfiguration: DataStoreConfiguration) {
         self.modelRegistration = modelRegistration
@@ -79,7 +82,10 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
         self.dispatchedModelSyncedEvents = [:]
     }
     #else
-    /// No-argument init that uses defaults for all providers
+    /// Initializer
+    /// - Parameters:
+    ///   - modelRegistration: Register DataStore models.
+    ///   - dataStoreConfiguration: Configuration object for DataStore
     public init(modelRegistration: AmplifyModelRegistration,
                 configuration dataStoreConfiguration: DataStoreConfiguration = .default) {
         self.modelRegistration = modelRegistration

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin.swift
@@ -55,6 +55,30 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
         }
     }
 
+    #if os(watchOS)
+    /// No-argument init that uses defaults for all providers
+    public init(modelRegistration: AmplifyModelRegistration,
+                configuration dataStoreConfiguration: DataStoreConfiguration) {
+        self.modelRegistration = modelRegistration
+        self.configuration = InternalDatastoreConfiguration(
+            isSyncEnabled: false,
+            validAPIPluginKey: "awsAPIPlugin",
+            validAuthPluginKey: "awsCognitoAuthPlugin",
+            pluginConfiguration: dataStoreConfiguration)
+
+        self.storageEngineBehaviorFactory =
+        StorageEngine.init(
+            isSyncEnabled:
+                dataStoreConfiguration:
+                validAPIPluginKey:
+                validAuthPluginKey:
+                modelRegistryVersion:
+                userDefault:
+        )
+        self.dataStorePublisher = DataStorePublisher()
+        self.dispatchedModelSyncedEvents = [:]
+    }
+    #else
     /// No-argument init that uses defaults for all providers
     public init(modelRegistration: AmplifyModelRegistration,
                 configuration dataStoreConfiguration: DataStoreConfiguration = .default) {
@@ -77,10 +101,11 @@ final public class AWSDataStorePlugin: DataStoreCategoryPlugin {
         self.dataStorePublisher = DataStorePublisher()
         self.dispatchedModelSyncedEvents = [:]
     }
-
+    #endif
+    
     /// Internal initializer for testing
     init(modelRegistration: AmplifyModelRegistration,
-         configuration dataStoreConfiguration: DataStoreConfiguration = .default,
+         configuration dataStoreConfiguration: DataStoreConfiguration = .testDefault(),
          storageEngineBehaviorFactory: StorageEngineBehaviorFactory? = nil,
          dataStorePublisher: ModelSubcriptionBehavior,
          operationQueue: OperationQueue = OperationQueue(),

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Configuration/DataStoreConfiguration+Helper.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Configuration/DataStoreConfiguration+Helper.swift
@@ -25,6 +25,7 @@ extension DataStoreConfiguration {
     ///   - syncMaxRecords: the number of records to sync per execution
     ///   - syncPageSize: the page size of each sync execution
     ///   - authModeStrategy: authorization strategy (.default | multiauth)
+    ///   - disableSubscriptions: called before establishing subscriptions. Return true to disable subscriptions.
     /// - Returns: an instance of `DataStoreConfiguration` with the passed parameters.
     public static func custom(
         errorHandler: @escaping DataStoreErrorHandler = { error in
@@ -84,7 +85,10 @@ extension DataStoreConfiguration {
     #endif
     
     #if os(watchOS)
-    /// The default configuration.
+    /// Default configuration with subscriptions disabled for watchOS. DataStore uses subscriptions via websockets,
+    /// which work on the watchOS simulator but not on the device. Running DataStore on watchOS with subscriptions
+    /// enabled is only possible during special circumstances such as actively streaming audio.
+    /// See https://github.com/aws-amplify/amplify-swift/pull/3368 for more details.
     public static var subscriptionsDisabled: DataStoreConfiguration {
         .custom(disableSubscriptions: { false })
     }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Configuration/DataStoreConfiguration+Helper.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Configuration/DataStoreConfiguration+Helper.swift
@@ -15,6 +15,41 @@ extension DataStoreConfiguration {
     public static let defaultSyncMaxRecords: UInt = 10_000
     public static let defaultSyncPageSize: UInt = 1_000
 
+    #if os(watchOS)
+    /// Creates a custom configuration. The only required property is `conflictHandler`.
+    ///
+    /// - Parameters:
+    ///   - errorHandler: a callback function called on unhandled errors
+    ///   - conflictHandler: a callback called when a conflict could not be resolved by the service
+    ///   - syncInterval: how often the sync engine will run (in seconds)
+    ///   - syncMaxRecords: the number of records to sync per execution
+    ///   - syncPageSize: the page size of each sync execution
+    ///   - authModeStrategy: authorization strategy (.default | multiauth)
+    /// - Returns: an instance of `DataStoreConfiguration` with the passed parameters.
+    public static func custom(
+        errorHandler: @escaping DataStoreErrorHandler = { error in
+            Amplify.Logging.error(error: error)
+        },
+        conflictHandler: @escaping DataStoreConflictHandler = { _, resolve  in
+            resolve(.applyRemote)
+        },
+        syncInterval: TimeInterval = DataStoreConfiguration.defaultSyncInterval,
+        syncMaxRecords: UInt = DataStoreConfiguration.defaultSyncMaxRecords,
+        syncPageSize: UInt = DataStoreConfiguration.defaultSyncPageSize,
+        syncExpressions: [DataStoreSyncExpression] = [],
+        authModeStrategy: AuthModeStrategyType = .default,
+        disableSubscriptions: @escaping () -> Bool
+    ) -> DataStoreConfiguration {
+        return DataStoreConfiguration(errorHandler: errorHandler,
+                                      conflictHandler: conflictHandler,
+                                      syncInterval: syncInterval,
+                                      syncMaxRecords: syncMaxRecords,
+                                      syncPageSize: syncPageSize,
+                                      syncExpressions: syncExpressions,
+                                      authModeStrategy: authModeStrategy,
+                                      disableSubscriptions: disableSubscriptions)
+    }
+    #else
     /// Creates a custom configuration. The only required property is `conflictHandler`.
     ///
     /// - Parameters:
@@ -46,6 +81,7 @@ extension DataStoreConfiguration {
                                       syncExpressions: syncExpressions,
                                       authModeStrategy: authModeStrategy)
     }
+    #endif
 
     /// The default configuration.
     public static var `default`: DataStoreConfiguration {

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Configuration/DataStoreConfiguration+Helper.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Configuration/DataStoreConfiguration+Helper.swift
@@ -83,7 +83,12 @@ extension DataStoreConfiguration {
     }
     #endif
     
-    #if !os(watchOS)
+    #if os(watchOS)
+    /// The default configuration.
+    public static var subscriptionsDisabled: DataStoreConfiguration {
+        .custom(disableSubscriptions: { false })
+    }
+    #else
     /// The default configuration.
     public static var `default`: DataStoreConfiguration {
         .custom()
@@ -96,6 +101,7 @@ extension DataStoreConfiguration {
         .custom(disableSubscriptions: disableSubscriptions)
     }
     #else
+    /// Internal method for testing
     static func testDefault() -> DataStoreConfiguration {
         .custom()
     }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Configuration/DataStoreConfiguration+Helper.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Configuration/DataStoreConfiguration+Helper.swift
@@ -82,10 +82,22 @@ extension DataStoreConfiguration {
                                       authModeStrategy: authModeStrategy)
     }
     #endif
-
+    
+    #if !os(watchOS)
     /// The default configuration.
     public static var `default`: DataStoreConfiguration {
         .custom()
     }
-
+    #endif
+    
+    #if os(watchOS)
+    /// Internal method for testing
+    static func testDefault(disableSubscriptions: @escaping () -> Bool = { false }) -> DataStoreConfiguration {
+        .custom(disableSubscriptions: disableSubscriptions)
+    }
+    #else
+    static func testDefault() -> DataStoreConfiguration {
+        .custom()
+    }
+    #endif
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Configuration/DataStoreConfiguration.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Configuration/DataStoreConfiguration.swift
@@ -70,6 +70,27 @@ public struct DataStoreConfiguration {
     /// Authorization mode strategy
     public var authModeStrategyType: AuthModeStrategyType
 
+    public let disableSubscriptions: () -> Bool
+    
+    #if os(watchOS)
+    init(errorHandler: @escaping DataStoreErrorHandler,
+         conflictHandler: @escaping DataStoreConflictHandler,
+         syncInterval: TimeInterval,
+         syncMaxRecords: UInt,
+         syncPageSize: UInt,
+         syncExpressions: [DataStoreSyncExpression],
+         authModeStrategy: AuthModeStrategyType = .default,
+         disableSubscriptions: @escaping () -> Bool) {
+        self.errorHandler = errorHandler
+        self.conflictHandler = conflictHandler
+        self.syncInterval = syncInterval
+        self.syncMaxRecords = syncMaxRecords
+        self.syncPageSize = syncPageSize
+        self.syncExpressions = syncExpressions
+        self.authModeStrategyType = authModeStrategy
+        self.disableSubscriptions = disableSubscriptions
+    }
+    #else
     init(errorHandler: @escaping DataStoreErrorHandler,
          conflictHandler: @escaping DataStoreConflictHandler,
          syncInterval: TimeInterval,
@@ -84,6 +105,7 @@ public struct DataStoreConfiguration {
         self.syncPageSize = syncPageSize
         self.syncExpressions = syncExpressions
         self.authModeStrategyType = authModeStrategy
+        self.disableSubscriptions = { false }
     }
-
+    #endif
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Migration/MutationSyncMetadataCopy.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Migration/MutationSyncMetadataCopy.swift
@@ -12,7 +12,7 @@ extension MutationSyncMetadataMigration {
     public struct MutationSyncMetadataCopy: Model {
         public let id: String
         public var deleted: Bool
-        public var lastChangedAt: Int
+        public var lastChangedAt: Int64
         public var version: Int
 
         // MARK: - CodingKeys
@@ -36,7 +36,7 @@ extension MutationSyncMetadataMigration {
             definition.fields(
                 .id(),
                 .field(sync.deleted, is: .required, ofType: .bool),
-                .field(sync.lastChangedAt, is: .required, ofType: .int),
+                .field(sync.lastChangedAt, is: .required, ofType: .int64),
                 .field(sync.version, is: .required, ofType: .int)
             )
         }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Migration/MutationSyncMetadataCopy.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Migration/MutationSyncMetadataCopy.swift
@@ -36,7 +36,7 @@ extension MutationSyncMetadataMigration {
             definition.fields(
                 .id(),
                 .field(sync.deleted, is: .required, ofType: .bool),
-                .field(sync.lastChangedAt, is: .required, ofType: .int64),
+                .field(sync.lastChangedAt, is: .required, ofType: .int),
                 .field(sync.version, is: .required, ofType: .int)
             )
         }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/ModelSchema+SQLite.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/ModelSchema+SQLite.swift
@@ -92,7 +92,7 @@ extension ModelField: SQLColumn {
         switch type {
         case .string, .enum, .date, .dateTime, .time, .model:
             return .text
-        case .int, .bool, .timestamp:
+        case .int, .int64, .bool, .timestamp:
             return .integer
         case .double:
             return .real

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/ModelSchema+SQLite.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/ModelSchema+SQLite.swift
@@ -92,7 +92,7 @@ extension ModelField: SQLColumn {
         switch type {
         case .string, .enum, .date, .dateTime, .time, .model:
             return .text
-        case .int, .int64, .bool, .timestamp:
+        case .int, .bool, .timestamp:
             return .integer
         case .double:
             return .real

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/ModelValueConverter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/ModelValueConverter+SQLite.swift
@@ -31,9 +31,13 @@ public struct SQLiteModelValueConverter: ModelValueConverter {
         case .string:
             return value as? String
         case .int:
-            return value as? Int
-        case .int64:
-            return value as? Int64
+            if let intValue = value as? Int {
+                return intValue
+            }
+            if let int64Value = value as? Int64 {
+                return int64Value
+            }
+            return nil
         case .double:
             return value as? Double
         case .date, .dateTime, .time:
@@ -70,7 +74,7 @@ public struct SQLiteModelValueConverter: ModelValueConverter {
         switch fieldType {
         case .string, .date, .dateTime, .time:
             return value as? String
-        case .int, .int64:
+        case .int:
             return value as? Int64
         case .double:
             return value as? Double

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/ModelValueConverter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/ModelValueConverter+SQLite.swift
@@ -32,6 +32,8 @@ public struct SQLiteModelValueConverter: ModelValueConverter {
             return value as? String
         case .int:
             return value as? Int
+        case .int64:
+            return value as? Int64
         case .double:
             return value as? Double
         case .date, .dateTime, .time:
@@ -68,7 +70,7 @@ public struct SQLiteModelValueConverter: ModelValueConverter {
         switch fieldType {
         case .string, .date, .dateTime, .time:
             return value as? String
-        case .int:
+        case .int, .int64:
             return value as? Int64
         case .double:
             return value as? Double

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/Support/Model+Sort.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/Support/Model+Sort.swift
@@ -109,7 +109,13 @@ extension ModelSchema {
             return ModelValueCompare(value1Optional: value1Optional,
                                      value2Optional: value2Optional)
                 .sortComparator(sortOrder: sortOrder)
-
+        case .int64:
+            guard let value1Optional = value1 as? Int64?, let value2Optional = value2 as? Int64? else {
+                return false
+            }
+            return ModelValueCompare(value1Optional: value1Optional,
+                                     value2Optional: value2Optional)
+                .sortComparator(sortOrder: sortOrder)
         case .double:
             guard let value1Optional = value1 as? Double?, let value2Optional = value2 as? Double? else {
                 return false

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/Support/Model+Sort.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/Support/Model+Sort.swift
@@ -103,19 +103,19 @@ extension ModelSchema {
                                      value2Optional: value2Optional)
                 .sortComparator(sortOrder: sortOrder)
         case .int, .timestamp:
-            guard let value1Optional = value1 as? Int?, let value2Optional = value2 as? Int? else {
-                return false
+            if let value1Optional = value1 as? Int?, let value2Optional = value2 as? Int? {
+                return ModelValueCompare(value1Optional: value1Optional,
+                                         value2Optional: value2Optional)
+                    .sortComparator(sortOrder: sortOrder)
             }
-            return ModelValueCompare(value1Optional: value1Optional,
-                                     value2Optional: value2Optional)
-                .sortComparator(sortOrder: sortOrder)
-        case .int64:
-            guard let value1Optional = value1 as? Int64?, let value2Optional = value2 as? Int64? else {
-                return false
+            
+            if let value1Optional = value1 as? Int64?, let value2Optional = value2 as? Int64? {
+                return ModelValueCompare(value1Optional: value1Optional,
+                                         value2Optional: value2Optional)
+                    .sortComparator(sortOrder: sortOrder)
             }
-            return ModelValueCompare(value1Optional: value1Optional,
-                                     value2Optional: value2Optional)
-                .sortComparator(sortOrder: sortOrder)
+            
+            return false
         case .double:
             guard let value1Optional = value1 as? Double?, let value2Optional = value2 as? Double? else {
                 return false

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Events/OutboxMutationEvent.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Events/OutboxMutationEvent.swift
@@ -36,7 +36,7 @@ public struct OutboxMutationEvent {
     public struct OutboxMutationEventElement {
         public let model: Model
         public var version: Int?
-        public var lastChangedAt: Int?
+        public var lastChangedAt: Int64?
         public var deleted: Bool?
     }
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -67,7 +67,7 @@ final class InitialSyncOperation: AsynchronousOperation {
         }
     }
 
-    private func getLastSyncTime() -> Int? {
+    private func getLastSyncTime() -> Int64? {
         guard !isCancelled else {
             finish(result: .successfulVoid)
             return nil
@@ -109,7 +109,7 @@ final class InitialSyncOperation: AsynchronousOperation {
         }
     }
 
-    private func query(lastSyncTime: Int?, nextToken: String? = nil) async {
+    private func query(lastSyncTime: Int64?, nextToken: String? = nil) async {
         guard !isCancelled else {
             finish(result: .successfulVoid)
             return
@@ -160,7 +160,7 @@ final class InitialSyncOperation: AsynchronousOperation {
 
     /// Disposes of the query results: Stops if error, reconciles results if success, and kick off a new query if there
     /// is a next token
-    private func handleQueryResults(lastSyncTime: Int?,
+    private func handleQueryResults(lastSyncTime: Int64?,
                                     graphQLResult: Result<SyncQueryResult, GraphQLResponseError<SyncQueryResult>>) {
         guard !isCancelled else {
             finish(result: .successfulVoid)
@@ -198,7 +198,7 @@ final class InitialSyncOperation: AsynchronousOperation {
         }
     }
 
-    private func updateModelSyncMetadata(lastSyncTime: Int?) {
+    private func updateModelSyncMetadata(lastSyncTime: Int64?) {
         guard !isCancelled else {
             finish(result: .successfulVoid)
             return

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
@@ -86,7 +86,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
                                   authModeStrategy: resolvedAuthStrategy)
 
         let reconciliationQueueFactory = reconciliationQueueFactory ??
-            AWSIncomingEventReconciliationQueue.init(modelSchemas:api:storageAdapter:syncExpressions:auth:authModeStrategy:modelReconciliationQueueFactory:)
+        AWSIncomingEventReconciliationQueue.init(modelSchemas:api:storageAdapter:syncExpressions:auth:authModeStrategy:modelReconciliationQueueFactory:disableSubscriptions:)
 
         let initialSyncOrchestratorFactory = initialSyncOrchestratorFactory ??
             AWSInitialSyncOrchestrator.init(dataStoreConfiguration:authModeStrategy:api:reconciliationQueue:storageAdapter:)
@@ -289,7 +289,8 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
                                                                dataStoreConfiguration.syncExpressions,
                                                                auth,
                                                                authModeStrategy,
-                                                               nil)
+                                                               nil,
+                                                               dataStoreConfiguration.disableSubscriptions)
         reconciliationQueueSink = reconciliationQueue?
             .publisher
             .sink(

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/OperationDisabledSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/OperationDisabledSubscriptionEventPublisher.swift
@@ -1,0 +1,31 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import AWSPluginsCore
+import Combine
+
+final class OperationDisabledIncomingSubscriptionEventPublisher: IncomingSubscriptionEventPublisher {
+
+    private let subscriptionEventSubject: PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>
+
+    var publisher: AnyPublisher<IncomingSubscriptionEventPublisherEvent, DataStoreError> {
+        return subscriptionEventSubject.eraseToAnyPublisher()
+    }
+
+    init() {
+        self.subscriptionEventSubject = PassthroughSubject<IncomingSubscriptionEventPublisherEvent, DataStoreError>()
+
+        let apiError = APIError.operationError(AppSyncErrorType.operationDisabled.rawValue, "", nil)
+        let dataStoreError = DataStoreError.api(apiError, nil)
+        subscriptionEventSubject.send(completion: .failure(dataStoreError))
+    
+    }
+
+    func cancel() {
+    }
+}

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -209,8 +209,8 @@ final class AWSModelReconciliationQueue: ModelReconciliationQueue {
                 return
             }
             if case let .api(error, _) = dataStoreError,
-               case let APIError.operationError(_, _, underlyingError) = error,
-               isOperationDisabledError(underlyingError) {
+               case let APIError.operationError(errorMessage, _, underlyingError) = error,
+               isOperationDisabledError(errorMessage, underlyingError) {
                 log.verbose("[InitializeSubscription.3] AWSModelReconciliationQueue determined isOperationDisabledError \(modelSchema.name)")
                 modelReconciliationQueueSubject.send(.disconnected(modelName: modelSchema.name, reason: .operationDisabled))
                 return
@@ -284,7 +284,12 @@ extension AWSModelReconciliationQueue {
         return false
     }
 
-    private func isOperationDisabledError(_ error: Error?) -> Bool {
+    private func isOperationDisabledError(_ errorMessage: String?, _ error: Error?) -> Bool {
+        if let errorMessage = errorMessage,
+            case .operationDisabled = AppSyncErrorType(errorMessage) {
+            return true
+        }
+        
         if let responseError = error as? GraphQLResponseError<ResponseType>,
            let graphQLError = graphqlErrors(from: responseError)?.first,
            let errorTypeValue = errorTypeValueFrom(graphQLError: graphQLError),

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Support/Model+Compare.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Support/Model+Compare.swift
@@ -62,6 +62,13 @@ extension ModelSchema {
                 if !compare(value1Optional, value2Optional) {
                     return false
                 }
+            case .int64:
+                guard let value1Optional = value1 as? Int64?, let value2Optional = value2 as? Int64? else {
+                    return false
+                }
+                if !compare(value1Optional, value2Optional) {
+                    return false
+                }
             case .double:
                 guard let value1Optional = value1 as? Double?, let value2Optional = value2 as? Double? else {
                     return false

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Support/Model+Compare.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Support/Model+Compare.swift
@@ -56,19 +56,17 @@ extension ModelSchema {
                     return false
                 }
             case .int:
-                guard let value1Optional = value1 as? Int?, let value2Optional = value2 as? Int? else {
-                    return false
+                if let value1Optional = value1 as? Int?, let value2Optional = value2 as? Int? {
+                    if !compare(value1Optional, value2Optional) {
+                        return false
+                    }
                 }
-                if !compare(value1Optional, value2Optional) {
-                    return false
+                if let value1Optional = value1 as? Int64?, let value2Optional = value2 as? Int64? {
+                    if !compare(value1Optional, value2Optional) {
+                        return false
+                    }
                 }
-            case .int64:
-                guard let value1Optional = value1 as? Int64?, let value2Optional = value2 as? Int64? else {
-                    return false
-                }
-                if !compare(value1Optional, value2Optional) {
-                    return false
-                }
+                return false
             case .double:
                 guard let value1Optional = value1 as? Double?, let value2Optional = value2 as? Double? else {
                     return false

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginAmplifyVersionableTests.swift
@@ -13,7 +13,12 @@ import AWSDataStorePlugin
 class AWSDataStorePluginAmplifyVersionableTests: XCTestCase {
 
     func testVersionExists() {
+        #if os(watchOS)
+        let plugin = AWSDataStorePlugin(modelRegistration: AmplifyModels(),
+                                        configuration: .custom(disableSubscriptions: { false }))
+        #else
         let plugin = AWSDataStorePlugin(modelRegistration: AmplifyModels())
+        #endif
         XCTAssertNotNil(plugin.version)
     }
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginAmplifyVersionableTests.swift
@@ -15,7 +15,7 @@ class AWSDataStorePluginAmplifyVersionableTests: XCTestCase {
     func testVersionExists() {
         #if os(watchOS)
         let plugin = AWSDataStorePlugin(modelRegistration: AmplifyModels(),
-                                        configuration: .custom(disableSubscriptions: { false }))
+                                        configuration: .subscriptionsDisabled)
         #else
         let plugin = AWSDataStorePlugin(modelRegistration: AmplifyModels())
         #endif

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreCategoryConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreCategoryConfigurationTests.swift
@@ -16,7 +16,13 @@ class AWSDataStorePluginConfigurationTests: XCTestCase {
     }
 
     func testDoesNotThrowOnMissingConfig() throws {
+        #if os(watchOS)
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
+                                        configuration: .custom(disableSubscriptions: { false }))
+        #else
         let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration())
+    
+        #endif
         try Amplify.add(plugin: plugin)
 
         let categoryConfig = DataStoreCategoryConfiguration(plugins: ["NonExistentPlugin": true])

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreCategoryConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreCategoryConfigurationTests.swift
@@ -18,7 +18,7 @@ class AWSDataStorePluginConfigurationTests: XCTestCase {
     func testDoesNotThrowOnMissingConfig() throws {
         #if os(watchOS)
         let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
-                                        configuration: .custom(disableSubscriptions: { false }))
+                                        configuration: .subscriptionsDisabled)
         #else
         let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration())
     

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
@@ -36,9 +36,9 @@ class SQLiteStorageEngineAdapterJsonTests: XCTestCase {
             try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
 
             let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
-                                                  dataStoreConfiguration: .default)
+                                                  dataStoreConfiguration: .testDefault())
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -676,7 +676,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
         let metadata = MutationSyncMetadata(modelId: modelId,
                                             modelName: modelName,
                                             deleted: false,
-                                            lastChangedAt: Int(Date().timeIntervalSince1970),
+                                            lastChangedAt: Int64(Date().timeIntervalSince1970),
                                             version: 1)
 
         storageAdapter.save(metadata) { result in
@@ -700,12 +700,12 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
         let metadata1 = MutationSyncMetadata(modelId: UUID().uuidString,
                                              modelName: modelName,
                                              deleted: false,
-                                             lastChangedAt: Int(Date().timeIntervalSince1970),
+                                             lastChangedAt: Int64(Date().timeIntervalSince1970),
                                              version: 1)
         let metadata2 = MutationSyncMetadata(modelId: UUID().uuidString,
                                              modelName: modelName,
                                              deleted: false,
-                                             lastChangedAt: Int(Date().timeIntervalSince1970),
+                                             lastChangedAt: Int64(Date().timeIntervalSince1970),
                                              version: 1)
 
         let saveMetadata1 = expectation(description: "save metadata1 success")

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/StorageAdapterMutationSyncTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/StorageAdapterMutationSyncTests.swift
@@ -32,7 +32,7 @@ class StorageAdapterMutationSyncTests: BaseDataStoreTests {
             MutationSyncMetadata(modelId: $0.id,
                                  modelName: Post.modelName,
                                  deleted: false,
-                                 lastChangedAt: Int(Date().timeIntervalSince1970),
+                                 lastChangedAt: Int64(Date().timeIntervalSince1970),
                                  version: 1)
         }
         populateData(syncMetadataList)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/CascadeDeleteOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/CascadeDeleteOperationTests.swift
@@ -29,7 +29,7 @@ class CascadeDeleteOperationTests: StorageEngineTestsBase {
 
             syncEngine = MockRemoteSyncEngine()
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEnginePublisherTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEnginePublisherTests.swift
@@ -24,7 +24,7 @@ class StorageEnginePublisherTests: StorageEngineTestsBase {
             try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
             syncEngine = MockRemoteSyncEngine()
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsDelete.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsDelete.swift
@@ -28,7 +28,7 @@ class StorageEngineTestsDelete: StorageEngineTestsBase {
 
             syncEngine = MockRemoteSyncEngine()
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsHasMany.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsHasMany.swift
@@ -29,7 +29,7 @@ class StorageEngineTestsHasMany: StorageEngineTestsBase {
 
             syncEngine = MockRemoteSyncEngine()
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsHasOne.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsHasOne.swift
@@ -28,7 +28,7 @@ class StorageEngineTestsHasOne: StorageEngineTestsBase {
 
             syncEngine = MockRemoteSyncEngine()
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsLazyPostComment4V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsLazyPostComment4V2Tests.swift
@@ -29,7 +29,7 @@ final class StorageEngineTestsLazyPostComment4V2Tests: StorageEngineTestsBase, S
             
             syncEngine = MockRemoteSyncEngine()
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsManyToMany.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsManyToMany.swift
@@ -28,7 +28,7 @@ class StorageEngineTestsManyToMany: StorageEngineTestsBase {
 
             syncEngine = MockRemoteSyncEngine()
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsOptionalAssociation.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsOptionalAssociation.swift
@@ -28,7 +28,7 @@ class StorageEngineTestsOptionalAssociation: StorageEngineTestsBase {
 
             syncEngine = MockRemoteSyncEngine()
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsPostComment4V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsPostComment4V2Tests.swift
@@ -28,7 +28,7 @@ final class StorageEngineTestsPostComment4V2Tests: StorageEngineTestsBase, Share
 
             syncEngine = MockRemoteSyncEngine()
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsSQLiteIndex.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsSQLiteIndex.swift
@@ -34,7 +34,7 @@ class StorageEngineTestsSQLiteIndex: StorageEngineTestsBase {
             try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
             syncEngine = MockRemoteSyncEngine()
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/ObserveQueryTaskRunnerTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/ObserveQueryTaskRunnerTests.swift
@@ -43,7 +43,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             sortInput: nil,
             storageEngine: storageEngine,
             dataStorePublisher: dataStorePublisher,
-            dataStoreConfiguration: .default,
+            dataStoreConfiguration: .testDefault(),
             dispatchedModelSyncedEvent: AtomicValue(initialValue: false),
             dataStoreStatePublisher: dataStoreStateSubject.eraseToAnyPublisher())
         let snapshots = taskRunner.sequence
@@ -96,7 +96,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             sortInput: nil,
             storageEngine: storageEngine,
             dataStorePublisher: dataStorePublisher,
-            dataStoreConfiguration: .default,
+            dataStoreConfiguration: .testDefault(),
             dispatchedModelSyncedEvent: dispatchedModelSyncedEvent,
             dataStoreStatePublisher: dataStoreStateSubject.eraseToAnyPublisher())
         let snapshots = taskRunner.sequence
@@ -157,7 +157,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             sortInput: nil,
             storageEngine: storageEngine,
             dataStorePublisher: dataStorePublisher,
-            dataStoreConfiguration: .default,
+            dataStoreConfiguration: .testDefault(),
             dispatchedModelSyncedEvent: AtomicValue(initialValue: false),
             dataStoreStatePublisher: dataStoreStateSubject.eraseToAnyPublisher())
         let post = Post(title: "model1",
@@ -204,7 +204,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             sortInput: nil,
             storageEngine: storageEngine,
             dataStorePublisher: dataStorePublisher,
-            dataStoreConfiguration: .default,
+            dataStoreConfiguration: .testDefault(),
             dispatchedModelSyncedEvent: AtomicValue(initialValue: false),
             dataStoreStatePublisher: dataStoreStateSubject.eraseToAnyPublisher())
         let snapshots = taskRunner.sequence
@@ -260,7 +260,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             sortInput: nil,
             storageEngine: storageEngine,
             dataStorePublisher: dataStorePublisher,
-            dataStoreConfiguration: .default,
+            dataStoreConfiguration: .testDefault(),
             dispatchedModelSyncedEvent: AtomicValue(initialValue: false),
             dataStoreStatePublisher: dataStoreStateSubject.eraseToAnyPublisher())
         let snapshots = taskRunner.sequence
@@ -320,7 +320,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             sortInput: nil,
             storageEngine: storageEngine,
             dataStorePublisher: dataStorePublisher,
-            dataStoreConfiguration: .default,
+            dataStoreConfiguration: .testDefault(),
             dispatchedModelSyncedEvent: AtomicValue(initialValue: false),
             dataStoreStatePublisher: dataStoreStateSubject.eraseToAnyPublisher())
         let snapshots = taskRunner.sequence
@@ -369,7 +369,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             sortInput: nil,
             storageEngine: storageEngine,
             dataStorePublisher: dataStorePublisher,
-            dataStoreConfiguration: .default,
+            dataStoreConfiguration: .testDefault(),
             dispatchedModelSyncedEvent: AtomicValue(initialValue: false),
             dataStoreStatePublisher: dataStoreStateSubject.eraseToAnyPublisher())
         let snapshots = taskRunner.sequence
@@ -409,7 +409,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             sortInput: nil,
             storageEngine: storageEngine,
             dataStorePublisher: dataStorePublisher,
-            dataStoreConfiguration: .default,
+            dataStoreConfiguration: .testDefault(),
             dispatchedModelSyncedEvent: AtomicValue(initialValue: false),
             dataStoreStatePublisher: dataStoreStateSubject.eraseToAnyPublisher())
         let snapshots = taskRunner.sequence
@@ -455,7 +455,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             sortInput: nil,
             storageEngine: storageEngine,
             dataStorePublisher: dataStorePublisher,
-            dataStoreConfiguration: .default,
+            dataStoreConfiguration: .testDefault(),
             dispatchedModelSyncedEvent: AtomicValue(initialValue: false),
             dataStoreStatePublisher: dataStoreStateSubject.eraseToAnyPublisher())
         let snapshots = taskRunner.sequence
@@ -497,7 +497,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             sortInput: nil,
             storageEngine: storageEngine,
             dataStorePublisher: dataStorePublisher,
-            dataStoreConfiguration: .default,
+            dataStoreConfiguration: .testDefault(),
             dispatchedModelSyncedEvent: AtomicValue(initialValue: false),
             dataStoreStatePublisher: dataStoreStateSubject.eraseToAnyPublisher())
         let post = Post(title: "model1",
@@ -556,7 +556,7 @@ class ObserveQueryTaskRunnerTests: XCTestCase {
             sortInput: QuerySortInput.ascending(Post.keys.id).asSortDescriptors(),
             storageEngine: storageEngine,
             dataStorePublisher: dataStorePublisher,
-            dataStoreConfiguration: .default,
+            dataStoreConfiguration: .testDefault(),
             dispatchedModelSyncedEvent: AtomicValue(initialValue: true),
             dataStoreStatePublisher: dataStoreStateSubject.eraseToAnyPublisher())
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/APICategoryDependencyTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/APICategoryDependencyTests.swift
@@ -63,11 +63,11 @@ extension APICategoryDependencyTests {
         try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
 
         let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
-                                              dataStoreConfiguration: .default)
+                                              dataStoreConfiguration: .testDefault())
         let validAPIPluginKey = "MockAPICategoryPlugin"
         let validAuthPluginKey = "MockAuthCategoryPlugin"
         let storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOperationSyncExpressionTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOperationSyncExpressionTests.swift
@@ -37,7 +37,14 @@ class InitialSyncOperationSyncExpressionTests: XCTestCase {
     func initialSyncOperation(withSyncExpression syncExpression: DataStoreSyncExpression,
                               responder: APIPluginQueryResponder) -> InitialSyncOperation {
         apiPlugin.responders[.queryRequestListener] = responder
-        let configuration  = DataStoreConfiguration.custom(syncPageSize: 10, syncExpressions: [syncExpression])
+        #if os(watchOS)
+        let configuration  = DataStoreConfiguration.custom(syncPageSize: 10, 
+                                                           syncExpressions: [syncExpression],
+                                                           disableSubscriptions: { false })
+        #else
+        let configuration  = DataStoreConfiguration.custom(syncPageSize: 10, 
+                                                           syncExpressions: [syncExpression])
+        #endif
         return InitialSyncOperation(
             modelSchema: MockSynced.schema,
             api: apiPlugin,

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -29,7 +29,7 @@ class InitialSyncOperationTests: XCTestCase {
     ///    - It reads sync metadata from storage
     func testReadsMetadata() {
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
-            let startDateMilliseconds = Int(Date().timeIntervalSince1970) * 1_000
+            let startDateMilliseconds = Int64(Date().timeIntervalSince1970) * 1_000
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: startDateMilliseconds)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
             listener?(event)
@@ -90,7 +90,7 @@ class InitialSyncOperationTests: XCTestCase {
     func testQueriesAPI() {
         let apiWasQueried = expectation(description: "API was queried for a PaginatedList of AnyModel")
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
-            let startDateMilliseconds = Int(Date().timeIntervalSince1970) * 1_000
+            let startDateMilliseconds = Int64(Date().timeIntervalSince1970) * 1_000
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: startDateMilliseconds)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
             listener?(event)
@@ -148,7 +148,7 @@ class InitialSyncOperationTests: XCTestCase {
     ///    - The method invokes a completion callback when complete
     func testInvokesPublisherCompletion() {
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
-            let startDateMilliseconds = Int(Date().timeIntervalSince1970) * 1_000
+            let startDateMilliseconds = Int64(Date().timeIntervalSince1970) * 1_000
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: startDateMilliseconds)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
             listener?(event)
@@ -203,7 +203,7 @@ class InitialSyncOperationTests: XCTestCase {
         var nextTokens = ["token1", "token2"]
 
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
-            let startedAt = Int(Date().timeIntervalSince1970)
+            let startedAt = Int64(Date().timeIntervalSince1970)
             let nextToken = nextTokens.isEmpty ? nil : nextTokens.removeFirst()
             let list = PaginatedList<AnyModel>(items: [], nextToken: nextToken, startedAt: startedAt)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
@@ -254,13 +254,13 @@ class InitialSyncOperationTests: XCTestCase {
     /// - Then:
     ///    - The method submits the returned data to the reconciliation queue
     func testSubmitsToReconciliationQueue() {
-        let startedAtMilliseconds = Int(Date().timeIntervalSince1970) * 1_000
+        let startedAtMilliseconds = Int64(Date().timeIntervalSince1970) * 1_000
         let model = MockSynced(id: "1")
         let anyModel = AnyModel(model)
         let metadata = MutationSyncMetadata(modelId: "1",
                                             modelName: MockSynced.modelName,
                                             deleted: false,
-                                            lastChangedAt: Int(Date().timeIntervalSince1970),
+                                            lastChangedAt: Int64(Date().timeIntervalSince1970),
                                             version: 1)
         let mutationSync = MutationSync(model: anyModel, syncMetadata: metadata)
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
@@ -331,7 +331,7 @@ class InitialSyncOperationTests: XCTestCase {
     /// - Then:
     ///    - The method submits the returned data to the reconciliation queue
     func testUpdatesSyncMetadata() throws {
-        let startDateMilliseconds = Int(Date().timeIntervalSince1970) * 1_000
+        let startDateMilliseconds = Int64(Date().timeIntervalSince1970) * 1_000
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
             let startedAt = startDateMilliseconds
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: startedAt)
@@ -477,7 +477,7 @@ class InitialSyncOperationTests: XCTestCase {
     ///    - It performs a sync query against the API category with a "lastSync" time from the last start time of
     ///      the stored metadata
     func testQueriesFromLastSync() throws {
-        let startDateMilliseconds = (Int(Date().timeIntervalSince1970) - 100) * 1_000
+        let startDateMilliseconds = (Int64(Date().timeIntervalSince1970) - 100) * 1_000
 
         let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
         try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas + [MockSynced.schema])
@@ -496,7 +496,7 @@ class InitialSyncOperationTests: XCTestCase {
 
         let apiWasQueried = expectation(description: "API was queried for a PaginatedList of AnyModel")
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { request, listener in
-            let lastSync = request.variables?["lastSync"] as? Int
+            let lastSync = request.variables?["lastSync"] as? Int64
             XCTAssertEqual(lastSync, startDateMilliseconds)
 
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: nil)
@@ -548,7 +548,7 @@ class InitialSyncOperationTests: XCTestCase {
 
     func testBaseQueryWhenExpiredLastSync() throws {
         // Set start date to 100 seconds in the past
-        let startDateMilliSeconds = (Int(Date().timeIntervalSince1970) - 100) * 1_000
+        let startDateMilliSeconds = (Int64(Date().timeIntervalSince1970) - 100) * 1_000
 
         let storageAdapter = try SQLiteStorageEngineAdapter(connection: Connection(.inMemory))
         try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas + [MockSynced.schema])

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
@@ -44,7 +44,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
         let reconciliationQueue = MockReconciliationQueue()
 
         let orchestrator: AWSInitialSyncOrchestrator =
-        AWSInitialSyncOrchestrator(dataStoreConfiguration: .default,
+        AWSInitialSyncOrchestrator(dataStoreConfiguration: .testDefault(),
                                    authModeStrategy: AWSDefaultAuthModeStrategy(),
                                    api: apiPlugin,
                                    reconciliationQueue: reconciliationQueue,
@@ -144,7 +144,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
         let reconciliationQueue = MockReconciliationQueue()
 
         let orchestrator: AWSInitialSyncOrchestrator =
-        AWSInitialSyncOrchestrator(dataStoreConfiguration: .default,
+        AWSInitialSyncOrchestrator(dataStoreConfiguration: .testDefault(),
                                    authModeStrategy: AWSDefaultAuthModeStrategy(),
                                    api: apiPlugin,
                                    reconciliationQueue: reconciliationQueue,
@@ -254,7 +254,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
 
         let reconciliationQueue = MockReconciliationQueue()
 
-        let orchestrator = AWSInitialSyncOrchestrator(dataStoreConfiguration: .default,
+        let orchestrator = AWSInitialSyncOrchestrator(dataStoreConfiguration: .testDefault(),
                                                       authModeStrategy: AWSDefaultAuthModeStrategy(),
                                                       api: apiPlugin,
                                                       reconciliationQueue: reconciliationQueue,
@@ -322,7 +322,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
         let reconciliationQueue = MockReconciliationQueue()
 
         let orchestrator: AWSInitialSyncOrchestrator =
-            AWSInitialSyncOrchestrator(dataStoreConfiguration: .default,
+            AWSInitialSyncOrchestrator(dataStoreConfiguration: .testDefault(),
                                        authModeStrategy: AWSDefaultAuthModeStrategy(),
                                        api: apiPlugin,
                                        reconciliationQueue: reconciliationQueue,
@@ -397,7 +397,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
         let reconciliationQueue = MockReconciliationQueue()
 
         let orchestrator: AWSInitialSyncOrchestrator =
-            AWSInitialSyncOrchestrator(dataStoreConfiguration: .default,
+            AWSInitialSyncOrchestrator(dataStoreConfiguration: .testDefault(),
                                        authModeStrategy: AWSDefaultAuthModeStrategy(),
                                        api: apiPlugin,
                                        reconciliationQueue: reconciliationQueue,
@@ -441,7 +441,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
         let reconciliationQueue = MockReconciliationQueue()
         
         let orchestrator =
-        AWSInitialSyncOrchestrator(dataStoreConfiguration: .default,
+        AWSInitialSyncOrchestrator(dataStoreConfiguration: .testDefault(),
                                    authModeStrategy: AWSDefaultAuthModeStrategy(),
                                    api: apiPlugin,
                                    reconciliationQueue: reconciliationQueue,

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
@@ -28,7 +28,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
         ModelRegistry.reset()
         PostCommentModelRegistration().registerModels(registry: ModelRegistry.self)
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
-            let startedAt = Int(Date().timeIntervalSince1970)
+            let startedAt = Int64(Date().timeIntervalSince1970)
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: startedAt)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
             listener?(event)
@@ -126,7 +126,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
                     .failure(APIError.operationError("", "", nil))
                 listener?(event)
             } else if request.document.contains("SyncComments") {
-                let startedAt = Int(Date().timeIntervalSince1970)
+                let startedAt = Int64(Date().timeIntervalSince1970)
                 let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: startedAt)
                 let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
                 listener?(event)
@@ -239,7 +239,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
         TestModelsWithNoAssociations().registerModels(registry: ModelRegistry.self)
 
         let responder = QueryRequestListenerResponder<PaginatedList<AnyModel>> { _, listener in
-            let startedAt = Int(Date().timeIntervalSince1970)
+            let startedAt = Int64(Date().timeIntervalSince1970)
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: startedAt)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
             listener?(event)
@@ -306,7 +306,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
                 commentWasQueried.fulfill()
             }
 
-            let startedAt = Int(Date().timeIntervalSince1970)
+            let startedAt = Int64(Date().timeIntervalSince1970)
             let list = PaginatedList<AnyModel>(items: [], nextToken: nil, startedAt: startedAt)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))
             listener?(event)
@@ -380,7 +380,7 @@ class InitialSyncOrchestratorTests: XCTestCase {
                 commentWasQueried.fulfill()
             }
 
-            let startedAt = Int(Date().timeIntervalSince1970)
+            let startedAt = Int64(Date().timeIntervalSince1970)
             let nextToken = nextTokens.isEmpty ? nil : nextTokens.removeFirst()
             let list = PaginatedList<AnyModel>(items: [], nextToken: nextToken, startedAt: startedAt)
             let event: GraphQLOperation<PaginatedList<AnyModel>>.OperationResult = .success(.success(list))

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/ModelSyncedEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/ModelSyncedEventEmitterTests.swift
@@ -49,7 +49,7 @@ class ModelSyncedEventEmitterTests: XCTestCase {
         let anyPostMetadata = MutationSyncMetadata(modelId: "1",
                                                    modelName: Post.modelName,
                                                    deleted: false,
-                                                   lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                   lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                    version: 1)
         let testPost = Post(id: "1", title: "post1", content: "content", createdAt: .now())
         let anyPost = AnyModel(testPost)
@@ -129,7 +129,7 @@ class ModelSyncedEventEmitterTests: XCTestCase {
         let anyPostMetadata = MutationSyncMetadata(modelId: "1",
                                                    modelName: "",
                                                    deleted: false,
-                                                   lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                   lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                    version: 1)
         let testPost = Post(id: "1", title: "post1", content: "content", createdAt: .now())
         let anyPost = AnyModel(testPost)
@@ -202,7 +202,7 @@ class ModelSyncedEventEmitterTests: XCTestCase {
         let anyPostMetadata = MutationSyncMetadata(modelId: "1",
                                                    modelName: Post.modelName,
                                                    deleted: false,
-                                                   lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                   lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                    version: 1)
         let testPost = Post(id: "1", title: "post1", content: "content", createdAt: .now())
         let anyPost = AnyModel(testPost)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/ModelSyncedEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/ModelSyncedEventEmitterTests.swift
@@ -20,7 +20,7 @@ class ModelSyncedEventEmitterTests: XCTestCase {
     var reconciliationQueue: MockAWSIncomingEventReconciliationQueue?
 
     override func setUp() {
-        initialSyncOrchestrator = MockAWSInitialSyncOrchestrator(dataStoreConfiguration: .default,
+        initialSyncOrchestrator = MockAWSInitialSyncOrchestrator(dataStoreConfiguration: .testDefault(),
                                                                  api: nil,
                                                                  reconciliationQueue: nil,
                                                                  storageAdapter: nil)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
@@ -56,7 +56,7 @@ class SyncEventEmitterTests: XCTestCase {
                                                                       syncExpressions: [],
                                                                       auth: nil)
 
-        initialSyncOrchestrator = MockAWSInitialSyncOrchestrator(dataStoreConfiguration: .default,
+        initialSyncOrchestrator = MockAWSInitialSyncOrchestrator(dataStoreConfiguration: .testDefault(),
                                                                  api: nil,
                                                                  reconciliationQueue: nil,
                                                                  storageAdapter: nil)
@@ -131,7 +131,7 @@ class SyncEventEmitterTests: XCTestCase {
                                                                       syncExpressions: [],
                                                                       auth: nil)
 
-        initialSyncOrchestrator = MockAWSInitialSyncOrchestrator(dataStoreConfiguration: .default,
+        initialSyncOrchestrator = MockAWSInitialSyncOrchestrator(dataStoreConfiguration: .testDefault(),
                                                                  api: nil,
                                                                  reconciliationQueue: nil,
                                                                  storageAdapter: nil)
@@ -229,7 +229,7 @@ class SyncEventEmitterTests: XCTestCase {
                                                                       syncExpressions: [],
                                                                       auth: nil)
 
-        initialSyncOrchestrator = MockAWSInitialSyncOrchestrator(dataStoreConfiguration: .default,
+        initialSyncOrchestrator = MockAWSInitialSyncOrchestrator(dataStoreConfiguration: .testDefault(),
                                                                  api: nil,
                                                                  reconciliationQueue: nil,
                                                                  storageAdapter: nil)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
@@ -45,7 +45,7 @@ class SyncEventEmitterTests: XCTestCase {
         let anyPostMetadata = MutationSyncMetadata(modelId: "1",
                                                    modelName: Post.modelName,
                                                    deleted: false,
-                                                   lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                   lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                    version: 1)
         let anyPostMutationSync = MutationSync<AnyModel>(model: anyPost, syncMetadata: anyPostMetadata)
         let postMutationEvent = try MutationEvent(untypedModel: testPost, mutationType: .create)
@@ -196,7 +196,7 @@ class SyncEventEmitterTests: XCTestCase {
         let anyPostMetadata = MutationSyncMetadata(modelId: "1",
                                                    modelName: Post.modelName,
                                                    deleted: false,
-                                                   lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                   lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                    version: 1)
         let anyPostMutationSync = MutationSync<AnyModel>(model: anyPost, syncMetadata: anyPostMetadata)
 
@@ -207,7 +207,7 @@ class SyncEventEmitterTests: XCTestCase {
         let anyCommentMetadata = MutationSyncMetadata(modelId: "1",
                                                       modelName: Comment.modelName,
                                                       deleted: true,
-                                                      lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                      lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                       version: 2)
         let anyCommentMutationSync = MutationSync<AnyModel>(model: anyComment, syncMetadata: anyCommentMetadata)
         let commentMutationEvent = try MutationEvent(untypedModel: testComment, mutationType: .delete)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionTests.swift
@@ -41,7 +41,7 @@ class LocalSubscriptionTests: XCTestCase {
 
             let syncEngine = RemoteSyncEngine(
                 storageAdapter: storageAdapter,
-                dataStoreConfiguration: .default,
+                dataStoreConfiguration: .testDefault(),
                 authModeStrategy: AWSDefaultAuthModeStrategy(),
                 outgoingMutationQueue: outgoingMutationQueue,
                 mutationEventIngester: mutationDatabaseAdapter,
@@ -54,7 +54,7 @@ class LocalSubscriptionTests: XCTestCase {
             )
 
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionWithJSONModelTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionWithJSONModelTests.swift
@@ -43,7 +43,7 @@ class LocalSubscriptionWithJSONModelTests: XCTestCase {
 
             let syncEngine = RemoteSyncEngine(
                 storageAdapter: storageAdapter,
-                dataStoreConfiguration: .default,
+                dataStoreConfiguration: .testDefault(),
                 authModeStrategy: AWSDefaultAuthModeStrategy(),
                 outgoingMutationQueue: outgoingMutationQueue,
                 mutationEventIngester: mutationDatabaseAdapter,
@@ -56,7 +56,7 @@ class LocalSubscriptionWithJSONModelTests: XCTestCase {
             )
 
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
@@ -37,12 +37,12 @@ class AWSMutationEventIngesterTests: XCTestCase {
             try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
 
             let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
-                                                  dataStoreConfiguration: .default)
+                                                  dataStoreConfiguration: .testDefault())
 
             let validAPIPluginKey = "MockAPICategoryPlugin"
             let validAuthPluginKey = "MockAuthCategoryPlugin"
             let storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                              dataStoreConfiguration: .default,
+                                              dataStoreConfiguration: .testDefault(),
                                               syncEngine: syncEngine,
                                               validAPIPluginKey: validAPIPluginKey,
                                               validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
@@ -62,7 +62,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
 
         let mutationQueue = OutgoingMutationQueue(
             storageAdapter: storageAdapter,
-            dataStoreConfiguration: .default,
+            dataStoreConfiguration: .testDefault(),
             authModeStrategy: AWSDefaultAuthModeStrategy()
         )
         try setUpDataStore(mutationQueue: mutationQueue)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
@@ -25,7 +25,7 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
         await tryOrFail {
             try setUpStorageAdapter()
             try setUpDataStore(mutationQueue: OutgoingMutationQueue(storageAdapter: storageAdapter,
-                                                                    dataStoreConfiguration: .default,
+                                                                    dataStoreConfiguration: .testDefault(),
                                                                     authModeStrategy: AWSDefaultAuthModeStrategy()))
         }
         let post = Post(title: "Post title",
@@ -190,7 +190,7 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
 
         await tryOrFail {
             try setUpDataStore(mutationQueue: OutgoingMutationQueue(storageAdapter: storageAdapter,
-                                                                    dataStoreConfiguration: .default,
+                                                                    dataStoreConfiguration: .testDefault(),
                                                                     authModeStrategy: AWSDefaultAuthModeStrategy()))
             try await startAmplify()
         }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
@@ -34,7 +34,7 @@ class OutgoingMutationQueueMockStateTest: XCTestCase {
         storageAdapter = MockSQLiteStorageEngineAdapter()
         mutationQueue = OutgoingMutationQueue(stateMachine,
                                               storageAdapter: storageAdapter,
-                                              dataStoreConfiguration: .default,
+                                              dataStoreConfiguration: .testDefault(),
                                               authModeStrategy: AWSDefaultAuthModeStrategy())
         eventSource = MockMutationEventSource()
         publisher = AWSMutationEventPublisher(eventSource: eventSource)
@@ -51,7 +51,7 @@ class OutgoingMutationQueueMockStateTest: XCTestCase {
 
         mutationQueue = OutgoingMutationQueue(stateMachine,
                                               storageAdapter: storageAdapter,
-                                              dataStoreConfiguration: .default,
+                                              dataStoreConfiguration: .testDefault(),
                                               authModeStrategy: AWSDefaultAuthModeStrategy())
         waitForExpectations(timeout: 1)
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -50,7 +50,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             expectCompletion.fulfill()
         }
         let expectErrorHandlerCalled = expectation(description: "Expect error handler called")
-        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+        let configuration = custom(errorHandler: { error in
             guard let dataStoreError = error as? DataStoreError,
                 case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
                     XCTFail("Expected API error with mutationEvent")
@@ -96,7 +96,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             expectCompletion.fulfill()
         }
         let expectErrorHandlerCalled = expectation(description: "Expect error handler called")
-        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+        let configuration = custom(errorHandler: { error in
             guard let dataStoreError = error as? DataStoreError,
                   case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
                 XCTFail("Expected API error with mutationEvent")
@@ -139,7 +139,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             expectCompletion.fulfill()
         }
         let expectErrorHandlerCalled = expectation(description: "Expect error handler called")
-        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+        let configuration = custom(errorHandler: { error in
             guard let dataStoreError = error as? DataStoreError,
                   case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
                 XCTFail("Expected API error with mutationEvent")
@@ -182,7 +182,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             expectCompletion.fulfill()
         }
         let expectErrorHandlerCalled = expectation(description: "Expect error handler called")
-        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+        let configuration = custom(errorHandler: { error in
             guard let dataStoreError = error as? DataStoreError,
                   case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
                 XCTFail("Expected API error with mutationEvent")
@@ -227,7 +227,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             expectCompletion.fulfill()
         }
         let expectErrorHandlerCalled = expectation(description: "Expect error handler called")
-        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+        let configuration = custom(errorHandler: { error in
             guard let dataStoreError = error as? DataStoreError,
                   case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
                 XCTFail("Expected API error with mutationEvent")
@@ -278,7 +278,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             self.assertSuccessfulNil(result)
             expectCompletion.fulfill()
         }
-        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+        let configuration = custom(errorHandler: { error in
             guard let dataStoreError = error as? DataStoreError,
                   case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
                 XCTFail("Expected API error with mutationEvent")
@@ -318,7 +318,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             self.assertSuccessfulNil(result)
             expectCompletion.fulfill()
         }
-        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+        let configuration = custom(errorHandler: { error in
             guard let dataStoreError = error as? DataStoreError,
                   case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
                 XCTFail("Expected API error with mutationEvent")
@@ -357,7 +357,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             self.assertSuccessfulNil(result)
             expectCompletion.fulfill()
         }
-        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+        let configuration = custom(errorHandler: { error in
             guard let dataStoreError = error as? DataStoreError,
                   case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
                 XCTFail("Expected API error with mutationEvent")
@@ -396,7 +396,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             self.assertSuccessfulNil(result)
             expectCompletion.fulfill()
         }
-        let configuration = DataStoreConfiguration.custom(errorHandler: { error in
+        let configuration = custom(errorHandler: { error in
             guard let dataStoreError = error as? DataStoreError,
                   case let .api(amplifyError, mutationEventOptional) = dataStoreError else {
                 XCTFail("Expected API error with mutationEvent")
@@ -448,7 +448,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             XCTAssertEqual(dataStoreError.errorDescription, "Missing remote model from the response from AppSync.")
             expectCompletion.fulfill()
         }
-        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: .default,
+        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: .testDefault(),
                                                                mutationEvent: mutationEvent,
                                                                api: mockAPIPlugin,
                                                                storageAdapter: storageAdapter,
@@ -484,7 +484,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             XCTAssertEqual(dataStoreError.errorDescription, "Should never get conflict unhandled for create mutation")
             expectCompletion.fulfill()
         }
-        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: .default,
+        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: .testDefault(),
                                                                mutationEvent: mutationEvent,
                                                                api: mockAPIPlugin,
                                                                storageAdapter: storageAdapter,
@@ -514,7 +514,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             self.assertSuccessfulNil(result)
             expectCompletion.fulfill()
         }
-        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: .default,
+        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: .testDefault(),
                                                                mutationEvent: mutationEvent,
                                                                api: mockAPIPlugin,
                                                                storageAdapter: storageAdapter,
@@ -561,7 +561,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
         }
 
         let expectConflicthandlerCalled = expectation(description: "Expect conflict handler called")
-        let configuration = DataStoreConfiguration.custom(conflictHandler: { data, resolve  in
+        let configuration = custom(conflictHandler: { data, resolve  in
             guard let localPost = data.local as? Post,
                 let remotePost = data.remote as? Post else {
                 XCTFail("Couldn't get Posts from local and remote data")
@@ -638,7 +638,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
         }
 
         let expectConflicthandlerCalled = expectation(description: "Expect conflict handler called")
-        let configuration = DataStoreConfiguration.custom(conflictHandler: { data, resolve  in
+        let configuration = custom(conflictHandler: { data, resolve  in
             guard let localPost = data.local as? Post,
                 let remotePost = data.remote as? Post else {
                 XCTFail("Couldn't get Posts from local and remote data")
@@ -731,7 +731,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                 expectHubEvent.fulfill()
             }
         }
-        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: .default,
+        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: .testDefault(),
                                                                mutationEvent: mutationEvent,
                                                                api: mockAPIPlugin,
                                                                storageAdapter: storageAdapter,
@@ -794,7 +794,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                 expectHubEvent.fulfill()
             }
         }
-        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: .default,
+        let operation = ProcessMutationErrorFromCloudOperation(dataStoreConfiguration: .testDefault(),
                                                                mutationEvent: mutationEvent,
                                                                api: mockAPIPlugin,
                                                                storageAdapter: storageAdapter,
@@ -864,7 +864,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
             }
         }
         let expectConflicthandlerCalled = expectation(description: "Expect conflict handler called")
-        let configuration = DataStoreConfiguration.custom(conflictHandler: { data, resolve  in
+        let configuration = custom(conflictHandler: { data, resolve  in
             guard let localPost = data.local as? Post,
                 let remotePost = data.remote as? Post else {
                 XCTFail("Couldn't get Posts from local and remote data")
@@ -933,7 +933,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
         }
 
         let expectConflicthandlerCalled = expectation(description: "Expect conflict handler called")
-        let configuration = DataStoreConfiguration.custom(conflictHandler: { data, resolve  in
+        let configuration = custom(conflictHandler: { data, resolve  in
             guard let localPost = data.local as? Post,
                 let remotePost = data.remote as? Post else {
                 XCTFail("Couldn't get Posts from local and remote data")
@@ -1012,7 +1012,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
         }
 
         let expectConflicthandlerCalled = expectation(description: "Expect conflict handler called")
-        let configuration = DataStoreConfiguration.custom(conflictHandler: { data, resolve  in
+        let configuration = custom(conflictHandler: { data, resolve  in
             guard let localPost = data.local as? Post,
                 let remotePost = data.remote as? Post else {
                 XCTFail("Couldn't get Posts from local and remote data")
@@ -1091,7 +1091,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
 
         let expectConflicthandlerCalled = expectation(description: "Expect conflict handler called")
         let expectErrorHandlerCalled = expectation(description: "Expect error handler called")
-        let configuration = DataStoreConfiguration.custom(errorHandler: { _ in
+        let configuration = custom(errorHandler: { _ in
             expectErrorHandlerCalled.fulfill()
         }, conflictHandler: { data, resolve in
             guard let localPost = data.local as? Post,
@@ -1151,7 +1151,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                        errorType: .operationDisabled)
 
         let operation = ProcessMutationErrorFromCloudOperation(
-            dataStoreConfiguration: DataStoreConfiguration.default,
+            dataStoreConfiguration: DataStoreConfiguration.testDefault(),
             mutationEvent: mutationEvent,
             api: mockAPIPlugin,
             storageAdapter: storageAdapter,
@@ -1244,5 +1244,34 @@ extension ProcessMutationErrorFromCloudOperationTests {
                      locations: nil,
                      path: nil,
                      extensions: ["errorType": .string(errorType.rawValue)])
+    }
+    
+    private func custom(errorHandler: DataStoreErrorHandler? = nil,
+                        conflictHandler: (DataStoreConflictHandler)? = nil) -> DataStoreConfiguration {
+        if let conflictHandler = conflictHandler, let errorHandler = errorHandler {
+            #if os(watchOS)
+            return .custom(errorHandler: errorHandler,
+                           conflictHandler: conflictHandler,
+                           disableSubscriptions: { false })
+            #else
+            return .custom(errorHandler: errorHandler,
+                    conflictHandler: conflictHandler)
+            #endif
+        } else if let errorHandler = errorHandler {
+            #if os(watchOS)
+            return .custom(errorHandler: errorHandler,
+                           disableSubscriptions: { false })
+            #else
+            return .custom(errorHandler: errorHandler)
+            #endif
+        } else if let conflictHandler = conflictHandler {
+            #if os(watchOS)
+            return .custom(conflictHandler: conflictHandler,
+                           disableSubscriptions: { false })
+            #else
+            return .custom(conflictHandler: conflictHandler)
+            #endif
+        }
+        return .testDefault()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
@@ -41,9 +41,9 @@ class RemoteSyncAPIInvocationTests: XCTestCase {
             try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
 
             let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
-                                                  dataStoreConfiguration: .default)
+                                                  dataStoreConfiguration: .testDefault())
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
@@ -33,7 +33,7 @@ class RemoteSyncEngineTests: XCTestCase {
         do {
             remoteSyncEngine = try RemoteSyncEngine(
                 storageAdapter: storageAdapter,
-                dataStoreConfiguration: .default,
+                dataStoreConfiguration: .testDefault(),
                 outgoingMutationQueue: mockOutgoingMutationQueue,
                 initialSyncOrchestratorFactory: MockAWSInitialSyncOrchestrator.factory,
                 reconciliationQueueFactory: MockAWSIncomingEventReconciliationQueue.factory,

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -39,7 +39,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         anyPostMetadata = MutationSyncMetadata(modelId: "1",
                                                modelName: testPost.modelName,
                                                deleted: false,
-                                               lastChangedAt: Int(Date().timeIntervalSince1970),
+                                               lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                version: 1)
         anyPostMutationSync = MutationSync<AnyModel>(model: anyPost, syncMetadata: anyPostMetadata)
 
@@ -48,7 +48,7 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         let anyPostDeleteMetadata = MutationSyncMetadata(modelId: "2",
                                                          modelName: testPost.modelName,
                                                          deleted: true,
-                                                         lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                         lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                          version: 2)
         anyPostDeletedMutationSync = MutationSync<AnyModel>(model: anyPostDelete, syncMetadata: anyPostDeleteMetadata)
         anyPostMutationEvent = MutationEvent(id: "1",
@@ -338,12 +338,12 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         let metadata1 = MutationSyncMetadata(modelId: model1.id,
                                              modelName: model1.modelName,
                                              deleted: false,
-                                             lastChangedAt: Int(Date().timeIntervalSince1970),
+                                             lastChangedAt: Int64(Date().timeIntervalSince1970),
                                              version: 1)
         let metadata2 = MutationSyncMetadata(modelId: model2.id,
                                              modelName: model2.modelName,
                                              deleted: false,
-                                             lastChangedAt: Int(Date().timeIntervalSince1970),
+                                             lastChangedAt: Int64(Date().timeIntervalSince1970),
                                              version: 1)
         let remoteModel1 = MutationSync<AnyModel>(model: model1, syncMetadata: metadata1)
         let remoteModel2 = MutationSync<AnyModel>(model: model2, syncMetadata: metadata2)
@@ -491,12 +491,12 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         let metadata1 = MutationSyncMetadata(modelId: model1.id,
                                              modelName: model1.modelName,
                                              deleted: false,
-                                             lastChangedAt: Int(Date().timeIntervalSince1970),
+                                             lastChangedAt: Int64(Date().timeIntervalSince1970),
                                              version: 1)
         let metadata2 = MutationSyncMetadata(modelId: model2.id,
                                              modelName: model2.modelName,
                                              deleted: false,
-                                             lastChangedAt: Int(Date().timeIntervalSince1970),
+                                             lastChangedAt: Int64(Date().timeIntervalSince1970),
                                              version: 1)
         let remoteModel1 = MutationSync<AnyModel>(model: model1, syncMetadata: metadata1)
         let remoteModel2 = MutationSync<AnyModel>(model: model2, syncMetadata: metadata2)
@@ -504,12 +504,12 @@ class ReconcileAndLocalSaveOperationTests: XCTestCase {
         let localMetadata1 = MutationSyncMetadata(modelId: model1.id,
                                                   modelName: model1.modelName,
                                                   deleted: false,
-                                                  lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                  lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                   version: 3)
         let localMetadata2 = MutationSyncMetadata(modelId: model2.id,
                                                   modelName: model2.modelName,
                                                   deleted: false,
-                                                  lastChangedAt: Int(Date().timeIntervalSince1970),
+                                                  lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                   version: 4)
         operation.publisher
             .sink { completion in

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ReconcileAndSaveQueueTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ReconcileAndSaveQueueTests.swift
@@ -23,7 +23,7 @@ class ReconcileAndSaveQueueTests: XCTestCase {
         anyPostMetadata = MutationSyncMetadata(modelId: "1",
                                                modelName: testPost.modelName,
                                                deleted: false,
-                                               lastChangedAt: Int(Date().timeIntervalSince1970),
+                                               lastChangedAt: Int64(Date().timeIntervalSince1970),
                                                version: 1)
         anyPostMutationSync = MutationSync<AnyModel>(model: anyPost, syncMetadata: anyPostMetadata)
         anyPostMutationSync = MutationSync<AnyModel>(model: anyPost, syncMetadata: anyPostMetadata)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/MutationEventExtensionsTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/MutationEventExtensionsTests.swift
@@ -361,7 +361,7 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
         let metadata = MutationSyncMetadata(modelId: model.identifier(schema: MutationEvent.schema).stringValue,
                                             modelName: model.modelName,
                                             deleted: false,
-                                            lastChangedAt: Int(Date().timeIntervalSince1970),
+                                            lastChangedAt: Int64(Date().timeIntervalSince1970),
                                             version: version)
         return MutationSync(model: AnyModel(model), syncMetadata: metadata)
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/BaseDataStoreTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/BaseDataStoreTests.swift
@@ -36,9 +36,9 @@ class BaseDataStoreTests: XCTestCase {
             try storageAdapter.setUp(modelSchemas: StorageEngine.systemModelSchemas)
 
             let syncEngine = try RemoteSyncEngine(storageAdapter: storageAdapter,
-                                                  dataStoreConfiguration: .default)
+                                                  dataStoreConfiguration: .testDefault())
             storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Foundation+TestExtensions.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Foundation+TestExtensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Date {
-    var unixSeconds: Int {
-        Int(timeIntervalSince1970)
+    var unixSeconds: Int64 {
+        Int64(timeIntervalSince1970)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/LocalStoreIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/LocalStoreIntegrationTestBase.swift
@@ -21,7 +21,12 @@ class LocalStoreIntegrationTestBase: XCTestCase {
         continueAfterFailure = false
 
         do {
+            #if os(watchOS)
+            try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models, 
+                                                       configuration: .custom(disableSubscriptions:  { false })))
+            #else
             try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models))
+            #endif
             try Amplify.configure(AmplifyConfiguration(dataStore: nil))
         } catch {
             XCTFail(String(describing: error))

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/LocalStoreIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/LocalStoreIntegrationTestBase.swift
@@ -23,7 +23,7 @@ class LocalStoreIntegrationTestBase: XCTestCase {
         do {
             #if os(watchOS)
             try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models, 
-                                                       configuration: .custom(disableSubscriptions:  { false })))
+                                                       configuration: .subscriptionsDisabled))
             #else
             try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models))
             #endif

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
@@ -13,7 +13,7 @@ import Combine
 @testable import AWSDataStorePlugin
 
 class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue {
-    static let factory: IncomingEventReconciliationQueueFactory = { modelSchemas, api, storageAdapter, syncExpressions, auth, _, _  in
+    static let factory: IncomingEventReconciliationQueueFactory = { modelSchemas, api, storageAdapter, syncExpressions, auth, _, _, _ in
         MockAWSIncomingEventReconciliationQueue(modelSchemas: modelSchemas,
                                                 api: api,
                                                 storageAdapter: storageAdapter,

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/SyncEngineTestBase.swift
@@ -127,7 +127,7 @@ class SyncEngineTestBase: XCTestCase {
                                     resolver: RemoteSyncEngine.Resolver.resolve(currentState:action:))
 
         syncEngine = RemoteSyncEngine(storageAdapter: storageAdapter,
-                                      dataStoreConfiguration: .default,
+                                      dataStoreConfiguration: .testDefault(),
                                       authModeStrategy: AWSDefaultAuthModeStrategy(),
                                       outgoingMutationQueue: mutationQueue,
                                       mutationEventIngester: mutationDatabaseAdapter,
@@ -156,7 +156,7 @@ class SyncEngineTestBase: XCTestCase {
         let validAuthPluginKey = "MockAuthCategoryPlugin"
 
         let storageEngine = StorageEngine(storageAdapter: storageAdapter,
-                                          dataStoreConfiguration: .default,
+                                          dataStoreConfiguration: .testDefault(),
                                           syncEngine: syncEngine,
                                           validAPIPluginKey: validAPIPluginKey,
                                           validAuthPluginKey: validAuthPluginKey)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreAuthBaseTest.swift
@@ -164,8 +164,11 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
         do {
             setupCredentials(forAuthStrategy: testType)
 
+            #if os(watchOS)
+            let datastoreConfig = DataStoreConfiguration.custom(authModeStrategy: testType.authStrategy, disableSubscriptions: { false })
+            #else
             let datastoreConfig = DataStoreConfiguration.custom(authModeStrategy: testType.authStrategy)
-
+            #endif
             try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models,
                                                        configuration: datastoreConfig))
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthIAMTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthIAMTests/AWSDataStoreAuthBaseTest.swift
@@ -195,8 +195,11 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
         do {
             setupCredentials(forAuthStrategy: testType)
 
+            #if os(watchOS)
+            let datastoreConfig = DataStoreConfiguration.custom(authModeStrategy: testType.authStrategy, disableSubscriptions: { false })
+            #else
             let datastoreConfig = DataStoreConfiguration.custom(authModeStrategy: testType.authStrategy)
-
+            #endif
             try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models,
                                                        configuration: datastoreConfig))
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/11/AWSDataStoreIntSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/11/AWSDataStoreIntSortKeyTest.swift
@@ -40,10 +40,17 @@ class AWSDataStoreIntSortKeyTest: XCTestCase {
         try Amplify.add(plugin: AWSAPIPlugin(
             sessionFactory: AmplifyURLSessionFactory())
         )
+        #if os(watchOS)
+        try Amplify.add(plugin: AWSDataStorePlugin(
+            modelRegistration: TestModels(),
+            configuration: .custom(syncMaxRecords: 100, disableSubscriptions: { false })
+        ))
+        #else
         try Amplify.add(plugin: AWSDataStorePlugin(
             modelRegistration: TestModels(),
             configuration: .custom(syncMaxRecords: 100)
         ))
+        #endif
         Amplify.Logging.logLevel = .verbose
         try Amplify.configure(config)
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/12/AWSDataStoreFloatSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/12/AWSDataStoreFloatSortKeyTest.swift
@@ -40,10 +40,17 @@ class AWSDataStoreFloatSortKeyTest: XCTestCase {
         try Amplify.add(plugin: AWSAPIPlugin(
             sessionFactory: AmplifyURLSessionFactory())
         )
+        #if os(watchOS)
+        try Amplify.add(plugin: AWSDataStorePlugin(
+            modelRegistration: TestModels(),
+            configuration: .custom(syncMaxRecords: 100, disableSubscriptions: { false })
+        ))
+        #else
         try Amplify.add(plugin: AWSDataStorePlugin(
             modelRegistration: TestModels(),
             configuration: .custom(syncMaxRecords: 100)
         ))
+        #endif
         Amplify.Logging.logLevel = .verbose
         try Amplify.configure(config)
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/13/AWSDataStoreDateTimeSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/13/AWSDataStoreDateTimeSortKeyTest.swift
@@ -40,10 +40,17 @@ class AWSDataStoreDateTimeSortKeyTest: XCTestCase {
         try Amplify.add(plugin: AWSAPIPlugin(
             sessionFactory: AmplifyURLSessionFactory())
         )
+        #if os(watchOS)
+        try Amplify.add(plugin: AWSDataStorePlugin(
+            modelRegistration: TestModels(),
+            configuration: .custom(syncMaxRecords: 100, disableSubscriptions: { false })
+        ))
+        #else
         try Amplify.add(plugin: AWSDataStorePlugin(
             modelRegistration: TestModels(),
             configuration: .custom(syncMaxRecords: 100)
         ))
+        #endif
         Amplify.Logging.logLevel = .verbose
         try Amplify.configure(config)
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/14/AWSDataStoreDateSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/14/AWSDataStoreDateSortKeyTest.swift
@@ -40,10 +40,17 @@ class AWSDataStoreDateSortKeyTest: XCTestCase {
         try Amplify.add(plugin: AWSAPIPlugin(
             sessionFactory: AmplifyURLSessionFactory())
         )
+        #if os(watchOS)
+        try Amplify.add(plugin: AWSDataStorePlugin(
+            modelRegistration: TestModels(),
+            configuration: .custom(syncMaxRecords: 100, disableSubscriptions: { false })
+        ))
+        #else
         try Amplify.add(plugin: AWSDataStorePlugin(
             modelRegistration: TestModels(),
             configuration: .custom(syncMaxRecords: 100)
         ))
+        #endif
         Amplify.Logging.logLevel = .verbose
         try Amplify.configure(config)
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/15/AWSDataStoreTimeSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/15/AWSDataStoreTimeSortKeyTest.swift
@@ -40,10 +40,17 @@ class AWSDataStoreTimeSortKeyTest: XCTestCase {
         try Amplify.add(plugin: AWSAPIPlugin(
             sessionFactory: AmplifyURLSessionFactory())
         )
+        #if os(watchOS)
+        try Amplify.add(plugin: AWSDataStorePlugin(
+            modelRegistration: TestModels(),
+            configuration: .custom(syncMaxRecords: 100, disableSubscriptions: { false })
+        ))
+        #else
         try Amplify.add(plugin: AWSDataStorePlugin(
             modelRegistration: TestModels(),
             configuration: .custom(syncMaxRecords: 100)
         ))
+        #endif
         Amplify.Logging.logLevel = .verbose
         try Amplify.configure(config)
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/9/AWSDataStoreCompositeSortKeyIdentifierTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/9/AWSDataStoreCompositeSortKeyIdentifierTest.swift
@@ -34,10 +34,17 @@ class AWSDataStoreCompositeSortKeyIdentifierTest: XCTestCase {
         try Amplify.add(plugin: AWSAPIPlugin(
             sessionFactory: AmplifyURLSessionFactory())
         )
+        #if os(watchOS)
+        try Amplify.add(plugin: AWSDataStorePlugin(
+            modelRegistration: TestModels(),
+            configuration: .custom(syncMaxRecords: 100, disableSubscriptions: { false })
+        ))
+        #else
         try Amplify.add(plugin: AWSDataStorePlugin(
             modelRegistration: TestModels(),
             configuration: .custom(syncMaxRecords: 100)
         ))
+        #endif
         Amplify.Logging.logLevel = .verbose
         try Amplify.configure(config)
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStorePrimaryKeyBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStorePrimaryKeyBaseTest.swift
@@ -36,10 +36,17 @@ class AWSDataStorePrimaryKeyBaseTest: XCTestCase {
     func setup(withModels models: AmplifyModelRegistration) {
         do {
             loadAmplifyConfig()
+            #if os(watchOS)
+            try Amplify.add(plugin: AWSDataStorePlugin(
+                modelRegistration: models,
+                configuration: .custom(syncMaxRecords: 100, disableSubscriptions: { false })
+            ))
+            #else
             try Amplify.add(plugin: AWSDataStorePlugin(
                 modelRegistration: models,
                 configuration: .custom(syncMaxRecords: 100)
             ))
+            #endif
 
             try Amplify.add(plugin: AWSAPIPlugin(sessionFactory: AmplifyURLSessionFactory()))
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStoreSortKeyBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStoreSortKeyBaseTest.swift
@@ -36,10 +36,17 @@ class AWSDataStoreSortKeyBaseTest: XCTestCase {
     ) async throws {
         let config = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: "testconfiguration/\(configFile)")
         try Amplify.add(plugin: AWSAPIPlugin(sessionFactory: AmplifyURLSessionFactory()))
+        #if os(watchOS)
+        try Amplify.add(plugin: AWSDataStorePlugin(
+            modelRegistration: models,
+            configuration: .custom(syncMaxRecords: 100, disableSubscriptions: { false })
+        ))
+        #else
         try Amplify.add(plugin: AWSDataStorePlugin(
             modelRegistration: models,
             configuration: .custom(syncMaxRecords: 100)
         ))
+        #endif
 
         Amplify.Logging.logLevel = .verbose
         try Amplify.configure(config)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/AWSDataStorePluginConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/AWSDataStorePluginConfigurationTests.swift
@@ -19,7 +19,11 @@ class AWSDataStorePluginConfigurationTests: XCTestCase {
     // Note this test requires the ability to write a new database in the Documents directcory, so it must be embedded
     // in a host app
     func testDoesNotThrowOnMissingConfig() throws {
+        #if os(watchOS)
+        let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(), configuration: .subscriptionsDisabled)
+        #else
         let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration())
+        #endif
         try Amplify.add(plugin: plugin)
 
         let amplifyConfig = AmplifyConfiguration()

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario1Tests+WatchOS.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario1Tests+WatchOS.swift
@@ -1,0 +1,77 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension DataStoreConnectionScenario1Tests {
+    
+    #if os(watchOS)
+    func testStartAndSync() async throws {
+        await setUp(withModels: TestModelRegistration(),
+                    dataStoreConfiguration: .custom(syncMaxRecords: 100, disableSubscriptions: { true }))
+        try await startAmplifyAndWaitForSync()
+    }
+
+    func testSaveReconciled() async throws {
+        await setUp(withModels: TestModelRegistration(),
+                    dataStoreConfiguration: .custom(syncMaxRecords: 100, disableSubscriptions: { true }))
+        try await startAmplifyAndWaitForSync()
+        
+        let team = Team1(name: "name1")
+        let project = Project1(team: team)
+        let syncedTeamReceived = expectation(description: "received team from sync path")
+        var hubListener = Amplify.Hub.listen(to: .dataStore,
+                                             eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
+            guard let mutationEvent = payload.data as? MutationEvent else {
+                XCTFail("Could not cast payload to mutation event")
+                return
+            }
+
+            if let syncedTeam = try? mutationEvent.decodeModel() as? Team1,
+               syncedTeam == team {
+                syncedTeamReceived.fulfill()
+            }
+        }
+        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
+            XCTFail("Listener not registered for hub")
+            return
+        }
+
+        _ = try await Amplify.DataStore.save(team)
+        await fulfillment(of: [syncedTeamReceived], timeout: networkTimeout)
+        
+        let syncProjectReceived = expectation(description: "received project from sync path")
+        hubListener = Amplify.Hub.listen(to: .dataStore,
+                                             eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
+            guard let mutationEvent = payload.data as? MutationEvent else {
+                XCTFail("Could not cast payload to mutation event")
+                return
+            }
+
+            if let syncedProject = try? mutationEvent.decodeModel() as? Project1,
+                      syncedProject == project {
+                syncProjectReceived.fulfill()
+            }
+        }
+        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
+            XCTFail("Listener not registered for hub")
+            return
+        }
+        _ = try await Amplify.DataStore.save(project)
+        await fulfillment(of: [syncProjectReceived], timeout: networkTimeout)
+
+        let queriedProjectOptional = try await Amplify.DataStore.query(Project1.self, byId: project.id)
+        guard let queriedProject = queriedProjectOptional else {
+            XCTFail("Failed")
+            return
+        }
+        XCTAssertEqual(queriedProject.id, project.id)
+        XCTAssertEqual(queriedProject.team, team)
+    }
+    #endif
+    
+}

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario1Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario1Tests.swift
@@ -42,6 +42,99 @@ class DataStoreConnectionScenario1Tests: SyncEngineIntegrationTestBase {
         let version: String = "1"
     }
     
+
+    // MARK: - Disable Real Time Updates
+    
+    func testStartAndSync() async throws {
+        await setUp(withModels: TestModelRegistration(),
+                    logLevel: .verbose,
+                    dataStoreConfiguration: .custom(syncMaxRecords: 100, disableSubscriptions: { true }))
+        try await startAmplifyAndWaitForSync()
+    }
+    
+    func testStartAndSyncAndRestartAndSync() async throws {
+        var disabledRealTimeUpdates = true
+        let disableSubscriptions = {
+            disabledRealTimeUpdates
+        }
+        await setUp(withModels: TestModelRegistration(),
+                    logLevel: .verbose,
+                    dataStoreConfiguration: .custom(syncMaxRecords: 100, disableSubscriptions: disableSubscriptions))
+        try await startAmplifyAndWaitForSync()
+        disabledRealTimeUpdates = false
+        try await Amplify.DataStore.stop()
+        try await Amplify.DataStore.start()
+        
+        let eventReceived = expectation(description: "DataStore ready event")
+        let sink = Amplify.Hub.publisher(for: .dataStore)
+            .filter { $0.eventName == HubPayload.EventName.DataStore.ready }
+            .sink { _ in
+                eventReceived.fulfill()
+            }
+
+        try await Amplify.DataStore.start()
+
+        await fulfillment(of: [eventReceived], timeout: 10)
+    }
+    
+    func testSaveReconciled() async throws {
+        await setUp(withModels: TestModelRegistration(),
+                    logLevel: .verbose,
+                    dataStoreConfiguration: .custom(syncMaxRecords: 100, disableSubscriptions: { true }))
+        try await startAmplifyAndWaitForSync()
+        
+        let team = Team1(name: "name1")
+        let project = Project1(team: team)
+        let syncedTeamReceived = expectation(description: "received team from sync path")
+        var hubListener = Amplify.Hub.listen(to: .dataStore,
+                                             eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
+            guard let mutationEvent = payload.data as? MutationEvent else {
+                XCTFail("Could not cast payload to mutation event")
+                return
+            }
+
+            if let syncedTeam = try? mutationEvent.decodeModel() as? Team1,
+               syncedTeam == team {
+                syncedTeamReceived.fulfill()
+            }
+        }
+        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
+            XCTFail("Listener not registered for hub")
+            return
+        }
+
+        _ = try await Amplify.DataStore.save(team)
+        await fulfillment(of: [syncedTeamReceived], timeout: networkTimeout)
+        
+        let syncProjectReceived = expectation(description: "received project from sync path")
+        hubListener = Amplify.Hub.listen(to: .dataStore,
+                                             eventName: HubPayload.EventName.DataStore.syncReceived) { payload in
+            guard let mutationEvent = payload.data as? MutationEvent else {
+                XCTFail("Could not cast payload to mutation event")
+                return
+            }
+
+            if let syncedProject = try? mutationEvent.decodeModel() as? Project1,
+                      syncedProject == project {
+                syncProjectReceived.fulfill()
+            }
+        }
+        guard try await HubListenerTestUtilities.waitForListener(with: hubListener, timeout: 5.0) else {
+            XCTFail("Listener not registered for hub")
+            return
+        }
+        _ = try await Amplify.DataStore.save(project)
+        await fulfillment(of: [syncProjectReceived], timeout: networkTimeout)
+
+        let queriedProjectOptional = try await Amplify.DataStore.query(Project1.self, byId: project.id)
+        guard let queriedProject = queriedProjectOptional else {
+            XCTFail("Failed")
+            return
+        }
+        XCTAssertEqual(queriedProject.id, project.id)
+        XCTAssertEqual(queriedProject.team, team)
+    }
+    
     func testSaveTeamAndProjectSyncToCloud() async throws {
         await setUp(withModels: TestModelRegistration())
         try await startAmplifyAndWaitForSync()

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreConfigurationTests.swift
@@ -23,7 +23,11 @@ class DataStoreConfigurationTests: XCTestCase {
     func testConfigureWithSameSchemaDoesNotDeleteDatabase() async throws {
         let previousVersion = "previousVersion"
         do {
+            #if os(watchOS)
+            let dataStorePlugin = AWSDataStorePlugin(modelRegistration: AmplifyModels(version: previousVersion), configuration: .subscriptionsDisabled)
+            #else
             let dataStorePlugin = AWSDataStorePlugin(modelRegistration: AmplifyModels(version: previousVersion))
+            #endif
             try Amplify.add(plugin: dataStorePlugin)
             try Amplify.configure(AmplifyConfiguration(dataStore: nil))
         } catch {
@@ -37,7 +41,11 @@ class DataStoreConfigurationTests: XCTestCase {
         await Amplify.reset()
 
         do {
+            #if os(watchOS)
+            let dataStorePlugin = AWSDataStorePlugin(modelRegistration: AmplifyModels(version: previousVersion), configuration: .subscriptionsDisabled)
+            #else
             let dataStorePlugin = AWSDataStorePlugin(modelRegistration: AmplifyModels(version: previousVersion))
+            #endif
             try Amplify.add(plugin: dataStorePlugin)
             try Amplify.configure(AmplifyConfiguration(dataStore: nil))
         } catch {
@@ -60,7 +68,11 @@ class DataStoreConfigurationTests: XCTestCase {
         let prevoisVersion = "previousVersion"
 
         do {
+            #if os(watchOS)
+            let dataStorePlugin = AWSDataStorePlugin(modelRegistration: AmplifyModels(version: prevoisVersion), configuration: .subscriptionsDisabled)
+            #else
             let dataStorePlugin = AWSDataStorePlugin(modelRegistration: AmplifyModels(version: prevoisVersion))
+            #endif
             try Amplify.add(plugin: dataStorePlugin)
             try Amplify.configure(AmplifyConfiguration(dataStore: nil))
         } catch {
@@ -73,7 +85,11 @@ class DataStoreConfigurationTests: XCTestCase {
         await Amplify.reset()
 
         do {
+            #if os(watchOS)
+            let dataStorePlugin = AWSDataStorePlugin(modelRegistration: AmplifyModels(version: "1234"), configuration: .subscriptionsDisabled)
+            #else
             let dataStorePlugin = AWSDataStorePlugin(modelRegistration: AmplifyModels(version: "1234"))
+            #endif
             try Amplify.add(plugin: dataStorePlugin)
             try Amplify.configure(AmplifyConfiguration(dataStore: nil))
         } catch {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -589,10 +589,17 @@ class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
         let syncExpression = DataStoreSyncExpression(modelSchema: Post.schema) {
             Post.keys.createdAt >= startTime
         }
+        #if os(watchOS)
+        await setUp(
+            withModels: TestModelRegistration(),
+            dataStoreConfiguration: .custom(syncExpressions: [syncExpression], disableSubscriptions: { false })
+        )
+        #else
         await setUp(
             withModels: TestModelRegistration(),
             dataStoreConfiguration: .custom(syncExpressions: [syncExpression])
         )
+        #endif
         try await startAmplifyAndWaitForSync()
 
         let postCount = 1_000

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
@@ -164,18 +164,30 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
     ///
     func testInitialSyncWithPredicate() async throws {
         let startTime = Temporal.DateTime.now()
+        #if os(watchOS)
+        let configuration: DataStoreConfiguration = .custom(
+            syncMaxRecords: 100,
+            syncExpressions: [
+                DataStoreSyncExpression(
+                    modelSchema: Post.schema,
+                    modelPredicate: { Post.keys.createdAt.ge(startTime) }
+                )
+            ],
+            disableSubscriptions: { false })
+        #else
+        let configuration: DataStoreConfiguration = .custom(
+            syncMaxRecords: 100,
+            syncExpressions: [
+                DataStoreSyncExpression(
+                    modelSchema: Post.schema,
+                    modelPredicate: { Post.keys.createdAt.ge(startTime) }
+                )
+            ])
+        #endif
         await setUp(
             withModels: TestModelRegistration(),
             logLevel: .verbose,
-            dataStoreConfiguration: .custom(
-                syncMaxRecords: 100,
-                syncExpressions: [
-                    DataStoreSyncExpression(
-                        modelSchema: Post.schema,
-                        modelPredicate: { Post.keys.createdAt.ge(startTime) }
-                    )
-                ]
-            )
+            dataStoreConfiguration: configuration
         )
         try startAmplify()
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
@@ -49,7 +49,11 @@ class HubEventsIntegrationTestBase: XCTestCase {
     func configureAmplify(withModels models: AmplifyModelRegistration) throws {
         let amplifyConfig = try TestConfigHelper.retrieveAmplifyConfiguration(forResource: Self.amplifyConfigurationFile)
 
+        #if os(watchOS)
+        try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models, configuration: .subscriptionsDisabled))
+        #else
         try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models))
+        #endif
         try Amplify.add(plugin: AWSAPIPlugin(
             modelRegistration: models,
             sessionFactory: AmplifyURLSessionFactory()

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
@@ -59,12 +59,21 @@ class SyncEngineIntegrationTestBase: DataStoreTestBase {
                 modelRegistration: models,
                 sessionFactory: AmplifyURLSessionFactory()
             ))
+            #if os(watchOS)
+            try Amplify.add(
+                plugin: AWSDataStorePlugin(
+                    modelRegistration: models,
+                    configuration: dataStoreConfiguration ?? .custom(syncMaxRecords: 100, disableSubscriptions: { false })
+                )
+            )
+            #else
             try Amplify.add(
                 plugin: AWSDataStorePlugin(
                     modelRegistration: models,
                     configuration: dataStoreConfiguration ?? .custom(syncMaxRecords: 100)
                 )
             )
+            #endif
         } catch {
             XCTFail(String(describing: error))
             return

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/AWSDataStoreLazyLoadBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/AWSDataStoreLazyLoadBaseTest.swift
@@ -66,8 +66,13 @@ class AWSDataStoreLazyLoadBaseTest: XCTestCase {
             setupConfig()
             Amplify.Logging.logLevel = logLevel
             
+            #if os(watchOS)
+            try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models,
+                                                       configuration: .custom(syncMaxRecords: 100, disableSubscriptions: { false })))
+            #else
             try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models,
                                                        configuration: .custom(syncMaxRecords: 100)))
+            #endif
             try Amplify.add(plugin: AWSAPIPlugin(sessionFactory: AmplifyURLSessionFactory()))
             try Amplify.configure(amplifyConfig)
             
@@ -85,7 +90,12 @@ class AWSDataStoreLazyLoadBaseTest: XCTestCase {
             setupConfig()
             Amplify.Logging.logLevel = logLevel
             
+            #if os(watchOS)
+            try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models, configuration: .subscriptionsDisabled))
+            #else
             try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models))
+            #endif
+                            
             try Amplify.configure(amplifyConfig)
             
             try await deleteMutationEvents()

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreAuthBaseTest.swift
@@ -198,8 +198,12 @@ class AWSDataStoreAuthBaseTest: XCTestCase {
         do {
             setupCredentials(forAuthStrategy: testType)
 
+            #if os(watchOS)
+            let datastoreConfig = DataStoreConfiguration.custom(authModeStrategy: testType.authStrategy, disableSubscriptions: { false })
+            #else
             let datastoreConfig = DataStoreConfiguration.custom(authModeStrategy: testType.authStrategy)
-
+            #endif
+            
             try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models,
                                                        configuration: datastoreConfig))
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TestSupport/SyncEngineIntegrationV2TestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TestSupport/SyncEngineIntegrationV2TestBase.swift
@@ -53,8 +53,13 @@ class SyncEngineIntegrationV2TestBase: DataStoreTestBase {
                 modelRegistration: models,
                 sessionFactory: AmplifyURLSessionFactory()
             ))
+            #if os(watchOS)
+            try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models,
+                                                       configuration: .custom(syncMaxRecords: 100, disableSubscriptions: { false })))
+            #else
             try Amplify.add(plugin: AWSDataStorePlugin(modelRegistration: models,
                                                        configuration: .custom(syncMaxRecords: 100)))
+            #endif
         } catch {
             XCTFail(String(describing: error))
             return

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreHostApp.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 		21977DBF289C171A005B49D6 /* TestConfigHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21977DBE289C1719005B49D6 /* TestConfigHelper.swift */; };
 		219B518528E3A4B00080EDCC /* DataStoreConnectionOptionalAssociations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BBFA00289BFE3400B32A39 /* DataStoreConnectionOptionalAssociations.swift */; };
 		219B518628E3A7150080EDCC /* DataStoreHubEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BBF9EE289BFE3400B32A39 /* DataStoreHubEvent.swift */; };
+		21A418212B0E78F400FF89E1 /* DataStoreConnectionScenario1Tests+WatchOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A418202B0E78F400FF89E1 /* DataStoreConnectionScenario1Tests+WatchOS.swift */; };
 		21AA64B72AC5D78B001C6D3B /* TodoCognitoMultiOwner+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210445622AB4F6C900420AF9 /* TodoCognitoMultiOwner+Schema.swift */; };
 		21AA64B82AC5D791001C6D3B /* TodoCognitoMultiOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210445612AB4F6C900420AF9 /* TodoCognitoMultiOwner.swift */; };
 		21AB5C2A297AE56D00CCA482 /* AWSDataStoreLazyLoadPostTagSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21AB5C29297AE56D00CCA482 /* AWSDataStoreLazyLoadPostTagSnapshotTests.swift */; };
@@ -1724,6 +1725,7 @@
 		219253BD28BFE84000820737 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		21977D84289C1633005B49D6 /* primarykey_schema.graphql */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = primarykey_schema.graphql; sourceTree = "<group>"; };
 		21977DBE289C1719005B49D6 /* TestConfigHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestConfigHelper.swift; sourceTree = "<group>"; };
+		21A418202B0E78F400FF89E1 /* DataStoreConnectionScenario1Tests+WatchOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataStoreConnectionScenario1Tests+WatchOS.swift"; sourceTree = "<group>"; };
 		21AB5C29297AE56D00CCA482 /* AWSDataStoreLazyLoadPostTagSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDataStoreLazyLoadPostTagSnapshotTests.swift; sourceTree = "<group>"; };
 		21AB5C4829819BF000CCA482 /* Nested.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Nested.swift; sourceTree = "<group>"; };
 		21AB5C4929819BF000CCA482 /* NestedTypeTestModel+Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NestedTypeTestModel+Schema.swift"; sourceTree = "<group>"; };
@@ -2879,6 +2881,7 @@
 				21BBF9F6289BFE3400B32A39 /* DataStoreConnectionScenario4Tests.swift */,
 				21BBF9F4289BFE3400B32A39 /* DataStoreConnectionScenario5Tests.swift */,
 				21BBF9F8289BFE3400B32A39 /* DataStoreConnectionScenario6Tests.swift */,
+				21A418202B0E78F400FF89E1 /* DataStoreConnectionScenario1Tests+WatchOS.swift */,
 			);
 			path = Connection;
 			sourceTree = "<group>";
@@ -5302,6 +5305,7 @@
 				21BBFDC7289C06E400B32A39 /* Blog6+Schema.swift in Sources */,
 				21BBFD34289C06E400B32A39 /* MenuType.swift in Sources */,
 				21BBFC0B289C037000B32A39 /* TestModelV2Registration.swift in Sources */,
+				21A418212B0E78F400FF89E1 /* DataStoreConnectionScenario1Tests+WatchOS.swift in Sources */,
 				21BBFD7A289C06E400B32A39 /* Attendee8V2+Schema.swift in Sources */,
 				21BBFD8B289C06E400B32A39 /* ListStringContainer+Schema.swift in Sources */,
 				21BBFD94289C06E400B32A39 /* NestedTypeTestModel+Schema.swift in Sources */,


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/3220

## Table of Contents

1. [fix(DataStore): Store larger than 32-bit values in Int64 over Int #3367](https://github.com/aws-amplify/amplify-swift/pull/3367)
2. [feat(DataStore): DisableSubscriptions flag for watchOS #3368](https://github.com/aws-amplify/amplify-swift/pull/3368) (You are here)
3. [fix: watchOS support - disable network monitoring, add client timeout #141](https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/141)


## Description
<!-- Why is this change required? What problem does it solve? -->

DataStore’s sync engine currently does not start successfully on watchOS. The reason for this is due to the lack of low-level networking capabilities on watchOS, which DataStore uses when establishing subscriptions for real-time data. When DataStore’s sync engine attempts to establish the websocket connection, it will hang on connecting, never completing the sync engine activation steps. 

Low-level networking on watchOS is limited but there are special circumstances in which an app does allow low-level networking, such as websockets, to work. They are listed [here](https://developer.apple.com/documentation/technotes/tn3135-low-level-networking-on-watchos):

* While actively streaming audio
* While running a call with CallKit

This PR introduces a **required** client configuration option to disable subscriptions when building on watchOS. When building an watchOS app, set this value to what is required for your app to work properly. In most cases, if you are not operating in the special circumstance, then set the implementation of `disableSubscriptions` to return **true**

```swift
let plugin = AWSDataStorePlugin(modelRegistration: AmplifyModels(),
                                        configuration: .custom(disableSubscriptions: { true }))
```

**Limited Functionality**

With this value set to `true`, during the runtime of the app, data saved from other devices will not appear on the current device until DataStore has been restarted.

DataStore will start when any of the DataStore operations are called, or explicitly through `DataStore.start()`. When it starts, it will sync the latest data from the remote store. 

**Force restart DataStore**

You may find it useful to restart DataStore by calling `DataStore.stop()` followed by `DataStore.start()` in parts of you application such as navigating to a view of the app that uses data from DataStore or based on some end-user actions.

**Conflict Handler**
If two devices are operating on the same model data, and DataStore is running without subscriptions, there will likely be conflicts. To handle conflicting updates, based on your use cases, you can implement `conflictHandler` to make decisions such as when there's a conflict, to retry the local model, remote model, or a merged model to be re-synced.  [See conflict resolution for more details](https://docs.amplify.aws/swift/build-a-backend/more-features/datastore/conflict-resolution/)

**Special Circumstances**

If you are building a watchOS app in which uses low-level networking during the special circumstance, you can re-enable subscriptions to get real-time updates during the special circumstances:

```swift
var subscriptionsDisabled = true
let disableSubscriptions = {
    subscriptionsDisabled
}
try Amplify.add(plugin: AWSAPIPlugin())
try Amplify.add(plugin: AWSDataStorePlugin(
    modelRegistration: AmplifyModels(),
    configuration: .custom(disableSubscriptions: disableSubscriptions)))
try Amplify.configure()
    
// 1. Activate special circumstances
AVAudioSession.sharedInstance().activate(options: [], completionHandler: { _, _ in 
    print("AVAudioSession activated.")
    
    // 2. enable subscriptions
    subscriptionsDisabled = false 

    // 3. restart datastore
    try await Amplify.DataStore.stop() 
    try await Amplify.DataStore.start()
})

// ...
// 4. When deactivating the audio session, disable subscriptions, and restart DataStore.
try AVAudioSession.sharedInstance().setActive(false)
subscriptionsDisabled = true
try await Amplify.DataStore.stop() 
try await Amplify.DataStore.start()

```

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
