### PR TITLE
fix: use non-failable UTF8View Data init when converting from String

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/Model+Codable.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Model+Codable.swift
@@ -33,14 +33,7 @@ extension Model where Self: Codable {
             resolvedDecoder = JSONDecoder(dateDecodingStrategy: ModelDateFormatting.decodingStrategy)
         }
 
-        guard let data = json.data(using: .utf8) else {
-            throw DataStoreError.decodingError(
-                "Invalid JSON string. Could not convert the passed JSON string into a UTF-8 Data object",
-                "Ensure the JSON doesn't contain any invalid UTF-8 data:\n\n\(json)"
-            )
-        }
-
-        return try resolvedDecoder.decode(Self.self, from: data)
+        return try resolvedDecoder.decode(Self.self, from: Data(json.utf8))
     }
 
     /// De-serialize a `Dictionary` into an instance of the concrete type that conforms

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelValueConverter.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelValueConverter.swift
@@ -63,9 +63,6 @@ extension ModelValueConverter {
     ///   application making any change to these `public` types should be backward compatible, otherwise it will be a
     ///   breaking change.
     public static func fromJSON(_ value: String) throws -> Any? {
-        guard let data = value.data(using: .utf8) else {
-            return nil
-        }
-        return try JSONSerialization.jsonObject(with: data)
+        return try JSONSerialization.jsonObject(with: Data(value.utf8))
     }
 }

