### PR TITLE
test(datastore): fix compiler errors in watchos unit tests due to missing `disableSubscriptions` arg

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -23,17 +23,22 @@ class InitialSyncOperationTests: XCTestCase {
     }
 
     // MARK: - GetLastSyncTime
-    
+
     func testFullSyncWhenLastSyncPredicateNilAndCurrentSyncPredicateNonNil() {
         let lastSyncTime: Int64 = 123456
         let lastSyncPredicate: String? = nil
         let currentSyncPredicate = DataStoreConfiguration.custom(
             syncExpressions: [
-                .syncExpression(MockSynced.schema,
-                                where: { MockSynced.keys.id.eq("123")})])
+                .syncExpression(
+                    MockSynced.schema,
+                    where: { MockSynced.keys.id.eq("123") }
+                )
+            ],
+            disableSubscriptions: { false }
+        )
         let expectedSyncType = SyncType.fullSync
         let expectedLastSync: Int64? = nil
-        
+
         let syncStartedReceived = expectation(description: "Sync started received, sync operation started")
         let operation = InitialSyncOperation(
             modelSchema: MockSynced.schema,
@@ -60,25 +65,24 @@ class InitialSyncOperationTests: XCTestCase {
                                                             lastSync: lastSyncTime,
                                                             syncPredicate: lastSyncPredicate)
         XCTAssertEqual(operation.getLastSyncTime(lastSyncMetadataLastSyncNil), expectedLastSync)
-    
+
         waitForExpectations(timeout: 1)
         sink.cancel()
     }
-    
+
     func testFullSyncWhenLastSyncPredicateNonNilAndCurrentSyncPredicateNil() {
         let lastSyncTime: Int64 = 123456
         let lastSyncPredicate: String? = "non nil"
-        let currentSyncPredicate = DataStoreConfiguration.default
         let expectedSyncType = SyncType.fullSync
         let expectedLastSync: Int64? = nil
-        
+
         let syncStartedReceived = expectation(description: "Sync started received, sync operation started")
         let operation = InitialSyncOperation(
             modelSchema: MockSynced.schema,
             api: nil,
             reconciliationQueue: nil,
             storageAdapter: nil,
-            dataStoreConfiguration: currentSyncPredicate,
+            dataStoreConfiguration: .custom(disableSubscriptions: { false }),
             authModeStrategy: AWSDefaultAuthModeStrategy())
         let sink = operation
             .publisher
@@ -98,21 +102,26 @@ class InitialSyncOperationTests: XCTestCase {
                                                             lastSync: lastSyncTime,
                                                             syncPredicate: lastSyncPredicate)
         XCTAssertEqual(operation.getLastSyncTime(lastSyncMetadataLastSyncNil), expectedLastSync)
-    
+
         waitForExpectations(timeout: 1)
         sink.cancel()
     }
-    
+
     func testFullSyncWhenLastSyncPredicateDifferentFromCurrentSyncPredicate() {
         let lastSyncTime: Int64 = 123456
         let lastSyncPredicate: String? = "non nil different from current predicate"
         let currentSyncPredicate = DataStoreConfiguration.custom(
             syncExpressions: [
-                .syncExpression(MockSynced.schema,
-                                where: { MockSynced.keys.id.eq("123")})])
+                .syncExpression(
+                    MockSynced.schema,
+                    where: { MockSynced.keys.id.eq("123") }
+                )
+            ],
+            disableSubscriptions: { false }
+        )
         let expectedSyncType = SyncType.fullSync
         let expectedLastSync: Int64? = nil
-        
+
         let syncStartedReceived = expectation(description: "Sync started received, sync operation started")
         let operation = InitialSyncOperation(
             modelSchema: MockSynced.schema,
@@ -139,22 +148,27 @@ class InitialSyncOperationTests: XCTestCase {
                                                             lastSync: lastSyncTime,
                                                             syncPredicate: lastSyncPredicate)
         XCTAssertEqual(operation.getLastSyncTime(lastSyncMetadataLastSyncNil), expectedLastSync)
-    
+
         waitForExpectations(timeout: 1)
         sink.cancel()
     }
-    
+
     func testDeltaSyncWhenLastSyncPredicateSameAsCurrentSyncPredicate() {
         let startDateSeconds = (Int64(Date().timeIntervalSince1970) - 100)
         let lastSyncTime: Int64 = startDateSeconds * 1_000
         let lastSyncPredicate: String? = "{\"field\":\"id\",\"operator\":{\"type\":\"equals\",\"value\":\"123\"}}"
         let currentSyncPredicate = DataStoreConfiguration.custom(
             syncExpressions: [
-                .syncExpression(MockSynced.schema,
-                                where: { MockSynced.keys.id.eq("123")})])
+                .syncExpression(
+                    MockSynced.schema,
+                    where: { MockSynced.keys.id.eq("123") }
+                )
+            ],
+            disableSubscriptions: { false }
+        )
         let expectedSyncType = SyncType.deltaSync
         let expectedLastSync: Int64? = lastSyncTime
-        
+
         let syncStartedReceived = expectation(description: "Sync started received, sync operation started")
         let operation = InitialSyncOperation(
             modelSchema: MockSynced.schema,
@@ -181,13 +195,13 @@ class InitialSyncOperationTests: XCTestCase {
                                                             lastSync: lastSyncTime,
                                                             syncPredicate: lastSyncPredicate)
         XCTAssertEqual(operation.getLastSyncTime(lastSyncMetadataLastSyncNil), expectedLastSync)
-    
+
         waitForExpectations(timeout: 1)
         sink.cancel()
     }
-    
+
     // MARK: - `main()` tests
-    
+
     /// - Given: An InitialSyncOperation
     /// - When:
     ///    - I invoke main()


### PR DESCRIPTION
## Description
<!-- Why is this change required? What problem does it solve? -->
DataStore watchOS unit tests are currently failing on `main` due to a missing required argument `disableSubscriptions` for watchOS (introduced: https://github.com/aws-amplify/amplify-swift/pull/3368) to tests added in https://github.com/aws-amplify/amplify-swift/pull/2757

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
