### PR TITLE
feat(Auth): Add passwordless unit tests

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/PasswordlessSignInHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/PasswordlessSignInHelper.swift
@@ -38,10 +38,10 @@ struct PasswordlessSignInHelper: DefaultLogger {
         log.verbose("Starting execution")
         await taskHelper.didStateMachineConfigured()
 
+        // Make sure current state is a valid state to initialize sign in
+        try await validateCurrentState()
+        
         do {
-            // Make sure current state is a valid state to initialize sign in
-            try await validateCurrentState()
-
             // Start sign in
             return try await startPasswordlessSignIn()
         } catch {
@@ -191,6 +191,10 @@ struct PasswordlessSignInHelper: DefaultLogger {
                 await sendCancelSignInEvent()
             case .signedOut:
                 return
+            case .notConfigured:
+                throw AuthError.configuration(
+                    "Authentication state machine is not configured",
+                    AuthPluginErrorConstants.invalidStateError)
             default: continue
             }
         }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInWithMagicLinkTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInWithMagicLinkTask.swift
@@ -19,6 +19,9 @@ class AWSAuthConfirmSignInWithMagicLinkTask: AuthConfirmSignInWithMagicLinkTask,
     init(_ request: AuthConfirmSignInWithMagicLinkRequest,
          stateMachine: AuthStateMachine) throws {
 
+        if let validationError = request.hasError() {
+            throw validationError
+        }
         let username = try MagicLinkTokenParser.extractUserName(from: request.challengeResponse)
         passwordlessSignInHelper = PasswordlessSignInHelper(
             authStateMachine: stateMachine,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthConfirmSignInWithMagicLinkTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthConfirmSignInWithMagicLinkTaskTests.swift
@@ -20,7 +20,10 @@ enum ConfirmMagicLinkDevice {
 }
 
 class AWSAuthConfirmSignInWithMagicLinkTaskTests: BasePluginTest {
+
     private var confirmMagicLinkDevice : ConfirmMagicLinkDevice = .local
+    let validMagicLinkToken = "eyJ1c2VybmFtZSI6InRlc3RAZXhhbXBsZS5jb20iLCJpYXQiOjE3MDExODkwODksImV4cCI6MTcwMTE4OTY4OX0.AQIDBAUGBwgJ"
+
     override var initialState: AuthState {
         switch confirmMagicLinkDevice {
         case .local:
@@ -137,7 +140,6 @@ class AWSAuthConfirmSignInWithMagicLinkTaskTests: BasePluginTest {
     ///
     func testSuccessfulConfirmSignInWithMagicLinkFromDifferentDevice() async {
         setUpFor(confirmMagicLinkDevice: .remote)
-        let validMagicLinkToken = "eyJ1c2VybmFtZSI6InRlc3RAZXhhbXBsZS5jb20iLCJpYXQiOjE3MDExODkwODksImV4cCI6MTcwMTE4OTY4OX0.AQIDBAUGBwgJ"
         let customerMetadata = [
             "somekey": "somevalue"
         ]
@@ -157,7 +159,7 @@ class AWSAuthConfirmSignInWithMagicLinkTaskTests: BasePluginTest {
             },
             mockRespondToAuthChallengeResponse: { request in
                 XCTAssertEqual(request.challengeName, .customChallenge)
-                XCTAssertEqual(request.challengeResponses?["ANSWER"], validMagicLinkToken)
+                XCTAssertEqual(request.challengeResponses?["ANSWER"], self.validMagicLinkToken)
                 XCTAssertEqual(request.clientMetadata?["Amplify.Passwordless.signInMethod"], "MAGIC_LINK")
                 XCTAssertEqual(request.clientMetadata?["Amplify.Passwordless.action"], "CONFIRM")
                 XCTAssertEqual(request.clientMetadata?["somekey"], "somevalue")
@@ -181,5 +183,1002 @@ class AWSAuthConfirmSignInWithMagicLinkTaskTests: BasePluginTest {
             XCTFail("Received failure with error \(error)")
         }
     }
+
+    /// Test a confirmSignIn call with an empty confirmation code
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a successful response
+    /// - When:
+    ///    - I invoke confirmSignIn with an empty confirmation code
+    /// - Then:
+    ///    - I should get an .validation error
+    ///
+    func testConfirmSignInWithEmptyResponse() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                XCTFail("Cognito service should not be called")
+                return .testData()
+            })
+
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: "",
+                options: option)
+            XCTFail("Should not succeed")
+        } catch {
+            guard case AuthError.validation = error else {
+                XCTFail("Should produce validation error instead of \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with an empty confirmation code followed by a second valid confirmSignIn call
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a successful response
+    /// - When:
+    ///    - I invoke second confirmSignIn after confirmSignIn with an empty confirmation code
+    /// - Then:
+    ///    - I should get a successful result with .done as the next step
+    ///
+    func testSuccessfullyConfirmSignInAfterAFailedConfirmSignIn() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                return .testData()
+            })
+
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: "",
+                options: option)
+            XCTFail("Should not succeed")
+        } catch {
+            guard case AuthError.validation = error else {
+                XCTFail("Should produce validation error instead of \(error)")
+                return
+            }
+
+            do {
+                let confirmSignInResult = try await plugin.confirmSignInWithMagicLink(
+                    challengeResponse: validMagicLinkToken,
+                    options: option)
+                XCTAssertTrue(confirmSignInResult.isSignedIn, "Signin result should be complete")
+            } catch {
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+    }
+
+    // MARK: Service error handling test
+
+    /// Test a confirmSignIn call with aliasExistsException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   aliasExistsException response
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .aliasExists as underlyingError
+    ///
+    func testConfirmSignInWithAliasExistsException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.AliasExistsException(
+                    message: "Exception"
+                )
+            })
+
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            XCTAssertEqual(underlyingError as? AWSCognitoAuthError, .aliasExists)
+        }
+    }
+
+    /// Test a confirmSignIn call with CodeMismatchException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   CodeMismatchException response
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .codeMismatch as underlyingError
+    ///
+    func testConfirmSignInWithCodeMismatchException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                return RespondToAuthChallengeOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_CHALLENGE_RESPONSE",
+                        "errorCode": "CodeMismatchException"
+                    ],
+                    session: "session")
+            })
+
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .codeMismatch = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be codeMismatch \(error)")
+                return
+            }
+        }
+    }
+
+    func testConfirmSignInRetryWithCodeMismatchException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                return RespondToAuthChallengeOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_CHALLENGE_RESPONSE",
+                        "errorCode": "CodeMismatchException"
+                    ],
+                    session: "session")
+            })
+
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .codeMismatch = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be codeMismatch \(error)")
+                return
+            }
+
+            self.mockIdentityProvider = MockIdentityProvider(
+                mockInitiateAuthResponse: { _ in
+                    return InitiateAuthOutput(
+                        authenticationResult: .none,
+                        challengeName: .customChallenge,
+                        challengeParameters: [
+                            "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                        ],
+                        session: "someSession")
+                },
+                mockRespondToAuthChallengeResponse: { _ in
+                    return .testData()
+                })
+            do {
+                let confirmSignInResult = try await plugin.confirmSignInWithMagicLink(
+                    challengeResponse: validMagicLinkToken,
+                    options: option)
+                XCTAssertTrue(confirmSignInResult.isSignedIn, "Signin result should be complete")
+            } catch {
+                XCTFail("Received failure with error \(error)")
+            }
+
+        }
+    }
+
+    /// Test a confirmSignIn call with CodeExpiredException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   CodeExpiredException response
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .codeExpired as underlyingError
+    ///
+    func testConfirmSignInWithExpiredCodeException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.ExpiredCodeException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .codeExpired = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be codeExpired \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with InternalErrorException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a InternalErrorException response
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get an .unknown error
+    ///
+    func testConfirmSignInWithInternalErrorException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.InternalErrorException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.unknown = error else {
+                XCTFail("Should produce an unknown error instead of \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with InvalidLambdaResponseException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidLambdaResponseException response
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .lambda as underlyingError
+    ///
+    func testConfirmSignInWithInvalidLambdaResponseException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.InvalidLambdaResponseException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be lambda \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with InvalidParameterException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidParameterException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with  .invalidParameter as underlyingError
+    ///
+    func testConfirmSignInWithInvalidParameterException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.InvalidParameterException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be invalidParameter \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with InvalidPasswordException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidPasswordException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with  .invalidPassword as underlyingError
+    ///
+    func testConfirmSignInWithInvalidPasswordException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.InvalidPasswordException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .invalidPassword = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be invalidPassword \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with InvalidSmsRoleAccessPolicy response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidSmsRoleAccessPolicyException response
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with  .smsRole as underlyingError
+    ///
+    func testConfirmSignInWithinvalidSmsRoleAccessPolicyException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.InvalidSmsRoleAccessPolicyException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .smsRole = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be invalidPassword \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with InvalidSmsRoleTrustRelationship response from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   CodeDeliveryFailureException response
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with  .smsRole as underlyingError
+    ///
+    func testConfirmSignInWithInvalidSmsRoleTrustRelationshipException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.InvalidSmsRoleTrustRelationshipException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .smsRole = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be invalidPassword \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn with User pool configuration from service
+    ///
+    /// - Given: an auth plugin with mocked service with no User Pool configuration
+    ///
+    /// - When:
+
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .configuration error
+    ///
+    func testConfirmSignInWithInvalidUserPoolConfigurationException() async {
+        let identityPoolConfigData = Defaults.makeIdentityConfigData()
+        let authorizationEnvironment = BasicAuthorizationEnvironment(
+            identityPoolConfiguration: identityPoolConfigData,
+            cognitoIdentityFactory: Defaults.makeIdentity)
+        let environment = AuthEnvironment(
+            configuration: .identityPools(identityPoolConfigData),
+            userPoolConfigData: nil,
+            identityPoolConfigData: identityPoolConfigData,
+            authenticationEnvironment: nil,
+            authorizationEnvironment: authorizationEnvironment,
+            credentialsClient: Defaults.makeCredentialStoreOperationBehavior(),
+            logger: Amplify.Logging.logger(forCategory: "awsCognitoAuthPluginTest")
+        )
+        let stateMachine = Defaults.authStateMachineWith(environment: environment,
+                                                         initialState: .notConfigured)
+
+        let plugin = AWSCognitoAuthPlugin()
+        plugin.configure(
+            authConfiguration: .identityPools(identityPoolConfigData),
+            authEnvironment: environment,
+            authStateMachine: stateMachine,
+            credentialStoreStateMachine: Defaults.makeDefaultCredentialStateMachine(),
+            hubEventHandler: MockAuthHubEventBehavior(),
+            analyticsHandler: MockAnalyticsHandler())
+
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.configuration(_, _, _) = error else {
+                XCTFail("Should produce configuration instead produced \(error)")
+                return
+            }
+        }
+
+    }
+
+    /// Test a confirmSignIn with MFAMethodNotFoundException from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   MFAMethodNotFoundException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with  .mfaMethodNotFound as underlyingError
+    ///
+    func testCofirmSignInWithMFAMethodNotFoundException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.MFAMethodNotFoundException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should not succeed")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .mfaMethodNotFound = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be mfaMethodNotFound \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with NotAuthorizedException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   NotAuthorizedException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .notAuthorized error
+    ///
+    func testConfirmSignInWithNotAuthorizedException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.NotAuthorizedException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.notAuthorized = error else {
+                XCTFail("Should produce notAuthorized error instead of \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn with PasswordResetRequiredException from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   PasswordResetRequiredException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .resetPassword as next step
+    ///
+    func testConfirmSignInWithPasswordResetRequiredException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.PasswordResetRequiredException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("`confirmSignInWithOTP` Should not succeed")
+        }
+        catch {
+            guard case AuthError.service(_, _, _) = error else {
+                XCTFail("Should produce service error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+
+    /// Test a confirmSignIn call with SoftwareTokenMFANotFoundException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   SoftwareTokenMFANotFoundException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .softwareTokenMFANotEnabled as underlyingError
+    ///
+    func testConfirmSignInWithSoftwareTokenMFANotFoundException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.SoftwareTokenMFANotFoundException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .softwareTokenMFANotEnabled = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be softwareTokenMFANotEnabled \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with TooManyRequestsException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   TooManyRequestsException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .requestLimitExceeded as underlyingError
+    ///
+    func testConfirmSignInWithTooManyRequestsException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.TooManyRequestsException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be requestLimitExceeded \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with UnexpectedLambdaException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   UnexpectedLambdaException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .lambda as underlyingError
+    ///
+    func testConfirmSignInWithUnexpectedLambdaException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.UnexpectedLambdaException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be lambda \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with UserLambdaValidationException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   UserLambdaValidationException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .lambda as underlyingError
+    ///
+    func testConfirmSignInWithUserLambdaValidationException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.UserLambdaValidationException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be lambda \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with UserNotConfirmedException response from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   UserNotConfirmedException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get .confirmSignUp as next step
+    ///
+    func testConfirmSignInWithUserNotConfirmedException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.UserNotConfirmedException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("`confirmSignInWithOTP` Should not succeed")
+        }
+        catch {
+            guard case AuthError.service(_, _, _) = error else {
+                XCTFail("Should produce service error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with UserNotFound response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   UserNotFoundException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .userNotFound error
+    ///
+    func testConfirmSignInWithUserNotFoundException() async {
+        setUpFor(confirmMagicLinkDevice: .local)
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockInitiateAuthResponse: { _ in
+                return InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            },
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.UserNotFoundException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithMagicLinkRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithMagicLink(
+                challengeResponse: validMagicLinkToken,
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be userNotFound \(error)")
+                return
+            }
+        }
+    }
+
 
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthConfirmSignInWithOTPTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthConfirmSignInWithOTPTaskTests.swift
@@ -273,6 +273,22 @@ class AWSAuthConfirmSignInWithOTPTaskTests: BasePluginTest {
         }
     }
 
+    /// Test a confirmSignIn call with CodeMismatchException response from service
+    ///  and then a successful sign in
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   CodeMismatchException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with an invalid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .codeMismatch as underlyingError
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should be able to sign in
+    ///
     func testConfirmSignInRetryWithCodeMismatchException() async {
         self.mockIdentityProvider = MockIdentityProvider(
             mockRespondToAuthChallengeResponse: { _ in
@@ -448,42 +464,6 @@ class AWSAuthConfirmSignInWithOTPTaskTests: BasePluginTest {
             }
             guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
                 XCTFail("Underlying error should be invalidParameter \(error)")
-                return
-            }
-        }
-    }
-
-    /// Test a confirmSignIn call with InvalidPasswordException response from service
-    ///
-    /// - Given: an auth plugin with mocked service. Mocked service should mock a
-    ///   InvalidPasswordException response
-    ///
-    /// - When:
-    ///    - I invoke confirmSignIn with a valid confirmation code
-    /// - Then:
-    ///    - I should get a .service error with  .invalidPassword as underlyingError
-    ///
-    func testConfirmSignInWithInvalidPasswordException() async {
-
-        self.mockIdentityProvider = MockIdentityProvider(
-            mockRespondToAuthChallengeResponse: { _ in
-                throw AWSCognitoIdentityProvider.InvalidPasswordException(
-                    message: "Exception"
-                )
-            })
-        let option = AuthConfirmSignInWithOTPRequest.Options()
-        do {
-            _ = try await plugin.confirmSignInWithOTP(
-                challengeResponse: "code",
-                options: option)
-            XCTFail("Should return an error if the result from service is invalid")
-        } catch {
-            guard case AuthError.service(_, _, let underlyingError) = error else {
-                XCTFail("Should produce service error instead of \(error)")
-                return
-            }
-            guard case .invalidPassword = (underlyingError as? AWSCognitoAuthError) else {
-                XCTFail("Underlying error should be invalidPassword \(error)")
                 return
             }
         }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthConfirmSignInWithOTPTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthConfirmSignInWithOTPTaskTests.swift
@@ -130,4 +130,794 @@ class AWSAuthConfirmSignInWithOTPTaskTests: BasePluginTest {
         }
     }
 
+    /// Test a confirmSignIn call with an empty confirmation code
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a successful response
+    /// - When:
+    ///    - I invoke confirmSignIn with an empty confirmation code
+    /// - Then:
+    ///    - I should get an .validation error
+    ///
+    func testConfirmSignInWithEmptyResponse() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                XCTFail("Cognito service should not be called")
+                return .testData()
+            })
+
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+        _ = try await plugin.confirmSignInWithOTP(
+            challengeResponse: "",
+            options: option)
+            XCTFail("Should not succeed")
+        } catch {
+            guard case AuthError.validation = error else {
+                XCTFail("Should produce validation error instead of \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with an empty confirmation code followed by a second valid confirmSignIn call
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a successful response
+    /// - When:
+    ///    - I invoke second confirmSignIn after confirmSignIn with an empty confirmation code
+    /// - Then:
+    ///    - I should get a successful result with .done as the next step
+    ///
+    func testSuccessfullyConfirmSignInAfterAFailedConfirmSignIn() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                return .testData()
+            })
+
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "",
+                options: option)
+            XCTFail("Should not succeed")
+        } catch {
+            guard case AuthError.validation = error else {
+                XCTFail("Should produce validation error instead of \(error)")
+                return
+            }
+
+            do {
+                let result = try await plugin.confirmSignInWithOTP(
+                    challengeResponse: "code",
+                    options: option)
+                XCTAssertTrue(result.isSignedIn, "Signin result should be complete")
+            } catch {
+                XCTFail("Received failure with error \(error)")
+            }
+        }
+    }
+
+    // MARK: Service error handling test
+
+    /// Test a confirmSignIn call with aliasExistsException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   aliasExistsException response
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .aliasExists as underlyingError
+    ///
+    func testConfirmSignInWithAliasExistsException() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.AliasExistsException(
+                    message: "Exception"
+                )
+            })
+
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            XCTAssertEqual(underlyingError as? AWSCognitoAuthError, .aliasExists)
+        }
+    }
+
+    /// Test a confirmSignIn call with CodeMismatchException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   CodeMismatchException response
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .codeMismatch as underlyingError
+    ///
+    func testConfirmSignInWithCodeMismatchException() async {
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                return RespondToAuthChallengeOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_CHALLENGE_RESPONSE",
+                        "errorCode": "CodeMismatchException"
+                    ],
+                    session: "session")
+            })
+
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .codeMismatch = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be codeMismatch \(error)")
+                return
+            }
+        }
+    }
+
+    func testConfirmSignInRetryWithCodeMismatchException() async {
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                return RespondToAuthChallengeOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_CHALLENGE_RESPONSE",
+                        "errorCode": "CodeMismatchException"
+                    ],
+                    session: "session")
+            })
+
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .codeMismatch = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be codeMismatch \(error)")
+                return
+            }
+
+            self.mockIdentityProvider = MockIdentityProvider(
+                mockRespondToAuthChallengeResponse: { _ in
+                    return .testData()
+                })
+            do {
+                let confirmSignInResult = try await plugin.confirmSignInWithOTP(
+                    challengeResponse: "code",
+                    options: option)
+                XCTAssertTrue(confirmSignInResult.isSignedIn, "Signin result should be complete")
+            } catch {
+                XCTFail("Received failure with error \(error)")
+            }
+
+        }
+    }
+
+    /// Test a confirmSignIn call with CodeExpiredException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   CodeExpiredException response
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .codeExpired as underlyingError
+    ///
+    func testConfirmSignInWithExpiredCodeException() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.ExpiredCodeException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .codeExpired = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be codeExpired \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with InternalErrorException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a InternalErrorException response
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get an .unknown error
+    ///
+    func testConfirmSignInWithInternalErrorException() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.InternalErrorException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.unknown = error else {
+                XCTFail("Should produce an unknown error instead of \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with InvalidLambdaResponseException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidLambdaResponseException response
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .lambda as underlyingError
+    ///
+    func testConfirmSignInWithInvalidLambdaResponseException() async {
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.InvalidLambdaResponseException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be lambda \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with InvalidParameterException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidParameterException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with  .invalidParameter as underlyingError
+    ///
+    func testConfirmSignInWithInvalidParameterException() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.InvalidParameterException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be invalidParameter \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with InvalidPasswordException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidPasswordException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with  .invalidPassword as underlyingError
+    ///
+    func testConfirmSignInWithInvalidPasswordException() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.InvalidPasswordException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .invalidPassword = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be invalidPassword \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with InvalidSmsRoleAccessPolicy response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidSmsRoleAccessPolicyException response
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with  .smsRole as underlyingError
+    ///
+    func testConfirmSignInWithinvalidSmsRoleAccessPolicyException() async {
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.InvalidSmsRoleAccessPolicyException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .smsRole = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be invalidPassword \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with InvalidSmsRoleTrustRelationship response from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   CodeDeliveryFailureException response
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with  .smsRole as underlyingError
+    ///
+    func testConfirmSignInWithInvalidSmsRoleTrustRelationshipException() async {
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.InvalidSmsRoleTrustRelationshipException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .smsRole = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be invalidPassword \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn with User pool configuration from service
+    ///
+    /// - Given: an auth plugin with mocked service with no User Pool configuration
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .configuration error
+    ///
+    func testConfirmSignInWithInvalidUserPoolConfigurationException() async {
+        let identityPoolConfigData = Defaults.makeIdentityConfigData()
+        let authorizationEnvironment = BasicAuthorizationEnvironment(
+            identityPoolConfiguration: identityPoolConfigData,
+            cognitoIdentityFactory: Defaults.makeIdentity)
+        let environment = AuthEnvironment(
+            configuration: .identityPools(identityPoolConfigData),
+            userPoolConfigData: nil,
+            identityPoolConfigData: identityPoolConfigData,
+            authenticationEnvironment: nil,
+            authorizationEnvironment: authorizationEnvironment,
+            credentialsClient: Defaults.makeCredentialStoreOperationBehavior(),
+            logger: Amplify.Logging.logger(forCategory: "awsCognitoAuthPluginTest")
+        )
+        let stateMachine = Defaults.authStateMachineWith(environment: environment,
+                                                         initialState: .notConfigured)
+        let plugin = AWSCognitoAuthPlugin()
+        plugin.configure(
+            authConfiguration: .identityPools(identityPoolConfigData),
+            authEnvironment: environment,
+            authStateMachine: stateMachine,
+            credentialStoreStateMachine: Defaults.makeDefaultCredentialStateMachine(),
+            hubEventHandler: MockAuthHubEventBehavior(),
+            analyticsHandler: MockAnalyticsHandler())
+
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.configuration(_, _, _) = error else {
+                XCTFail("Should produce configuration instead produced \(error)")
+                return
+            }
+        }
+
+    }
+
+    /// Test a confirmSignIn with MFAMethodNotFoundException from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   MFAMethodNotFoundException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with  .mfaMethodNotFound as underlyingError
+    ///
+    func testCofirmSignInWithMFAMethodNotFoundException() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.MFAMethodNotFoundException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should not succeed")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .mfaMethodNotFound = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be mfaMethodNotFound \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with NotAuthorizedException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   NotAuthorizedException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .notAuthorized error
+    ///
+    func testConfirmSignInWithNotAuthorizedException() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.NotAuthorizedException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.notAuthorized = error else {
+                XCTFail("Should produce notAuthorized error instead of \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn with PasswordResetRequiredException from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   PasswordResetRequiredException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .resetPassword as next step
+    ///
+    func testConfirmSignInWithPasswordResetRequiredException() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.PasswordResetRequiredException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("`confirmSignInWithOTP` Should not succeed")
+        }
+        catch {
+            guard case AuthError.service(_, _, _) = error else {
+                XCTFail("Should produce service error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+
+    /// Test a confirmSignIn call with SoftwareTokenMFANotFoundException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   SoftwareTokenMFANotFoundException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .softwareTokenMFANotEnabled as underlyingError
+    ///
+    func testConfirmSignInWithSoftwareTokenMFANotFoundException() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.SoftwareTokenMFANotFoundException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .softwareTokenMFANotEnabled = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be softwareTokenMFANotEnabled \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with TooManyRequestsException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   TooManyRequestsException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .requestLimitExceeded as underlyingError
+    ///
+    func testConfirmSignInWithTooManyRequestsException() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.TooManyRequestsException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be requestLimitExceeded \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with UnexpectedLambdaException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   UnexpectedLambdaException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .lambda as underlyingError
+    ///
+    func testConfirmSignInWithUnexpectedLambdaException() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.UnexpectedLambdaException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be lambda \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with UserLambdaValidationException response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   UserLambdaValidationException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .service error with .lambda as underlyingError
+    ///
+    func testConfirmSignInWithUserLambdaValidationException() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.UserLambdaValidationException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be lambda \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with UserNotConfirmedException response from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   UserNotConfirmedException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get .confirmSignUp as next step
+    ///
+    func testConfirmSignInWithUserNotConfirmedException() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.UserNotConfirmedException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("`confirmSignInWithOTP` Should not succeed")
+        }
+        catch {
+            guard case AuthError.service(_, _, _) = error else {
+                XCTFail("Should produce service error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a confirmSignIn call with UserNotFound response from service
+    ///
+    /// - Given: an auth plugin with mocked service. Mocked service should mock a
+    ///   UserNotFoundException response
+    ///
+    /// - When:
+    ///    - I invoke confirmSignIn with a valid confirmation code
+    /// - Then:
+    ///    - I should get a .userNotFound error
+    ///
+    func testConfirmSignInWithUserNotFoundException() async {
+
+        self.mockIdentityProvider = MockIdentityProvider(
+            mockRespondToAuthChallengeResponse: { _ in
+                throw AWSCognitoIdentityProvider.UserNotFoundException(
+                    message: "Exception"
+                )
+            })
+        let option = AuthConfirmSignInWithOTPRequest.Options()
+        do {
+            _ = try await plugin.confirmSignInWithOTP(
+                challengeResponse: "code",
+                options: option)
+            XCTFail("Should return an error if the result from service is invalid")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error else {
+                XCTFail("Should produce service error instead of \(error)")
+                return
+            }
+            guard case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Underlying error should be userNotFound \(error)")
+                return
+            }
+        }
+    }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInPluginTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInPluginTests.swift
@@ -878,7 +878,7 @@ class AWSAuthSignInPluginTests: BasePluginTest {
             XCTFail("Should not produce result - \(result)")
         } catch {
             guard case AuthError.configuration = error else {
-                XCTFail("Should produce configuration intead produced \(error)")
+                XCTFail("Should produce configuration instead produced \(error)")
                 return
             }
         }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithMagicLinkTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithMagicLinkTaskTests.swift
@@ -1049,7 +1049,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
                 XCTFail("Result should be .done for next step")
                 return
             }
-            XCTAssertTrue(result2.isSignedIn)
+            XCTAssertFalse(result2.isSignedIn)
         } catch {
             XCTFail("Received failure with error \(error)")
         }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithMagicLinkTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithMagicLinkTaskTests.swift
@@ -688,7 +688,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             XCTFail("Should not produce result - \(result)")
         } catch {
             guard case AuthError.configuration = error else {
-                XCTFail("Should produce configuration intead produced \(error)")
+                XCTFail("Should produce configuration instead produced \(error)")
                 return
             }
         }
@@ -1029,16 +1029,15 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
                     ],
                     session: "someSession")
             }, mockRespondToAuthChallengeResponse: { _ in
-                RespondToAuthChallengeOutput(
-                    authenticationResult: .init(
-                        accessToken: Defaults.validAccessToken,
-                        expiresIn: 300,
-                        idToken: "idToken",
-                        newDeviceMetadata: nil,
-                        refreshToken: "refreshToken",
-                        tokenType: ""),
-                    challengeName: .none,
-                    challengeParameters: [:],
+                return RespondToAuthChallengeOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_CHALLENGE_RESPONSE",
+                        "attributeName": "email",
+                        "deliveryMedium": "EMAIL",
+                        "destination": "S***@g***"
+                    ],
                     session: "session")
             })
             let result2 = try await plugin.signInWithMagicLink(
@@ -1046,7 +1045,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
                 flow: .signIn,
                 redirectURL: redirectURL,
                 options: options)
-            guard case .done =  result2.nextStep else {
+            guard case .confirmSignInWithMagicLink =  result2.nextStep else {
                 XCTFail("Result should be .done for next step")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithMagicLinkTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithMagicLinkTaskTests.swift
@@ -13,12 +13,42 @@ import ClientRuntime
 
 class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
 
+    let username = "username"
+    let redirectURL = "https://example.com/magic-link/##code##"
+
     override var initialState: AuthState {
         AuthState.configured(.signedOut(.init(lastKnownUserName: nil)), .configured)
     }
     
     override func setUp() {
         plugin = AWSCognitoAuthPlugin()
+    }
+
+    private func setUpWith(
+        authPasswordlessEnvironment: AuthPasswordlessEnvironment? = nil,
+        authConfiguration: AuthConfiguration = Defaults.makeDefaultAuthConfigData()) {
+            let environment = Defaults.makeDefaultAuthEnvironment(
+                identityPoolFactory: { self.mockIdentity },
+                userPoolFactory: { self.mockIdentityProvider },
+                authPasswordlessEnvironment: authPasswordlessEnvironment
+            )
+
+            let statemachine = Defaults.makeDefaultAuthStateMachine(
+                initialState: initialState,
+                identityPoolFactory: { self.mockIdentity },
+                userPoolFactory: { self.mockIdentityProvider })
+
+            plugin?.configure(
+                authConfiguration: authConfiguration,
+                authEnvironment: environment,
+                authStateMachine: statemachine,
+                credentialStoreStateMachine: Defaults.makeDefaultCredentialStateMachine(),
+                hubEventHandler: MockAuthHubEventBehavior(),
+                analyticsHandler: MockAnalyticsHandler())
+        }
+
+    private func makeAuthPasswordlessClient() -> AuthPasswordlessBehavior {
+        self.mockAuthPasswordlessProvider
     }
 
     /// Test happy path for signInWithMagicLink
@@ -31,8 +61,6 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///    - I should get the info in next step
     ///
     func testSignInWithMagicLink() async {
-        let username = "username"
-        let redirectURL = "https://example.com/magic-link/##code##"
         setUpWith(authPasswordlessEnvironment:
                     BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
         let clientMetadata = [
@@ -51,7 +79,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.signInMethod"], "MAGIC_LINK")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.action"], "REQUEST")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.deliveryMedium"], "EMAIL")
-            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], redirectURL)
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], self.redirectURL)
             XCTAssertEqual(input.clientMetadata?["somekey"], "somevalue")
 
             return RespondToAuthChallengeOutput(
@@ -109,11 +137,9 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///    - I should get the correct info in next step
     ///
     func testSignUpAndSignInWithMagicLink() async {
-        let username = "username"
-        let redirectURL = "https://example.com/magic-link/##code##"
         self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
             XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
-            XCTAssertEqual(payload.username, username)
+            XCTAssertEqual(payload.username, self.username)
             XCTAssertEqual(payload.deliveryMedium, "EMAIL")
             XCTAssertEqual(payload.userAttributes?["somekey"], "somevalue")
             XCTAssertEqual(payload.userPoolId, Defaults.userPoolId)
@@ -142,7 +168,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.signInMethod"], "MAGIC_LINK")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.action"], "REQUEST")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.deliveryMedium"], "EMAIL")
-            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], redirectURL)
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], self.redirectURL)
             XCTAssertEqual(input.clientMetadata?["somekey"], "somevalue")
 
             return RespondToAuthChallengeOutput(
@@ -202,11 +228,9 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///    - I should get an error
     ///
     func testSignUpAndSignInWithMagicLinkWithMissingEndpointURL() async {
-        let username = "username"
-        let redirectURL = "https://example.com/magic-link/##code##"
         self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
             XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
-            XCTAssertEqual(payload.username, username)
+            XCTAssertEqual(payload.username, self.username)
             XCTAssertEqual(payload.deliveryMedium, "EMAIL")
             XCTAssertEqual(payload.userAttributes?["somekey"], "somevalue")
             XCTAssertEqual(payload.userPoolId, Defaults.userPoolId)
@@ -240,7 +264,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.signInMethod"], "MAGIC_LINK")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.action"], "REQUEST")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.deliveryMedium"], "EMAIL")
-            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], redirectURL)
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], self.redirectURL)
             XCTAssertEqual(input.clientMetadata?["somekey"], "somevalue")
 
             return RespondToAuthChallengeOutput(
@@ -293,11 +317,9 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///    - I should get an error
     ///
     func testSignUpAndSignInWithMagicLinkWithNilPasswordlessClient() async {
-        let username = "username"
-        let redirectURL = "https://example.com/magic-link/##code##"
         self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
             XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
-            XCTAssertEqual(payload.username, username)
+            XCTAssertEqual(payload.username, self.username)
             XCTAssertEqual(payload.deliveryMedium, "EMAIL")
             XCTAssertEqual(payload.userAttributes?["somekey"], "somevalue")
             XCTAssertEqual(payload.userPoolId, Defaults.userPoolId)
@@ -324,7 +346,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.signInMethod"], "MAGIC_LINK")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.action"], "REQUEST")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.deliveryMedium"], "EMAIL")
-            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], redirectURL)
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], self.redirectURL)
             XCTAssertEqual(input.clientMetadata?["somekey"], "somevalue")
 
             return RespondToAuthChallengeOutput(
@@ -377,11 +399,9 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///    - I should get an error
     ///
     func testSignUpAndSignInWithMagicLinkWithMissingUserPoolConfig() async {
-        let username = "username"
-        let redirectURL = "https://example.com/magic-link/##code##"
         self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
             XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
-            XCTAssertEqual(payload.username, username)
+            XCTAssertEqual(payload.username, self.username)
             XCTAssertEqual(payload.deliveryMedium, "EMAIL")
             XCTAssertEqual(payload.userAttributes?["somekey"], "somevalue")
             XCTAssertEqual(payload.userPoolId, Defaults.userPoolId)
@@ -408,7 +428,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.signInMethod"], "MAGIC_LINK")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.action"], "REQUEST")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.deliveryMedium"], "EMAIL")
-            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], redirectURL)
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], self.redirectURL)
             XCTAssertEqual(input.clientMetadata?["somekey"], "somevalue")
 
             return RespondToAuthChallengeOutput(
@@ -461,11 +481,9 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
     ///    - I should get an error
     ///
     func testSignUpAndSignInWithMagicLinkWithEmptyEndpointURL() async {
-        let username = "username"
-        let redirectURL = "https://example.com/magic-link/##code##"
         self.mockAuthPasswordlessProvider = MockAuthPasswordlessBehavior(mockGetAuthPasswordlessResponse: { url, payload in
             XCTAssertEqual(url.absoluteString, Defaults.passwordlessSignUpEndpoint)
-            XCTAssertEqual(payload.username, username)
+            XCTAssertEqual(payload.username, self.username)
             XCTAssertEqual(payload.deliveryMedium, "EMAIL")
             XCTAssertEqual(payload.userAttributes?["somekey"], "somevalue")
             XCTAssertEqual(payload.userPoolId, Defaults.userPoolId)
@@ -497,7 +515,7 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.signInMethod"], "MAGIC_LINK")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.action"], "REQUEST")
             XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.deliveryMedium"], "EMAIL")
-            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], redirectURL)
+            XCTAssertEqual(input.clientMetadata?["Amplify.Passwordless.redirectUri"], self.redirectURL)
             XCTAssertEqual(input.clientMetadata?["somekey"], "somevalue")
 
             return RespondToAuthChallengeOutput(
@@ -538,31 +556,505 @@ class AWSAuthSignInWithMagicLinkTaskTests: BasePluginTest {
             XCTAssertEqual(recoverySuggestion, AuthPluginErrorConstants.configurationError)
         }
     }
