### PR TITLE
fix(storage): Fixing watchOS crash when dealing with big files

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/Bytes.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/Bytes.swift
@@ -16,22 +16,22 @@ enum Bytes {
     case kilobytes(Int)
     case bytes(Int)
 
-    var bytes: Int {
+    var bytes: UInt64 {
         switch self {
         case .terabytes(let tb):
-            return Int(pow(1_024.0, 4.0)) * tb
+            return UInt64(pow(1_024.0, 4.0)) * UInt64(tb)
         case .gigabytes(let gb):
-            return Int(pow(1_024.0, 3.0)) * gb
+            return UInt64(pow(1_024.0, 3.0)) * UInt64(gb)
         case .megabytes(let mb):
-            return Int(pow(1_024.0, 2.0)) * mb
+            return UInt64(pow(1_024.0, 2.0)) * UInt64(mb)
         case .kilobytes(let kb):
-            return 1_024 * kb
+            return 1_024 * UInt64(kb)
         case .bytes(let b):
-            return b
+            return UInt64(b)
         }
     }
 
-    var bits: Int {
+    var bits: UInt64 {
         return bytes * 8
     }
 }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/FileHandle+UInt64.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/FileHandle+UInt64.swift
@@ -1,0 +1,43 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+extension FileHandle {
+    /// Reads data synchronously up to the specified number of bytes.
+    /// - Parameter bytes: The number of bytes to read from the file handle.
+    /// - Parameter bytesReadLimit: The maximum number of bytes that can be read at a time. Defaults to `Int.max`.
+    /// - Returns: The data available through the receiver up to a maximum of length bytes, or the maximum size that can be represented by a Data object.
+    /// - Throws: An error if attempts to determine the file-handle type fail or if attempts to read from the file or channel fail.
+    func read(bytes: UInt64, bytesReadLimit: Int = Int.max) throws -> Data {
+        // Read as much as it's possible considering the `bytesReadLimit` maximum
+        let bytesRead = bytes <= bytesReadLimit ? Int(bytes) : bytesReadLimit
+        guard var data = try readData(upToCount: bytesRead) else {
+            // There is no more data to read from the file
+            return Data()
+        }
+
+        // If there's remaining bytes to read, do it and append to the current data
+        let remainingBytes = bytes - UInt64(bytesRead)
+        if remainingBytes > 0 {
+            try data.append(read(
+                bytes: remainingBytes,
+                bytesReadLimit: bytesReadLimit
+            ))
+        }
+
+        return data
+    }
+
+    private func readData(upToCount length: Int) throws -> Data? {
+        if #available(iOS 13.4, macOS 10.15.4, tvOS 13.4, *) {
+            return try read(upToCount: length)
+        } else {
+            return readData(ofLength: length)
+        }
+    }
+}

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/FileSystem.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/FileSystem.swift
@@ -185,7 +185,7 @@ class FileSystem {
     ///   - offset: position to start reading
     ///   - length: length of the part
     ///   - completionHandler: completion handler
-    func createPartialFile(fileURL: URL, offset: Int, length: Int, completionHandler: @escaping (Result<URL, Error>) -> Void) {
+    func createPartialFile(fileURL: URL, offset: UInt64, length: UInt64, completionHandler: @escaping (Result<URL, Error>) -> Void) {
         // 4.5 MB (1 MB per part)
         // 1024 1024 1024 1024 512
 
@@ -198,8 +198,8 @@ class FileSystem {
                 defer {
                     try? fileHandle.close()
                 }
-                try fileHandle.seek(toOffset: UInt64(offset))
-                let data = fileHandle.readData(ofLength: length)
+                try fileHandle.seek(toOffset: offset)
+                let data = try fileHandle.read(bytes: length)
                 let fileURL = try self.createTemporaryFile(data: data)
                 completionHandler(.success(fileURL))
             } catch {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StoragePersistableTransferTask.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StoragePersistableTransferTask.swift
@@ -108,8 +108,8 @@ struct StoragePersistableMultipartUpload: Codable {
 struct StoragePersistableSubTask: Codable {
     let uploadId: UploadID
     let partNumber: PartNumber
-    let bytes: Int
-    let bytesTransferred: Int
+    let bytes: UInt64
+    let bytesTransferred: UInt64
     let taskIdentifier: TaskIdentifier? // once an UploadPart starts uploading it will have a taskIdentifier
     let eTag: String?
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageServiceSessionDelegate.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageServiceSessionDelegate.swift
@@ -165,7 +165,7 @@ extension StorageServiceSessionDelegate: URLSessionTaskDelegate {
                 return
             }
 
-            multipartUploadSession.handle(uploadPartEvent: .progressUpdated(partNumber: partNumber, bytesTransferred: Int(bytesSent), taskIdentifier: task.taskIdentifier))
+            multipartUploadSession.handle(uploadPartEvent: .progressUpdated(partNumber: partNumber, bytesTransferred: UInt64(bytesSent), taskIdentifier: task.taskIdentifier))
         case .upload(let onEvent):
             let progress = Progress(totalUnitCount: totalBytesExpectedToSend)
             progress.completedUnitCount = totalBytesSent

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageUploadPartEvent.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageUploadPartEvent.swift
@@ -10,7 +10,7 @@ import Foundation
 enum StorageUploadPartEvent {
     case queued(partNumber: PartNumber)
     case started(partNumber: PartNumber, taskIdentifier: TaskIdentifier)
-    case progressUpdated(partNumber: PartNumber, bytesTransferred: Int, taskIdentifier: TaskIdentifier)
+    case progressUpdated(partNumber: PartNumber, bytesTransferred: UInt64, taskIdentifier: TaskIdentifier)
     case completed(partNumber: PartNumber, eTag: String, taskIdentifier: TaskIdentifier)
     case failed(partNumber: PartNumber, error: Error)
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileHandleTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileHandleTests.swift
@@ -1,0 +1,47 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import AWSS3StoragePlugin
+
+class FileHandleTests: XCTestCase {
+    
+    /// Given: A FileHandle and a file
+    /// When: `read(bytes:bytesReadLimit)` is invoked with `bytesReadLimit` being lower than `bytes`
+    /// Then: Only `bytesReadLimit` bytes will be read at a time, but all `bytes` will be read and returned
+    func testRead_withBytesHigherThanLimit_shouldSucceedByReadingMultipleTimes() throws {
+        let sourceString = "012345678910" // 11 bytes
+        let sourceData = sourceString.data(using: .utf8)!
+        let sourceFile = try createFile(from: sourceData)
+        XCTAssertEqual(try StorageRequestUtils.getSize(sourceFile), UInt64(sourceString.count))
+        
+        let fileSystem = FileSystem()
+        let bytesReadLimit = 2
+        
+        let fileHandle = try FileHandle(forReadingFrom: sourceFile)
+        let firstPartData = try fileHandle.read(bytes: 5, bytesReadLimit: bytesReadLimit)
+        let firstPartString = String(decoding: firstPartData, as: UTF8.self)
+        XCTAssertEqual(firstPartString, "01234") // i.e. the first 5 bytes
+        
+        let secondPartData = try fileHandle.read(bytes: 5, bytesReadLimit: bytesReadLimit)
+        let secondPartString = String(decoding: secondPartData, as: UTF8.self)
+        XCTAssertEqual(secondPartString, "56789") // i.e. the second 5 bytes
+        
+        let thirdPartData = try fileHandle.read(bytes: 5, bytesReadLimit: bytesReadLimit)
+        let thirdPartString = String(decoding: thirdPartData, as: UTF8.self)
+        XCTAssertEqual(thirdPartString, "10") // i.e. the remaining bytes
+        
+        try FileManager.default.removeItem(at: sourceFile)
+    }
+
+    private func createFile(from data: Data) throws -> URL {
+        let fileUrl = try FileManager.default.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+            .appendingPathComponent("\(UUID().uuidString).tmp")
+        try data.write(to: fileUrl, options: .atomic)
+        return fileUrl
+    }
+}

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileSystemTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileSystemTests.swift
@@ -18,7 +18,7 @@ extension FileSystem {
     /// - Parameter bytes: bytes
     /// - Returns: random data
     func randomData(bytes: Bytes) -> Data {
-        let count = bytes.bytes
+        let count = Int(bytes.bytes)
         var bytes = [Int8](repeating: 0, count: count)
         // Fill bytes with secure random data
         let status = SecRandomCopyBytes(
@@ -174,7 +174,7 @@ class FileSystemTests: XCTestCase {
         defer {
             fs.removeFileIfExists(fileURL: fileURL)
         }
-        var offset = 0
+        var offset: UInt64 = 0
         var step: ((Int) -> Void)?
         let queue = DispatchQueue(label: "done-count-queue")
 
@@ -190,7 +190,7 @@ class FileSystemTests: XCTestCase {
             let part = parts[index]
 
             print("Creating partial file [\(index)]")
-            fs.createPartialFile(fileURL: fileURL, offset: offset, length: part.count) { result in
+            fs.createPartialFile(fileURL: fileURL, offset: offset, length: UInt64(part.count)) { result in
                 do {
                     let partFileURL = try result.get()
                     let fileContents = try String(contentsOf: partFileURL)
@@ -210,7 +210,7 @@ class FileSystemTests: XCTestCase {
                     XCTFail("Failed to create partial file: \(error)")
                 }
             }
-            offset += part.count
+            offset += UInt64(part.count)
             step?(index + 1)
         }
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/MockMultipartUploadClient.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/MockMultipartUploadClient.swift
@@ -21,7 +21,7 @@ class MockMultipartUploadClient: StorageMultipartUploadClient {
 
     var didCreate: ((StorageMultipartUploadSession) -> Void)?
     var didStartPartUpload: ((StorageMultipartUploadSession, PartNumber) -> Void)?
-    var didTransferBytesForPartUpload: ((StorageMultipartUploadSession, PartNumber, Int) -> Void)?
+    var didTransferBytesForPartUpload: ((StorageMultipartUploadSession, PartNumber, UInt64) -> Void)?
     var shouldFailPartUpload: ((StorageMultipartUploadSession, PartNumber) -> Bool)?
     var didCompletePartUpload: ((StorageMultipartUploadSession, PartNumber, String, TaskIdentifier) -> Void)?
     var didFailPartUpload: ((StorageMultipartUploadSession, PartNumber, Error) -> Void)?

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageMultipartUploadSessionTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageMultipartUploadSessionTests.swift
@@ -321,7 +321,7 @@ class StorageMultipartUploadSessionTests: XCTestCase {
     // MARK: - Private -
 
     private func createFile() throws -> URL {
-        let size = minimumPartSize
+        let size = Int(minimumPartSize)
         let parts: [String] = [
             Array(repeating: "a", count: size).joined(),
             Array(repeating: "b", count: size).joined(),

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageTransferDatabaseTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageTransferDatabaseTests.swift
@@ -196,11 +196,11 @@ class StorageTransferDatabaseTests: XCTestCase {
                 subTask.uploadPart = .pending(bytes: Bytes.megabytes(5).bytes)
                 if index == 0 {
                     parts[index] = .inProgress(bytes: part.bytes,
-                                               bytesTransferred: Int(Double(part.bytes) * 0.75),
+                                               bytesTransferred: UInt64(Double(part.bytes) * 0.75),
                                                taskIdentifier: sessionTask.taskIdentifier)
                 } else if index == 1 {
                     parts[index] = .inProgress(bytes: part.bytes,
-                                               bytesTransferred: Int(Double(part.bytes) * 0.25),
+                                               bytesTransferred: UInt64(Double(part.bytes) * 0.25),
                                                taskIdentifier: sessionTask.taskIdentifier)
                 }
             } else {

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageUploadPartSizeTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageUploadPartSizeTests.swift
@@ -48,7 +48,7 @@ class StorageUploadPartSizeTests: XCTestCase {
 
     func testUploadPartSizeForLargeValidFile() throws {
         // use a file size which requires increasing from minimum part size
-        let fileSize = UInt64(minimumPartSize * maximumPartCount * 10)
+        let fileSize = minimumPartSize * UInt64(maximumPartCount) * 10
         let partSize = assertNoThrow(try StorageUploadPartSize(fileSize: fileSize))
         XCTAssertNotNil(partSize)
         if let partSize = partSize,
@@ -62,7 +62,7 @@ class StorageUploadPartSizeTests: XCTestCase {
 
     func testUploadPartSizeForSuperCrazyBigFile() throws {
         // use the maximum object size / max part count
-        let fileSize = UInt64(maximumObjectSize / maximumPartCount)
+        let fileSize = maximumObjectSize / UInt64(maximumPartCount)
         let partSize = assertNoThrow(try StorageUploadPartSize(fileSize: fileSize))
         XCTAssertNotNil(partSize)
         if let partSize = partSize,

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageUploadPartTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageUploadPartTests.swift
@@ -15,9 +15,9 @@ class StorageUploadPartTests: XCTestCase {
     func testUploadPartCreation() throws {
         // Creates an array of upload parts with 21 parts
         // where the last part is 512 bytes.
-        let lastPartSize = 512
+        let lastPartSize: UInt64 = 512
         let partSize: StorageUploadPartSize = .default
-        let fileSize: UInt64 = UInt64(partSize.size * 20 + lastPartSize)
+        let fileSize = partSize.size * 20 + lastPartSize
         let parts = try StorageUploadParts(fileSize: fileSize, partSize: partSize)
         XCTAssertEqual(parts.count, 21)
         XCTAssertEqual(parts.pending.count, parts.count)
@@ -43,8 +43,8 @@ class StorageUploadPartTests: XCTestCase {
         XCTAssertEqual(parts.inProgress.count, parts.count)
         XCTAssertEqual(parts.failed.count, 0)
         XCTAssertEqual(parts.completed.count, 0)
-        XCTAssertEqual(parts.totalBytes, 100 * parts.count)
-        XCTAssertEqual(parts.bytesTransferred, 50 * parts.count)
+        XCTAssertEqual(parts.totalBytes, UInt64(100 * parts.count))
+        XCTAssertEqual(parts.bytesTransferred, UInt64(50 * parts.count))
         XCTAssertEqual(parts.percentTransferred, 0.5)
     }
 


### PR DESCRIPTION
## Issue \#
- https://github.com/aws-amplify/amplify-swift/issues/3378

## Description
This PR changes `Int` to `UInt64` in several Storage objects when representing bytes.
watchOS's `Int` is actually a `Int32` due to its **arm64_32** architecture, so attempting to convert >= 2GB into bytes results in an overflown error.

The only special handing is our usage of [`FileHandle.read(upToCount:)`](https://developer.apple.com/documentation/foundation/filehandle/3516317-read), which we use to split a file into parts for multipart uploads.
Since the `count` attribute is an `Int`, but the theoretical maximum size for a part is 5GB, attempting to directly cast it could crash. In practice, this **very** unlikely to happen as having a part with size >= 2GB with the current implementation can only happen for files of size bigger than 20TB.

We can argue that by the time an Apple Watch can handle 20TB files, then the **arm64_32** architecture would likely be long gone. But anyways, just to be extra cautious, I've prevented this situation by implementing a simple check that will "split" reads that exceed `Int.max` bytes.

## General Checklist
<!-- Check or cross out if not relevant -->

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] [All integration tests pass](https://github.com/aws-amplify/amplify-swift/actions/runs/7036933593/job/19150632272)
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
