### PR TITLE
fix(DataStore): Reconcile mutation responses from conflict handler path

### DIFF
--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -285,7 +285,8 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
             api: api,
             storageAdapter: storageAdapter,
             graphQLResponseError: graphQLResponseError,
-            apiError: apiError
+            apiError: apiError,
+            reconciliationQueue: reconciliationQueue
         ) { [weak self] result in
             guard let self = self else {
                 return

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPlugin/Sync/MutationSync/OutgoingMutationQueue/ProcessMutationErrorFromCloudOperation.swift
@@ -29,13 +29,15 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
     private let completion: (Result<MutationEvent?, Error>) -> Void
     private var mutationOperation: AtomicValue<GraphQLOperation<MutationSync<AnyModel>>?>
     private weak var api: APICategoryGraphQLBehavior?
-
+    private weak var reconciliationQueue: IncomingEventReconciliationQueue?
+    
     init(dataStoreConfiguration: DataStoreConfiguration,
          mutationEvent: MutationEvent,
          api: APICategoryGraphQLBehavior,
          storageAdapter: StorageEngineAdapter,
          graphQLResponseError: GraphQLResponseError<MutationSync<AnyModel>>? = nil,
          apiError: APIError? = nil,
+         reconciliationQueue: IncomingEventReconciliationQueue? = nil,
          completion: @escaping (Result<MutationEvent?, Error>) -> Void) {
         self.dataStoreConfiguration = dataStoreConfiguration
         self.mutationEvent = mutationEvent
@@ -43,6 +45,7 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
         self.storageAdapter = storageAdapter
         self.graphQLResponseError = graphQLResponseError
         self.apiError = apiError
+        self.reconciliationQueue = reconciliationQueue
         self.completion = completion
         self.mutationOperation = AtomicValue(initialValue: nil)
 
@@ -316,9 +319,24 @@ class ProcessMutationErrorFromCloudOperation: AsynchronousOperation {
             dataStoreConfiguration.errorHandler(error)
         }
 
-        if case .success(let response) = cloudResult,
-            case .failure(let error) = response {
-            dataStoreConfiguration.errorHandler(error)
+        if case let .success(graphQLResponse) = cloudResult {
+            if case .failure(let error) = graphQLResponse {
+                dataStoreConfiguration.errorHandler(error)
+            } else if case let .success(graphQLResult) = graphQLResponse {
+                guard let reconciliationQueue = reconciliationQueue else {
+                    let dataStoreError = DataStoreError.configuration(
+                        "reconciliationQueue is unexpectedly nil",
+                                """
+                                The reference to reconciliationQueue has been released while an ongoing mutation was being processed.
+                                \(AmplifyErrorMessages.reportBugToAWS())
+                                """
+                    )
+                    finish(result: .failure(dataStoreError))
+                    return
+                }
+                
+                reconciliationQueue.offer([graphQLResult], modelName: mutationEvent.modelName)
+            }
         }
 
         finish(result: .success(nil))

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -25,7 +25,8 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     var storageAdapter: StorageEngineAdapter!
     var localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
     let queue = OperationQueue()
-
+    let reconciliationQueue = MockReconciliationQueue()
+    
     override func setUp() {
         tryOrFail {
             try setUpWithAPI()
@@ -585,6 +586,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                                api: mockAPIPlugin,
                                                                storageAdapter: storageAdapter,
                                                                graphQLResponseError: graphQLResponseError,
+                                                               reconciliationQueue: reconciliationQueue,
                                                                completion: completion)
 
         queue.addOperation(operation)
@@ -662,6 +664,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                                api: mockAPIPlugin,
                                                                storageAdapter: storageAdapter,
                                                                graphQLResponseError: graphQLResponseError,
+                                                               reconciliationQueue: reconciliationQueue,
                                                                completion: completion)
 
         queue.addOperation(operation)
@@ -956,6 +959,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                                api: mockAPIPlugin,
                                                                storageAdapter: storageAdapter,
                                                                graphQLResponseError: graphQLResponseError,
+                                                               reconciliationQueue: reconciliationQueue,
                                                                completion: completion)
 
         queue.addOperation(operation)
@@ -1035,6 +1039,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
                                                                api: mockAPIPlugin,
                                                                storageAdapter: storageAdapter,
                                                                graphQLResponseError: graphQLResponseError,
+                                                               reconciliationQueue: reconciliationQueue,
                                                                completion: completion)
         queue.addOperation(operation)
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
`v1` version of https://github.com/aws-amplify/amplify-swift/pull/3370

## Description
<!-- Why is this change required? What problem does it solve? -->

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