-    
-    private func setUpWith(
-        authPasswordlessEnvironment: AuthPasswordlessEnvironment? = nil,
-        authConfiguration: AuthConfiguration = Defaults.makeDefaultAuthConfigData()) {
-        let environment = Defaults.makeDefaultAuthEnvironment(
-            identityPoolFactory: { self.mockIdentity },
-            userPoolFactory: { self.mockIdentityProvider },
-            authPasswordlessEnvironment: authPasswordlessEnvironment
-        )
 
-        let statemachine = Defaults.makeDefaultAuthStateMachine(
-            initialState: initialState,
-            identityPoolFactory: { self.mockIdentity },
-            userPoolFactory: { self.mockIdentityProvider })
 
-        plugin?.configure(
-            authConfiguration: authConfiguration,
-            authEnvironment: environment,
-            authStateMachine: statemachine,
-            credentialStoreStateMachine: Defaults.makeDefaultCredentialStateMachine(),
-            hubEventHandler: MockAuthHubEventBehavior(),
-            analyticsHandler: MockAnalyticsHandler())
+    // MARK: - Service error for initiateAuth
+
+    /// Test a signIn with `InternalErrorException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InternalErrorException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .unknown error
+    ///
+    func testSignInWithInternalErrorException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.InternalErrorException()
+        })
+
+        let options = AuthSignInWithMagicLinkRequest.Options()
+        do {
+            let result = try await plugin.signInWithMagicLink(
+                username: username,
+                flow: .signIn,
+                redirectURL: redirectURL,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.unknown = error else {
+                XCTFail("Should produce unknown error")
+                return
+            }
+        }
     }
