### PR TITLE
fix(datastore): update pending mutation events version from mutation response

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/SyncMutationToCloudOperation.swift
@@ -103,6 +103,18 @@ class SyncMutationToCloudOperation: AsynchronousOperation {
         }
     }
 
+    /// Always retrieve and use the largest version when available. The source of the version comes
+    /// from either the MutationEvent itself, which represents the queue request, or the persisted version
+    /// from the metadata table.
+    ///
+    /// **Version in the Mutation Event**. If there are mulitple mutation events pending, each outgoing
+    /// mutation processing will result in synchronously updating the pending mutation's version
+    /// before enqueuing the mutation response for reconciliation.
+    ///
+    /// **Version persisted in the metadata table**: Reconciliation will persist the latest version in the
+    /// metadata table. In cases of quick consecutive updates, the MutationEvent's version could
+    /// be greater than the persisted since the MutationEvent is updated from the original thread that
+    /// processed the outgoing mutation.
     private func getLatestVersion(_ mutationEvent: MutationEvent) -> Int? {
         let latestSyncedMetadataVersion = getLatestSyncMetadata()?.version
         let mutationEventVersion = mutationEvent.version

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Support/MutationEvent+Extensions.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Support/MutationEvent+Extensions.swift
@@ -1,0 +1,104 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+import Dispatch
+import AWSPluginsCore
+
+extension MutationEvent {
+    // Consecutive operations that modify a model results in a sequence of pending mutation events that
+    // have the current version of the model. The first mutation event has the correct version of the model,
+    // while the subsequent events will have lower versions if the first mutation event is successfully synced
+    // to the cloud. By reconciling the pending mutation events after syncing the first mutation event,
+    // we attempt to update the pending version to the latest version from the response.
+    // The before and after conditions for consecutive update scenarios are as below:
+    //  - Save, then immediately update
+    //      Queue Before - [(version: nil, inprocess: true, type: .create),
+    //                      (version: nil, inprocess: false, type: .update)]
+    //      Response - [version: 1, type: .create]
+    //      Queue After - [(version: 1, inprocess: false, type: .update)]
+    //  - Save, then immediately delete
+    //      Queue Before - [(version: nil, inprocess: true, type: .create),
+    //                      (version: nil, inprocess: false, type: .delete)]
+    //      Response - [version: 1, type: .create]
+    //      Queue After - [(version: 1, inprocess: false, type: .delete)]
+    //  - Save, sync, then immediately update and delete
+    //      Queue Before (After save, sync)
+    //          - [(version: 1, inprocess: true, type: .update), (version: 1, inprocess: false, type: .delete)]
+    //      Response - [version: 2, type: .update]
+    //      Queue After - [(version: 2, inprocess: false, type: .delete)]
+    //
+    // For a given model `id`, checks the version of the head of pending mutation event queue
+    // against the API response version in `mutationSync` and saves it in the mutation event table if
+    // the response version is a newer one
+    static func reconcilePendingMutationEventsVersion(sent mutationEvent: MutationEvent,
+                                                      received mutationSync: MutationSync<AnyModel>,
+                                                      storageAdapter: StorageEngineAdapter,
+                                                      completion: @escaping DataStoreCallback<Void>) {
+        MutationEvent.pendingMutationEvents(
+            forMutationEvent: mutationEvent,
+            storageAdapter: storageAdapter
+        ) { queryResult in
+            switch queryResult {
+            case .failure(let dataStoreError):
+                completion(.failure(dataStoreError))
+            case .success(let localMutationEvents):
+                guard let existingEvent = localMutationEvents.first else {
+                    completion(.success(()))
+                    return
+                }
+
+                guard let reconciledEvent = reconcile(pendingMutationEvent: existingEvent,
+                                                      with: mutationEvent,
+                                                      responseMutationSync: mutationSync) else {
+                    completion(.success(()))
+                    return
+                }
+
+                storageAdapter.save(reconciledEvent, condition: nil, eagerLoad: true) { result in
+                    switch result {
+                    case .failure(let dataStoreError):
+                        completion(.failure(dataStoreError))
+                    case .success:
+                        completion(.success(()))
+                    }
+                }
+            }
+        }
+    }
+
+    static func reconcile(pendingMutationEvent: MutationEvent,
+                          with requestMutationEvent: MutationEvent,
+                          responseMutationSync: MutationSync<AnyModel>) -> MutationEvent? {
+        // return if version of the pending mutation event is not nil and
+        // is >= version contained in the response
+        if pendingMutationEvent.version != nil &&
+            pendingMutationEvent.version! >= responseMutationSync.syncMetadata.version {
+            return nil
+        }
+
+        do {
+            let responseModel = responseMutationSync.model.instance
+            let requestModel = try requestMutationEvent.decodeModel()
+
+            // check if the data sent in the request is the same as the response
+            // if it is, update the pending mutation event version to the response version
+            guard let modelSchema = ModelRegistry.modelSchema(from: requestMutationEvent.modelName),
+                  modelSchema.compare(responseModel, requestModel) else {
+                return nil
+            }
+
+            var pendingMutationEvent = pendingMutationEvent
+            pendingMutationEvent.version = responseMutationSync.syncMetadata.version
+            return pendingMutationEvent
+        } catch {
+            Amplify.log.verbose("Error decoding models: \(error)")
+            return nil
+        }
+    }
+
+}

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/MutationEventExtensionsTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/MutationEventExtensionsTests.swift
@@ -14,7 +14,6 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-// TODO: This flaky test has been disabled, tracking issue: https://github.com/aws-amplify/amplify-ios/issues/1831
 // swiftlint:disable type_body_length
 class MutationEventExtensionsTest: BaseDataStoreTests {
 
@@ -23,7 +22,6 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
     /// - When: The sent model matches the received model and the first pending mutation event version is `nil`.
     /// - Then: The pending mutation event version should be updated to the received model version of 1.
     func testSentModelWithNilVersion_Reconciled() throws {
-        throw XCTSkip("TODO: fix this test")
         let modelId = UUID().uuidString
         let post = Post(id: modelId, title: "title", content: "content", createdAt: .now())
         let requestMutationEvent = try createMutationEvent(model: post,
@@ -88,7 +86,6 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
     /// - Then: The first pending mutation event(update) version should be updated to the received model version of 1
     ///         and the second pending mutation event version(delete) should not be updated.
     func testSentModelWithNilVersion_SecondPendingEventNotReconciled() throws {
-        throw XCTSkip("TODO: fix this test")
         let modelId = UUID().uuidString
         let post = Post(id: modelId, title: "title", content: "content", createdAt: .now())
         let requestMutationEvent = try createMutationEvent(model: post,
@@ -158,7 +155,6 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
     /// - When: The sent model matches the received model and the first pending mutation event version is 2.
     /// - Then: The first pending mutation event version should NOT be updated.
     func testSentModelVersionNewerThanResponseVersion_PendingEventNotReconciled() throws {
-        throw XCTSkip("TODO: fix this test")
         let modelId = UUID().uuidString
         let post1 = Post(id: modelId, title: "title1", content: "content1", createdAt: .now())
         let post2 = Post(id: modelId, title: "title2", content: "content2", createdAt: .now())
@@ -221,7 +217,6 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
     /// - When: The sent model doesn't match the received model and the first pending mutation event version is 1.
     /// - Then: The first pending mutation event version should NOT be updated.
     func testSentModelNotEqualToResponseModel_PendingEventNotReconciled() throws {
-        throw XCTSkip("TODO: fix this test")
         let modelId = UUID().uuidString
         let post1 = Post(id: modelId, title: "title1", content: "content1", createdAt: .now())
         let post2 = Post(id: modelId, title: "title2", content: "content2", createdAt: .now())
@@ -285,7 +280,6 @@ class MutationEventExtensionsTest: BaseDataStoreTests {
     /// - When: The sent model matches the received model and the first pending mutation event version is 1.
     /// - Then: The first pending mutation event version should be updated to received mutation sync version i.e. 2.
     func testPendingVersionReconciledSuccess() throws {
-        throw XCTSkip("TODO: fix this test")
         let modelId = UUID().uuidString
         let post1 = Post(id: modelId, title: "title1", content: "content1", createdAt: .now())
         let post2 = Post(id: modelId, title: "title2", content: "content2", createdAt: .now())

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/MutationEventExtensionsTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/MutationEventExtensionsTests.swift
@@ -1,0 +1,404 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import SQLite
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSDataStorePlugin
+@testable import AWSPluginsCore
+
+// TODO: This flaky test has been disabled, tracking issue: https://github.com/aws-amplify/amplify-ios/issues/1831
+// swiftlint:disable type_body_length
+class MutationEventExtensionsTest: BaseDataStoreTests {
+
+    /// - Given: A pending mutation events queue with event containing `nil` version, a sent mutation
+    ///         event model that matches the received mutation sync model. The received mutation sync has version 1.
+    /// - When: The sent model matches the received model and the first pending mutation event version is `nil`.
+    /// - Then: The pending mutation event version should be updated to the received model version of 1.
+    func testSentModelWithNilVersion_Reconciled() throws {
+        throw XCTSkip("TODO: fix this test")
+        let modelId = UUID().uuidString
+        let post = Post(id: modelId, title: "title", content: "content", createdAt: .now())
+        let requestMutationEvent = try createMutationEvent(model: post,
+                                                           mutationType: .create,
+                                                           createdAt: .now(),
+                                                           version: nil,
+                                                           inProcess: true)
+        let pendingMutationEvent = try createMutationEvent(model: post,
+                                                           mutationType: .update,
+                                                           createdAt: .now().add(value: 1, to: .second),
+                                                           version: nil)
+        let responseMutationSync = createMutationSync(model: post, version: 1)
+
+        setUpPendingMutationQueue(post, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
+
+        let reconciledEvent = MutationEvent.reconcile(pendingMutationEvent: pendingMutationEvent,
+                                                      with: requestMutationEvent,
+                                                      responseMutationSync: responseMutationSync)
+        XCTAssertNotNil(reconciledEvent)
+        XCTAssertEqual(reconciledEvent?.version, responseMutationSync.syncMetadata.version)
+
+        let queryAfterUpdatingVersionExpectation = expectation(description: "update mutation should be latest version")
+        let updatingVersionExpectation = expectation(description: "update latest mutation event with response version")
+
+        // update the version of head of mutation event table for given model id to the version of `mutationSync`
+        MutationEvent.reconcilePendingMutationEventsVersion(sent: requestMutationEvent,
+                                                             received: responseMutationSync,
+                                                             storageAdapter: storageAdapter) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("Error : \(error)")
+            case .success:
+                updatingVersionExpectation.fulfill()
+            }
+        }
+        wait(for: [updatingVersionExpectation], timeout: 1)
+
+        // query for head of mutation event table for given model id and check if it has the updated version
+        MutationEvent.pendingMutationEvents(forModel: post,
+                                            storageAdapter: storageAdapter) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("Error : \(error)")
+            case .success(let mutationEvents):
+                guard !mutationEvents.isEmpty, let head = mutationEvents.first else {
+                    XCTFail("Failure while updating version")
+                    return
+                }
+                XCTAssertEqual(head.version, responseMutationSync.syncMetadata.version)
+                XCTAssertEqual(head.mutationType, MutationEvent.MutationType.update.rawValue)
+                queryAfterUpdatingVersionExpectation.fulfill()
+            }
+        }
+        wait(for: [queryAfterUpdatingVersionExpectation], timeout: 1)
+    }
+
+    /// - Given: A pending mutation events queue with two events(update and delete) containing `nil` version,
+    ///         a sent mutation event model that matches the received mutation sync model. The received mutation
+    ///         sync has version 1.
+    /// - When: The sent model matches the received model, the first pending mutation event(update) version is `nil` and
+    ///         the second pending mutation event(delete) version is `nil`.
+    /// - Then: The first pending mutation event(update) version should be updated to the received model version of 1
+    ///         and the second pending mutation event version(delete) should not be updated.
+    func testSentModelWithNilVersion_SecondPendingEventNotReconciled() throws {
+        throw XCTSkip("TODO: fix this test")
+        let modelId = UUID().uuidString
+        let post = Post(id: modelId, title: "title", content: "content", createdAt: .now())
+        let requestMutationEvent = try createMutationEvent(model: post,
+                                                           mutationType: .create,
+                                                           createdAt: .now(),
+                                                           version: nil,
+                                                           inProcess: true)
+        let pendingUpdateMutationEvent = try createMutationEvent(model: post,
+                                                                 mutationType: .update,
+                                                                 createdAt: .now().add(value: 1, to: .second),
+                                                                 version: nil)
+        let pendingDeleteMutationEvent = try createMutationEvent(model: post,
+                                                                 mutationType: .delete,
+                                                                 createdAt: .now().add(value: 2, to: .second),
+                                                                 version: nil)
+        let responseMutationSync = createMutationSync(model: post, version: 1)
+
+        setUpPendingMutationQueue(post,
+                                  [requestMutationEvent, pendingUpdateMutationEvent, pendingDeleteMutationEvent],
+                                  pendingUpdateMutationEvent)
+
+        let reconciledEvent = MutationEvent.reconcile(pendingMutationEvent: pendingUpdateMutationEvent,
+                                                      with: requestMutationEvent,
+                                                      responseMutationSync: responseMutationSync)
+        XCTAssertNotNil(reconciledEvent)
+        XCTAssertEqual(reconciledEvent?.version, responseMutationSync.syncMetadata.version)
+
+        let queryAfterUpdatingVersionExpectation = expectation(description: "update mutation should be latest version")
+        let updatingVersionExpectation = expectation(description: "update latest mutation event with response version")
+
+        // update the version of head of mutation event table for given model id to the version of `mutationSync`
+        MutationEvent.reconcilePendingMutationEventsVersion(sent: requestMutationEvent,
+                                                             received: responseMutationSync,
+                                                             storageAdapter: storageAdapter) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("Error : \(error)")
+            case .success:
+                updatingVersionExpectation.fulfill()
+            }
+        }
+        wait(for: [updatingVersionExpectation], timeout: 1)
+
+        // query for head of mutation event table for given model id and check if it has the updated version
+        MutationEvent.pendingMutationEvents(forModel: post,
+                                            storageAdapter: storageAdapter) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("Error : \(error)")
+            case .success(let mutationEvents):
+                guard !mutationEvents.isEmpty, let head = mutationEvents.first, let last = mutationEvents.last else {
+                    XCTFail("Failure while updating version")
+                    return
+                }
+                XCTAssertEqual(head.version, responseMutationSync.syncMetadata.version)
+                XCTAssertEqual(head.mutationType, MutationEvent.MutationType.update.rawValue)
+                XCTAssertEqual(last, pendingDeleteMutationEvent)
+                queryAfterUpdatingVersionExpectation.fulfill()
+            }
+        }
+        wait(for: [queryAfterUpdatingVersionExpectation], timeout: 1)
+    }
+
+    /// - Given: A pending mutation events queue with event containing version 2, a sent mutation event model
+    ///         that matches the received mutation sync model having version 2. The received mutation sync has
+    ///         version 1.
+    /// - When: The sent model matches the received model and the first pending mutation event version is 2.
+    /// - Then: The first pending mutation event version should NOT be updated.
+    func testSentModelVersionNewerThanResponseVersion_PendingEventNotReconciled() throws {
+        throw XCTSkip("TODO: fix this test")
+        let modelId = UUID().uuidString
+        let post1 = Post(id: modelId, title: "title1", content: "content1", createdAt: .now())
+        let post2 = Post(id: modelId, title: "title2", content: "content2", createdAt: .now())
+        let requestMutationEvent = try createMutationEvent(model: post1,
+                                                           mutationType: .create,
+                                                           createdAt: .now(),
+                                                           version: 2,
+                                                           inProcess: true)
+        let pendingMutationEvent = try createMutationEvent(model: post2,
+                                                           mutationType: .update,
+                                                           createdAt: .now().add(value: 1, to: .second),
+                                                           version: 2)
+        let responseMutationSync = createMutationSync(model: post1, version: 1)
+
+        setUpPendingMutationQueue(post1, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
+
+        let reconciledEvent = MutationEvent.reconcile(pendingMutationEvent: pendingMutationEvent,
+                                                      with: requestMutationEvent,
+                                                      responseMutationSync: responseMutationSync)
+        XCTAssertNil(reconciledEvent)
+
+        let queryAfterUpdatingVersionExpectation = expectation(description: "update mutation should have version 2")
+        let updatingVersionExpectation =
+            expectation(description: "don't update latest mutation event with response version")
+
+        MutationEvent.reconcilePendingMutationEventsVersion(sent: requestMutationEvent,
+                                                             received: responseMutationSync,
+                                                             storageAdapter: storageAdapter) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("Error : \(error)")
+            case .success:
+                updatingVersionExpectation.fulfill()
+            }
+        }
+        wait(for: [updatingVersionExpectation], timeout: 1)
+
+        // query for head of mutation event table for given model id and check if it has the correct version
+        MutationEvent.pendingMutationEvents(forModel: post1,
+                                            storageAdapter: storageAdapter) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("Error : \(error)")
+            case .success(let mutationEvents):
+                guard !mutationEvents.isEmpty, let head = mutationEvents.first else {
+                    XCTFail("Failure while updating version")
+                    return
+                }
+                XCTAssertNotEqual(head.version, responseMutationSync.syncMetadata.version)
+                XCTAssertEqual(head, pendingMutationEvent)
+                queryAfterUpdatingVersionExpectation.fulfill()
+            }
+        }
+        wait(for: [queryAfterUpdatingVersionExpectation], timeout: 1)
+    }
+
+    /// - Given: A pending mutation events queue with event containing version 1, a sent mutation event model
+    ///         that doesn't match the received mutation sync model having version 1. The received mutation
+    ///         sync has version 2.
+    /// - When: The sent model doesn't match the received model and the first pending mutation event version is 1.
+    /// - Then: The first pending mutation event version should NOT be updated.
+    func testSentModelNotEqualToResponseModel_PendingEventNotReconciled() throws {
+        throw XCTSkip("TODO: fix this test")
+        let modelId = UUID().uuidString
+        let post1 = Post(id: modelId, title: "title1", content: "content1", createdAt: .now())
+        let post2 = Post(id: modelId, title: "title2", content: "content2", createdAt: .now())
+        let post3 = Post(id: modelId, title: "title3", content: "content3", createdAt: .now())
+        let requestMutationEvent = try createMutationEvent(model: post1,
+                                                           mutationType: .update,
+                                                           createdAt: .now(),
+                                                           version: 1,
+                                                           inProcess: true)
+        let pendingMutationEvent = try createMutationEvent(model: post2,
+                                                           mutationType: .update,
+                                                           createdAt: .now().add(value: 1, to: .second),
+                                                           version: 1)
+        let responseMutationSync = createMutationSync(model: post3, version: 2)
+
+        setUpPendingMutationQueue(post1, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
+
+        let reconciledEvent = MutationEvent.reconcile(pendingMutationEvent: pendingMutationEvent,
+                                                      with: requestMutationEvent,
+                                                      responseMutationSync: responseMutationSync)
+        XCTAssertNil(reconciledEvent)
+
+        let queryAfterUpdatingVersionExpectation = expectation(description: "update mutation should have version 1")
+        let updatingVersionExpectation =
+            expectation(description: "don't update latest mutation event with response version")
+
+        MutationEvent.reconcilePendingMutationEventsVersion(sent: requestMutationEvent,
+                                                             received: responseMutationSync,
+                                                             storageAdapter: storageAdapter) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("Error : \(error)")
+            case .success:
+                updatingVersionExpectation.fulfill()
+            }
+        }
+        wait(for: [updatingVersionExpectation], timeout: 1)
+
+        // query for head of mutation event table for given model id and check if it has the correct version
+        MutationEvent.pendingMutationEvents(forModel: post1,
+                                            storageAdapter: storageAdapter) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("Error : \(error)")
+            case .success(let mutationEvents):
+                guard !mutationEvents.isEmpty, let head = mutationEvents.first else {
+                    XCTFail("Failure while updating version")
+                    return
+                }
+                XCTAssertNotEqual(head.version, responseMutationSync.syncMetadata.version)
+                XCTAssertEqual(head, pendingMutationEvent)
+                queryAfterUpdatingVersionExpectation.fulfill()
+            }
+        }
+        wait(for: [queryAfterUpdatingVersionExpectation], timeout: 1)
+    }
+
+    /// - Given: A pending mutation events queue with event containing version 1, a sent mutation event model
+    ///         that matches the received mutation sync model having version 1. The received mutation sync
+    ///         has version 2.
+    /// - When: The sent model matches the received model and the first pending mutation event version is 1.
+    /// - Then: The first pending mutation event version should be updated to received mutation sync version i.e. 2.
+    func testPendingVersionReconciledSuccess() throws {
+        throw XCTSkip("TODO: fix this test")
+        let modelId = UUID().uuidString
+        let post1 = Post(id: modelId, title: "title1", content: "content1", createdAt: .now())
+        let post2 = Post(id: modelId, title: "title2", content: "content2", createdAt: .now())
+        let requestMutationEvent = try createMutationEvent(model: post1,
+                                                           mutationType: .update,
+                                                           createdAt: .now(),
+                                                           version: 1,
+                                                           inProcess: true)
+        let pendingMutationEvent = try createMutationEvent(model: post2,
+                                                           mutationType: .update,
+                                                           createdAt: .now().add(value: 1, to: .second),
+                                                           version: 1)
+        let responseMutationSync = createMutationSync(model: post1, version: 2)
+
+        setUpPendingMutationQueue(post1, [requestMutationEvent, pendingMutationEvent], pendingMutationEvent)
+
+        let reconciledEvent = MutationEvent.reconcile(pendingMutationEvent: pendingMutationEvent,
+                                                      with: requestMutationEvent,
+                                                      responseMutationSync: responseMutationSync)
+        XCTAssertNotNil(reconciledEvent)
+        XCTAssertEqual(reconciledEvent?.version, responseMutationSync.syncMetadata.version)
+
+        let queryAfterUpdatingVersionExpectation = expectation(description: "update mutation should have version 2")
+        let updatingVersionExpectation = expectation(description: "update latest mutation event with response version")
+
+        MutationEvent.reconcilePendingMutationEventsVersion(sent: requestMutationEvent,
+                                                             received: responseMutationSync,
+                                                             storageAdapter: storageAdapter) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("Error : \(error)")
+            case .success:
+                updatingVersionExpectation.fulfill()
+            }
+        }
+        wait(for: [updatingVersionExpectation], timeout: 1)
+
+        // query for head of mutation event table for given model id and check if it has the correct version
+        MutationEvent.pendingMutationEvents(forModel: post1,
+                                            storageAdapter: storageAdapter) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("Error : \(error)")
+            case .success(let mutationEvents):
+                guard !mutationEvents.isEmpty, let head = mutationEvents.first else {
+                    XCTFail("Failure while updating version")
+                    return
+                }
+                XCTAssertEqual(head.version, responseMutationSync.syncMetadata.version)
+                XCTAssertEqual(head.mutationType, MutationEvent.MutationType.update.rawValue)
+                queryAfterUpdatingVersionExpectation.fulfill()
+            }
+        }
+        wait(for: [queryAfterUpdatingVersionExpectation], timeout: 1)
+    }
+
+    private func createMutationEvent(model: Model,
+                                     mutationType: MutationEvent.MutationType,
+                                     createdAt: Temporal.DateTime,
+                                     version: Int? = nil,
+                                     inProcess: Bool = false) throws -> MutationEvent {
+        return MutationEvent(id: UUID().uuidString,
+                             modelId: model.identifier(schema: MutationEvent.schema).stringValue,
+                             modelName: model.modelName,
+                             json: try model.toJSON(),
+                             mutationType: mutationType,
+                             createdAt: createdAt,
+                             version: version,
+                             inProcess: inProcess)
+    }
+
+    private func createMutationSync(model: Model, version: Int = 1) -> MutationSync<AnyModel> {
+        let metadata = MutationSyncMetadata(modelId: model.identifier(schema: MutationEvent.schema).stringValue,
+                                            modelName: model.modelName,
+                                            deleted: false,
+                                            lastChangedAt: Int64(Date().timeIntervalSince1970),
+                                            version: version)
+        return MutationSync(model: AnyModel(model), syncMetadata: metadata)
+    }
+
+    private func setUpPendingMutationQueue(_ model: Model,
+                                           _ mutationEvents: [MutationEvent],
+                                           _ expectedHeadOfQueue: MutationEvent) {
+        for mutationEvent in mutationEvents {
+            let mutationEventSaveExpectation = expectation(description: "save mutation event success")
+            storageAdapter.save(mutationEvent) { result in
+                guard case .success = result else {
+                    XCTFail("Failed to save metadata")
+                    return
+                }
+                mutationEventSaveExpectation.fulfill()
+            }
+            wait(for: [mutationEventSaveExpectation], timeout: 1)
+        }
+
+        // verify the head of queue is expected
+        let headOfQueueExpectation = expectation(description: "head of mutation event queue is as expected")
+        MutationEvent.pendingMutationEvents(
+            forModel: model,
+            storageAdapter: storageAdapter
+        ) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("Error : \(error)")
+            case .success(let events):
+                guard !events.isEmpty, let head = events.first else {
+                    XCTFail("Failure while fetching mutation events")
+                    return
+                }
+                XCTAssertEqual(head, expectedHeadOfQueue)
+                headOfQueueExpectation.fulfill()
+            }
+        }
+        wait(for: [headOfQueueExpectation], timeout: 1)
+    }
+}


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

- rollback the logic for updating the version of pending mutation events in the queue upon receiving a mutation response from the remote server with the same model id.
- detect the mutation event version based on both latest synced metadata and existing mutation event's version.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