--- a/AmplifyFunctionalTests/AmplifyConfigurationInitFromFileTests.swift
+++ b/AmplifyFunctionalTests/AmplifyConfigurationInitFromFileTests.swift
@@ -22,7 +22,7 @@ class AmplifyConfigurationInitFromFileTests: XCTestCase {
         }
         """
 
-        let configData = configString.data(using: .utf8)!
+        let configData = Data(configString.utf8)
         let configURL = FileManager
             .default
             .temporaryDirectory

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/AuthenticationTokenAuthInterceptor.swift
@@ -55,8 +55,8 @@ class AuthenticationTokenAuthInterceptor: AuthInterceptorAsync {
         let authHeader = TokenAuthHeader(token: authToken, host: host)
         let base64Auth = AppSyncJSONHelper.base64AuthenticationBlob(authHeader)
 
-        let payloadData = SubscriptionConstants.emptyPayload.data(using: .utf8)
-        let payloadBase64 = payloadData?.base64EncodedString()
+        let payloadData = Data(SubscriptionConstants.emptyPayload.utf8)
+        let payloadBase64 = payloadData.base64EncodedString()
 
         guard var urlComponents = URLComponents(url: request.url, resolvingAgainstBaseURL: false) else {
             return request

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
@@ -54,8 +54,8 @@ class IAMAuthInterceptor: AuthInterceptorAsync {
         }
         let base64Auth = AppSyncJSONHelper.base64AuthenticationBlob(authHeader)
 
-        let payloadData = payloadString.data(using: .utf8)
-        let payloadBase64 = payloadData?.base64EncodedString()
+        let payloadData = Data(payloadString.utf8)
+        let payloadBase64 = payloadData.base64EncodedString()
 
         guard var urlComponents = URLComponents(url: request.url, resolvingAgainstBaseURL: false) else {
             return request
@@ -91,7 +91,7 @@ class IAMAuthInterceptor: AuthInterceptorAsync {
             .withHeader(name: RealtimeProviderConstants.contentEncodingKey, value: RealtimeProviderConstants.iamEncoding)
             .withHeader(name: URLRequestConstants.Header.contentType, value: RealtimeProviderConstants.iamConentType)
             .withHeader(name: URLRequestConstants.Header.host, value: host)
-            .withBody(.data(payload.data(using: .utf8)))
+            .withBody(.data(Data(payload.utf8)))
 
         /// 2. The request is SigV4 signed by using all the available headers on the request. By signing the request, the signature is added to
         /// the request headers as authorization and security token.

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSHTTPURLResponseTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSHTTPURLResponseTests.swift
@@ -11,7 +11,7 @@ import XCTest
 class AWSHTTPURLResponseTests: XCTestCase {
 
     func testAWSHTTPURLResponse() throws {
-        let body = "responseBody".data(using: .utf8)
+        let body = Data("responseBody".utf8)
         let httpResponse = HTTPURLResponse(url: URL(string: "dummyString")!,
                                            statusCode: 200,
                                            httpVersion: "1.1",
@@ -35,7 +35,7 @@ class AWSHTTPURLResponseTests: XCTestCase {
     }
 
     func testAWSHTTPURLResponseNSCoding() {
-        let body = "responseBody".data(using: .utf8)
+        let body = Data("responseBody".utf8)
         let httpResponse = HTTPURLResponse(url: URL(string: "dummyString")!,
                                            statusCode: 200,
                                            httpVersion: "1.1",

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLMutateCombineTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLMutateCombineTests.swift
@@ -16,7 +16,7 @@ class GraphQLMutateCombineTests: OperationTestBase {
 
     func testMutateSucceeds() throws {
         let testJSONData: JSONValue = ["foo": true]
-        let sentData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
+        let sentData = Data(#"{"data": {"foo": true}}"#.utf8)
         try setUpPluginForSingleResponse(sending: sentData, for: .graphQL)
 
         let request = GraphQLRequest(document: testDocument, variables: nil, responseType: JSONValue.self)
@@ -52,7 +52,7 @@ class GraphQLMutateCombineTests: OperationTestBase {
     }
 
     func testMutateHandlesResponseError() throws {
-        let sentData = #"{"data": {"foo": true}, "errors": []}"# .data(using: .utf8)!
+        let sentData = Data(#"{"data": {"foo": true}, "errors": []}"#.utf8)
         try setUpPluginForSingleResponse(sending: sentData, for: .graphQL)
 
         let request = GraphQLRequest(document: testDocument, variables: nil, responseType: JSONValue.self)

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLQueryCombineTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLQueryCombineTests.swift
@@ -16,7 +16,7 @@ class GraphQLQueryCombineTests: OperationTestBase {
 
     func testQuerySucceeds() throws {
         let testJSONData: JSONValue = ["foo": true]
-        let sentData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
+        let sentData = Data(#"{"data": {"foo": true}}"#.utf8)
         try setUpPluginForSingleResponse(sending: sentData, for: .graphQL)
 
         let request = GraphQLRequest(document: testDocument, variables: nil, responseType: JSONValue.self)
@@ -52,7 +52,7 @@ class GraphQLQueryCombineTests: OperationTestBase {
     }
 
     func testQueryHandlesResponseError() throws {
-        let sentData = #"{"data": {"foo": true}, "errors": []}"# .data(using: .utf8)!
+        let sentData = Data(#"{"data": {"foo": true}, "errors": []}"#.utf8)
         try setUpPluginForSingleResponse(sending: sentData, for: .graphQL)
 
         let request = GraphQLRequest(document: testDocument, variables: nil, responseType: JSONValue.self)

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeCombineTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeCombineTests.swift
@@ -72,7 +72,7 @@ class GraphQLSubscribeCombineTests: OperationTestBase {
         receivedDataValueError.isInverted = true
 
         let testJSON: JSONValue = ["foo": true]
-        let testData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
+        let testData = Data(#"{"data": {"foo": true}}"#.utf8)
 
         try await subscribe(expecting: testJSON)
         await fulfillment(of: [onSubscribeInvoked], timeout: 0.05)
@@ -117,7 +117,7 @@ class GraphQLSubscribeCombineTests: OperationTestBase {
     }
 
     func testDecodingError() async throws {
-        let testData = #"{"data": {"foo": true}, "errors": []}"# .data(using: .utf8)!
+        let testData = Data(#"{"data": {"foo": true}, "errors": []}"#.utf8)
         receivedCompletionFailure.isInverted = true
         receivedDataValueSuccess.isInverted = true
 
@@ -134,7 +134,7 @@ class GraphQLSubscribeCombineTests: OperationTestBase {
 
     func testMultipleSuccessValues() async throws {
         let testJSON: JSONValue = ["foo": true]
-        let testData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
+        let testData = Data(#"{"data": {"foo": true}}"#.utf8)
         receivedCompletionFailure.isInverted = true
         receivedDataValueError.isInverted = true
         receivedDataValueSuccess.expectedFulfillmentCount = 2
@@ -152,8 +152,8 @@ class GraphQLSubscribeCombineTests: OperationTestBase {
     }
 
     func testMixedSuccessAndErrorValues() async throws {
-        let successfulTestData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
-        let invalidTestData = #"{"data": {"foo": true}, "errors": []}"# .data(using: .utf8)!
+        let successfulTestData = Data(#"{"data": {"foo": true}}"#.utf8)
+        let invalidTestData = Data(#"{"data": {"foo": true}, "errors": []}"#.utf8)
         receivedCompletionFailure.isInverted = true
         receivedDataValueSuccess.expectedFulfillmentCount = 2
 

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTaskTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTaskTests.swift
@@ -76,7 +76,7 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
         receivedDataValueError.isInverted = true
 
         let testJSON: JSONValue = ["foo": true]
-        let testData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
+        let testData = Data(#"{"data": {"foo": true}}"#.utf8)
 
         try await subscribe(expecting: testJSON)
         await fulfillment(of: [onSubscribeInvoked], timeout: 0.05)
@@ -169,7 +169,7 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
     }
 
     func testDecodingError() async throws {
-        let testData = #"{"data": {"foo": true}, "errors": []}"# .data(using: .utf8)!
+        let testData = Data(#"{"data": {"foo": true}, "errors": []}"#.utf8)
         receivedCompletionFailure.isInverted = true
         receivedDataValueSuccess.isInverted = true
 
@@ -186,7 +186,7 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
 
     func testMultipleSuccessValues() async throws {
         let testJSON: JSONValue = ["foo": true]
-        let testData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
+        let testData = Data(#"{"data": {"foo": true}}"#.utf8)
 
         receivedCompletionFailure.isInverted = true
         receivedDataValueError.isInverted = true
@@ -205,8 +205,8 @@ class GraphQLSubscribeTasksTests: OperationTestBase {
     }
 
     func testMixedSuccessAndErrorValues() async throws {
-        let successfulTestData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
-        let invalidTestData = #"{"data": {"foo": true}, "errors": []}"# .data(using: .utf8)!
+        let successfulTestData = Data(#"{"data": {"foo": true}}"#.utf8)
+        let invalidTestData = Data(#"{"data": {"foo": true}, "errors": []}"#.utf8)
 
         receivedCompletionFailure.isInverted = true
         receivedDataValueSuccess.expectedFulfillmentCount = 2

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTests.swift
@@ -64,7 +64,7 @@ class GraphQLSubscribeTests: OperationTestBase {
     /// - The completion handler is invoked with a normal termination
     func testHappyPath() throws {
         let testJSON: JSONValue = ["foo": true]
-        let testData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
+        let testData = Data(#"{"data": {"foo": true}}"#.utf8)
         receivedCompletionFinish.shouldTrigger = true
         receivedCompletionFailure.shouldTrigger = false
         receivedConnected.shouldTrigger = true
@@ -152,7 +152,7 @@ class GraphQLSubscribeTests: OperationTestBase {
     /// - The value handler is invoked with a disconnection message
     /// - The completion handler is invoked with a normal termination
     func testDecodingError() throws {
-        let testData = #"{"data": {"foo": true}, "errors": []}"# .data(using: .utf8)!
+        let testData = Data(#"{"data": {"foo": true}, "errors": []}"#.utf8)
         receivedCompletionFinish.shouldTrigger = true
         receivedCompletionFailure.shouldTrigger = false
         receivedConnected.shouldTrigger = true
@@ -173,7 +173,7 @@ class GraphQLSubscribeTests: OperationTestBase {
 
     func testMultipleSuccessValues() throws {
         let testJSON: JSONValue = ["foo": true]
-        let testData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
+        let testData = Data(#"{"data": {"foo": true}}"#.utf8)
         receivedCompletionFinish.shouldTrigger = true
         receivedCompletionFailure.shouldTrigger = false
         receivedConnected.shouldTrigger = true
@@ -195,8 +195,8 @@ class GraphQLSubscribeTests: OperationTestBase {
     }
 
     func testMixedSuccessAndErrorValues() throws {
-        let successfulTestData = #"{"data": {"foo": true}}"# .data(using: .utf8)!
-        let invalidTestData = #"{"data": {"foo": true}, "errors": []}"# .data(using: .utf8)!
+        let successfulTestData = Data(#"{"data": {"foo": true}}"#.utf8)
+        let invalidTestData = Data(#"{"data": {"foo": true}, "errors": []}"#.utf8)
         receivedCompletionFinish.shouldTrigger = true
         receivedCompletionFailure.shouldTrigger = false
         receivedConnected.shouldTrigger = true

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ASF/CognitoUserPoolASF.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ASF/CognitoUserPoolASF.swift
@@ -103,9 +103,7 @@ struct CognitoUserPoolASF: AdvancedSecurityBehavior {
         }
         let key = SymmetricKey(data: keyData)
         let content = "\(Self.asfVersion)\(contextJson)"
-        guard let  data = content.data(using: .utf8) else {
-            throw ASFError.hashData
-        }
+        let data = Data(content.utf8)
         let hmac = HMAC<SHA256>.authenticationCode(for: data, using: key)
         let hmacData = Data(hmac)
         return hmacData.base64EncodedString()
@@ -121,9 +119,7 @@ struct CognitoUserPoolASF: AdvancedSecurityBehavior {
         guard let jsonString = String(data: jsonData, encoding: .utf8) else {
             throw ASFError.stringConversion
         }
-        guard let data = jsonString.data(using: .utf8) else {
-            throw ASFError.dataConversion
-        }
+        let data = Data(jsonString.utf8)
         return data.base64EncodedString()
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/VerifyDevicePasswordSRP+Calculations.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/VerifyDevicePasswordSRP+Calculations.swift
@@ -86,10 +86,10 @@ extension VerifyDevicePasswordSRP {
                            serviceSecretBlock: Data) -> Data {
         let key = SymmetricKey(data: authenticationKey)
         var hmac = HMAC<SHA256>.init(key: key)
-        hmac.update(data: deviceGroupKey.data(using: .utf8)!)
-        hmac.update(data: deviceKey.data(using: .utf8)!)
+        hmac.update(data: Data(deviceGroupKey.utf8))
+        hmac.update(data: Data(deviceKey.utf8))
         hmac.update(data: serviceSecretBlock)
-        hmac.update(data: srpTimeStamp.data(using: .utf8)!)
+        hmac.update(data: Data(srpTimeStamp.utf8))
         return Data(hmac.finalize())
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/VerifyPasswordSRP+Calculations.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/VerifyPasswordSRP+Calculations.swift
@@ -93,10 +93,10 @@ extension VerifyPasswordSRP {
                            serviceSecretBlock: Data) -> Data {
         let key = SymmetricKey(data: authenticationKey)
         var hmac = HMAC<SHA256>.init(key: key)
-        hmac.update(data: poolName.data(using: .utf8)!)
-        hmac.update(data: srpUserName.data(using: .utf8)!)
+        hmac.update(data: Data(poolName.utf8))
+        hmac.update(data: Data(srpUserName.utf8))
         hmac.update(data: serviceSecretBlock)
-        hmac.update(data: srpTimeStamp.data(using: .utf8)!)
+        hmac.update(data: Data(srpTimeStamp.utf8))
         return Data(hmac.finalize())
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/RespondToAuthChallenge.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/RespondToAuthChallenge.swift
@@ -49,20 +49,15 @@ extension RespondToAuthChallenge {
 
     /// Helper method to extract MFA types from parameters
     private func getMFATypes(forKey key: String) -> Set<MFAType> {
-        var mfaTypes = Set<MFAType>()
-        guard let mfaTypeParametersData = parameters?[key]?.data(using: .utf8),
+        guard let mfaTypeParameters = parameters?[key],
               let mfaTypesArray = try? JSONDecoder().decode(
-                [String].self, from: mfaTypeParametersData) else {
-            return mfaTypes
-        }
+                [String].self,
+                from: Data(mfaTypeParameters.utf8)
+              ) 
+        else { return .init() }
 
-        for mfaTypeValue in mfaTypesArray {
-            if let mfaType = MFAType(rawValue: String(mfaTypeValue)) {
-                mfaTypes.insert(mfaType)
-            }
-        }
-
-        return mfaTypes
+        let mfaTypes = mfaTypesArray.compactMap(MFAType.init(rawValue:))
+        return Set(mfaTypes)
     }
 
     var debugDictionary: [String: Any] {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ClientSecretHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ClientSecretHelper.swift
@@ -31,11 +31,11 @@ enum ClientSecretHelper {
         userPoolClientId: String,
         clientSecret: String
     ) -> String {
-        let clientSecretData = clientSecret.data(using: .utf8)!
+        let clientSecretData = Data(clientSecret.utf8)
         let clientSecretByteArray = [UInt8](clientSecretData)
         let key = SymmetricKey(data: clientSecretByteArray)
 
-        let clientData = (username + userPoolClientId).data(using: .utf8)!
+        let clientData = Data((username + userPoolClientId).utf8)
 
         let mac = HMAC<SHA256>.authenticationCode(for: clientData, using: key)
         let macBase64 = Data(mac).base64EncodedString()

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUIRequestHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUIRequestHelper.swift
@@ -115,7 +115,7 @@ struct HostedUIRequestHelper {
 
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
-        urlRequest.httpBody = body.data(using: .utf8)
+        urlRequest.httpBody = Data(body.utf8)
         urlRequest.addHeaders(using: configuration)
         return urlRequest
     }
@@ -145,7 +145,7 @@ struct HostedUIRequestHelper {
 
             var urlRequest = URLRequest(url: url)
             urlRequest.httpMethod = "POST"
-            urlRequest.httpBody = body.data(using: .utf8)
+            urlRequest.httpBody = Data(body.utf8)
             urlRequest.addHeaders(using: configuration)
             return urlRequest
         }
@@ -159,11 +159,10 @@ struct HostedUIRequestHelper {
 
 private extension URLRequest {
     mutating func addHeaders(using configuration: HostedUIConfigurationData) {
-        guard let clientSecret = configuration.clientSecret,
-              let value = "\(configuration.clientId):\(clientSecret)".data(using: .utf8) else {
+        guard let clientSecret = configuration.clientSecret else {
             return
         }
-
+        let value = Data("\(configuration.clientId):\(clientSecret)".utf8)
         setValue("Basic \(value.base64EncodedString())", forHTTPHeaderField: "Authorization")
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AmplifySRP/HKDF.swift
+++ b/AmplifyPlugins/Auth/Sources/AmplifySRP/HKDF.swift
@@ -23,7 +23,7 @@ public enum HMACKeyDerivationFunction {
                                 outputLength: outputLength)
         } else {
             let pseudoRandomKey = extractPseudoRandomKey(salt: salt, inputKeyMaterial: keyingMaterial)
-            return expand(pseudoRandomKey: pseudoRandomKey, info: info?.data(using: .utf8), outputLength: outputLength)
+            return expand(pseudoRandomKey: pseudoRandomKey, info: info.map { Data($0.utf8) }, outputLength: outputLength)
         }
     }
 
@@ -34,11 +34,10 @@ public enum HMACKeyDerivationFunction {
                              outputLength: Int) -> Data {
         let key = SymmetricKey(data: keyingMaterial)
         var hkdf: SymmetricKey
-        if let infoData = info?.data(using: .utf8) {
+        if let info {
             hkdf = HKDF<SHA256>.deriveKey(inputKeyMaterial: key,
-                                          salt: salt, info: infoData,
+                                          salt: salt, info: Data(info.utf8),
                                           outputByteCount: outputLength)
-
         } else {
             hkdf = HKDF<SHA256>.deriveKey(inputKeyMaterial: key,
                                           salt: salt,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MockCredentialStoreBehavior.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MockCredentialStoreBehavior.swift
@@ -28,7 +28,7 @@ class MockKeychainStoreBehavior: KeychainStoreBehavior {
     }
 
     func _getData(_ key: String) throws -> Data {
-        return data.data(using: .utf8)!
+        return Data(data.utf8)
     }
 
     func _set(_ value: String, key: String) throws { }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyDevicePasswordSRPSignatureTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyDevicePasswordSRPSignatureTests.swift
@@ -119,7 +119,7 @@ class VerifyDevicePasswordSRPSignatureTests: XCTestCase {
             deviceKey: "deviceKey",
             deviceSecret: "deviceSecret",
             saltHex: "saltHex",
-            secretBlock: "secretBlock".data(using: .utf8) ?? Data(),
+            secretBlock: Data("secretBlock".utf8),
             serverPublicBHexString: "serverPublicBHexString",
             srpClient: srpClient
         )
@@ -136,7 +136,7 @@ private class MockSRPClientBehavior: SRPClientBehavior {
         return "UHexValue"
     }
 
-    static var authenticationKey: Result<Data, Error> = .success("AuthenticationKey".data(using: .utf8)!)
+    static var authenticationKey: Result<Data, Error> = .success(Data("AuthenticationKey".utf8))
     static func generateAuthenticationKey(
         sharedSecretHexValue: String,
         uHexValue: String
@@ -145,7 +145,7 @@ private class MockSRPClientBehavior: SRPClientBehavior {
     }
     
     static func reset() {
-        authenticationKey = .success("AuthenticationKey".data(using: .utf8)!)
+        authenticationKey = .success(Data("AuthenticationKey".utf8))
     }
     
     func generateClientKeyPair() -> SRPKeys {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/DefaultConfig.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/DefaultConfig.swift
@@ -382,7 +382,7 @@ struct MockASF: AdvancedSecurityBehavior {
 extension AmplifyConfiguration {
 
     static func testData() -> AmplifyConfiguration {
-        return try! AmplifyConfiguration.decodeAmplifyConfiguration(from: json.data(using: .utf8)!)
+        return try! AmplifyConfiguration.decodeAmplifyConfiguration(from: Data(json.utf8))
     }
 
     static let json: String = """

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/HostedUIRequestHelperTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/HostedUIRequestHelperTests.swift
@@ -36,11 +36,10 @@ class HostedUIRequestHelperTests: XCTestCase {
     }
 
     private var encodedSecret: String? {
-        guard let clientSecret = configuration.clientSecret,
-              let value = "\(configuration.clientId):\(clientSecret)".data(using: .utf8) else {
+        guard let clientSecret = configuration.clientSecret else {
             return nil
         }
-
+        let value = Data("\(configuration.clientId):\(clientSecret)".utf8)
         return value.base64EncodedString()
     }
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
@@ -58,8 +58,8 @@ public struct GraphQLFilterConverter {
 
     /// Deserialize the JSON string converted with `GraphQLFilterConverter.toJSON()` to `GraphQLFilter`
     public static func fromJSON(_ value: String) throws -> GraphQLFilter {
-        guard let data = value.data(using: .utf8),
-            let filter = try JSONSerialization.jsonObject(with: data) as? GraphQLFilter else {
+        let data = Data(value.utf8)
+        guard let filter = try JSONSerialization.jsonObject(with: data) as? GraphQLFilter else {
             return Fatal.preconditionFailure("Could not serialize to GraphQLFilter from: \(self))")
         }
 

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/MutationSync/MutationSyncMetadataTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/MutationSync/MutationSyncMetadataTests.swift
@@ -47,11 +47,7 @@ class MutationSyncMetadataTests: XCTestCase {
     func testDecodeMutationSync() {
         do {
             let decoder = JSONDecoder(dateDecodingStrategy: ModelDateFormatting.decodingStrategy)
-
-            guard let data = postSyncJSON.data(using: .utf8) else {
-                XCTFail("JSON could not be converted into data")
-                return
-            }
+            let data = Data(postSyncJSON.utf8)
             let mutationSync = try decoder.decode(MutationSync<Post>.self, from: data)
             let model = mutationSync.model
             XCTAssertEqual(model.id, "post-id")
@@ -75,11 +71,7 @@ class MutationSyncMetadataTests: XCTestCase {
     func testDecodeAnyModelMutationSync() {
         do {
             let decoder = JSONDecoder(dateDecodingStrategy: ModelDateFormatting.decodingStrategy)
-
-            guard let data = postSyncJSON.data(using: .utf8) else {
-                XCTFail("JSON could not be converted into data")
-                return
-            }
+            let data = Data(postSyncJSON.utf8)
             let mutationSync = try decoder.decode(MutationSync<AnyModel>.self, from: data)
             let model = mutationSync.model
             XCTAssertEqual(model.id, "post-id")

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/PaginatedListTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/PaginatedListTests.swift
@@ -63,11 +63,7 @@ class PaginatedListTests: XCTestCase {
     func testDecodePaginatedList() {
         do {
             let decoder = JSONDecoder(dateDecodingStrategy: ModelDateFormatting.decodingStrategy)
-
-            guard let data = syncQueryJSON.data(using: .utf8) else {
-                XCTFail("JSON could not be converted into data")
-                return
-            }
+            let data = Data(syncQueryJSON.utf8)
             let paginatedList = try decoder.decode(PaginatedList<Post>.self, from: data)
             XCTAssertNotNil(paginatedList)
             XCTAssertNotNil(paginatedList.startedAt)
@@ -85,11 +81,7 @@ class PaginatedListTests: XCTestCase {
     func testDecodePaginatedListFromEmptyItems() {
         do {
             let decoder = JSONDecoder(dateDecodingStrategy: ModelDateFormatting.decodingStrategy)
-
-            guard let data = emptyItemsSyncQueryJSON.data(using: .utf8) else {
-                XCTFail("JSON could not be converted into data")
-                return
-            }
+            let data = Data(emptyItemsSyncQueryJSON.utf8)
             let paginatedList = try decoder.decode(PaginatedList<Post>.self, from: data)
             XCTAssertNotNil(paginatedList)
             XCTAssertNotNil(paginatedList.startedAt)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -1220,9 +1220,7 @@ extension ProcessMutationErrorFromCloudOperationTests {
                                          version: Int = 1,
                                          errorType: AppSyncErrorType? = .conflictUnhandled)
         throws -> GraphQLResponseError<MutationSync<AnyModel>>? {
-        guard let data = try post.toJSON().data(using: .utf8) else {
-            return nil
-        }
+        let data = Data(try post.toJSON().utf8)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = ModelDateFormatting.decodingStrategy
         let remoteData = try decoder.decode(JSONValue.self, from: data)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SerializedModelWrappers/Comment3Wrapper.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SerializedModelWrappers/Comment3Wrapper.swift
@@ -35,7 +35,7 @@ class Comment3Wrapper: NSCopying {
     }
 
     init(json: String) throws {
-        let data = json.data(using: .utf8)!
+        let data = Data(json.utf8)
         let map = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
         self.model = FlutterSerializedModel(id: map!["id"] as! String, map: try FlutterDataStoreRequestUtils.getJSONValue(map!))
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SerializedModelWrappers/Comment4Wrapper.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SerializedModelWrappers/Comment4Wrapper.swift
@@ -26,7 +26,7 @@ class Comment4Wrapper: NSCopying {
     }
 
     init(json: String) throws {
-        let data = json.data(using: .utf8)!
+        let data = Data(json.utf8)
         let map = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
         self.model = FlutterSerializedModel(id: map!["id"] as! String, map: try FlutterDataStoreRequestUtils.getJSONValue(map!))
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SerializedModelWrappers/Post3Wrapper.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SerializedModelWrappers/Post3Wrapper.swift
@@ -38,7 +38,7 @@ class Post3Wrapper: NSCopying {
     }
 
     init(json: String) throws {
-        let data = json.data(using: .utf8)!
+        let data = Data(json.utf8)
         let map = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
         self.model = FlutterSerializedModel(id: map!["id"] as! String, map: try FlutterDataStoreRequestUtils.getJSONValue(map!))
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SerializedModelWrappers/Post4Wrapper.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SerializedModelWrappers/Post4Wrapper.swift
@@ -39,7 +39,7 @@ class Post4Wrapper: NSCopying {
     }
 
     init(json: String) throws {
-        let data = json.data(using: .utf8)!
+        let data = Data(json.utf8)
         let map = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
         self.model = FlutterSerializedModel(id: map!["id"] as! String, map: try FlutterDataStoreRequestUtils.getJSONValue(map!))
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SerializedModelWrappers/Post5Wrapper.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SerializedModelWrappers/Post5Wrapper.swift
@@ -29,7 +29,7 @@ class Post5Wrapper: NSCopying {
     }
 
     init(json: String) throws {
-        let data = json.data(using: .utf8)!
+        let data = Data(json.utf8)
         let map = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
         self.model = FlutterSerializedModel(id: map!["id"] as! String, map: try FlutterDataStoreRequestUtils.getJSONValue(map!))
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SerializedModelWrappers/Post6Wrapper.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SerializedModelWrappers/Post6Wrapper.swift
@@ -30,7 +30,7 @@ class Post6Wrapper: NSCopying {
     }
 
     init(json: String) throws {
-        let data = json.data(using: .utf8)!
+        let data = Data(json.utf8)
         let map = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
         self.model = FlutterSerializedModel(id: map!["id"] as! String, map: try FlutterDataStoreRequestUtils.getJSONValue(map!))
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SerializedModelWrappers/PostWrapper.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SerializedModelWrappers/PostWrapper.swift
@@ -32,7 +32,7 @@ class PostWrapper: NSCopying {
     }
 
     init(json: String) throws {
-        let data = json.data(using: .utf8)!
+        let data = Data(json.utf8)
         let map = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
         self.model = FlutterSerializedModel(id: map!["id"] as! String, map: try FlutterDataStoreRequestUtils.getJSONValue(map!))
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/TestFlutterModelRegistration.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/TestFlutterModelRegistration.swift
@@ -17,7 +17,7 @@ struct TestFlutterModelRegistration: AmplifyModelRegistration {
             resolvedDecoder = JSONDecoder(dateDecodingStrategy: ModelDateFormatting.decodingStrategy)
         }
         // Convert jsonstring to object
-        let data = jsonString.data(using: .utf8)!
+        let data = Data(jsonString.utf8)
         let jsonValue = try resolvedDecoder.decode(JSONValue.self, from: data)
         if case .array(let jsonArray) = jsonValue,
            case .object(let jsonObj) = jsonArray[0],

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AwsPinpointAnalyticsKeychainMigrationTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AwsPinpointAnalyticsKeychainMigrationTests.swift
@@ -33,7 +33,7 @@ class AWSPinpointAnalyticsKeyValueStoreTests: XCTestCase {
 
     func testDeviceTokenMigrateFromUserDefaultsToKeychain() {
         let deviceToken = "000102030405060708090a0b0c0d0e0f"
-        let deviceTokenData = deviceToken.data(using: .utf8)
+        let deviceTokenData = Data(deviceToken.utf8)
         userDefaults.setValue(deviceTokenData, forKey: EndpointClient.Constants.deviceTokenKey)
         
         var currentKeychainDeviceToken = try? self.keychain._getData(EndpointClient.Constants.deviceTokenKey)

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EndpointClientTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EndpointClientTests.swift
@@ -56,10 +56,10 @@ class EndpointClientTests: XCTestCase {
                                                             endpointId: "oldEndpoint",
                                                             deviceToken: "oldToken",
                                                             demographic: oldDemographic)
-        let newToken = "newToken".data(using: .utf8)
+        let newToken = Data("newToken".utf8)
         do {
             try keychain._set(Data(), key: EndpointClient.Constants.endpointProfileKey)
-            try keychain._set(newToken!, key: EndpointClient.Constants.deviceTokenKey)
+            try keychain._set(newToken, key: EndpointClient.Constants.deviceTokenKey)
         } catch {
             XCTFail("Fail to setup test data")
         }
@@ -78,7 +78,7 @@ class EndpointClientTests: XCTestCase {
         XCTAssertTrue(endpointProfile === storedEndpointProfile, "Expected stored PinpointEndpointProfile object")
         XCTAssertEqual(endpointProfile.applicationId, currentApplicationId)
         XCTAssertEqual(endpointProfile.endpointId, currentEndpointId)
-        XCTAssertEqual(endpointProfile.deviceToken, newToken?.asHexString())
+        XCTAssertEqual(endpointProfile.deviceToken, newToken.asHexString())
         XCTAssertNotEqual(endpointProfile.demographic, oldDemographic)
         XCTAssertEqual(endpointProfile.demographic.appVersion, endpointInformation.appVersion)
         XCTAssertEqual(endpointProfile.demographic.make, "apple")
@@ -198,9 +198,9 @@ class EndpointClientTests: XCTestCase {
 
     @discardableResult
     private func storeToken(_ deviceToken: String) -> Data? {
-        let newToken = Data(hexString: deviceToken) ?? deviceToken.data(using: .utf8)
+        let newToken = Data(hexString: deviceToken) ?? Data(deviceToken.utf8)
         do {
-            try keychain._set(newToken!, key: EndpointClient.Constants.deviceTokenKey)
+            try keychain._set(newToken, key: EndpointClient.Constants.deviceTokenKey)
         } catch {
             XCTFail("Fail to setup test data")
         }

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSession.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSession.swift
@@ -68,10 +68,7 @@ final class AWSCloudWatchLoggingSession {
             return "guest"
         }
 
-        guard let userIdentifierData = userIdentifier.data(using: .utf8) else {
-            throw AWSCloudWatchLoggingError.sessionInternalErrorForUserId
-        }
-
+        let userIdentifierData = Data(userIdentifier.utf8)
         var hash = SHA256()
         hash.update(data: userIdentifierData)
 

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Persistence/LogEntryCodec.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Persistence/LogEntryCodec.swift
@@ -35,9 +35,7 @@ struct LogEntryCodec {
     
     func decode(string: String) throws -> LogEntry? {
         let trimmed = string.trim()
-        guard let data = trimmed.data(using: .utf8) else {
-            throw DecodingError.stringNotUtf8(string)
-        }
+        let data = Data(trimmed.utf8)
         return try decode(data: data)
     }
     

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogEntryTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogEntryTests.swift
@@ -63,7 +63,7 @@ final class LogEntryTests: XCTestCase {
             "message": "\(message)"
         }
         """
-        let encoded = try XCTUnwrap(json.data(using: .utf8))
+        let encoded = Data(json.utf8)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .millisecondsSince1970
         let decoded = try decoder.decode(LogEntry.self, from: encoded)

--- a/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginClientBehaviourTests.swift
+++ b/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginClientBehaviourTests.swift
@@ -135,7 +135,7 @@ class AWSPinpointPushNotificationsPluginClientBehaviourTests: AWSPinpointPushNot
     
     // MARK: - Register Device tests
     func testRegisterDevice_shouldUpdateDeviceToken() async throws {
-        let apnsToken = "apnsToken".data(using: .utf8)!
+        let apnsToken = Data("apnsToken".utf8)
         try await plugin.registerDevice(apnsToken: apnsToken)
         
         XCTAssertEqual(mockPinpoint.currentEndpointProfileCount, 1)

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
@@ -20,7 +20,7 @@ class PredictionsPluginConfigurationTests: XCTestCase {
     ///    - I should get a valid configuration object
     ///
     func testConfiguration() {
-        let inputJsonData = """
+        let inputJsonData = Data("""
         {
         "defaultRegion": "us-west-2",
         "convert": {
@@ -65,7 +65,7 @@ class PredictionsPluginConfigurationTests: XCTestCase {
             }
         }
         }
-        """.data(using: .utf8)!
+        """.utf8)
         do {
             let configuration = try JSONDecoder().decode(PredictionsPluginConfiguration.self, from: inputJsonData)
             XCTAssertNotNil(configuration, "Configuration should not be nil")
@@ -89,7 +89,7 @@ class PredictionsPluginConfigurationTests: XCTestCase {
     ///    - I should get a valid configuration object
     ///
     func testConfigurationWithOnlyConvert() {
-        let inputJsonData = """
+        let inputJsonData = Data("""
         {
         "defaultRegion": "us-west-2",
         "convert": {
@@ -109,7 +109,7 @@ class PredictionsPluginConfigurationTests: XCTestCase {
             }
         }
         }
-        """.data(using: .utf8)!
+        """.utf8)
         do {
             let configuration = try JSONDecoder().decode(PredictionsPluginConfiguration.self, from: inputJsonData)
             XCTAssertNotNil(configuration, "Configuration should not be nil")
@@ -127,7 +127,7 @@ class PredictionsPluginConfigurationTests: XCTestCase {
     ///    - I should get an error
     ///
     func testNoRegionUnderSubsection() {
-        let inputJsonData = """
+        let inputJsonData = Data("""
         {
         "defaultRegion": "us-west-2",
         "convert": {
@@ -137,7 +137,7 @@ class PredictionsPluginConfigurationTests: XCTestCase {
             }
         }
         }
-        """.data(using: .utf8)!
+        """.utf8)
         do {
             _ = try JSONDecoder().decode(PredictionsPluginConfiguration.self, from: inputJsonData)
             XCTFail("Should throw an error because region is not present")
@@ -155,11 +155,11 @@ class PredictionsPluginConfigurationTests: XCTestCase {
     ///    - I should get a valid configuration object
     ///
     func testConfigurationWithNoSubsections() {
-        let inputJsonData = """
+        let inputJsonData = Data("""
         {
         "defaultRegion": "us-west-2"
         }
-        """.data(using: .utf8)!
+        """.utf8)
         do {
             let configuration = try JSONDecoder().decode(PredictionsPluginConfiguration.self, from: inputJsonData)
             XCTAssertNotNil(configuration, "Configuration should not be nil")

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginAsyncBehaviorTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginAsyncBehaviorTests.swift
@@ -48,7 +48,7 @@ class AWSS3StoragePluginAsyncBehaviorTests: XCTestCase {
     }
 
     func testPluginDownloadDataAsync() async throws {
-        let input = "AWS".data(using: .utf8)!
+        let input = Data("AWS".utf8)
         storageService.storageServiceDownloadEvents = [.completed(input)]
 
         let task = storagePlugin.downloadData(key: testKey, options: nil)

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StoragePutDataOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StoragePutDataOperationTests.swift
@@ -177,7 +177,7 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
         for _ in 1 ... 20 {
             testLargeDataString += testLargeDataString
         }
-        let testLargeData = testLargeDataString.data(using: .utf8)!
+        let testLargeData = Data(testLargeDataString.utf8)
         XCTAssertTrue(testLargeData.count > StorageUploadDataRequest.Options.multiPartUploadSizeThreshold,
                       "Could not create data object greater than MultiPartUploadSizeThreshold")
         let expectedUploadSource = UploadSource.data(testLargeData)

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceTests.swift
@@ -338,7 +338,7 @@ class AWSS3StorageServiceTests: XCTestCase {
     /// When: upload is invoked
     /// Then: A .failed event is dispatched with an .unknown error
     func testUpload_withoutPreSignedURL_shouldSendFailEvent() {
-        let data = "someData".data(using: .utf8)!
+        let data = Data("someData".utf8)
         let expectation = self.expectation(description: "Upload")
         service.upload(
             serviceKey: "key",
@@ -364,7 +364,7 @@ class AWSS3StorageServiceTests: XCTestCase {
     /// When: upload is invoked
     /// Then: An .initiated event is dispatched
     func testUpload_withPreSignedURL_shouldSendInitiatedEvent() {
-        let data = "someData".data(using: .utf8)!
+        let data = Data("someData".utf8)
         let expectation = self.expectation(description: "Upload")
         service.preSignedURLBuilder = MockAWSS3PreSignedURLBuilder()
         service.upload(

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileHandleTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileHandleTests.swift
@@ -15,7 +15,7 @@ class FileHandleTests: XCTestCase {
     /// Then: Only `bytesReadLimit` bytes will be read at a time, but all `bytes` will be read and returned
     func testRead_withBytesHigherThanLimit_shouldSucceedByReadingMultipleTimes() throws {
         let sourceString = "012345678910" // 11 bytes
-        let sourceData = sourceString.data(using: .utf8)!
+        let sourceData = Data(sourceString.utf8)
         let sourceFile = try createFile(from: sourceData)
         XCTAssertEqual(try StorageRequestUtils.getSize(sourceFile), UInt64(sourceString.count))
         

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileSystemTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileSystemTests.swift
@@ -166,10 +166,7 @@ class FileSystemTests: XCTestCase {
 
         let fs = FileSystem()
 
-        guard let data = string.data(using: .utf8) else {
-            XCTFail("Failed to create data for file")
-            return
-        }
+        let data = Data(string.utf8)
         let fileURL = try fs.createTemporaryFile(data: data)
         defer {
             fs.removeFileIfExists(fileURL: fileURL)

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageMultipartUploadSessionTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageMultipartUploadSessionTests.swift
@@ -332,11 +332,7 @@ class StorageMultipartUploadSessionTests: XCTestCase {
         ]
         let string = parts.joined()
 
-        guard let data = string.data(using: .utf8) else {
-            XCTFail("Failed to create data for file")
-            throw Failure.unableToCreateData
-        }
-
+        let data = Data(string.utf8)
         let fileURL = try FileSystem.default.createTemporaryFile(data: data)
         return fileURL
     }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageTransferTaskTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageTransferTaskTests.swift
@@ -448,8 +448,8 @@ class StorageTransferTaskTests: XCTestCase {
             sessionTask: nil,
             proxyStorageTask: nil
         )
-        task.responseData = "Test".data(using: .utf8)
-        
+        task.responseData = Data("Test".utf8)
+
         XCTAssertEqual(task.responseText, "Test")
     }
     

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsGetterTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsGetterTests.swift
@@ -73,7 +73,7 @@ class StorageRequestUtilsGetterTests: XCTestCase {
         let key = "testGetSizeForFileUploadSourceReturnsSize"
         let filePath = NSTemporaryDirectory() + key + ".tmp"
         let fileURL = URL(fileURLWithPath: filePath)
-        FileManager.default.createFile(atPath: filePath, contents: key.data(using: .utf8), attributes: nil)
+        FileManager.default.createFile(atPath: filePath, contents: Data(key.utf8), attributes: nil)
         let result = try StorageRequestUtils.getSize(fileURL)
         XCTAssertNotNil(result)
     }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsValidatorTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsValidatorTests.swift
@@ -111,7 +111,7 @@ class StorageRequestUtilsValidatorTests: XCTestCase {
         let key = "testValidateFileExistsForUrlSuccess"
         let filePath = NSTemporaryDirectory() + key + ".tmp"
         let fileURL = URL(fileURLWithPath: filePath)
-        FileManager.default.createFile(atPath: filePath, contents: key.data(using: .utf8), attributes: nil)
+        FileManager.default.createFile(atPath: filePath, contents: Data(key.utf8), attributes: nil)
 
         let result = StorageRequestUtils.validateFileExists(fileURL)
         XCTAssertNil(result)

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginAccelerateIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginAccelerateIntegrationTests.swift
@@ -21,7 +21,7 @@ class AWSS3StoragePluginAccelerateIntegrationTests: AWSS3StoragePluginTestBase {
     /// Then: The operation completes successfully.
     func testUploadDataWithAccelerateDisabledExplicitly() async throws {
         let key = UUID().uuidString
-        let data = try XCTUnwrap(key.data(using: .utf8))
+        let data = Data(key.utf8)
         let task = Amplify.Storage.uploadData(key: key,
                                               data: data,
                                               options: .init(pluginOptions:["useAccelerateEndpoint": useAccelerateEndpoint]))
@@ -34,7 +34,7 @@ class AWSS3StoragePluginAccelerateIntegrationTests: AWSS3StoragePluginTestBase {
     /// Then: The operation fails.
     func testUploadDataWithAccelerateDisabledExplicitlyToWrongType() async throws {
         let key = UUID().uuidString
-        let data = try XCTUnwrap(key.data(using: .utf8))
+        let data = Data(key.utf8)
         do {
             let task = Amplify.Storage.uploadData(key: key,
                                                   data: data,
@@ -55,7 +55,7 @@ class AWSS3StoragePluginAccelerateIntegrationTests: AWSS3StoragePluginTestBase {
         let filePath = NSTemporaryDirectory() + key + ".tmp"
 
         let fileURL = URL(fileURLWithPath: filePath)
-        FileManager.default.createFile(atPath: filePath, contents: key.data(using: .utf8), attributes: nil)
+        FileManager.default.createFile(atPath: filePath, contents: Data(key.utf8), attributes: nil)
         defer {
             try? FileManager.default.removeItem(at: fileURL)
         }
@@ -84,7 +84,7 @@ class AWSS3StoragePluginAccelerateIntegrationTests: AWSS3StoragePluginTestBase {
     /// Then: The operation completes successfully with the data retrieved.
     func testDownloadDataToMemory() async throws {
         let key = UUID().uuidString
-        let data = try XCTUnwrap(key.data(using: .utf8))
+        let data = Data(key.utf8)
         let uploadTask = Amplify.Storage.uploadData(key: key,
                                                     data: data,
                                                     options: .init(pluginOptions:["useAccelerateEndpoint": useAccelerateEndpoint]))

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginAccessLevelTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginAccessLevelTests.swift
@@ -66,11 +66,7 @@ class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase {
         }
 
         let key = UUID().uuidString
-        guard let dataInput = UUID().uuidString.data(using: .utf8) else {
-            XCTFail("Failed to create test data")
-            return
-        }
-
+        let dataInput = Data(UUID().uuidString.utf8)
         do {
             logger.debug("Upload [\(accessLevel)]")
             let uploadDataOptions = StorageUploadDataRequest.Options(accessLevel: accessLevel)
@@ -122,10 +118,7 @@ class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase {
             logger.debug("Testing storage access level: \(accessLevel)")
 
             let key = UUID().uuidString
-            guard let dataInput = UUID().uuidString.data(using: .utf8) else {
-                XCTFail("Failed to create test data")
-                return
-            }
+            let dataInput = Data(UUID().uuidString.utf8)
             logger.debug("Upload [\(accessLevel)]")
             let uploadDataOptions = StorageUploadDataRequest.Options(accessLevel: accessLevel)
             let uploadKey = try await Amplify.Storage.uploadData(key: key, data: dataInput, options: uploadDataOptions).value
@@ -190,7 +183,7 @@ class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase {
 
                     logger.debug("Uploading as user1 with \(testRun.accessLevel) access level")
                     let options = StorageUploadDataRequest.Options(accessLevel: testRun.accessLevel)
-                    _ = try await Amplify.Storage.uploadData(key: testRun.key, data: testRun.key.data(using: .utf8)!, options: options).value
+                    _ = try await Amplify.Storage.uploadData(key: testRun.key, data: Data(testRun.key.utf8), options: options).value
 
                     logger.debug("Getting list as user1")
                     let listOptions1 = StorageListRequest.Options(accessLevel: testRun.accessLevel,

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginBasicIntegrationTests.swift
@@ -61,7 +61,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Then: The operation completes successfully
     func testUploadData() async throws {
         let key = UUID().uuidString
-        let data = key.data(using: .utf8)!
+        let data = Data(key.utf8)
 
         _ = try await Amplify.Storage.uploadData(key: key, data: data, options: nil).value
         _ = try await Amplify.Storage.remove(key: key)
@@ -79,7 +79,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Then: The operation completes successfully
     func testUploadEmptyData() async throws {
         let key = UUID().uuidString
-        let data = "".data(using: .utf8)!
+        let data = Data("".utf8)
         _ = try await Amplify.Storage.uploadData(key: key, data: data, options: nil).value
         _ = try await Amplify.Storage.remove(key: key)
 
@@ -95,7 +95,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
         let filePath = NSTemporaryDirectory() + key + ".tmp"
 
         let fileURL = URL(fileURLWithPath: filePath)
-        FileManager.default.createFile(atPath: filePath, contents: key.data(using: .utf8), attributes: nil)
+        FileManager.default.createFile(atPath: filePath, contents: Data(key.utf8), attributes: nil)
 
         _ = try await Amplify.Storage.uploadFile(key: key, local: fileURL, options: nil).value
         _ = try await Amplify.Storage.remove(key: key)
@@ -115,7 +115,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
         let key = UUID().uuidString
         let filePath = NSTemporaryDirectory() + key + ".tmp"
         let fileURL = URL(fileURLWithPath: filePath)
-        FileManager.default.createFile(atPath: filePath, contents: "".data(using: .utf8), attributes: nil)
+        FileManager.default.createFile(atPath: filePath, contents: Data("".utf8), attributes: nil)
 
         _ = try await Amplify.Storage.uploadFile(key: key, local: fileURL, options: nil).value
         _ = try await Amplify.Storage.remove(key: key)
@@ -173,7 +173,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     /// Then: The operation completes successfully with the data retrieved
     func testDownloadDataToMemory() async throws {
         let key = UUID().uuidString
-        try await uploadData(key: key, data: key.data(using: .utf8)!)
+        try await uploadData(key: key, data: Data(key.utf8))
         _ = try await Amplify.Storage.downloadData(key: key, options: .init()).value
         _ = try await Amplify.Storage.remove(key: key)
     }
@@ -184,7 +184,7 @@ class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
     func testDownloadFile() async throws {
         let key = UUID().uuidString
         let timestamp = String(Date().timeIntervalSince1970)
-        let timestampData = timestamp.data(using: .utf8)!
+        let timestampData = Data(timestamp.utf8)
         try await uploadData(key: key, data: timestampData)
         let filePath = NSTemporaryDirectory() + key + ".tmp"
         let fileURL = URL(fileURLWithPath: filePath)

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginPrefixKeyResolverTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginPrefixKeyResolverTests.swift
@@ -48,7 +48,7 @@ class AWSS3StoragePluginKeyResolverTests: AWSS3StoragePluginTestBase {
     ///
     func testUploadListDownload() async throws {
         let key = UUID().uuidString
-        let data = key.data(using: .utf8)!
+        let data = Data(key.utf8)
         let uploadCompleted = expectation(description: "upload completed")
         Task {
             do {
@@ -88,7 +88,7 @@ class AWSS3StoragePluginKeyResolverTests: AWSS3StoragePluginTestBase {
     ///
     func testUploadRemoveDownload() async {
         let key = UUID().uuidString
-        let data = key.data(using: .utf8)!
+        let data = Data(key.utf8)
         let done = expectation(description: "done")
 
         Task {

--- a/AmplifyTests/CategoryTests/Notifications/Push/PushNotificationsCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Notifications/Push/PushNotificationsCategoryClientAPITests.swift
@@ -48,7 +48,7 @@ class PushNotificationsCategoryClientAPITests: XCTestCase {
     }
 
     func testRegisterDeviceToken_shouldSucceed() async throws {
-        let data = "Data".data(using: .utf8)!
+        let data = Data("Data".utf8)
         let expectedMessage = "registerDevice(token:\(data))"
         let methodInvoked = expectation(description: "Expected method was invoked on plugin")
         plugin.listeners.append { message in

--- a/AmplifyTests/CoreTests/AmplifyConfigurationInitializationTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyConfigurationInitializationTests.swift
@@ -97,7 +97,7 @@ class AmplifyConfigurationInitializationTests: XCTestCase {
             .appendingPathComponent("amplifyconfiguration.json")
 
         let poorlyFormedJSON = #"{"foo"}"#
-        let configData = poorlyFormedJSON.data(using: .utf8)!
+        let configData = Data(poorlyFormedJSON.utf8)
         try configData.write(to: configFilePath)
 
         XCTAssertThrowsError(try AmplifyConfiguration(configurationFile: configFilePath)) { error in
@@ -117,7 +117,7 @@ class AmplifyConfigurationInitializationTests: XCTestCase {
             .appendingPathComponent("amplifyconfiguration.json")
 
         let poorlyFormedJSON = #"{"foo": true}"#
-        let configData = poorlyFormedJSON.data(using: .utf8)!
+        let configData = Data(poorlyFormedJSON.utf8)
         try configData.write(to: configFilePath)
 
         let amplifyConfig = try AmplifyConfiguration(configurationFile: configFilePath)

--- a/AmplifyTests/CoreTests/ConfigurationTests.swift
+++ b/AmplifyTests/CoreTests/ConfigurationTests.swift
@@ -134,7 +134,7 @@ class ConfigurationTests: XCTestCase {
         {"UserAgent":"aws-amplify-cli/2.0","Version":"1.0","storage":{"plugins":{"MockStorageCategoryPlugin":{}}}}
         """
 
-        let jsonData = jsonString.data(using: .utf8)!
+        let jsonData = Data(jsonString.utf8)
         let decoder = JSONDecoder()
         let config = try decoder.decode(AmplifyConfiguration.self, from: jsonData)
         XCTAssertNotNil(config.storage)

--- a/AmplifyTests/CoreTests/JSONValueTests.swift
+++ b/AmplifyTests/CoreTests/JSONValueTests.swift
@@ -13,8 +13,8 @@ class JSONValueTests: XCTestCase {
     func testDecode() throws {
         let decoder = JSONDecoder()
         let sourceString = #"{"stringValue": "a string", "numberValue": 123.45, "booleanValue": true}"#
-        let sourceData = sourceString.data(using: .utf8)
-        let decodedObject = try decoder.decode(JSONValue.self, from: sourceData!)
+        let sourceData = Data(sourceString.utf8)
+        let decodedObject = try decoder.decode(JSONValue.self, from: sourceData)
 
         let expectedObject: JSONValue = [
             "booleanValue": true,


### PR DESCRIPTION
## Description
There were many places in the code base still using `.data(using encoding: UInt) -> Data?` [[docs](https://developer.apple.com/documentation/foundation/nsstring/1416696-data)] to convert `String` -> `Data?`
This unnecessarily forces that code path to deal with nullability. In tests, that nullability was handled with a force unwrap or by using `try XCTUnwrap(...)`. In library code, it was typically done with a `guard let ... else` statement, which creates unnecessary logical branches and hurts readability.

This change moves usage of `.data(using encoding: UInt) -> Data?` to the non-failable `Data.init<S>(_ elements: S) where S: Sequence, S.Element == UInt8`.

```swift
// this
let data = string.data(using: .utf8)!
// becomes this
let data = Data(string.utf8)
```

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