-    
-    private func makeAuthPasswordlessClient() -> AuthPasswordlessBehavior {
-        self.mockAuthPasswordlessProvider
+
+    /// Test a signIn with `InvalidLambdaResponseException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidLambdaResponseException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .lambda error
+    ///
+    func testSignInWithInvalidLambdaResponseException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.InvalidLambdaResponseException()
+        })
+
+        let options = AuthSignInWithMagicLinkRequest.Options()
+        do {
+            let result = try await plugin.signInWithMagicLink(
+                username: username,
+                flow: .signIn,
+                redirectURL: redirectURL,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error,
+                  case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Should produce lambda error but instead produced \(error)")
+                return
+            }
+        }
     }
+
+    /// Test a signIn with `InvalidParameterException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidParameterException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .invalidParameter error
+    ///
+    func testSignInWithInvalidParameterException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.InvalidParameterException()
+        })
+
+        let options = AuthSignInWithMagicLinkRequest.Options()
+        do {
+            let result = try await plugin.signInWithMagicLink(
+                username: username,
+                flow: .signIn,
+                redirectURL: redirectURL,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error,
+                  case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Should produce invalidParameter error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn with `InvalidUserPoolConfigurationException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidUserPoolConfigurationException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .configuration error
+    ///
+    func testSignInWithInvalidUserPoolConfigurationException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.InvalidUserPoolConfigurationException()
+        })
+
+        let options = AuthSignInWithMagicLinkRequest.Options()
+        do {
+            let result = try await plugin.signInWithMagicLink(
+                username: username,
+                flow: .signIn,
+                redirectURL: redirectURL,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.configuration = error else {
+                XCTFail("Should produce configuration intead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn with `NotAuthorizedException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   NotAuthorizedException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .notAuthorized error
+    ///
+    func testSignInWithNotAuthorizedException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.NotAuthorizedException()
+        })
+
+        let options = AuthSignInWithMagicLinkRequest.Options()
+        do {
+            let result = try await plugin.signInWithMagicLink(
+                username: username,
+                flow: .signIn,
+                redirectURL: redirectURL,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.notAuthorized = error else {
+                XCTFail("Should produce notAuthorized error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn with `PasswordResetRequiredException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   PasswordResetRequiredException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .resetPassword as next step
+    ///
+    func testSignInWithPasswordResetRequiredException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.PasswordResetRequiredException()
+        })
+
+        let options = AuthSignInWithMagicLinkRequest.Options()
+        do {
+            let result = try await plugin.signInWithMagicLink(
+                username: username,
+                flow: .signIn,
+                redirectURL: redirectURL,
+                options: options)
+            XCTFail("`signInWithOTP` Should not succeed")
+        }
+        catch {
+            guard case AuthError.service(_, _, _) = error else {
+                XCTFail("Should produce userNotFound error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn with `ResourceNotFoundException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   ResourceNotFoundException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .resourceNotFound error
+    ///
+    func testSignInWithResourceNotFoundException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.ResourceNotFoundException()
+        })
+
+        let options = AuthSignInWithMagicLinkRequest.Options()
+        do {
+            let result = try await plugin.signInWithMagicLink(
+                username: username,
+                flow: .signIn,
+                redirectURL: redirectURL,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error,
+                  case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Should produce resourceNotFound error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn with `TooManyRequestsException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   TooManyRequestsException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .requestLimitExceeded error
+    ///
+    func testSignInWithTooManyRequestsException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.TooManyRequestsException()
+        })
+
+        let options = AuthSignInWithMagicLinkRequest.Options()
+        do {
+            let result = try await plugin.signInWithMagicLink(
+                username: username,
+                flow: .signIn,
+                redirectURL: redirectURL,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error,
+                  case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Should produce requestLimitExceeded error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn with `UnexpectedLambdaException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   UnexpectedLambdaException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .lambda error
+    ///
+    func testSignInWithUnexpectedLambdaException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.UnexpectedLambdaException()
+        })
+
+        let options = AuthSignInWithMagicLinkRequest.Options()
+        do {
+            let result = try await plugin.signInWithMagicLink(
+                username: username,
+                flow: .signIn,
+                redirectURL: redirectURL,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error,
+                  case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Should produce lambda error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn with `UserLambdaValidationException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   UserLambdaValidationException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .lambda error
+    ///
+    func testSignInWithUserLambdaValidationException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.UserLambdaValidationException()
+        })
+
+        let options = AuthSignInWithMagicLinkRequest.Options()
+        do {
+            let result = try await plugin.signInWithMagicLink(
+                username: username,
+                flow: .signIn,
+                redirectURL: redirectURL,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error,
+                  case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Should produce lambda error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn with `UserNotFoundException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   UserNotFoundException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .userNotFound error
+    ///
+    func testSignInWithUserNotFoundException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.UserNotFoundException()
+        })
+
+        let options = AuthSignInWithMagicLinkRequest.Options()
+        do {
+            let result = try await plugin.signInWithMagicLink(
+                username: username,
+                flow: .signIn,
+                redirectURL: redirectURL,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error,
+                  case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Should produce userNotFound error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: - Service error for RespondToAuthChallenge
+
+    /// Test a signIn with `AliasExistsException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   AliasExistsException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .aliasExists error
+    ///
+    func testSignInWithAliasExistsException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            return InitiateAuthOutput(
+                authenticationResult: .none,
+                challengeName: .customChallenge,
+                challengeParameters: [
+                    "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                ],
+                session: "someSession")
+        }, mockRespondToAuthChallengeResponse: { _ in
+            throw AWSCognitoIdentityProvider.AliasExistsException()
+        })
+
+        let options = AuthSignInWithMagicLinkRequest.Options()
+        do {
+            let result = try await plugin.signInWithMagicLink(
+                username: username,
+                flow: .signIn,
+                redirectURL: redirectURL,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error,
+                  case .aliasExists = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Should produce aliasExists error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn restart while another sign in is in progress
+    ///
+    /// - Given: Given an auth plugin with mocked service and a in progress signIn waiting for SMS verification
+    ///
+    /// - When:
+    ///    - I invoke another signIn with valid values
+    /// - Then:
+    ///    - I should get a .done response
+    ///
+    func testRestartSignIn() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            return InitiateAuthOutput(
+                authenticationResult: .none,
+                challengeName: .customChallenge,
+                challengeParameters: [
+                    "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                ],
+                session: "someSession")
+        }, mockRespondToAuthChallengeResponse: { _ in
+            return RespondToAuthChallengeOutput(
+                authenticationResult: .none,
+                challengeName: .customChallenge,
+                challengeParameters: [
+                    "nextStep": "PROVIDE_CHALLENGE_RESPONSE",
+                    "attributeName": "email",
+                    "deliveryMedium": "EMAIL",
+                    "destination": "S***@g***"
+                ],
+                session: "session")
+        })
+
+        let options = AuthSignInWithMagicLinkRequest.Options()
+        do {
+            let result = try await plugin.signInWithMagicLink(
+                username: username,
+                flow: .signIn,
+                redirectURL: redirectURL,
+                options: options)
+            guard case .confirmSignInWithMagicLink =  result.nextStep else {
+                XCTFail("Result should be .confirmSignInWithMagicLink for next step instead got. \(result.nextStep)")
+                return
+            }
+            XCTAssertFalse(result.isSignedIn)
+            self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+                InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            }, mockRespondToAuthChallengeResponse: { _ in
+                RespondToAuthChallengeOutput(
+                    authenticationResult: .init(
+                        accessToken: Defaults.validAccessToken,
+                        expiresIn: 300,
+                        idToken: "idToken",
+                        newDeviceMetadata: nil,
+                        refreshToken: "refreshToken",
+                        tokenType: ""),
+                    challengeName: .none,
+                    challengeParameters: [:],
+                    session: "session")
+            })
+            let result2 = try await plugin.signInWithMagicLink(
+                username: username,
+                flow: .signIn,
+                redirectURL: redirectURL,
+                options: options)
+            guard case .done =  result2.nextStep else {
+                XCTFail("Result should be .done for next step")
+                return
+            }
+            XCTAssertTrue(result2.isSignedIn)
+        } catch {
+            XCTFail("Received failure with error \(error)")
+        }
+    }
+
+
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithOTPTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithOTPTaskTests.swift
@@ -21,7 +21,34 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
     override func setUp() {
         plugin = AWSCognitoAuthPlugin()
     }
-    
+
+    private func setUpWith(
+        authPasswordlessEnvironment: AuthPasswordlessEnvironment? = nil,
+        authConfiguration: AuthConfiguration = Defaults.makeDefaultAuthConfigData()) {
+            let environment = Defaults.makeDefaultAuthEnvironment(
+                identityPoolFactory: { self.mockIdentity },
+                userPoolFactory: { self.mockIdentityProvider },
+                authPasswordlessEnvironment: authPasswordlessEnvironment
+            )
+
+            let statemachine = Defaults.makeDefaultAuthStateMachine(
+                initialState: initialState,
+                identityPoolFactory: { self.mockIdentity },
+                userPoolFactory: { self.mockIdentityProvider })
+
+            plugin?.configure(
+                authConfiguration: authConfiguration,
+                authEnvironment: environment,
+                authStateMachine: statemachine,
+                credentialStoreStateMachine: Defaults.makeDefaultCredentialStateMachine(),
+                hubEventHandler: MockAuthHubEventBehavior(),
+                analyticsHandler: MockAnalyticsHandler())
+        }
+
+    private func makeAuthPasswordlessClient() -> AuthPasswordlessBehavior {
+        self.mockAuthPasswordlessProvider
+    }
+
     /// Test happy path for signInWithOTP
     ///
     /// - Given: An auth plugin with mocked service.
@@ -532,31 +559,504 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
             XCTAssertEqual(recoverySuggestion, AuthPluginErrorConstants.configurationError)
         }
     }
