### PR TITLE
fix(datastore): configure json encoder with sorted key

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/Model+Codable.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Model+Codable.swift
@@ -71,11 +71,15 @@ extension Model where Self: Codable {
     ///   application making any change to these `public` types should be backward compatible, otherwise it will be a
     ///   breaking change.
     public func toJSON(encoder: JSONEncoder? = nil) throws -> String {
-        let resolvedEncoder: JSONEncoder
+        var resolvedEncoder: JSONEncoder
         if let encoder = encoder {
             resolvedEncoder = encoder
         } else {
             resolvedEncoder = JSONEncoder(dateEncodingStrategy: ModelDateFormatting.encodingStrategy)
+        }
+
+        if isKnownUniquelyReferenced(&resolvedEncoder) {
+            resolvedEncoder.outputFormatting = .sortedKeys
         }
 
         let data = try resolvedEncoder.encode(self)

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelValueConverter.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelValueConverter.swift
@@ -44,7 +44,9 @@ extension ModelValueConverter {
     }
 
     static var jsonEncoder: JSONEncoder {
-        JSONEncoder(dateEncodingStrategy: ModelDateFormatting.encodingStrategy)
+        let encoder = JSONEncoder(dateEncodingStrategy: ModelDateFormatting.encodingStrategy)
+        encoder.outputFormatting = .sortedKeys
+        return encoder
     }
 
     /// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/SQLModelValueConverterTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Models/SQLModelValueConverterTests.swift
@@ -52,7 +52,7 @@ class SQLModelValueConverterTests: BaseDataStoreTests {
     ///     - bool must be `Int` (1 or 0)
     ///     - the remaining types should not change
     func testModelWithEveryTypeConversionToBindings() {
-        let nonModelJSON = "{\"someString\":\"string\",\"someEnum\":\"foo\"}"
+        let nonModelJSON = "{\"someEnum\":\"foo\",\"someString\":\"string\"}"
         let example = exampleModel
 
         // convert model to SQLite Bindings

--- a/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/AWSDataStoreCategoryPluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -26,7 +26,7 @@ class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
     var localPost = Post(title: "localTitle", content: "localContent", createdAt: .now())
     let queue = OperationQueue()
     let reconciliationQueue = MockReconciliationQueue()
-    
+
     override func setUp() {
         tryOrFail {
             try setUpWithAPI()

--- a/AmplifyTests/CoreTests/Model+CodableTests.swift
+++ b/AmplifyTests/CoreTests/Model+CodableTests.swift
@@ -11,11 +11,11 @@ import AmplifyTestCommon
 
 class ModelCodableTests: XCTestCase {
     let postJSONWithFractionalSeconds = """
-    {"id":"post-1","title":"title","content":"content","comments":[],"createdAt":"1970-01-12T13:46:40.123Z"}
+    {"comments":[],"content":"content","createdAt":"1970-01-12T13:46:40.123Z","id":"post-1","title":"title"}
     """
 
     let postJSONWithoutFractionalSeconds = """
-    {"id":"post-1","title":"title","content":"content","comments":[],"createdAt":"1970-01-12T13:46:40Z"}
+    {"comments":[],"content":"content","createdAt":"1970-01-12T13:46:40Z","id":"post-1","title":"title"}
     """
 
     override func setUp() {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
https://github.com/aws-amplify/amplify-swift/pull/3057

- configure json encoder with sorted key

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
