### PR TITLE
fix(DataStore): watchOS subscription disabled configuration value

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Configuration/DataStoreConfiguration+Helper.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Configuration/DataStoreConfiguration+Helper.swift
@@ -90,7 +90,7 @@ extension DataStoreConfiguration {
     /// enabled is only possible during special circumstances such as actively streaming audio.
     /// See https://github.com/aws-amplify/amplify-swift/pull/3368 for more details.
     public static var subscriptionsDisabled: DataStoreConfiguration {
-        .custom(disableSubscriptions: { false })
+        .custom(disableSubscriptions: { true })
     }
     #else
     /// The default configuration.

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreCategoryConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreCategoryConfigurationTests.swift
@@ -14,7 +14,13 @@ class AWSDataStorePluginConfigurationTests: XCTestCase {
     override func setUp() async throws {
         await Amplify.reset()
     }
-
+    
+    #if os(watchOS)
+    func testSubscriptionDisabledTrue() throws {
+        XCTAssertTrue(DataStoreConfiguration.subscriptionsDisabled.disableSubscriptions())
+    }
+    #endif
+    
     func testDoesNotThrowOnMissingConfig() throws {
         #if os(watchOS)
         let plugin = AWSDataStorePlugin(modelRegistration: TestModelRegistration(),
@@ -33,5 +39,5 @@ class AWSDataStorePluginConfigurationTests: XCTestCase {
             XCTFail("Should not throw even if not supplied with a plugin-specific config.")
         }
     }
-
+    
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
`subscriptionsDisabled` was incorrectly setting `disableSubscriptions` to return false. This wasn't caught since the  developers tracking the original PR https://github.com/aws-amplify/amplify-swift/pull/3368 were using `.custom(disableSubscriptions)` as communicated to them. `subscriptionDisabled` is available as well and more targetted for customers that don't expect to change the `disableSubscriptions` return value.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass https://github.com/aws-amplify/amplify-swift/actions/runs/7277517432
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
