### PR TITLE
chore: add closed issue visibility auto comment action workflow

### DIFF
--- a/.github/workflows/closed_issue_message.yml
+++ b/.github/workflows/closed_issue_message.yml
@@ -1,0 +1,17 @@
+
+name: Closed Issue Message
+on:
+    issues:
+       types: [closed]
+jobs:
+    auto_comment:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: aws-actions/closed-issue-message@v1
+          with:
+            repo-token: "${{ secrets.GITHUB_TOKEN }}"
+            message: |
+                     ### ⚠️COMMENT VISIBILITY WARNING⚠️
+                     Comments on closed issues are hard for our team to see.
+                     If you need more assistance, please either tag a team member or open a new issue that references this one.
+                     If you wish to keep having a conversation with other community members under this issue feel free to do so.


### PR DESCRIPTION
## Description
Comments on closed issues can go unnoticed; the general guidance we give customers is to open a new issue. This automates that process using [aws-actions/closed-issue-message](aws-actions/closed-issue-message).

Example:
![Screenshot 2023-11-21 at 11 14 38 AM](https://github.com/aws-amplify/amplify-swift/assets/52051793/39966512-2338-4a16-9b95-57b605411806)


## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [ ] ~Build succeeds with all target using Swift Package Manager~
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
