### PR TITLE
fix(Analytics): Fixing session duration being reported for non-stopped sessions

### DIFF
--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/PinpointEvent+PinpointClientTypes.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/PinpointEvent+PinpointClientTypes.swift
@@ -10,7 +10,14 @@ import AWSPluginsCore
 import Foundation
 
 extension PinpointEvent {
-    var clientTypeSession: PinpointClientTypes.Session {
+    var clientTypeSession: PinpointClientTypes.Session? {
+    #if os(watchOS)
+        // If the session duration cannot be represented by Int, return a nil session instead.
+        // This is extremely unlikely to happen since a session's stopTime is set when the app is closed
+        if let duration = session.duration, duration > Int.max {
+            return nil
+        }
+    #endif
         return PinpointClientTypes.Session(duration: Int(session.duration),
                                            id: session.sessionId,
                                            startTimestamp: session.startTime.asISO8601String,
@@ -46,5 +53,14 @@ extension Bundle {
 
     var appVersion: String {
         object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+    }
+}
+
+private extension Int {
+    init?(_ value: Int64?) {
+        guard let value = value else {
+            return nil
+        }
+        self.init(value)
     }
 }

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Session/PinpointSession.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Session/PinpointSession.swift
@@ -35,8 +35,11 @@ public class PinpointSession: Codable {
         return stopTime != nil
     }
 
-    var duration: Date.Millisecond {
-        let endTime = stopTime ?? Date()
+    var duration: Date.Millisecond? {
+        /// According to Pinpoint's documentation, `duration` is only required if `stopTime` is not nil.
+        guard let endTime = stopTime else {
+            return nil
+        }
         return endTime.millisecondsSince1970 - startTime.millisecondsSince1970
     }
 

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockPinpointClient.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockPinpointClient.swift
@@ -367,8 +367,10 @@ class MockPinpointClient: PinpointClientProtocol {
 
     var putEventsCount = 0
     var putEventsResult: Result<PutEventsOutput, Error> = .failure(CancellationError())
+    var putEventsLastInput: PutEventsInput?
     func putEvents(input: PutEventsInput) async throws -> PutEventsOutput {
         putEventsCount += 1
+        putEventsLastInput = input
         return try putEventsResult.get()
     }
 


### PR DESCRIPTION
## Description
According to [Pinpoint docs](https://docs.aws.amazon.com/pinpoint/latest/apireference/apps-application-id-events.html), the session duration: 
> is required if a value is provided for the StopTimestamp.

However we are currently sending a value even for non-stopped sessions, by reporting how much time has passed since the session started.

This could result in crashes on watchOS when attempting to submit old cached events with non-stopped sessions, since watchOS's `Int` is actually 32 bit. As an extra precaution, I've added an explicit check to validate that the session duration can be cast.

## General Checklist
<!-- Check or cross out if not relevant -->

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] [All integration tests pass](https://github.com/aws-amplify/amplify-swift/actions/runs/7119826273)
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [X] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
