### PR TITLE
chore: Adding checkbox validations to the release workflow trigger

### DIFF
--- a/.github/workflows/release_kickoff.yml
+++ b/.github/workflows/release_kickoff.yml
@@ -3,13 +3,34 @@ name: Release Amplify iOS
 
 on:
   workflow_dispatch:
+    inputs:
+      clearDays:
+        description: 'I confirm that today is either a CLEAR day or we have approval for release'
+        required: true
+        default: false
+        type: boolean
+      revertMain:
+        description: '⛔️ All previous commits to main have been reverted'
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   pull-requests: write
 
 jobs:
+  validation:
+    name: Validation
+    runs-on: ubuntu-latest
+    if: inputs.clearDays == false || inputs.revertMain == false
+    steps:
+      - run: |
+          echo '❌ You need to acknowledge the input validations before releasing ❌'
+          exit 1
+
   release:
     name: Release
+    needs: validation
     runs-on: macos-12
 
     steps:


### PR DESCRIPTION
## Description
This PR adds a couple of checkbox validations when triggering the release workflow:
- That we are in CLEAR DAYs or we have approval
- That we have reverted everything in main (This one is temporary)

<img width="316" alt="Screenshot 2023-11-22 at 10 10 31" src="https://github.com/aws-amplify/amplify-swift/assets/97059974/a846ab92-0bc0-465a-af49-cc04c14c255c">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
