### PR TITLE
test(predictions): remove non-predictable / non-valuable assertion in integration test

### DIFF
--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/AWSPredictionsPluginIntegrationTests/IdentifyBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/AWSPredictionsPluginIntegrationTests/IdentifyBasicIntegrationTests.swift
@@ -207,8 +207,6 @@ class IdentifyBasicIntegrationTests: AWSPredictionsPluginTestBase {
         XCTAssertFalse(result.tables.isEmpty)
         XCTAssertEqual(result.tables.count, 1)
         XCTAssertFalse(result.keyValues.isEmpty)
-        XCTAssertEqual(result.keyValues.count, 4)
-
     }
 
     /// Given:


### PR DESCRIPTION
### Problem
We're currently asserting an unpredictable value in a Predictions E2E test that doesn't provide value.

### Change
Removes assertion

### Context
`keyValues` is mapped from `TexttractClientTypes.Block` where the `Block`'s `BlockType` is a `KEY_VALUE_SET`.
> KEY_VALUE_SET - Stores the KEY and VALUE Block objects for linked text that's detected on a document page. Use the EntityType field to determine if a KEY_VALUE_SET object is a KEY Block object or a VALUE Block object.

[[Amazon Textract docs](https://docs.aws.amazon.com/textract/latest/dg/API_Block.html)]

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
