### PR TITLE
chore: add necessary write permission to closed issue message actions workflow

### DIFF
--- a/.github/workflows/closed_issue_message.yml
+++ b/.github/workflows/closed_issue_message.yml
@@ -3,6 +3,10 @@ name: Closed Issue Message
 on:
     issues:
        types: [closed]
+
+permissions:
+  issues: write
+
 jobs:
     auto_comment:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
The `closed-issue-message` action added in https://github.com/aws-amplify/amplify-swift/pull/3374 doesn't have the necessary permissions to post a comment to an issue.

Example failure: https://github.com/aws-amplify/amplify-swift/actions/runs/7172825929/job/19530846804

This PR adds the `write` permission to the workflow to allow the action to carry out its duties.
This change mirrors the existing permissions used by other comment actions e.g. [new_issue_maintainer](https://github.com/aws-amplify/amplify-swift/blob/main/.github/workflows/new_issue_maintainer.yml#L7-L8)

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [ ] ~Build succeeds with all target using Swift Package Manager~
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
