### PR TITLE
feat(auth): add passwordless request options for magiclink

### DIFF
--- a/Amplify/Categories/Auth/AuthCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategory+ClientBehavior.swift
@@ -92,7 +92,7 @@ extension AuthCategory: AuthCategoryBehavior {
         username: String,
         flow: AuthPasswordlessFlow,
         redirectURL: String,
-        options: AuthPasswordlessMagicLinkRequest.Options? = nil
+        options: AuthSignInWithMagicLinkRequest.Options? = nil
     ) async throws -> AuthSignInResult {
         try await plugin.signInWithMagicLink(
             username: username,
@@ -103,7 +103,7 @@ extension AuthCategory: AuthCategoryBehavior {
     
     public func confirmSignInWithMagicLink(
         challengeResponse: String,
-        options: AuthPasswordlessMagicLinkRequest.Options? = nil
+        options: AuthConfirmSignInWithMagicLinkRequest.Options? = nil
     ) async throws -> AuthSignInResult {
         try await plugin.confirmSignInWithMagicLink(
             challengeResponse: challengeResponse,

--- a/Amplify/Categories/Auth/AuthCategoryBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategoryBehavior.swift
@@ -160,7 +160,7 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
         username: String,
         flow: AuthPasswordlessFlow,
         redirectURL: String,
-        options: AuthPasswordlessMagicLinkRequest.Options?
+        options: AuthSignInWithMagicLinkRequest.Options?
     ) async throws -> AuthSignInResult
     
     /// Confirms Sign in with Magiclink flow
@@ -172,7 +172,7 @@ public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDevi
     ///   - options: Parameters specific to plugin behavior
     func confirmSignInWithMagicLink(
         challengeResponse: String,
-        options: AuthPasswordlessMagicLinkRequest.Options?
+        options: AuthConfirmSignInWithMagicLinkRequest.Options?
     ) async throws -> AuthSignInResult
 
     /// Initiates Sign in with OTP

--- a/Amplify/Categories/Auth/Request/AuthConfirmSignInWithMagicLinkRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthConfirmSignInWithMagicLinkRequest.swift
@@ -7,13 +7,14 @@
 
 import Foundation
 
-/// Request to confirm sign in a user with OTP flow
-public struct AuthConfirmSignInWithOTPRequest: AmplifyOperationRequest {
+/// Request to confirm sign in a user with magic link flow
+public struct AuthConfirmSignInWithMagicLinkRequest: AmplifyOperationRequest {
 
-    /// The value of `challengeResponse`is the OTP that is received on the destination provided during sign in request
+    /// The value of `challengeResponse` is the code that is received
+    /// by the user in magic link
     public let challengeResponse: String
 
-    /// Extra request options defined in `AuthConfirmSignInWithOTPRequest.Options`
+    /// Extra request options defined in `AuthConfirmSignInWithMagicLinkRequest.Options`
     public var options: Options
 
     public init(challengeResponse: String, options: Options) {
@@ -22,7 +23,7 @@ public struct AuthConfirmSignInWithOTPRequest: AmplifyOperationRequest {
     }
 }
 
-public extension AuthConfirmSignInWithOTPRequest {
+public extension AuthConfirmSignInWithMagicLinkRequest {
 
     struct Options {
 

--- a/Amplify/Categories/Auth/Request/AuthSignInWithMagicLinkRequest.swift
+++ b/Amplify/Categories/Auth/Request/AuthSignInWithMagicLinkRequest.swift
@@ -8,17 +8,29 @@
 import Foundation
 
 /// Request to sign in a user with Passwordless Magic Link flow
-public struct AuthPasswordlessMagicLinkRequest: AmplifyOperationRequest {
+public struct AuthSignInWithMagicLinkRequest: AmplifyOperationRequest {
 
-    /// Extra request options defined in `AuthPasswordlessMagicLinkRequest.Options`
+    /// User name for which the magic link was requested
+    public let username: String
+
+    /// The flow that the request should begin with.
+    public let flow: AuthPasswordlessFlow
+
+    /// The redirect url that the magic link will be configured with
+    public let redirectURL: String
+    
+    /// Extra request options defined in `AuthSignInWithMagicLinkRequest.Options`
     public var options: Options
 
-    public init(options: Options) {
+    public init(username: String, flow: AuthPasswordlessFlow, redirectURL: String, options: Options) {
+        self.username = username
+        self.flow = flow
+        self.redirectURL = redirectURL
         self.options = options
     }
 }
 
-public extension AuthPasswordlessMagicLinkRequest {
+public extension AuthSignInWithMagicLinkRequest {
 
     struct Options {
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
@@ -198,14 +198,14 @@ extension AWSCognitoAuthPlugin: AuthCategoryBehavior {
         username: String,
         flow: AuthPasswordlessFlow,
         redirectURL: String,
-        options: AuthPasswordlessMagicLinkRequest.Options?
+        options: AuthSignInWithMagicLinkRequest.Options?
     ) async throws -> AuthSignInResult {
         throw AuthError.unknown("Not Implemented")
     }
     
     public func confirmSignInWithMagicLink(
         challengeResponse: String,
-        options: AuthPasswordlessMagicLinkRequest.Options?
+        options: AuthConfirmSignInWithMagicLinkRequest.Options?
     ) async throws -> AuthSignInResult {
         throw AuthError.unknown("Not Implemented")
     }

--- a/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
@@ -114,14 +114,14 @@ class MockAuthCategoryPlugin: MessageReporter, AuthCategoryPlugin {
         username: String,
         flow: AuthPasswordlessFlow,
         redirectURL: String,
-        options: AuthPasswordlessMagicLinkRequest.Options?
+        options: AuthSignInWithMagicLinkRequest.Options?
     ) async throws -> AuthSignInResult {
         fatalError()
     }
     
     func confirmSignInWithMagicLink(
         challengeResponse: String,
-        options: AuthPasswordlessMagicLinkRequest.Options?
+        options: AuthConfirmSignInWithMagicLinkRequest.Options?
     ) async throws -> AuthSignInResult {
         fatalError()
     }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
None

## Description
<!-- Why is this change required? What problem does it solve? -->
- Add separate request options for magic link public apis
- Update mock plugin and tests

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
