### PR TITLE
feat(auth): add sign up implementation for otp and magiclink

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -42,13 +42,10 @@ extension AWSCognitoAuthPlugin {
         let credentialsClient = CredentialStoreOperationClient(
             credentialStoreStateMachine: credentialStoreMachine)
 
-        let authPasswordlessClient = AWSAuthPasswordlessClient(urlSession: makeURLSession())
-        
         let authResolver = AuthState.Resolver().eraseToAnyResolver()
         let authEnvironment = makeAuthEnvironment(
             authConfiguration: authConfiguration,
-            credentialsClient: credentialsClient,
-            authPasswordlessClient: authPasswordlessClient
+            credentialsClient: credentialsClient
         )
 
         let authStateMachine = StateMachine(resolver: authResolver, environment: authEnvironment)
@@ -157,15 +154,15 @@ extension AWSCognitoAuthPlugin {
 
     private func makeAuthEnvironment(
         authConfiguration: AuthConfiguration,
-        credentialsClient: CredentialStoreStateBehavior,
-        authPasswordlessClient: AuthPasswordlessBehavior
+        credentialsClient: CredentialStoreStateBehavior
     ) -> AuthEnvironment {
 
         switch authConfiguration {
         case .userPools(let userPoolConfigurationData):
             let authenticationEnvironment = authenticationEnvironment(
                 userPoolConfigData: userPoolConfigurationData)
-
+            let authPasswordlessClient =
+                (userPoolConfigurationData.passwordlessSignUpEndpoint != nil) ? AWSAuthPasswordlessClient(urlSession: makeURLSession()) : nil
             return AuthEnvironment(
                 configuration: authConfiguration,
                 userPoolConfigData: userPoolConfigurationData,
@@ -186,7 +183,7 @@ extension AWSCognitoAuthPlugin {
                 authenticationEnvironment: nil,
                 authorizationEnvironment: authorizationEnvironment,
                 credentialsClient: credentialsClient,
-                authPasswordlessClient: authPasswordlessClient,
+                authPasswordlessClient: nil,
                 logger: log)
 
         case .userPoolsAndIdentityPools(let userPoolConfigurationData,
@@ -195,6 +192,8 @@ extension AWSCognitoAuthPlugin {
                 userPoolConfigData: userPoolConfigurationData)
             let authorizationEnvironment = authorizationEnvironment(
                 identityPoolConfigData: identityPoolConfigurationData)
+            let authPasswordlessClient =
+                (userPoolConfigurationData.passwordlessSignUpEndpoint != nil) ? AWSAuthPasswordlessClient(urlSession: makeURLSession()) : nil
             return AuthEnvironment(
                 configuration: authConfiguration,
                 userPoolConfigData: userPoolConfigurationData,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
@@ -211,7 +211,8 @@ extension AWSCognitoAuthPlugin: AuthCategoryBehavior {
         let task = AWSAuthSignInWithMagicLinkTask(
             request,
             authStateMachine: self.authStateMachine,
-            configuration: authConfiguration)
+            configuration: self.authConfiguration,
+            authEnvironment: self.authEnvironment)
         return try await taskQueue.sync {
             return try await task.value
         } as! AuthSignInResult
@@ -228,7 +229,8 @@ extension AWSCognitoAuthPlugin: AuthCategoryBehavior {
         let task = try AWSAuthConfirmSignInWithMagicLinkTask(
             request,
             stateMachine: authStateMachine,
-            configuration: authConfiguration)
+            configuration: authConfiguration,
+            authEnvironment: authEnvironment)
         return try await taskQueue.sync {
             return try await task.value
         } as! AuthSignInResult
@@ -249,7 +251,8 @@ extension AWSCognitoAuthPlugin: AuthCategoryBehavior {
         let task = AWSAuthSignInWithOTPTask(
             request,
             authStateMachine: self.authStateMachine,
-            configuration: authConfiguration)
+            configuration: self.authConfiguration,
+            authEnvironment: self.authEnvironment)
         return try await taskQueue.sync {
             return try await task.value
         } as! AuthSignInResult

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
@@ -228,9 +228,7 @@ extension AWSCognitoAuthPlugin: AuthCategoryBehavior {
             options: options)
         let task = try AWSAuthConfirmSignInWithMagicLinkTask(
             request,
-            stateMachine: authStateMachine,
-            configuration: authConfiguration,
-            authEnvironment: authEnvironment)
+            stateMachine: authStateMachine)
         return try await taskQueue.sync {
             return try await task.value
         } as! AuthSignInResult
@@ -269,8 +267,7 @@ extension AWSCognitoAuthPlugin: AuthCategoryBehavior {
             options: options)
         let task = AWSAuthConfirmSignInWithOTPTask(
             request,
-            stateMachine: authStateMachine,
-            configuration: authConfiguration)
+            stateMachine: authStateMachine)
         return try await taskQueue.sync {
             return try await task.value
         } as! AuthSignInResult

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/AuthEnvironment.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/AuthEnvironment.swift
@@ -15,7 +15,6 @@ struct AuthEnvironment: Environment, LoggerProvider {
     let authenticationEnvironment: AuthenticationEnvironment?
     let authorizationEnvironment: AuthorizationEnvironment?
     let credentialsClient: CredentialStoreStateBehavior
-    let authPasswordlessClient: AuthPasswordlessBehavior?
     let logger: Logger
 }
 
@@ -40,6 +39,13 @@ extension AuthEnvironment: AuthenticationEnvironment {
             fatalError("Could not find authentication environment")
         }
         return authNEnv.srpSignInEnvironment
+    }
+    
+    var authPasswordlessEnvironment: AuthPasswordlessEnvironment? {
+        guard let environment = authenticationEnvironment else {
+            fatalError("Could not find authentication environment")
+        }
+        return environment.authPasswordlessEnvironment
     }
 }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/AuthPasswordlessEnvironment.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/AuthPasswordlessEnvironment.swift
@@ -1,0 +1,28 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+protocol AuthPasswordlessEnvironment: Environment {
+
+    typealias AuthPasswordlessFactory = () throws -> AuthPasswordlessBehavior
+
+    var authPasswordlessFactory: AuthPasswordlessFactory { get }
+}
+
+struct BasicPasswordlessEnvironment: AuthPasswordlessEnvironment {
+    let authPasswordlessFactory: AuthPasswordlessFactory
+}
+
+extension AuthEnvironment: AuthPasswordlessEnvironment {
+    var authPasswordlessFactory: AuthPasswordlessFactory {
+        guard let authPasswordlessFactory = authPasswordlessEnvironment?.authPasswordlessFactory else {
+            fatalError("Could not find auth passwordless environment")
+        }
+        return authPasswordlessFactory
+    }
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/AuthenticationEnvironment.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/AuthenticationEnvironment.swift
@@ -8,9 +8,12 @@
 protocol AuthenticationEnvironment: Environment {
 
     var srpSignInEnvironment: SRPSignInEnvironment { get }
+    
     var userPoolEnvironment: UserPoolEnvironment { get }
 
     var hostedUIEnvironment: HostedUIEnvironment? { get }
+    
+    var authPasswordlessEnvironment: AuthPasswordlessEnvironment? { get }
 }
 
 struct BasicAuthenticationEnvironment: AuthenticationEnvironment {
@@ -20,4 +23,6 @@ struct BasicAuthenticationEnvironment: AuthenticationEnvironment {
     let userPoolEnvironment: UserPoolEnvironment
 
     let hostedUIEnvironment: HostedUIEnvironment?
+    
+    let authPasswordlessEnvironment: AuthPasswordlessEnvironment?
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/PasswordlessSignUpHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/PasswordlessSignUpHelper.swift
@@ -10,17 +10,22 @@ import Amplify
 
 struct PasswordlessSignUpHelper: DefaultLogger {
 
+    private let authStateMachine: AuthStateMachine
+    private let taskHelper: AWSAuthTaskHelper
     private let authEnvironment: AuthEnvironment
     private let authConfiguration: AuthConfiguration?
     private let username: String
     private let signInRequestMetadata: PasswordlessCustomAuthRequest
     private let pluginOptions: Any?
 
-    init(configuration: AuthConfiguration?,
+    init(authStateMachine: AuthStateMachine,
+         configuration: AuthConfiguration?,
          authEnvironment: AuthEnvironment,
          username: String,
          signInRequestMetadata: PasswordlessCustomAuthRequest,
          pluginOptions: Any?) {
+        self.authStateMachine = authStateMachine
+        self.taskHelper = AWSAuthTaskHelper(authStateMachine: authStateMachine)
         self.authConfiguration = configuration
         self.authEnvironment = authEnvironment
         self.username = username
@@ -28,64 +33,133 @@ struct PasswordlessSignUpHelper: DefaultLogger {
         self.pluginOptions = pluginOptions
     }
 
-    func signUp() async -> Result<Void, AuthError> {
+    func signUp() async throws {
         log.verbose("Starting execution")
-        // Check if we have a user pool configuration
-        // User pool configuration is used retrieve API Gateway information,
-        // so that sign up flow can take place
-        guard let userPoolConfiguration = authConfiguration?.getUserPoolConfiguration() else {
-            let message = AuthPluginErrorConstants.configurationError
-            let authError = AuthError.configuration(
-                "Could not find user pool configuration",
-                message)
-            return .failure(authError)
-        }
+        await taskHelper.didStateMachineConfigured()
 
-        guard let authPasswordlessClient = authEnvironment.authPasswordlessClient else {
-            let message = AuthPluginErrorConstants.configurationError
-            let authError = AuthError.configuration(
-                "URL Session client is not set up",
-                message)
-            return .failure(authError)
+        do {
+            // Make sure current state is a valid state to begin sign up
+            try await validateCurrentState()
+
+            // Start sign up
+            
+            // Check if we have a user pool configuration
+            // User pool configuration is used retrieve API Gateway information,
+            // so that sign up flow can take place
+            guard let userPoolConfiguration = authConfiguration?.getUserPoolConfiguration() else {
+                let message = AuthPluginErrorConstants.configurationError
+                let authError = AuthError.configuration(
+                    "Could not find user pool configuration",
+                    message)
+                throw authError
+            }
+
+            guard let authPasswordlessClient = try authEnvironment.authPasswordlessEnvironment?.authPasswordlessFactory() else {
+                let message = AuthPluginErrorConstants.configurationError
+                let authError = AuthError.configuration(
+                    "URL Session client is not set up",
+                    message)
+                throw authError
+            }
+            
+            guard let endpoint = userPoolConfiguration.passwordlessSignUpEndpoint else {
+                let message = AuthPluginErrorConstants.configurationError
+                let authError = AuthError.configuration(
+                    "API Gateway endpoint not found in configuration",
+                    message)
+                throw authError
+            }
+            
+            guard let endpointURL = URL(string: endpoint) else {
+                let message = AuthPluginErrorConstants.configurationError
+                let authError = AuthError.configuration(
+                    "API Gateway URL is not valid",
+                    message)
+                throw authError
+            }
+            
+            guard let deliveryMedium = signInRequestMetadata.deliveryMedium else {
+                let message = AuthPluginErrorConstants.configurationError
+                let authError = AuthError.configuration(
+                    "Delivery medium is not specified",
+                    message)
+                throw authError
+            }
+            
+            var userAttributes : [String:String] = [:]
+            if let pluginOptions = pluginOptions as? AWSAuthSignUpAndSignInPasswordlessOptions,
+               let attributes = pluginOptions.userAttributes {
+                userAttributes = attributes
+            }
+            
+            let payload = PreInitiateAuthSignUpPayload(username: username,
+                                                       deliveryMedium: deliveryMedium.rawValue,
+                                                       userAttributes: userAttributes,
+                                                       userPoolId: userPoolConfiguration.poolId,
+                                                       region: userPoolConfiguration.region)
+            return try await authPasswordlessClient.preInitiateAuthSignUp(endpoint: endpointURL,
+                                                                          payload: payload)
+        } catch {
+
+            log.error(error: error)
+            
+            // If Passwordless SignUp, send sign in cancellation event
+            await sendCancelSignInEvent()
+
+            // Wait for sign in cancellation to complete
+            await waitForSignInCancel()
+
+            // throw error that came during sign up
+            throw error
         }
-        
-        guard let endpoint = userPoolConfiguration.passwordlessSignUpEndpoint else {
-            let message = AuthPluginErrorConstants.configurationError
-            let authError = AuthError.configuration(
-                "API Gateway endpoint not found in configuration",
-                message)
-            return .failure(authError)
+    }
+    
+    // MARK: State Validations
+
+    private func validateCurrentState() async throws {
+
+        let stateSequences = await authStateMachine.listen()
+        log.verbose("Validating current state")
+        for await state in stateSequences {
+            guard case .configured(let authenticationState, _) = state else {
+                continue
+            }
+            switch authenticationState {
+            case .signedIn:
+                let error = AuthError.invalidState(
+                    "There is already a user in signedIn state. SignOut the user first before calling signIn",
+                    AuthPluginErrorConstants.invalidStateError, nil)
+                throw error
+            case .signingIn:
+                log.verbose("Cancelling existing signIn flow")
+                await sendCancelSignInEvent()
+            case .signedOut:
+                return
+            default: continue
+            }
         }
-        
-        guard let endpointURL = URL(string: endpoint) else {
-            let message = AuthPluginErrorConstants.configurationError
-            let authError = AuthError.configuration(
-                "API Gateway URL is not valid",
-                message)
-            return .failure(authError)
+    }
+    
+    // MARK: Sign In Cancellation
+
+    private func sendCancelSignInEvent() async {
+        let event = AuthenticationEvent(eventType: .cancelSignIn)
+        await authStateMachine.send(event)
+    }
+
+    private func waitForSignInCancel() async {
+        let stateSequences = await authStateMachine.listen()
+        log.verbose("Wait for signIn to cancel")
+        for await state in stateSequences {
+            guard case .configured(let authenticationState, _) = state else {
+                continue
+            }
+            switch authenticationState {
+            case .signedOut:
+                return
+            default: continue
+            }
         }
-        
-        guard let deliveryMedium = signInRequestMetadata.deliveryMedium else {
-            let message = AuthPluginErrorConstants.configurationError
-            let authError = AuthError.configuration(
-                "Delivery medium is not specified",
-                message)
-            return .failure(authError)
-        }
-        
-        var userAttributes : [String:String] = [:]
-        if let pluginOptions = pluginOptions as? AWSAuthSignUpAndSignInPasswordlessOptions,
-           let attributes = pluginOptions.userAttributes {
-            userAttributes = attributes
-        }
-        
-        let payload = PreInitiateAuthSignUpPayload(username: username,
-                                                   deliveryMedium: deliveryMedium.rawValue,
-                                                   userAttributes: userAttributes,
-                                                   userPoolId: userPoolConfiguration.poolId,
-                                                   region: userPoolConfiguration.region)
-        return await authPasswordlessClient.preInitiateAuthSignUp(endpoint: endpointURL,
-                                                                  payload: payload)
     }
     
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/PasswordlessSignUpHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/PasswordlessSignUpHelper.swift
@@ -1,0 +1,91 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Amplify
+
+struct PasswordlessSignUpHelper: DefaultLogger {
+
+    private let authEnvironment: AuthEnvironment
+    private let authConfiguration: AuthConfiguration?
+    private let username: String
+    private let signInRequestMetadata: PasswordlessCustomAuthRequest
+    private let pluginOptions: Any?
+
+    init(configuration: AuthConfiguration?,
+         authEnvironment: AuthEnvironment,
+         username: String,
+         signInRequestMetadata: PasswordlessCustomAuthRequest,
+         pluginOptions: Any?) {
+        self.authConfiguration = configuration
+        self.authEnvironment = authEnvironment
+        self.username = username
+        self.signInRequestMetadata = signInRequestMetadata
+        self.pluginOptions = pluginOptions
+    }
+
+    func signUp() async -> Result<Void, AuthError> {
+        log.verbose("Starting execution")
+        // Check if we have a user pool configuration
+        // User pool configuration is used retrieve API Gateway information,
+        // so that sign up flow can take place
+        guard let userPoolConfiguration = authConfiguration?.getUserPoolConfiguration() else {
+            let message = AuthPluginErrorConstants.configurationError
+            let authError = AuthError.configuration(
+                "Could not find user pool configuration",
+                message)
+            return .failure(authError)
+        }
+
+        guard let authPasswordlessClient = authEnvironment.authPasswordlessClient else {
+            let message = AuthPluginErrorConstants.configurationError
+            let authError = AuthError.configuration(
+                "URL Session client is not set up",
+                message)
+            return .failure(authError)
+        }
+        
+        guard let endpoint = userPoolConfiguration.passwordlessSignUpEndpoint else {
+            let message = AuthPluginErrorConstants.configurationError
+            let authError = AuthError.configuration(
+                "API Gateway endpoint not found in configuration",
+                message)
+            return .failure(authError)
+        }
+        
+        guard let endpointURL = URL(string: endpoint) else {
+            let message = AuthPluginErrorConstants.configurationError
+            let authError = AuthError.configuration(
+                "API Gateway URL is not valid",
+                message)
+            return .failure(authError)
+        }
+        
+        guard let deliveryMedium = signInRequestMetadata.deliveryMedium else {
+            let message = AuthPluginErrorConstants.configurationError
+            let authError = AuthError.configuration(
+                "Delivery medium is not specified",
+                message)
+            return .failure(authError)
+        }
+        
+        var userAttributes : [String:String] = [:]
+        if let pluginOptions = pluginOptions as? AWSAuthSignUpAndSignInPasswordlessOptions,
+           let attributes = pluginOptions.userAttributes {
+            userAttributes = attributes
+        }
+        
+        let payload = PreInitiateAuthSignUpPayload(username: username,
+                                                   deliveryMedium: deliveryMedium.rawValue,
+                                                   userAttributes: userAttributes,
+                                                   userPoolId: userPoolConfiguration.poolId,
+                                                   region: userPoolConfiguration.region)
+        return await authPasswordlessClient.preInitiateAuthSignUp(endpoint: endpointURL,
+                                                                  payload: payload)
+    }
+    
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/UserPoolConfigurationData.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/UserPoolConfigurationData.swift
@@ -17,6 +17,7 @@ struct UserPoolConfigurationData: Equatable {
     let pinpointAppId: String?
     let hostedUIConfig: HostedUIConfigurationData?
     let authFlowType: AuthFlowType
+    let passwordlessSignUpEndpoint: String?
 
     init(
         poolId: String,
@@ -26,7 +27,8 @@ struct UserPoolConfigurationData: Equatable {
         clientSecret: String? = nil,
         pinpointAppId: String? = nil,
         authFlowType: AuthFlowType = .userSRP,
-        hostedUIConfig: HostedUIConfigurationData? = nil
+        hostedUIConfig: HostedUIConfigurationData? = nil,
+        passwordlessSignUpEndpoint: String? = nil
     ) {
         self.poolId = poolId
         self.clientId = clientId
@@ -36,6 +38,7 @@ struct UserPoolConfigurationData: Equatable {
         self.pinpointAppId = pinpointAppId
         self.hostedUIConfig = hostedUIConfig
         self.authFlowType = authFlowType
+        self.passwordlessSignUpEndpoint = passwordlessSignUpEndpoint
     }
 
     /// Amazon Cognito user pool: cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>,
@@ -56,7 +59,8 @@ extension UserPoolConfigurationData: CustomDebugDictionaryConvertible {
             "endpoint": endpoint ?? "N/A",
             "clientSecret": clientSecret.masked(interiorCount: 4),
             "pinpointAppId": pinpointAppId.masked(interiorCount: 4, retainingCount: 4),
-            "hostedUI": hostedUIConfig?.debugDescription ?? "N/A"
+            "hostedUI": hostedUIConfig?.debugDescription ?? "N/A",
+            "passwordlessSignUpEndpoint": passwordlessSignUpEndpoint ?? "N/A"
         ]
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ConfigurationHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ConfigurationHelper.swift
@@ -60,6 +60,12 @@ struct ConfigurationHelper {
         if case .string(let clientSecretFromConfig) = cognitoUserPoolJSON.value(at: "AppClientSecret") {
             clientSecret = clientSecretFromConfig
         }
+        
+        var passwordlessSignUpEndpoint: String?
+        // TODO: Update the JSON key after CDK has finalized on the format
+        if case .string(let passwordlessSignUpEndpointFromConfig) = cognitoUserPoolJSON.value(at: "PasswordlessSignUpEndpoint") {
+            passwordlessSignUpEndpoint = passwordlessSignUpEndpointFromConfig
+        }
 
         let hostedUIConfig = parseHostedConfiguration(
             configuration: config.value(at: "Auth.Default.OAuth"))
@@ -71,7 +77,8 @@ struct ConfigurationHelper {
                                          clientSecret: clientSecret,
                                          pinpointAppId: pinpointId,
                                          authFlowType: authFlowType,
-                                         hostedUIConfig: hostedUIConfig)
+                                         hostedUIConfig: hostedUIConfig,
+                                         passwordlessSignUpEndpoint: passwordlessSignUpEndpoint)
     }
 
     static func parseHostedConfiguration(configuration: JSONValue?) -> HostedUIConfigurationData? {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Passwordless/AWSAuthPasswordlessClient.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Passwordless/AWSAuthPasswordlessClient.swift
@@ -21,7 +21,7 @@ class AWSAuthPasswordlessClient : AuthPasswordlessBehavior {
     }
     
     func preInitiateAuthSignUp(endpoint: URL,
-                               payload: PreInitiateAuthSignUpPayload) async throws -> Result<Void, AuthError> {
+                               payload: PreInitiateAuthSignUpPayload) async -> Result<Void, AuthError> {
         
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
@@ -31,18 +31,18 @@ class AWSAuthPasswordlessClient : AuthPasswordlessBehavior {
             let (_, response) = try await self.data(for: request)
             
             guard let response = response as? HTTPURLResponse else {
-                throw AuthError.unknown("Response received is not a HTTPURLResponse")
+                return .failure(AuthError.unknown("Response received is not a HTTPURLResponse"))
             }
             
             if response.statusCode == 200 {
                 return .successfulVoid
             } else {
-                throw AuthError.unknown("Response received with status code: \(response.statusCode)")
+                return .failure(AuthError.unknown("Response received with status code: \(response.statusCode)"))
             }
         } catch {
-            throw AuthError.service(error.localizedDescription,
+            return .failure(AuthError.service(error.localizedDescription,
                                     "API Gateway returned an error. Please check the error message for more details.",
-                                    error)
+                                    error))
         }
     }
     

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Passwordless/AWSAuthPasswordlessClient.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Passwordless/AWSAuthPasswordlessClient.swift
@@ -21,7 +21,7 @@ class AWSAuthPasswordlessClient : AuthPasswordlessBehavior {
     }
     
     func preInitiateAuthSignUp(endpoint: URL,
-                               payload: PreInitiateAuthSignUpPayload) async -> Result<Void, AuthError> {
+                               payload: PreInitiateAuthSignUpPayload) async throws {
         
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
@@ -31,18 +31,18 @@ class AWSAuthPasswordlessClient : AuthPasswordlessBehavior {
             let (_, response) = try await self.data(for: request)
             
             guard let response = response as? HTTPURLResponse else {
-                return .failure(AuthError.unknown("Response received is not a HTTPURLResponse"))
+                throw AuthError.unknown("Response received is not a HTTPURLResponse")
             }
             
             if response.statusCode == 200 {
-                return .successfulVoid
+                return
             } else {
-                return .failure(AuthError.unknown("Response received with status code: \(response.statusCode)"))
+                throw AuthError.unknown("Response received with status code: \(response.statusCode)")
             }
         } catch {
-            return .failure(AuthError.service(error.localizedDescription,
+            throw AuthError.service(error.localizedDescription,
                                     "API Gateway returned an error. Please check the error message for more details.",
-                                    error))
+                                    error)
         }
     }
     

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Passwordless/AWSAuthPasswordlessClient.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Passwordless/AWSAuthPasswordlessClient.swift
@@ -34,9 +34,10 @@ class AWSAuthPasswordlessClient : AuthPasswordlessBehavior {
                 throw AuthError.unknown("Response received is not a HTTPURLResponse")
             }
             
-            if response.statusCode == 200 {
+            switch response.statusCode {
+            case 200..<300:
                 return
-            } else {
+            default:
                 throw AuthError.unknown("Response received with status code: \(response.statusCode)")
             }
         } catch {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Passwordless/AuthPasswordlessBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Passwordless/AuthPasswordlessBehavior.swift
@@ -14,6 +14,6 @@ protocol AuthPasswordlessBehavior {
     func preInitiateAuthSignUp(
         endpoint: URL,
         payload: PreInitiateAuthSignUpPayload) 
-    async throws -> Result<Void, AuthError>
+    async -> Result<Void, AuthError>
     
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Passwordless/AuthPasswordlessBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Passwordless/AuthPasswordlessBehavior.swift
@@ -14,6 +14,6 @@ protocol AuthPasswordlessBehavior {
     func preInitiateAuthSignUp(
         endpoint: URL,
         payload: PreInitiateAuthSignUpPayload) 
-    async -> Result<Void, AuthError>
+    async throws
     
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInWithMagicLinkTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInWithMagicLinkTask.swift
@@ -17,21 +17,16 @@ class AWSAuthConfirmSignInWithMagicLinkTask: AuthConfirmSignInWithMagicLinkTask,
     }
 
     init(_ request: AuthConfirmSignInWithMagicLinkRequest,
-         stateMachine: AuthStateMachine,
-         configuration: AuthConfiguration,
-         authEnvironment: AuthEnvironment) throws {
+         stateMachine: AuthStateMachine) throws {
 
         let username = try MagicLinkTokenParser.extractUserName(from: request.challengeResponse)
         passwordlessSignInHelper = PasswordlessSignInHelper(
             authStateMachine: stateMachine,
-            configuration: nil,
-            authEnvironment: authEnvironment,
             username: username,
             challengeAnswer: request.challengeResponse,
             signInRequestMetadata: .init(
                 signInMethod: .magicLink,
-                action: .confirm,
-                deliveryMedium: .email),
+                action: .confirm),
             passwordlessFlow: .signIn,
             pluginOptions: request.options.pluginOptions)
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInWithMagicLinkTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInWithMagicLinkTask.swift
@@ -18,17 +18,20 @@ class AWSAuthConfirmSignInWithMagicLinkTask: AuthConfirmSignInWithMagicLinkTask,
 
     init(_ request: AuthConfirmSignInWithMagicLinkRequest,
          stateMachine: AuthStateMachine,
-         configuration: AuthConfiguration) throws {
+         configuration: AuthConfiguration,
+         authEnvironment: AuthEnvironment) throws {
 
         let username = try MagicLinkTokenParser.extractUserName(from: request.challengeResponse)
         passwordlessSignInHelper = PasswordlessSignInHelper(
             authStateMachine: stateMachine,
             configuration: nil,
+            authEnvironment: authEnvironment,
             username: username,
             challengeAnswer: request.challengeResponse,
             signInRequestMetadata: .init(
                 signInMethod: .magicLink,
-                action: .confirm),
+                action: .confirm,
+                deliveryMedium: .email),
             passwordlessFlow: .signIn,
             pluginOptions: request.options.pluginOptions)
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInWithOTPTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInWithOTPTask.swift
@@ -18,8 +18,7 @@ class AWSAuthConfirmSignInWithOTPTask: AuthConfirmSignInWithOTPTask, DefaultLogg
     }
 
     init(_ request: AuthConfirmSignInWithOTPRequest,
-         stateMachine: AuthStateMachine,
-         configuration: AuthConfiguration) {
+         stateMachine: AuthStateMachine) {
         self.request = request
         self.confirmSignInHelper = PasswordlessConfirmSignInHelper(
             authStateMachine: stateMachine,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInWithOTPTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInWithOTPTask.swift
@@ -24,7 +24,8 @@ class AWSAuthConfirmSignInWithOTPTask: AuthConfirmSignInWithOTPTask, DefaultLogg
         self.confirmSignInHelper = PasswordlessConfirmSignInHelper(
             authStateMachine: stateMachine,
             challengeResponse: request.challengeResponse,
-            confirmSignInRequestMetadata: .init(signInMethod: .otp, action: .confirm),
+            confirmSignInRequestMetadata: .init(signInMethod: .otp, 
+                                                action: .confirm),
             pluginOptions: request.options.pluginOptions)
     }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInWithMagicLinkTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInWithMagicLinkTask.swift
@@ -16,13 +16,14 @@ class AWSAuthSignInWithMagicLinkTask: AuthSignInWithMagicLinkTask, DefaultLogger
         HubPayload.EventName.Auth.signInWithMagicLinkAPI
     }
 
-    // TODO: Add authEnvironment parameter here to access URLSessionClient
     init(_ request: AuthSignInWithMagicLinkRequest,
          authStateMachine: AuthStateMachine,
-         configuration: AuthConfiguration) {
+         configuration: AuthConfiguration,
+         authEnvironment: AuthEnvironment) {
         passwordlessSignInHelper = PasswordlessSignInHelper(
             authStateMachine: authStateMachine,
             configuration: configuration,
+            authEnvironment: authEnvironment,
             username: request.username,
             // NOTE: answer is not applicable in this scenario
             // because this event is only responsible for initializing the passwordless OTP workflow

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInWithMagicLinkTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInWithMagicLinkTask.swift
@@ -41,6 +41,7 @@ class AWSAuthSignInWithMagicLinkTask: AuthSignInWithMagicLinkTask, DefaultLogger
         
         // sign up helper
         passwordlessSignUpHelper = PasswordlessSignUpHelper(
+            authStateMachine: authStateMachine,
             configuration: configuration,
             authEnvironment: authEnvironment,
             username: request.username,
@@ -54,13 +55,9 @@ class AWSAuthSignInWithMagicLinkTask: AuthSignInWithMagicLinkTask, DefaultLogger
 
     func execute() async throws -> AuthSignInResult {
         if passwordlessFlow == .signUpAndSignIn {
-            let result = await passwordlessSignUpHelper.signUp()
-            switch result {
-            case .success():
-                log.verbose("Passwordless Sign Up flow success")
-            case .failure(let authError):
-                throw authError
-            }
+            log.verbose("Starting Passwordless Sign Up flow")
+            try await passwordlessSignUpHelper.signUp()
+            log.verbose("Passwordless Sign Up flow success")
         }
         
         return try await passwordlessSignInHelper.signIn()

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInWithMagicLinkTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInWithMagicLinkTask.swift
@@ -10,7 +10,9 @@ import AWSPluginsCore
 
 class AWSAuthSignInWithMagicLinkTask: AuthSignInWithMagicLinkTask, DefaultLogger {
 
+    let passwordlessFlow: AuthPasswordlessFlow
     let passwordlessSignInHelper: PasswordlessSignInHelper
+    let passwordlessSignUpHelper: PasswordlessSignUpHelper
 
     var eventName: HubPayloadEventName {
         HubPayload.EventName.Auth.signInWithMagicLinkAPI
@@ -20,10 +22,11 @@ class AWSAuthSignInWithMagicLinkTask: AuthSignInWithMagicLinkTask, DefaultLogger
          authStateMachine: AuthStateMachine,
          configuration: AuthConfiguration,
          authEnvironment: AuthEnvironment) {
+        passwordlessFlow = request.flow
+        
+        //sign in helper
         passwordlessSignInHelper = PasswordlessSignInHelper(
             authStateMachine: authStateMachine,
-            configuration: configuration,
-            authEnvironment: authEnvironment,
             username: request.username,
             // NOTE: answer is not applicable in this scenario
             // because this event is only responsible for initializing the passwordless OTP workflow
@@ -35,9 +38,31 @@ class AWSAuthSignInWithMagicLinkTask: AuthSignInWithMagicLinkTask, DefaultLogger
                 redirectURL: request.redirectURL),
             passwordlessFlow: request.flow,
             pluginOptions: request.options.pluginOptions)
+        
+        // sign up helper
+        passwordlessSignUpHelper = PasswordlessSignUpHelper(
+            configuration: configuration,
+            authEnvironment: authEnvironment,
+            username: request.username,
+            signInRequestMetadata: .init(
+                signInMethod: .magicLink,
+                action: .request,
+                deliveryMedium: .email,
+                redirectURL: request.redirectURL),
+            pluginOptions: request.options.pluginOptions)
     }
 
     func execute() async throws -> AuthSignInResult {
+        if passwordlessFlow == .signUpAndSignIn {
+            let result = await passwordlessSignUpHelper.signUp()
+            switch result {
+            case .success():
+                log.verbose("Passwordless Sign Up flow success")
+            case .failure(let authError):
+                throw authError
+            }
+        }
+        
         return try await passwordlessSignInHelper.signIn()
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInWithOTPTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInWithOTPTask.swift
@@ -40,6 +40,7 @@ class AWSAuthSignInWithOTPTask: AuthSignInWithOTPTask, DefaultLogger {
         
         // sign up helper
         passwordlessSignUpHelper = PasswordlessSignUpHelper(
+            authStateMachine: authStateMachine,
             configuration: configuration,
             authEnvironment: authEnvironment,
             username: request.username,
@@ -52,13 +53,9 @@ class AWSAuthSignInWithOTPTask: AuthSignInWithOTPTask, DefaultLogger {
 
     func execute() async throws -> AuthSignInResult {
         if passwordlessFlow == .signUpAndSignIn {
-            let result = await passwordlessSignUpHelper.signUp()
-            switch result {
-            case .success():
-                log.verbose("Passwordless Sign Up flow success")
-            case .failure(let authError):
-                throw authError
-            }
+            log.verbose("Starting Passwordless Sign Up flow")
+            try await passwordlessSignUpHelper.signUp()
+            log.verbose("Passwordless Sign Up flow success")
         }
         
         return try await passwordlessSignInHelper.signIn()

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInWithOTPTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInWithOTPTask.swift
@@ -16,13 +16,14 @@ class AWSAuthSignInWithOTPTask: AuthSignInWithOTPTask, DefaultLogger {
         HubPayload.EventName.Auth.signInWithOTPAPI
     }
 
-    // TODO: Add authEnvironment parameter here to access URLSessionClient
     init(_ request: AuthSignInWithOTPRequest,
          authStateMachine: AuthStateMachine,
-         configuration: AuthConfiguration) {
+         configuration: AuthConfiguration,
+         authEnvironment: AuthEnvironment) {
         passwordlessSignInHelper = PasswordlessSignInHelper(
             authStateMachine: authStateMachine,
             configuration: configuration,
+            authEnvironment: authEnvironment,
             username: request.username,
             // NOTE: answer is not applicable in this scenario
             // because this event is only responsible for initializing the passwordless workflow

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockAuthPasswordlessBehavior.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockAuthPasswordlessBehavior.swift
@@ -10,12 +10,16 @@ import Amplify
 @testable import AWSPluginsCore
 @testable import AWSCognitoAuthPlugin
 
-class MockAuthPasswordlessBehavior: AuthPasswordlessBehavior {
+struct MockAuthPasswordlessBehavior: AuthPasswordlessBehavior {
+    
+    typealias MockGetAuthPasswordlessResponse = (URL, PreInitiateAuthSignUpPayload) async throws -> Void
+    
+    let mockGetAuthPasswordlessResponse: MockGetAuthPasswordlessResponse?
     
     func preInitiateAuthSignUp(
         endpoint: URL,
         payload: PreInitiateAuthSignUpPayload)
-    async -> Result<Void, AuthError> {
-        return .successfulVoid
+    async throws {
+        return try await mockGetAuthPasswordlessResponse!(endpoint, payload)
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockAuthPasswordlessBehavior.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockAuthPasswordlessBehavior.swift
@@ -12,13 +12,10 @@ import Amplify
 
 class MockAuthPasswordlessBehavior: AuthPasswordlessBehavior {
     
-    public var preInitiateAuthSignUpCallCount = 0
-    
     func preInitiateAuthSignUp(
         endpoint: URL,
         payload: PreInitiateAuthSignUpPayload)
-    async throws -> Result<Void, AuthError> {
-        preInitiateAuthSignUpCallCount += 1
+    async -> Result<Void, AuthError> {
         return .successfulVoid
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/DefaultConfig.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/DefaultConfig.swift
@@ -20,6 +20,7 @@ enum Defaults {
     static let userPoolId = "XXX_XX"
     static let appClientId = "XXX"
     static let appClientSecret = "XXX"
+    static let passwordlessSignUpEndpoint = "https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/"
 
     static let validAccessToken = "eyJraWQiOiJRbWZIcnYyS1F2ZEtyRm5WYUNxbzd4MWM1ZjA3TFhFaFhZQ1VSSXU2eitvPSIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiI0MjEzZGY1ZS1mNzBiLTQ0MDUtYjhiNC05NjMzMjRhNmUwYjgiLCJkZXZpY2Vfa2V5IjoidXMtZWFzdC0xXzUyMDYxOTFjLTY5N2QtNGEzNC1iYTZmLWVmMDcwOGFkMzk3OSIsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC51cy1lYXN0LTEuYW1hem9uYXdzLmNvbVwvdXMtZWFzdC0xX2w2bksxOUFMUSIsImNsaWVudF9pZCI6IjY5OW91OHRhcXZhaDVvYzA3M29zZmo4bzgyIiwib3JpZ2luX2p0aSI6ImViMDRiOTcwLTY5NDEtNDVlZS05NTQ1LTY4ODk1ZTNlMDAwZiIsImV2ZW50X2lkIjoiODYyM2JlZDctMTBhYi00YzM1LTk0MzctMzdlMWY2YTkxZDg1IiwidG9rZW5fdXNlIjoiYWNjZXNzIiwic2NvcGUiOiJhd3MuY29nbml0by5zaWduaW4udXNlci5hZG1pbiIsImF1dGhfdGltZSI6MTY1OTA2OTMwNywiZXhwIjoxNjU5MDcyOTA3LCJpYXQiOjE2NTkwNjkzMDcsImp0aSI6ImE2ZWQ2MWE1LTFiMGUtNDgyZC04YmY1LTI1M2JiYWRhNjFhYyIsInVzZXJuYW1lIjoiaW50ZWd0ZXN0OWRlMmVlNDctY2I4MS00YjdhLWI4OTAtOGMyYzczZjRkN2RmIn0.Mjl-G9QGXF8KwZbQrxd3uNaOf4EChzltfklRp7inuxLTFLuKQqena8VctiSUQp4jDnBEBXw2Hu3D5ZvVyGoL0FQamxMvtPRIVl050XEir_RKk6M_d9Qp4pdDNH1HwJ-id9CgpvA3xpgpIH09n2voTMbgGGLO-ivuCsJCa0IbsRUJwrua-wkr5g3-3mmFFqrNrqyFhvuQRWQ6DoVo_bjwp3WVYmNq69PaxxYYXw7b-86DGGOC4kqAvQD9WiZtu8ad63kc5zJ-MjtbKfJLK8L4cyW6ga-kZn-6MjDIn8UoToWOtLncfFM1sJiucFCcPdZoM2jBJA5WDT_0QDwAOBQjMg"
 
@@ -45,7 +46,8 @@ enum Defaults {
                     "PoolId": userPoolId,
                     "AppClientId": appClientId,
                     "AppClientSecret": appClientSecret,
-                    "Region": regionString
+                    "Region": regionString,
+                    "PasswordlessSignUpEndpoint": passwordlessSignUpEndpoint
                 ]
             ],
             "Auth": [
@@ -101,7 +103,8 @@ enum Defaults {
                                   region: regionString,
                                   clientSecret: appClientSecret,
                                   pinpointAppId: "",
-                                  hostedUIConfig: withHostedUI)
+                                  hostedUIConfig: withHostedUI,
+                                  passwordlessSignUpEndpoint: passwordlessSignUpEndpoint   )
     }
 
     static func makeIdentityConfigData() -> IdentityPoolConfigurationData {
@@ -141,7 +144,8 @@ enum Defaults {
         authZEnvironment: BasicAuthorizationEnvironment? = nil,
         identityPoolFactory: @escaping () throws -> CognitoIdentityBehavior = makeIdentity,
         userPoolFactory: @escaping () throws -> CognitoUserPoolBehavior = makeDefaultUserPool,
-        hostedUIEnvironment: HostedUIEnvironment? = nil
+        hostedUIEnvironment: HostedUIEnvironment? = nil,
+        authPasswordlessClient: AuthPasswordlessBehavior? = nil
     ) -> AuthEnvironment {
         let userPoolConfigData = makeDefaultUserPoolConfigData()
         let identityPoolConfigData = makeIdentityConfigData()
@@ -168,7 +172,7 @@ enum Defaults {
             authenticationEnvironment: authenticationEnvironment,
             authorizationEnvironment: authZEnvironment ?? authorizationEnvironment,
             credentialsClient: makeCredentialStoreOperationBehavior(),
-            authPasswordlessClient: AWSAuthPasswordlessClient(urlSession: makeURLSession()),
+            authPasswordlessClient: authPasswordlessClient ?? AWSAuthPasswordlessClient(urlSession: makeURLSession()),
             logger: Amplify.Logging.logger(forCategory: "awsCognitoAuthPluginTest")
         )
         Amplify.Logging.logLevel = .verbose

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/DefaultConfig.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/DefaultConfig.swift
@@ -81,6 +81,12 @@ enum Defaults {
         MockAnalyticsHandler()
     }
     
+    static func makePasswordlessClient() -> AuthPasswordlessBehavior {
+        MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
+            
+        })
+    }
+    
     static func makeIdentity() throws -> CognitoIdentityBehavior {
         let getId: MockIdentity.MockGetIdResponse = { _ in
             return .init(identityId: "mockIdentityId")
@@ -121,7 +127,7 @@ enum Defaults {
     
     static func makeDefaultUserPoolConfigDataWithNilPasswordlessSignUpEndpoint(
         withHostedUI: HostedUIConfigurationData? = nil
-    )-> UserPoolConfigurationData {
+    ) -> UserPoolConfigurationData {
         UserPoolConfigurationData(poolId: userPoolId,
                                   clientId: appClientId,
                                   region: regionString,
@@ -169,7 +175,7 @@ enum Defaults {
         identityPoolFactory: @escaping () throws -> CognitoIdentityBehavior = makeIdentity,
         userPoolFactory: @escaping () throws -> CognitoUserPoolBehavior = makeDefaultUserPool,
         hostedUIEnvironment: HostedUIEnvironment? = nil,
-        authPasswordlessClient: AuthPasswordlessBehavior? = nil
+        authPasswordlessEnvironment: AuthPasswordlessEnvironment? = nil
     ) -> AuthEnvironment {
         let userPoolConfigData = makeDefaultUserPoolConfigData()
         let identityPoolConfigData = makeIdentityConfigData()
@@ -185,7 +191,8 @@ enum Defaults {
             cognitoUserPoolAnalyticsHandlerFactory: makeUserPoolAnalytics)
         let authenticationEnvironment = BasicAuthenticationEnvironment(srpSignInEnvironment: srpSignInEnvironment,
                                                                        userPoolEnvironment: userPoolEnvironment,
-                                                                       hostedUIEnvironment: hostedUIEnvironment)
+                                                                       hostedUIEnvironment: hostedUIEnvironment,
+                                                                       authPasswordlessEnvironment: authPasswordlessEnvironment)
         let authorizationEnvironment = BasicAuthorizationEnvironment(
             identityPoolConfiguration: identityPoolConfigData,
             cognitoIdentityFactory: identityPoolFactory)
@@ -196,7 +203,6 @@ enum Defaults {
             authenticationEnvironment: authenticationEnvironment,
             authorizationEnvironment: authZEnvironment ?? authorizationEnvironment,
             credentialsClient: makeCredentialStoreOperationBehavior(),
-            authPasswordlessClient: authPasswordlessClient,
             logger: Amplify.Logging.logger(forCategory: "awsCognitoAuthPluginTest")
         )
         Amplify.Logging.logLevel = .verbose

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/DefaultConfig.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/DefaultConfig.swift
@@ -106,6 +106,30 @@ enum Defaults {
                                   hostedUIConfig: withHostedUI,
                                   passwordlessSignUpEndpoint: passwordlessSignUpEndpoint   )
     }
+    
+    static func makeDefaultUserPoolConfigDataWithEmptySignUpEndpoint(
+        withHostedUI: HostedUIConfigurationData? = nil
+    )-> UserPoolConfigurationData {
+        UserPoolConfigurationData(poolId: userPoolId,
+                                  clientId: appClientId,
+                                  region: regionString,
+                                  clientSecret: appClientSecret,
+                                  pinpointAppId: "",
+                                  hostedUIConfig: withHostedUI,
+                                  passwordlessSignUpEndpoint: "")
+    }
+    
+    static func makeDefaultUserPoolConfigDataWithNilPasswordlessSignUpEndpoint(
+        withHostedUI: HostedUIConfigurationData? = nil
+    )-> UserPoolConfigurationData {
+        UserPoolConfigurationData(poolId: userPoolId,
+                                  clientId: appClientId,
+                                  region: regionString,
+                                  clientSecret: appClientSecret,
+                                  pinpointAppId: "",
+                                  hostedUIConfig: withHostedUI,
+                                  passwordlessSignUpEndpoint: nil)
+    }
 
     static func makeIdentityConfigData() -> IdentityPoolConfigurationData {
         IdentityPoolConfigurationData(poolId: identityPoolId,
@@ -172,7 +196,7 @@ enum Defaults {
             authenticationEnvironment: authenticationEnvironment,
             authorizationEnvironment: authZEnvironment ?? authorizationEnvironment,
             credentialsClient: makeCredentialStoreOperationBehavior(),
-            authPasswordlessClient: authPasswordlessClient ?? AWSAuthPasswordlessClient(urlSession: makeURLSession()),
+            authPasswordlessClient: authPasswordlessClient,
             logger: Amplify.Logging.logger(forCategory: "awsCognitoAuthPluginTest")
         )
         Amplify.Logging.logLevel = .verbose

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthConfirmSignInTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthConfirmSignInTaskTests.swift
@@ -494,7 +494,6 @@ class AuthenticationProviderConfirmSigninTests: BasePluginTest {
             authenticationEnvironment: nil,
             authorizationEnvironment: authorizationEnvironment,
             credentialsClient: Defaults.makeCredentialStoreOperationBehavior(),
-            authPasswordlessClient: nil,
             logger: Amplify.Logging.logger(forCategory: "awsCognitoAuthPluginTest")
         )
         let stateMachine = Defaults.authStateMachineWith(environment: environment,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithMagicLinkTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithMagicLinkTaskTests.swift
@@ -31,7 +31,8 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///    - I should get the info in next step
     ///
     func testSignInWithMagicLink() async {
-        
+        let username = "username"
+        let redirectURL = "https://example.com/magic-link/##code##"
         setUpWith(authPasswordlessEnvironment:
                     BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
         let clientMetadata = [
@@ -50,6 +51,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.signInMethod"], "MAGIC_LINK")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.action"], "REQUEST")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.deliveryMedium"], "EMAIL")
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], redirectURL)
             XCTAssertEqual(input.clientMetadata?["somekey"], "somevalue")
 
             return RespondToAuthChallengeOutput(
@@ -68,9 +70,9 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
         let options = AuthSignInWithMagicLinkRequest.Options(pluginOptions: pluginOptions)
         do {
             let result = try await plugin.signInWithMagicLink(
-                username: "username",
+                username: username,
                 flow: .signIn,
-                redirectURL: "https://example.com/magic-link/##code##",
+                redirectURL: redirectURL,
                 options: options)
             
            guard case .confirmSignInWithMagicLink(let codeDeliveryDetails, _) = result.nextStep else {
@@ -108,6 +110,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///
     func testSignUpAndSignInWithMagicLink() async {
         let username = "username"
+        let redirectURL = "https://example.com/magic-link/##code##"
         self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
             XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
             XCTAssertEqual(payload.username, username)
@@ -139,6 +142,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.signInMethod"], "MAGIC_LINK")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.action"], "REQUEST")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.deliveryMedium"], "EMAIL")
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], redirectURL)
             XCTAssertEqual(input.clientMetadata?["somekey"], "somevalue")
 
             return RespondToAuthChallengeOutput(
@@ -160,7 +164,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             let result = try await plugin.signInWithMagicLink(
                 username: username,
                 flow: .signUpAndSignIn,
-                redirectURL: "https://example.com/magic-link/##code##",
+                redirectURL: redirectURL,
                 options: options)
             
             
@@ -199,6 +203,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///
     func testSignUpAndSignInWithMagicLinkWithMissingEndpointURL() async {
         let username = "username"
+        let redirectURL = "https://example.com/magic-link/##code##"
         self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
             XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
             XCTAssertEqual(payload.username, username)
@@ -235,6 +240,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.signInMethod"], "MAGIC_LINK")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.action"], "REQUEST")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.deliveryMedium"], "EMAIL")
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], redirectURL)
             XCTAssertEqual(input.clientMetadata?["somekey"], "somevalue")
 
             return RespondToAuthChallengeOutput(
@@ -256,7 +262,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             let _ = try await plugin.signInWithMagicLink(
                 username: username,
                 flow: .signUpAndSignIn,
-                redirectURL: "https://example.com/magic-link/##code##",
+                redirectURL: redirectURL,
                 options: options)
             
             XCTFail("Should fail due to missing endpoint URL in configuration")
@@ -288,6 +294,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///
     func testSignUpAndSignInWithMagicLinkWithNilPasswordlessClient() async {
         let username = "username"
+        let redirectURL = "https://example.com/magic-link/##code##"
         self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
             XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
             XCTAssertEqual(payload.username, username)
@@ -317,6 +324,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.signInMethod"], "MAGIC_LINK")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.action"], "REQUEST")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.deliveryMedium"], "EMAIL")
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], redirectURL)
             XCTAssertEqual(input.clientMetadata?["somekey"], "somevalue")
 
             return RespondToAuthChallengeOutput(
@@ -338,7 +346,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             let _ = try await plugin.signInWithMagicLink(
                 username: username,
                 flow: .signUpAndSignIn,
-                redirectURL: "https://example.com/magic-link/##code##",
+                redirectURL: redirectURL,
                 options: options)
             
             XCTFail("Should fail")
@@ -370,6 +378,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///
     func testSignUpAndSignInWithMagicLinkWithMissingUserPoolConfig() async {
         let username = "username"
+        let redirectURL = "https://example.com/magic-link/##code##"
         self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
             XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
             XCTAssertEqual(payload.username, username)
@@ -399,6 +408,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.signInMethod"], "MAGIC_LINK")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.action"], "REQUEST")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.deliveryMedium"], "EMAIL")
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], redirectURL)
             XCTAssertEqual(input.clientMetadata?["somekey"], "somevalue")
 
             return RespondToAuthChallengeOutput(
@@ -420,7 +430,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             let _ = try await plugin.signInWithMagicLink(
                 username: username,
                 flow: .signUpAndSignIn,
-                redirectURL: "https://example.com/magic-link/##code##",
+                redirectURL: redirectURL,
                 options: options)
             
             XCTFail("Should fail")
@@ -452,6 +462,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///
     func testSignUpAndSignInWithMagicLinkWithEmptyEndpointURL() async {
         let username = "username"
+        let redirectURL = "https://example.com/magic-link/##code##"
         self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
             XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
             XCTAssertEqual(payload.username, username)
@@ -486,6 +497,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.signInMethod"], "MAGIC_LINK")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.action"], "REQUEST")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.deliveryMedium"], "EMAIL")
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], redirectURL)
             XCTAssertEqual(input.clientMetadata?["somekey"], "somevalue")
 
             return RespondToAuthChallengeOutput(
@@ -507,7 +519,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             let _ = try await plugin.signInWithMagicLink(
                 username: username,
                 flow: .signUpAndSignIn,
-                redirectURL: "https://example.com/magic-link/##code##",
+                redirectURL: redirectURL,
                 options: options)
             
             XCTFail("Should fail due to missing endpoint URL in configuration")

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithMagicLinkTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithMagicLinkTaskTests.swift
@@ -66,6 +66,8 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
                 redirectURL: "https://example.com/magic-link/##code##",
                 options: options)
             
+            XCTAssertEqual((self.mockAuthPasswordlessBehavior as! MockAuthPasswordlessBehavior).preInitiateAuthSignUpCallCount, 0)
+            
             guard case .confirmSignInWithMagicLink(let codeDeliveryDetails, _) = result.nextStep else {
                 XCTFail("Result should be .confirmSignInWithMagicLink for next step")
                 return
@@ -90,4 +92,79 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
         }
     }
 
+    /// Test happy path for signInAndSignUpWithMagicLink
+    ///
+    /// - Given: An auth plugin with mocked service.
+    ///
+    /// - When:
+    ///    - I invoke signInWithMagicLink with flow as `.signUpAndSignIn`
+    /// - Then:
+    ///    - I should get the correct info in next step
+    ///
+    func testSignUpAndSignInWithMagicLink() async {
+        let clientMetadata = [
+            "somekey": "somevalue"
+        ]
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
+            XCTAssertEqual(input.clientMetadata?["somekey"], "somevalue")
+            return InitiateAuthOutput(
+                authenticationResult: .none,
+                challengeName: .customChallenge,
+                challengeParameters: [
+                    "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                ],
+                session: "someSession")
+        }, mockRespondToAuthChallengeResponse: { input in
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.signInMethod"], "MAGIC_LINK")
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.action"], "REQUEST")
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.deliveryMedium"], "EMAIL")
+            XCTAssertEqual(input.clientMetadata?["somekey"], "somevalue")
+
+            return RespondToAuthChallengeOutput(
+                authenticationResult: .none,
+                challengeName: .customChallenge,
+                challengeParameters: [
+                    "nextStep": "PROVIDE_CHALLENGE_RESPONSE",
+                    "attributeName": "email",
+                    "deliveryMedium": "EMAIL",
+                    "destination": "S***@g***"
+                ],
+                session: "session")
+        })
+
+        let pluginOptions = AWSAuthSignInPasswordlessOptions(clientMetadata: clientMetadata)
+        let options = AuthSignInWithMagicLinkRequest.Options(pluginOptions: pluginOptions)
+        do {
+            let result = try await plugin.signInWithMagicLink(
+                username: "username",
+                flow: .signUpAndSignIn,
+                redirectURL: "https://example.com/magic-link/##code##",
+                options: options)
+            
+            XCTAssertEqual((self.mockAuthPasswordlessBehavior as! MockAuthPasswordlessBehavior).preInitiateAuthSignUpCallCount, 1)
+            
+            guard case .confirmSignInWithMagicLink(let codeDeliveryDetails, _) = result.nextStep else {
+                XCTFail("Result should be .confirmSignInWithMagicLink for next step")
+                return
+            }
+
+            guard case .email(let destination) = codeDeliveryDetails.destination else {
+                XCTFail("Result should contain codeDeliveryDetails.destination")
+                return
+            }
+
+            XCTAssertNotNil(destination, "Destination should not be nil")
+            XCTAssertEqual(destination, "S***@g***")
+
+            guard case .email = codeDeliveryDetails.attributeKey else {
+                XCTFail("Result for codeDeliveryDetails.attributeKey should be email")
+                return
+            }
+
+            XCTAssertFalse(result.isSignedIn, "Signin result should not be complete")
+        } catch {
+            XCTFail("Received failure with error \(error)")
+        }
+    }
+    
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithMagicLinkTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithMagicLinkTaskTests.swift
@@ -31,7 +31,9 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///    - I should get the info in next step
     ///
     func testSignInWithMagicLink() async {
-        setUpWith(passwordlessClient: MockAuthPasswordlessBehavior())
+        
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
         let clientMetadata = [
             "somekey": "somevalue"
         ]
@@ -105,9 +107,23 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///    - I should get the correct info in next step
     ///
     func testSignUpAndSignInWithMagicLink() async {
-        setUpWith(passwordlessClient: MockAuthPasswordlessBehavior())
+        let username = "username"
+        self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
+            XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
+            XCTAssertEqual(payload.username, username)
+            XCTAssertEqual(payload.deliveryMedium, "EMAIL")
+            XCTAssertEqual(payload.userAttributes?["somekey"], "somevalue")
+            XCTAssertEqual(payload.userPoolId, Defaults.userPoolId)
+            XCTAssertEqual(payload.region, Defaults.regionString)
+        })
+        
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
         
         let clientMetadata = [
+            "somekey": "somevalue"
+        ]
+        let userAttributes = [
             "somekey": "somevalue"
         ]
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
@@ -137,11 +153,12 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
                 session: "session")
         })
 
-        let pluginOptions = AWSAuthSignInPasswordlessOptions(clientMetadata: clientMetadata)
+        let pluginOptions = AWSAuthSignUpAndSignInPasswordlessOptions(userAttributes: userAttributes,
+                                                                      clientMetadata: clientMetadata)
         let options = AuthSignInWithMagicLinkRequest.Options(pluginOptions: pluginOptions)
         do {
             let result = try await plugin.signInWithMagicLink(
-                username: "username",
+                username: username,
                 flow: .signUpAndSignIn,
                 redirectURL: "https://example.com/magic-link/##code##",
                 options: options)
@@ -181,14 +198,28 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///    - I should get an error
     ///
     func testSignUpAndSignInWithMagicLinkWithMissingEndpointURL() async {
+        let username = "username"
+        self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
+            XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
+            XCTAssertEqual(payload.username, username)
+            XCTAssertEqual(payload.deliveryMedium, "EMAIL")
+            XCTAssertEqual(payload.userAttributes?["somekey"], "somevalue")
+            XCTAssertEqual(payload.userPoolId, Defaults.userPoolId)
+            XCTAssertEqual(payload.region, Defaults.regionString)
+        })
+        
         setUpWith(
-            passwordlessClient: MockAuthPasswordlessBehavior(),
+            authPasswordlessEnvironment:
+                        BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient),
             authConfiguration: .userPoolsAndIdentityPools(
                 Defaults.makeDefaultUserPoolConfigDataWithNilPasswordlessSignUpEndpoint(),
                 Defaults.makeIdentityConfigData())
         )
         
         let clientMetadata = [
+            "somekey": "somevalue"
+        ]
+        let userAttributes = [
             "somekey": "somevalue"
         ]
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
@@ -218,11 +249,12 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
                 session: "session")
         })
 
-        let pluginOptions = AWSAuthSignInPasswordlessOptions(clientMetadata: clientMetadata)
+        let pluginOptions = AWSAuthSignUpAndSignInPasswordlessOptions(userAttributes: userAttributes,
+                                                                      clientMetadata: clientMetadata)
         let options = AuthSignInWithMagicLinkRequest.Options(pluginOptions: pluginOptions)
         do {
             let _ = try await plugin.signInWithMagicLink(
-                username: "username",
+                username: username,
                 flow: .signUpAndSignIn,
                 redirectURL: "https://example.com/magic-link/##code##",
                 options: options)
@@ -247,7 +279,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     
     /// Test failure path for signInAndSignUpWithMagicLink
     ///
-    /// - Given: An auth plugin with mocked service and `nil` passwordless client
+    /// - Given: An auth plugin with mocked service and `nil` passwordless environment
     ///
     /// - When:
     ///    - I invoke signInWithMagicLink with flow as `.signUpAndSignIn`
@@ -255,9 +287,21 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///    - I should get an error
     ///
     func testSignUpAndSignInWithMagicLinkWithNilPasswordlessClient() async {
+        let username = "username"
+        self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
+            XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
+            XCTAssertEqual(payload.username, username)
+            XCTAssertEqual(payload.deliveryMedium, "EMAIL")
+            XCTAssertEqual(payload.userAttributes?["somekey"], "somevalue")
+            XCTAssertEqual(payload.userPoolId, Defaults.userPoolId)
+            XCTAssertEqual(payload.region, Defaults.regionString)
+        })
         setUpWith()
         
         let clientMetadata = [
+            "somekey": "somevalue"
+        ]
+        let userAttributes = [
             "somekey": "somevalue"
         ]
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
@@ -287,11 +331,12 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
                 session: "session")
         })
 
-        let pluginOptions = AWSAuthSignInPasswordlessOptions(clientMetadata: clientMetadata)
+        let pluginOptions = AWSAuthSignUpAndSignInPasswordlessOptions(userAttributes: userAttributes,
+                                                                      clientMetadata: clientMetadata)
         let options = AuthSignInWithMagicLinkRequest.Options(pluginOptions: pluginOptions)
         do {
             let _ = try await plugin.signInWithMagicLink(
-                username: "username",
+                username: username,
                 flow: .signUpAndSignIn,
                 redirectURL: "https://example.com/magic-link/##code##",
                 options: options)
@@ -324,9 +369,21 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///    - I should get an error
     ///
     func testSignUpAndSignInWithMagicLinkWithMissingUserPoolConfig() async {
+        let username = "username"
+        self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
+            XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
+            XCTAssertEqual(payload.username, username)
+            XCTAssertEqual(payload.deliveryMedium, "EMAIL")
+            XCTAssertEqual(payload.userAttributes?["somekey"], "somevalue")
+            XCTAssertEqual(payload.userPoolId, Defaults.userPoolId)
+            XCTAssertEqual(payload.region, Defaults.regionString)
+        })
         setUpWith(authConfiguration: .identityPools(Defaults.makeIdentityConfigData()))
         
         let clientMetadata = [
+            "somekey": "somevalue"
+        ]
+        let userAttributes = [
             "somekey": "somevalue"
         ]
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
@@ -356,11 +413,12 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
                 session: "session")
         })
 
-        let pluginOptions = AWSAuthSignInPasswordlessOptions(clientMetadata: clientMetadata)
+        let pluginOptions = AWSAuthSignUpAndSignInPasswordlessOptions(userAttributes: userAttributes,
+                                                                      clientMetadata: clientMetadata)
         let options = AuthSignInWithMagicLinkRequest.Options(pluginOptions: pluginOptions)
         do {
             let _ = try await plugin.signInWithMagicLink(
-                username: "username",
+                username: username,
                 flow: .signUpAndSignIn,
                 redirectURL: "https://example.com/magic-link/##code##",
                 options: options)
@@ -393,13 +451,26 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///    - I should get an error
     ///
     func testSignUpAndSignInWithMagicLinkWithEmptyEndpointURL() async {
+        let username = "username"
+        self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
+            XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
+            XCTAssertEqual(payload.username, username)
+            XCTAssertEqual(payload.deliveryMedium, "EMAIL")
+            XCTAssertEqual(payload.userAttributes?["somekey"], "somevalue")
+            XCTAssertEqual(payload.userPoolId, Defaults.userPoolId)
+            XCTAssertEqual(payload.region, Defaults.regionString)
+        })
         setUpWith(
-            passwordlessClient: MockAuthPasswordlessBehavior(),
+            authPasswordlessEnvironment:
+                        BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient),
             authConfiguration: .userPoolsAndIdentityPools(
                 Defaults.makeDefaultUserPoolConfigDataWithEmptySignUpEndpoint(),
                 Defaults.makeIdentityConfigData()))
         
         let clientMetadata = [
+            "somekey": "somevalue"
+        ]
+        let userAttributes = [
             "somekey": "somevalue"
         ]
         self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
@@ -429,11 +500,12 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
                 session: "session")
         })
 
-        let pluginOptions = AWSAuthSignInPasswordlessOptions(clientMetadata: clientMetadata)
+        let pluginOptions = AWSAuthSignUpAndSignInPasswordlessOptions(userAttributes: userAttributes,
+                                                                      clientMetadata: clientMetadata)
         let options = AuthSignInWithMagicLinkRequest.Options(pluginOptions: pluginOptions)
         do {
             let _ = try await plugin.signInWithMagicLink(
-                username: "username",
+                username: username,
                 flow: .signUpAndSignIn,
                 redirectURL: "https://example.com/magic-link/##code##",
                 options: options)
@@ -456,12 +528,12 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     }
     
     private func setUpWith(
-        passwordlessClient: AuthPasswordlessBehavior? = nil,
+        authPasswordlessEnvironment: AuthPasswordlessEnvironment? = nil,
         authConfiguration: AuthConfiguration = Defaults.makeDefaultAuthConfigData()) {
         let environment = Defaults.makeDefaultAuthEnvironment(
             identityPoolFactory: { self.mockIdentity },
             userPoolFactory: { self.mockIdentityProvider },
-            authPasswordlessClient: passwordlessClient
+            authPasswordlessEnvironment: authPasswordlessEnvironment
         )
 
         let statemachine = Defaults.makeDefaultAuthStateMachine(
@@ -476,5 +548,9 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             credentialStoreStateMachine: Defaults.makeDefaultCredentialStateMachine(),
             hubEventHandler: MockAuthHubEventBehavior(),
             analyticsHandler: MockAnalyticsHandler())
+    }
+    
+    private func makeAuthPasswordlessClient() -> AuthPasswordlessBehavior {
+        self.mockAuthPasswordlessProvider
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithOTPTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithOTPTaskTests.swift
@@ -68,6 +68,8 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
                 destination: .email,
                 options: options)
             
+            XCTAssertEqual((self.mockAuthPasswordlessBehavior as! MockAuthPasswordlessBehavior).preInitiateAuthSignUpCallCount, 0)
+            
             guard case .confirmSignInWithOTP(let codeDeliveryDetails, _) = result.nextStep else {
                 XCTFail("Result should be .confirmSignInWithOTP for next step")
                 return
@@ -92,4 +94,86 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
         }
     }
 
+    /// Test happy path for signUpAndSignInWithOTP
+    ///
+    /// - Given: An auth plugin with mocked service.
+    ///
+    /// - When:
+    ///    - I invoke signInWithOTP with flow as `.signUpAndSignIn`
+    /// - Then:
+    ///    - I should get `confirmSignInWithOTP` as the next step.
+    ///
+    func testSignUpAndSignInWithOTP() async {
+
+        let clientMetadata = [
+            "somekey": "somevalue"
+        ]
+        let userAttributes = [
+            "somekey": "somevalue"
+        ]
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
+            XCTAssertEqual(input.clientMetadata?["somekey"], "somevalue")
+            return InitiateAuthOutput(
+                authenticationResult: .none,
+                challengeName: .customChallenge,
+                challengeParameters: [
+                    "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                ],
+                session: "someSession")
+        }, mockRespondToAuthChallengeResponse: { input in
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.signInMethod"], "OTP")
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.action"], "REQUEST")
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.deliveryMedium"], "EMAIL")
+            XCTAssertEqual(input.clientMetadata?["somekey"], "somevalue")
+
+            return RespondToAuthChallengeOutput(
+                authenticationResult: .none,
+                challengeName: .customChallenge,
+                challengeParameters: [
+                    "nextStep": "PROVIDE_CHALLENGE_RESPONSE",
+                    "attributeName": "email",
+                    "deliveryMedium": "EMAIL",
+                    "destination": "S***@g***"
+                ],
+                session: "session")
+        })
+
+        let pluginOptions = AWSAuthSignUpAndSignInPasswordlessOptions(
+            userAttributes: userAttributes,
+            clientMetadata: clientMetadata
+        )
+        let options = AuthSignInWithOTPRequest.Options(pluginOptions: pluginOptions)
+        do {
+            let result = try await plugin.signInWithOTP(
+                username: "username",
+                flow: .signUpAndSignIn,
+                destination: .email,
+                options: options)
+            
+            XCTAssertEqual((self.mockAuthPasswordlessBehavior as! MockAuthPasswordlessBehavior).preInitiateAuthSignUpCallCount, 1)
+
+            guard case .confirmSignInWithOTP(let codeDeliveryDetails, _) = result.nextStep else {
+                XCTFail("Result should be .confirmSignInWithOTP for next step")
+                return
+            }
+
+            guard case .email(let destination) = codeDeliveryDetails.destination else {
+                XCTFail("Result should contain codeDeliveryDetails.destination")
+                return
+            }
+
+            XCTAssertNotNil(destination, "Destination should not be nil")
+            XCTAssertEqual(destination, "S***@g***")
+
+            guard case .email = codeDeliveryDetails.attributeKey else {
+                XCTFail("Result for codeDeliveryDetails.attributeKey should be email")
+                return
+            }
+
+            XCTAssertFalse(result.isSignedIn, "Signin result should not be complete")
+        } catch {
+            XCTFail("Received failure with error \(error)")
+        }
+    }
+    
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithOTPTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithOTPTaskTests.swift
@@ -32,7 +32,8 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
     ///    - I should get `confirmSignInWithOTP` as the next step. 
     ///
     func testSignInWithOTP() async {
-        setUpWith(passwordlessClient: MockAuthPasswordlessBehavior())
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
         let clientMetadata = [
             "somekey": "somevalue"
         ]
@@ -106,7 +107,18 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
     ///    - I should get `confirmSignInWithOTP` as the next step.
     ///
     func testSignUpAndSignInWithOTP() async {
-        setUpWith(passwordlessClient: MockAuthPasswordlessBehavior())
+        let username = "username"
+        self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
+            XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
+            XCTAssertEqual(payload.username, username)
+            XCTAssertEqual(payload.deliveryMedium, "EMAIL")
+            XCTAssertEqual(payload.userAttributes?["somekey"], "somevalue")
+            XCTAssertEqual(payload.userPoolId, Defaults.userPoolId)
+            XCTAssertEqual(payload.region, Defaults.regionString)
+        })
+        
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
         let clientMetadata = [
             "somekey": "somevalue"
         ]
@@ -147,7 +159,7 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
         let options = AuthSignInWithOTPRequest.Options(pluginOptions: pluginOptions)
         do {
             let result = try await plugin.signInWithOTP(
-                username: "username",
+                username: username,
                 flow: .signUpAndSignIn,
                 destination: .email,
                 options: options)
@@ -186,8 +198,17 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
     ///    - I should get an error
     ///
     func testSignUpAndSignInWithOTPWithMissingEndpointURL() async {
+        let username = "username"
+        self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
+            XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
+            XCTAssertEqual(payload.username, username)
+            XCTAssertEqual(payload.deliveryMedium, "EMAIL")
+            XCTAssertEqual(payload.userAttributes?["somekey"], "somevalue")
+            XCTAssertEqual(payload.userPoolId, Defaults.userPoolId)
+            XCTAssertEqual(payload.region, Defaults.regionString)
+        })
         setUpWith(
-            passwordlessClient: MockAuthPasswordlessBehavior(),
+            authPasswordlessEnvironment:BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient),
             authConfiguration: .userPoolsAndIdentityPools(
                 Defaults.makeDefaultUserPoolConfigDataWithNilPasswordlessSignUpEndpoint(),
                 Defaults.makeIdentityConfigData())
@@ -233,7 +254,7 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
         let options = AuthSignInWithOTPRequest.Options(pluginOptions: pluginOptions)
         do {
             let _ = try await plugin.signInWithOTP(
-                username: "username",
+                username: username,
                 flow: .signUpAndSignIn,
                 destination: .email,
                 options: options)
@@ -258,7 +279,7 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
     
     /// Test failure path for signInAndSignUpWithOTP
     ///
-    /// - Given: An auth plugin with mocked service and `nil` passwordless client
+    /// - Given: An auth plugin with mocked service and `nil` passwordless environment
     ///
     /// - When:
     ///    - I invoke signInWithOTP with flow as `.signUpAndSignIn`
@@ -266,6 +287,16 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
     ///    - I should get an error
     ///
     func testSignUpAndSignInWithOTPWithNilPasswordlessClient() async {
+        let username = "username"
+        self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
+            XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
+            XCTAssertEqual(payload.username, username)
+            XCTAssertEqual(payload.deliveryMedium, "EMAIL")
+            XCTAssertEqual(payload.userAttributes?["somekey"], "somevalue")
+            XCTAssertEqual(payload.userPoolId, Defaults.userPoolId)
+            XCTAssertEqual(payload.region, Defaults.regionString)
+        })
+        
         setUpWith()
         
         let clientMetadata = [
@@ -308,7 +339,7 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
         let options = AuthSignInWithOTPRequest.Options(pluginOptions: pluginOptions)
         do {
             let _ = try await plugin.signInWithOTP(
-                username: "username",
+                username: username,
                 flow: .signUpAndSignIn,
                 destination: .email,
                 options: options)
@@ -340,6 +371,16 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
     ///    - I should get an error
     ///
     func testSignUpAndSignInWithOTPWithMissingUserPoolConfig() async {
+        let username = "username"
+        self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
+            XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
+            XCTAssertEqual(payload.username, username)
+            XCTAssertEqual(payload.deliveryMedium, "EMAIL")
+            XCTAssertEqual(payload.userAttributes?["somekey"], "somevalue")
+            XCTAssertEqual(payload.userPoolId, Defaults.userPoolId)
+            XCTAssertEqual(payload.region, Defaults.regionString)
+        })
+        
         setUpWith(authConfiguration: .identityPools(Defaults.makeIdentityConfigData()))
         
         let clientMetadata = [
@@ -382,7 +423,7 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
         let options = AuthSignInWithOTPRequest.Options(pluginOptions: pluginOptions)
         do {
             let _ = try await plugin.signInWithOTP(
-                username: "username",
+                username: username,
                 flow: .signUpAndSignIn,
                 destination: .email,
                 options: options)
@@ -414,8 +455,18 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
     ///    - I should get an error
     ///
     func testSignUpAndSignInWithOTPWithEmptyEndpointURL() async {
+        let username = "username"
+        self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
+            XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
+            XCTAssertEqual(payload.username, username)
+            XCTAssertEqual(payload.deliveryMedium, "EMAIL")
+            XCTAssertEqual(payload.userAttributes?["somekey"], "somevalue")
+            XCTAssertEqual(payload.userPoolId, Defaults.userPoolId)
+            XCTAssertEqual(payload.region, Defaults.regionString)
+        })
         setUpWith(
-            passwordlessClient: MockAuthPasswordlessBehavior(),
+            authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient),
             authConfiguration: .userPoolsAndIdentityPools(
                 Defaults.makeDefaultUserPoolConfigDataWithEmptySignUpEndpoint(),
                 Defaults.makeIdentityConfigData()))
@@ -483,12 +534,12 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
     }
     
     private func setUpWith(
-        passwordlessClient: AuthPasswordlessBehavior? = nil,
+        authPasswordlessEnvironment: AuthPasswordlessEnvironment? = nil,
         authConfiguration: AuthConfiguration = Defaults.makeDefaultAuthConfigData()) {
         let environment = Defaults.makeDefaultAuthEnvironment(
             identityPoolFactory: { self.mockIdentity },
             userPoolFactory: { self.mockIdentityProvider },
-            authPasswordlessClient: passwordlessClient
+            authPasswordlessEnvironment: authPasswordlessEnvironment
         )
 
         let statemachine = Defaults.makeDefaultAuthStateMachine(
@@ -505,4 +556,7 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
             analyticsHandler: MockAnalyticsHandler())
     }
     
+    private func makeAuthPasswordlessClient() -> AuthPasswordlessBehavior {
+        self.mockAuthPasswordlessProvider
+    }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/ConfirmSignInTOTPTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/ConfirmSignInTOTPTaskTests.swift
@@ -512,7 +512,6 @@ class ConfirmSignInTOTPTaskTests: BasePluginTest {
             authenticationEnvironment: nil,
             authorizationEnvironment: authorizationEnvironment,
             credentialsClient: Defaults.makeCredentialStoreOperationBehavior(),
-            authPasswordlessClient: nil,
             logger: Amplify.Logging.logger(forCategory: "awsCognitoAuthPluginTest")
         )
         let stateMachine = Defaults.authStateMachineWith(environment: environment,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/ConfirmSignInWithMFASelectionTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/ConfirmSignInWithMFASelectionTaskTests.swift
@@ -548,7 +548,6 @@ class ConfirmSignInWithMFASelectionTaskTests: BasePluginTest {
             authenticationEnvironment: nil,
             authorizationEnvironment: authorizationEnvironment,
             credentialsClient: Defaults.makeCredentialStoreOperationBehavior(),
-            authPasswordlessClient: nil,
             logger: Amplify.Logging.logger(forCategory: "awsCognitoAuthPluginTest")
         )
         let stateMachine = Defaults.authStateMachineWith(environment: environment,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/ConfirmSignInWithSetUpMFATaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/ConfirmSignInWithSetUpMFATaskTests.swift
@@ -311,7 +311,6 @@ class ConfirmSignInWithSetUpMFATaskTests: BasePluginTest {
             authenticationEnvironment: nil,
             authorizationEnvironment: authorizationEnvironment,
             credentialsClient: Defaults.makeCredentialStoreOperationBehavior(),
-            authPasswordlessClient: nil,
             logger: Amplify.Logging.logger(forCategory: "awsCognitoAuthPluginTest")
         )
         let stateMachine = Defaults.authStateMachineWith(environment: environment,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/BasePluginTest.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/BasePluginTest.swift
@@ -11,13 +11,16 @@ import AWSCognitoIdentity
 @testable import AWSCognitoAuthPlugin
 
 class BasePluginTest: XCTestCase {
-
+    
     let apiTimeout = 2.0
     var mockIdentityProvider: CognitoUserPoolBehavior!
     lazy var mockIdentity: CognitoIdentityBehavior = {
         MockIdentity(
             mockGetIdResponse: getId,
             mockGetCredentialsResponse: getCredentials)
+    }()
+    lazy var mockAuthPasswordlessBehavior: AuthPasswordlessBehavior = {
+        MockAuthPasswordlessBehavior()
     }()
     var plugin: AWSCognitoAuthPlugin!
 
@@ -47,7 +50,9 @@ class BasePluginTest: XCTestCase {
 
         let environment = Defaults.makeDefaultAuthEnvironment(
             identityPoolFactory: { self.mockIdentity },
-            userPoolFactory: { self.mockIdentityProvider })
+            userPoolFactory: { self.mockIdentityProvider },
+            authPasswordlessClient: self.mockAuthPasswordlessBehavior
+        )
 
         let statemachine = Defaults.makeDefaultAuthStateMachine(
             initialState: initialState,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/BasePluginTest.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/BasePluginTest.swift
@@ -50,8 +50,7 @@ class BasePluginTest: XCTestCase {
 
         let environment = Defaults.makeDefaultAuthEnvironment(
             identityPoolFactory: { self.mockIdentity },
-            userPoolFactory: { self.mockIdentityProvider },
-            authPasswordlessClient: self.mockAuthPasswordlessBehavior
+            userPoolFactory: { self.mockIdentityProvider }
         )
 
         let statemachine = Defaults.makeDefaultAuthStateMachine(

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/BasePluginTest.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/BasePluginTest.swift
@@ -14,16 +14,15 @@ class BasePluginTest: XCTestCase {
     
     let apiTimeout = 2.0
     var mockIdentityProvider: CognitoUserPoolBehavior!
+    var mockAuthPasswordlessProvider: AuthPasswordlessBehavior!
+    var plugin: AWSCognitoAuthPlugin!
+    
     lazy var mockIdentity: CognitoIdentityBehavior = {
         MockIdentity(
             mockGetIdResponse: getId,
             mockGetCredentialsResponse: getCredentials)
     }()
-    lazy var mockAuthPasswordlessBehavior: AuthPasswordlessBehavior = {
-        MockAuthPasswordlessBehavior()
-    }()
-    var plugin: AWSCognitoAuthPlugin!
-
+    
     let getId: MockIdentity.MockGetIdResponse = { _ in
         return .init(identityId: "mockIdentityId")
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/Mocks/MockedAuthCognitoPlugin.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/Mocks/MockedAuthCognitoPlugin.swift
@@ -94,6 +94,12 @@ struct MockedAuthCognitoPluginHelper {
     private func makeUserPoolAnalytics() -> UserPoolAnalyticsBehavior {
         MockAnalyticsHandler()
     }
+    
+    private func makePasswordlessClient() -> AuthPasswordlessBehavior {
+        MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
+            
+        })
+    }
 
     private func makeCredentialStore() -> AmplifyAuthCredentialStoreBehavior {
         MockAmplifyStore()
@@ -124,7 +130,6 @@ struct MockedAuthCognitoPluginHelper {
                 authenticationEnvironment: authenticationEnvironment,
                 authorizationEnvironment: nil,
                 credentialsClient: makeCredentialStoreClient(),
-                authPasswordlessClient: AWSAuthPasswordlessClient(urlSession: makeURLSession()),
                 logger: log)
 
         case .identityPools(let identityPoolConfigurationData):
@@ -137,7 +142,6 @@ struct MockedAuthCognitoPluginHelper {
                 authenticationEnvironment: nil,
                 authorizationEnvironment: authorizationEnvironment,
                 credentialsClient: makeCredentialStoreClient(),
-                authPasswordlessClient: AWSAuthPasswordlessClient(urlSession: makeURLSession()),
                 logger: log)
 
         case .userPoolsAndIdentityPools(let userPoolConfigurationData,
@@ -153,7 +157,6 @@ struct MockedAuthCognitoPluginHelper {
                 authenticationEnvironment: authenticationEnvironment,
                 authorizationEnvironment: authorizationEnvironment,
                 credentialsClient: makeCredentialStoreClient(),
-                authPasswordlessClient: AWSAuthPasswordlessClient(urlSession: makeURLSession()),
                 logger: log)
         }
     }
@@ -169,9 +172,11 @@ struct MockedAuthCognitoPluginHelper {
             cognitoUserPoolASFFactory: makeCognitoASF,
             cognitoUserPoolAnalyticsHandlerFactory: makeUserPoolAnalytics)
         let hostedUIEnvironment = hostedUIEnvironment(userPoolConfigData)
+        let passwordlessEnvironment: AuthPasswordlessEnvironment? = (userPoolConfigData.passwordlessSignUpEndpoint != nil) ? BasicPasswordlessEnvironment(authPasswordlessFactory: makePasswordlessClient) : nil
         return BasicAuthenticationEnvironment(srpSignInEnvironment: srpSignInEnvironment,
                                               userPoolEnvironment: userPoolEnvironment,
-                                              hostedUIEnvironment: hostedUIEnvironment)
+                                              hostedUIEnvironment: hostedUIEnvironment,
+                                              authPasswordlessEnvironment: passwordlessEnvironment)
     }
 
     private func hostedUIEnvironment(_ configuration: UserPoolConfigurationData) -> HostedUIEnvironment? {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
None 
## Description
<!-- Why is this change required? What problem does it solve? -->
- Add sign up implementation for OTP
- Add sign up implementation for MagicLink
## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
