### PR TITLE
fix(DataStore): auth plugin requirement for single auth rule

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine+SyncRequirement.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine+SyncRequirement.swift
@@ -34,7 +34,9 @@ extension StorageEngine {
                 ))
             }
 
-            let authPluginRequired = StorageEngine.requiresAuthPlugin(api)
+            let authPluginRequired = StorageEngine.requiresAuthPlugin(
+                api,
+                authModeStrategy: dataStoreConfiguration.authModeStrategyType)
             guard authPluginRequired else {
                 syncEngine.start(api: apiGraphQL, auth: nil)
                 return .success(.successfullyInitialized)
@@ -96,22 +98,43 @@ extension StorageEngine {
         }
     }
 
-    static func requiresAuthPlugin(_ apiPlugin: APICategoryPlugin) -> Bool {
+    static func requiresAuthPlugin(_ apiPlugin: APICategoryPlugin, 
+                                   authModeStrategy: AuthModeStrategyType) -> Bool {
         let modelsRequireAuthPlugin = ModelRegistry.modelSchemas.contains { schema in
             guard schema.isSyncable  else {
                 return false
             }
-            return StorageEngine.requiresAuthPlugin(apiPlugin, authRules: schema.authRules)
+            return requiresAuthPlugin(apiPlugin, 
+                                      authRules: schema.authRules,
+                                      authModeStrategy: authModeStrategy)
         }
 
         return modelsRequireAuthPlugin
     }
 
-    static func requiresAuthPlugin(_ apiPlugin: APICategoryPlugin, authRules: [AuthRule]) -> Bool {
-        if let rulesRequireAuthPlugin = authRules.requireAuthPlugin {
-            return rulesRequireAuthPlugin
+    static func requiresAuthPlugin(_ apiPlugin: APICategoryPlugin, 
+                                   authRules: [AuthRule],
+                                   authModeStrategy: AuthModeStrategyType) -> Bool {
+        switch authModeStrategy {
+        case .default:
+            if authRules.isEmpty {
+                return false
+            }
+            // Only use the auth rule as determination for auth plugin requirement when there is
+            // exactly one. If there is more than one auth rule AND multi-auth is not enabled,
+            // then immediately fall back to using the default auth type configured on the APIPlugin because
+            // we do not have enough information to know which provider to use to make the determination.
+            if authRules.count == 1,
+                let singleAuthRule = authRules.first,
+               let ruleRequireAuthPlugin = singleAuthRule.requiresAuthPlugin {
+                return ruleRequireAuthPlugin
+            }
+        case .multiAuth:
+            if let rulesRequireAuthPlugin = authRules.requireAuthPlugin {
+                return rulesRequireAuthPlugin
+            }
         }
-
+        
         // Fall back to the endpoint's auth type if a determination cannot be made from the auth rules. This can
         // occur for older generation of the auth rules which do not have provider information such as the initial
         // single auth rule use cases. The auth type from the API is used to determine whether or not the auth
@@ -123,7 +146,7 @@ extension StorageEngine {
                 log.error(error: error)
             }
         }
-
+        
         log.warn("""
             Could not determine whether the auth plugin is required or not. The auth rules present
             may be missing provider information. When this happens, the API Plugin is used to determine

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine+SyncRequirement.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine+SyncRequirement.swift
@@ -98,8 +98,10 @@ extension StorageEngine {
         }
     }
 
-    static func requiresAuthPlugin(_ apiPlugin: APICategoryPlugin, 
-                                   authModeStrategy: AuthModeStrategyType) -> Bool {
+    static func requiresAuthPlugin(
+        _ apiPlugin: APICategoryPlugin,
+        authModeStrategy: AuthModeStrategyType
+    ) -> Bool {
         let modelsRequireAuthPlugin = ModelRegistry.modelSchemas.contains { schema in
             guard schema.isSyncable  else {
                 return false
@@ -112,9 +114,11 @@ extension StorageEngine {
         return modelsRequireAuthPlugin
     }
 
-    static func requiresAuthPlugin(_ apiPlugin: APICategoryPlugin, 
-                                   authRules: [AuthRule],
-                                   authModeStrategy: AuthModeStrategyType) -> Bool {
+    static func requiresAuthPlugin(
+        _ apiPlugin: APICategoryPlugin,
+        authRules: [AuthRule],
+        authModeStrategy: AuthModeStrategyType
+    ) -> Bool {
         switch authModeStrategy {
         case .default:
             if authRules.isEmpty {
@@ -134,7 +138,7 @@ extension StorageEngine {
                 return rulesRequireAuthPlugin
             }
         }
-        
+
         // Fall back to the endpoint's auth type if a determination cannot be made from the auth rules. This can
         // occur for older generation of the auth rules which do not have provider information such as the initial
         // single auth rule use cases. The auth type from the API is used to determine whether or not the auth
@@ -146,7 +150,7 @@ extension StorageEngine {
                 log.error(error: error)
             }
         }
-        
+
         log.warn("""
             Could not determine whether the auth plugin is required or not. The auth rules present
             may be missing provider information. When this happens, the API Plugin is used to determine

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine+SyncRequirement.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine+SyncRequirement.swift
@@ -130,7 +130,7 @@ extension StorageEngine {
             // then immediately fall back to using the default auth type configured on the APIPlugin because
             // we do not have enough information to know which provider to use to make the determination.
             if authRules.count == 1,
-                let singleAuthRule = authRules.first,
+               let singleAuthRule = authRules.first,
                let ruleRequireAuthPlugin = singleAuthRule.requiresAuthPlugin {
                 return ruleRequireAuthPlugin
             }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine+SyncRequirement.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine+SyncRequirement.swift
@@ -36,7 +36,8 @@ extension StorageEngine {
 
             let authPluginRequired = StorageEngine.requiresAuthPlugin(
                 api,
-                authModeStrategy: dataStoreConfiguration.authModeStrategyType)
+                authModeStrategy: dataStoreConfiguration.authModeStrategyType
+            )
             guard authPluginRequired else {
                 syncEngine.start(api: apiGraphQL, auth: nil)
                 return .success(.successfullyInitialized)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/StorageEngineSyncRequirementsTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/StorageEngineSyncRequirementsTests.swift
@@ -17,80 +17,91 @@ class StorageEngineSyncRequirementsTests: XCTestCase {
 
     func testRequiresAuthPluginFalseForMissingAuthRules() {
         let apiPlugin = MockAPICategoryPlugin()
-        let result = StorageEngine.requiresAuthPlugin(apiPlugin)
-        XCTAssertFalse(result)
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authModeStrategy: .default))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authModeStrategy: .multiAuth))
     }
 
     func testRequiresAuthPluginSingleAuthRuleAPIKey() {
         let apiPlugin = MockAPICategoryPlugin()
         let authRules = [AuthRule(allow: .owner, provider: .apiKey)]
-        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .default))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .multiAuth))
     }
 
     func testRequiresAuthPluginSingleAuthRuleOIDC() {
         let apiPlugin = MockAPICategoryPlugin()
         let authRules = [AuthRule(allow: .owner, provider: .oidc)]
-        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .default))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .multiAuth))
     }
 
     func testRequiresAuthPluginSingleAuthRuleFunction() {
         let apiPlugin = MockAPICategoryPlugin()
         let authRules = [AuthRule(allow: .private, provider: .function)]
-        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .default))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .multiAuth))
     }
 
     func testRequiresAuthPluginSingleAuthRuleUserPools() {
         let apiPlugin = MockAPICategoryPlugin()
         let authRules = [AuthRule(allow: .owner, provider: .userPools)]
-        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules))
+        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .default))
+        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .multiAuth))
     }
 
     func testRequiresAuthPluginSingleAuthRuleIAM() {
         let apiPlugin = MockAPICategoryPlugin()
         let authRules = [AuthRule(allow: .owner, provider: .iam)]
-        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules))
+        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .default))
+        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .multiAuth))
     }
 
     func testRequiresAuthPluginNoProvidersWithAuthTypeFunction() {
         let authRules = [AuthRule(allow: .owner)]
         let apiPlugin = MockAPIAuthInformationPlugin()
         apiPlugin.authType = .function
-        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .default))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .multiAuth))
     }
 
     func testRequiresAuthPluginNoProvidersWithAuthTypeAPIKey() {
         let authRules = [AuthRule(allow: .owner)]
         let apiPlugin = MockAPIAuthInformationPlugin()
         apiPlugin.authType = .apiKey
-        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .default))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .multiAuth))
     }
 
     func testRequiresAuthPluginNoProvidersWithAuthTypeUserPools() {
         let authRules = [AuthRule(allow: .owner)]
         let apiPlugin = MockAPIAuthInformationPlugin()
         apiPlugin.authType = .amazonCognitoUserPools
-        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules))
+        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .default))
+        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .multiAuth))
     }
 
     func testRequiresAuthPluginNoProvidersWithAuthTypeIAM() {
         let authRules = [AuthRule(allow: .owner)]
         let apiPlugin = MockAPIAuthInformationPlugin()
         apiPlugin.authType = .awsIAM
-        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules))
+        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .default))
+        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .multiAuth))
     }
 
     func testRequiresAuthPluginNoProvidersWithAuthTypeODIC() {
         let authRules = [AuthRule(allow: .owner)]
         let apiPlugin = MockAPIAuthInformationPlugin()
         apiPlugin.authType = .openIDConnect
-        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .default))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .multiAuth))
     }
 
     func testRequiresAuthPluginNoProvidersWithAuthTypeNone() {
         let authRules = [AuthRule(allow: .owner)]
         let apiPlugin = MockAPIAuthInformationPlugin()
         apiPlugin.authType = AWSAuthorizationType.none
-        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .default))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .multiAuth))
     }
 
     func testRequiresAuthPluginOIDCProvider() {
@@ -99,7 +110,41 @@ class StorageEngineSyncRequirementsTests: XCTestCase {
         apiPlugin.defaultAuthTypeError = APIError.unknown("Could not get default auth type", "", nil)
         let oidcProvider = MockOIDCAuthProvider()
         apiPlugin.authProviderFactory = MockAPIAuthProviderFactory(oidcProvider: oidcProvider)
-        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .default))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .multiAuth))
+    }
+    
+    func testRequiresAuthPluginOIDCProvider_MultiAuthRules() {
+        // OIDC requires an auth provider on the API, this is added below
+        let authRules = [AuthRule(allow: .owner, provider: .oidc),
+                         AuthRule(allow: .private, provider: .iam)]
+        let apiPlugin = MockAPIAuthInformationPlugin()
+        apiPlugin.defaultAuthTypeError = APIError.unknown("Could not get default auth type", "", nil)
+        let oidcProvider = MockOIDCAuthProvider()
+        apiPlugin.authProviderFactory = MockAPIAuthProviderFactory(oidcProvider: oidcProvider)
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, 
+                                                        authRules: authRules,
+                                                        authModeStrategy: .default),
+                       "Should be false since OIDC is the default auth type on the API.")
+        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin,
+                                                       authRules: authRules,
+                                                       authModeStrategy: .multiAuth),
+                      "Should be true since IAM requires auth plugin.")
+    }
+    
+    func testRequiresAuthPluginUserPoolProvider_MultiAuthRules() {
+        let authRules = [AuthRule(allow: .owner, provider: .userPools),
+                         AuthRule(allow: .private, provider: .iam)]
+        let apiPlugin = MockAPIAuthInformationPlugin()
+        apiPlugin.authType = AWSAuthorizationType.amazonCognitoUserPools
+        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin,
+                                                        authRules: authRules,
+                                                        authModeStrategy: .default),
+                       "Should be true since UserPool is the default auth type on the API.")
+        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin,
+                                                       authRules: authRules,
+                                                       authModeStrategy: .multiAuth),
+                      "Should be true since both UserPool and IAM requires auth plugin.")
     }
 
     func testRequiresAuthPluginFunctionProvider() {
@@ -108,14 +153,16 @@ class StorageEngineSyncRequirementsTests: XCTestCase {
         apiPlugin.defaultAuthTypeError = APIError.unknown("Could not get default auth type", "", nil)
         let functionProvider = MockFunctionAuthProvider()
         apiPlugin.authProviderFactory = MockAPIAuthProviderFactory(functionProvider: functionProvider)
-        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .default))
+        XCTAssertFalse(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .multiAuth))
     }
 
     func testRequiresAuthPluginWithAuthRules() {
         let authRules = [AuthRule(allow: .owner)]
         let apiPlugin = MockAPIAuthInformationPlugin()
         apiPlugin.defaultAuthTypeError = APIError.unknown("Could not get default auth type", "", nil)
-        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules))
+        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .default))
+        XCTAssertTrue(StorageEngine.requiresAuthPlugin(apiPlugin, authRules: authRules, authModeStrategy: .multiAuth))
     }
 
     // MARK: - AuthRules tests


