### PR TITLE
fix: appsync-realtime-client 3.1.2 watchOS support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
       "state" : {
-        "revision" : "c7ec93dcbbcd8abc90c74203937f207a7fcaa611",
-        "version" : "3.1.1"
+        "revision" : "a08684c5004e2049c29f57a5938beae9695a1ef7",
+        "version" : "3.1.2"
       }
     },
     {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

Taking on this version of AppSyncRealTimeClient will enable a few use cases from APIPlugin and DataStore

APIPlugin will allow watchOS subscriptions to be established during special circumstances. Otherwise, it wil timeout according to the client timeout logic built in the AppSyncRealTimeClient

DataStore will alow the sync engine to successfully establish subscriptions if disableSubscriptions are set to false. 

## AppSyncRealTimeClient 3.1.2

https://github.com/aws-amplify/aws-appsync-realtime-client-ios/releases/tag/3.1.2

fix: watchOS support - disable network monitoring, add client timeout (https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/141)



## General Checklist
<!-- Check or cross out if not relevant -->

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [X] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