-    
-    private func setUpWith(
-        authPasswordlessEnvironment: AuthPasswordlessEnvironment? = nil,
-        authConfiguration: AuthConfiguration = Defaults.makeDefaultAuthConfigData()) {
-        let environment = Defaults.makeDefaultAuthEnvironment(
-            identityPoolFactory: { self.mockIdentity },
-            userPoolFactory: { self.mockIdentityProvider },
-            authPasswordlessEnvironment: authPasswordlessEnvironment
-        )
 
-        let statemachine = Defaults.makeDefaultAuthStateMachine(
-            initialState: initialState,
-            identityPoolFactory: { self.mockIdentity },
-            userPoolFactory: { self.mockIdentityProvider })
 
-        plugin?.configure(
-            authConfiguration: authConfiguration,
-            authEnvironment: environment,
-            authStateMachine: statemachine,
-            credentialStoreStateMachine: Defaults.makeDefaultCredentialStateMachine(),
-            hubEventHandler: MockAuthHubEventBehavior(),
-            analyticsHandler: MockAnalyticsHandler())
+    // MARK: - Service error for initiateAuth
+
+    /// Test a signIn with `InternalErrorException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InternalErrorException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .unknown error
+    ///
+    func testSignInWithInternalErrorException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.InternalErrorException()
+        })
+
+        let options = AuthSignInWithOTPRequest.Options()
+        do {
+            let result = try await plugin.signInWithOTP(
+                username: "username",
+                flow: .signIn,
+                destination: .email,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.unknown = error else {
+                XCTFail("Should produce unknown error")
+                return
+            }
+        }
     }