### PR DESCRIPTION
## Issue \#
https://github.com/aws-amplify/amplify-flutter/issues/3967
https://github.com/aws-amplify/amplify-flutter/issues/3967#issuecomment-1875988560

## Description
<!-- Why is this change required? What problem does it solve? -->
The auth mode strategy and the auth rules are used in determination of whether the auth plugin is required for DataStore. Some common scenarios are
- No auth rules on the models does not require auth plugin
- Single auth rule on a model should make its determination based on the provider. 
  - OIDC/lambda - does not require auth plugin, but requires auth provider on the APIPLugin
  - APIKey - does not require auth plugin, the key is the configuration of the APIPlugin.
  - UserPools/IAM - requires auth plugin
- Multi-Auth rules with multi-auth enabled, require auth plugin if any of the rules requires auth plugin.

The issue in https://github.com/aws-amplify/amplify-flutter/issues/3967 describes the scenario
- multi-auth rules: OIDC and IAM
- OIDC auth provider on the APIPlugin
- multi-auth not enabled- only want to use the default authorization (OIDC) from the API

The problem was DataStore was requiring auth plugin for this scenario. The change in this PR addresses that by only checking the auth rules if and only if there is one auth rule when multi-auth is not enabled. If there is more than one auth rule, fall back to the API's default auth type. There are also some edge cases that remains the same in the logic and were not changed by this PR: if there are no auth rules, do not require auth plugin. if there is an auth rule but no provider can be found, also fall back to the API's default auth type.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
