### PR TITLE
fix(DataStore): Add 'weak self' to prevent retain cycles in OutgoingMutationQueue

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -70,9 +70,8 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
         self.stateMachineSink = self.stateMachine
             .$state
             .sink { [weak self] newState in
-                guard let self = self else {
-                    return
-                }
+                guard let self else { return }
+                
                 self.log.verbose("New state: \(newState)")
                 self.mutationDispatchQueue.async {
                     self.respond(to: newState)
@@ -322,7 +321,7 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
                                                           mutationSync: mutationSync)
             }
             self.queryMutationEventsFromStorage { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.stateMachine.notify(action: .processedEvent)
             }
         }
@@ -337,7 +336,7 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
                              sort: nil,
                              paginationInput: nil,
                              eagerLoad: true) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             
             switch result {
             case .success(let events):

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -138,7 +138,9 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
         self.api = api
         self.reconciliationQueue = reconciliationQueue
 
-        queryMutationEventsFromStorage {
+        queryMutationEventsFromStorage { [weak self] in
+            guard let self = self else { return }
+            
             self.operationQueue.isSuspended = false
             // State machine notification to ".receivedSubscription" will be handled in `receive(subscription:)`
             mutationEventPublisher.publisher.subscribe(self)
@@ -319,7 +321,8 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
                 self.dispatchOutboxMutationProcessedEvent(mutationEvent: mutationEvent,
                                                           mutationSync: mutationSync)
             }
-            self.queryMutationEventsFromStorage {
+            self.queryMutationEventsFromStorage { [weak self] in
+                guard let self = self else { return }
                 self.stateMachine.notify(action: .processedEvent)
             }
         }
@@ -333,7 +336,9 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
                              predicate: predicate,
                              sort: nil,
                              paginationInput: nil,
-                             eagerLoad: true) { result in
+                             eagerLoad: true) { [weak self] result in
+            guard let self = self else { return }
+            
             switch result {
             case .success(let events):
                 self.dispatchOutboxStatusEvent(isEmpty: events.isEmpty)


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/3325

## Description
<!-- Why is this change required? What problem does it solve? -->
The crash in the issue above points to OutgoingMutationQueue.swift:142
```swift
self.operationQueue.isSuspended = false
```

In this PR, we're addressing strong reference cycles in OutgoingMutationQueue by adding `weak self`. Calls to `Amplify.DataStore.stop()` will deintialize RemoteSyncEngine, which holds a single instance of the OutgoingMutationQueue. It's likely that OutgoingMutationQueue (`self`) is deallocated before one of the closures that have strong reference to `self` is executed. Then later, when it executes, it tries to access the deallocated `self` and crashes

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