-    
-    private func makeAuthPasswordlessClient() -> AuthPasswordlessBehavior {
-        self.mockAuthPasswordlessProvider
+
+    /// Test a signIn with `InvalidLambdaResponseException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidLambdaResponseException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .lambda error
+    ///
+    func testSignInWithInvalidLambdaResponseException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.InvalidLambdaResponseException()
+        })
+
+        let options = AuthSignInWithOTPRequest.Options()
+        do {
+            let result = try await plugin.signInWithOTP(
+                username: "username",
+                flow: .signIn,
+                destination: .email,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error,
+                  case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Should produce lambda error but instead produced \(error)")
+                return
+            }
+        }
     }
+
+    /// Test a signIn with `InvalidParameterException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidParameterException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .invalidParameter error
+    ///
+    func testSignInWithInvalidParameterException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.InvalidParameterException()
+        })
+
+        let options = AuthSignInWithOTPRequest.Options()
+        do {
+            let result = try await plugin.signInWithOTP(
+                username: "username",
+                flow: .signIn,
+                destination: .email,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error,
+                  case .invalidParameter = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Should produce invalidParameter error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn with `InvalidUserPoolConfigurationException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   InvalidUserPoolConfigurationException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .configuration error
+    ///
+    func testSignInWithInvalidUserPoolConfigurationException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.InvalidUserPoolConfigurationException()
+        })
+
+        let options = AuthSignInWithOTPRequest.Options()
+        do {
+            let result = try await plugin.signInWithOTP(
+                username: "username",
+                flow: .signIn,
+                destination: .email,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.configuration = error else {
+                XCTFail("Should produce configuration intead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn with `NotAuthorizedException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   NotAuthorizedException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .notAuthorized error
+    ///
+    func testSignInWithNotAuthorizedException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.NotAuthorizedException()
+        })
+
+        let options = AuthSignInWithOTPRequest.Options()
+        do {
+            let result = try await plugin.signInWithOTP(
+                username: "username",
+                flow: .signIn,
+                destination: .email,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.notAuthorized = error else {
+                XCTFail("Should produce notAuthorized error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn with `PasswordResetRequiredException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   PasswordResetRequiredException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .resetPassword as next step
+    ///
+    func testSignInWithPasswordResetRequiredException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.PasswordResetRequiredException()
+        })
+
+        let options = AuthSignInWithOTPRequest.Options()
+        do {
+            let result = try await plugin.signInWithOTP(
+                username: "username",
+                flow: .signIn,
+                destination: .email,
+                options: options)
+            XCTFail("`signInWithOTP` Should not succeed")
+        }
+        catch {
+            guard case AuthError.service(_, _, _) = error else {
+                XCTFail("Should produce service error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn with `ResourceNotFoundException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   ResourceNotFoundException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .resourceNotFound error
+    ///
+    func testSignInWithResourceNotFoundException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.ResourceNotFoundException()
+        })
+
+        let options = AuthSignInWithOTPRequest.Options()
+        do {
+            let result = try await plugin.signInWithOTP(
+                username: "username",
+                flow: .signIn,
+                destination: .email,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error,
+                  case .resourceNotFound = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Should produce resourceNotFound error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn with `TooManyRequestsException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   TooManyRequestsException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .requestLimitExceeded error
+    ///
+    func testSignInWithTooManyRequestsException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.TooManyRequestsException()
+        })
+
+        let options = AuthSignInWithOTPRequest.Options()
+        do {
+            let result = try await plugin.signInWithOTP(
+                username: "username",
+                flow: .signIn,
+                destination: .email,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error,
+                  case .requestLimitExceeded = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Should produce requestLimitExceeded error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn with `UnexpectedLambdaException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   UnexpectedLambdaException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .lambda error
+    ///
+    func testSignInWithUnexpectedLambdaException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.UnexpectedLambdaException()
+        })
+
+        let options = AuthSignInWithOTPRequest.Options()
+        do {
+            let result = try await plugin.signInWithOTP(
+                username: "username",
+                flow: .signIn,
+                destination: .email,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error,
+                  case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Should produce lambda error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn with `UserLambdaValidationException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   UserLambdaValidationException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .lambda error
+    ///
+    func testSignInWithUserLambdaValidationException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.UserLambdaValidationException()
+        })
+
+        let options = AuthSignInWithOTPRequest.Options()
+        do {
+            let result = try await plugin.signInWithOTP(
+                username: "username",
+                flow: .signIn,
+                destination: .email,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error,
+                  case .lambda = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Should produce lambda error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn with `UserNotFoundException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   UserNotFoundException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .userNotFound error
+    ///
+    func testSignInWithUserNotFoundException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            throw AWSCognitoIdentityProvider.UserNotFoundException()
+        })
+
+        let options = AuthSignInWithOTPRequest.Options()
+        do {
+            let result = try await plugin.signInWithOTP(
+                username: "username",
+                flow: .signIn,
+                destination: .email,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error,
+                  case .userNotFound = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Should produce userNotFound error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: - Service error for RespondToAuthChallenge
+
+    /// Test a signIn with `AliasExistsException` from service
+    ///
+    /// - Given: Given an auth plugin with mocked service. Mocked service should mock a
+    ///   AliasExistsException response for signIn
+    ///
+    /// - When:
+    ///    - I invoke signIn
+    /// - Then:
+    ///    - I should get a .service error with .aliasExists error
+    ///
+    func testSignInWithAliasExistsException() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            return InitiateAuthOutput(
+                authenticationResult: .none,
+                challengeName: .customChallenge,
+                challengeParameters: [
+                    "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                ],
+                session: "someSession")
+        }, mockRespondToAuthChallengeResponse: { _ in
+            throw AWSCognitoIdentityProvider.AliasExistsException()
+        })
+
+        let options = AuthSignInWithOTPRequest.Options()
+        do {
+            let result = try await plugin.signInWithOTP(
+                username: "username",
+                flow: .signIn,
+                destination: .email,
+                options: options)
+            XCTFail("Should not produce result - \(result)")
+        } catch {
+            guard case AuthError.service(_, _, let underlyingError) = error,
+                  case .aliasExists = (underlyingError as? AWSCognitoAuthError) else {
+                XCTFail("Should produce aliasExists error but instead produced \(error)")
+                return
+            }
+        }
+    }
+
+    /// Test a signIn restart while another sign in is in progress
+    ///
+    /// - Given: Given an auth plugin with mocked service and a in progress signIn waiting for SMS verification
+    ///
+    /// - When:
+    ///    - I invoke another signIn with valid values
+    /// - Then:
+    ///    - I should get a .done response
+    ///
+    func testRestartSignIn() async {
+        setUpWith(authPasswordlessEnvironment:
+                    BasicPasswordlessEnvironment(authPasswordlessFactory: makeAuthPasswordlessClient))
+        self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+            return InitiateAuthOutput(
+                authenticationResult: .none,
+                challengeName: .customChallenge,
+                challengeParameters: [
+                    "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                ],
+                session: "someSession")
+        }, mockRespondToAuthChallengeResponse: { _ in
+            return RespondToAuthChallengeOutput(
+                authenticationResult: .none,
+                challengeName: .customChallenge,
+                challengeParameters: [
+                    "nextStep": "PROVIDE_CHALLENGE_RESPONSE",
+                    "attributeName": "email",
+                    "deliveryMedium": "EMAIL",
+                    "destination": "S***@g***"
+                ],
+                session: "session")
+        })
+
+        let options = AuthSignInWithOTPRequest.Options()
+        do {
+            let result = try await plugin.signInWithOTP(
+                username: "username",
+                flow: .signIn,
+                destination: .email,
+                options: options)
+            guard case .confirmSignInWithOTP =  result.nextStep else {
+                XCTFail("Result should be .confirmSignInWithOTP for next step instead got. \(result.nextStep)")
+                return
+            }
+            XCTAssertFalse(result.isSignedIn)
+            self.mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { _ in
+                InitiateAuthOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_AUTH_PARAMETERS"
+                    ],
+                    session: "someSession")
+            }, mockRespondToAuthChallengeResponse: { _ in
+                RespondToAuthChallengeOutput(
+                    authenticationResult: .init(
+                        accessToken: Defaults.validAccessToken,
+                        expiresIn: 300,
+                        idToken: "idToken",
+                        newDeviceMetadata: nil,
+                        refreshToken: "refreshToken",
+                        tokenType: ""),
+                    challengeName: .none,
+                    challengeParameters: [:],
+                    session: "session")
+            })
+            let result2 = try await plugin.signInWithOTP(
+                username: "username",
+                flow: .signIn,
+                destination: .email,
+                options: options)
+            guard case .done =  result2.nextStep else {
+                XCTFail("Result should be .done for next step")
+                return
+            }
+            XCTAssertTrue(result2.isSignedIn)
+        } catch {
+            XCTFail("Received failure with error \(error)")
+        }
+    }
+
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithOTPTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithOTPTaskTests.swift
@@ -691,7 +691,7 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
             XCTFail("Should not produce result - \(result)")
         } catch {
             guard case AuthError.configuration = error else {
-                XCTFail("Should produce configuration intead produced \(error)")
+                XCTFail("Should produce configuration instead produced \(error)")
                 return
             }
         }
@@ -1032,16 +1032,15 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
                     ],
                     session: "someSession")
             }, mockRespondToAuthChallengeResponse: { _ in
-                RespondToAuthChallengeOutput(
-                    authenticationResult: .init(
-                        accessToken: Defaults.validAccessToken,
-                        expiresIn: 300,
-                        idToken: "idToken",
-                        newDeviceMetadata: nil,
-                        refreshToken: "refreshToken",
-                        tokenType: ""),
-                    challengeName: .none,
-                    challengeParameters: [:],
+                return RespondToAuthChallengeOutput(
+                    authenticationResult: .none,
+                    challengeName: .customChallenge,
+                    challengeParameters: [
+                        "nextStep": "PROVIDE_CHALLENGE_RESPONSE",
+                        "attributeName": "email",
+                        "deliveryMedium": "EMAIL",
+                        "destination": "S***@g***"
+                    ],
                     session: "session")
             })
             let result2 = try await plugin.signInWithOTP(
@@ -1049,7 +1048,7 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
                 flow: .signIn,
                 destination: .email,
                 options: options)
-            guard case .done =  result2.nextStep else {
+            guard case .confirmSignInWithOTP =  result2.nextStep else {
                 XCTFail("Result should be .done for next step")
                 return
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithOTPTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthSignInWithOTPTaskTests.swift
@@ -1052,7 +1052,7 @@ class AWSAuthSignInWithOTPTaskTests: BasePluginTest {
                 XCTFail("Result should be .done for next step")
                 return
             }
-            XCTAssertTrue(result2.isSignedIn)
+            XCTAssertFalse(result2.isSignedIn)
         } catch {
             XCTFail("Received failure with error \(error)")
         }


### PR DESCRIPTION
## Description
<!-- Why is this change required? What problem does it solve? -->
* Adding unit tests

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
