### PR TITLE
fix(Analytics): Making PinpointEndpointProfile thread safe.

### DIFF
--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin+ClientBehavior.swift
@@ -18,7 +18,7 @@ extension AWSPinpointAnalyticsPlugin {
         }
 
         Task {
-            let currentEndpointProfile =  await pinpoint.currentEndpointProfile()
+            var currentEndpointProfile =  await pinpoint.currentEndpointProfile()
             currentEndpointProfile.addUserId(userId)
             if let userProfile = userProfile {
                 currentEndpointProfile.addUserProfile(userProfile)

--- a/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginClientBehaviorTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginClientBehaviorTests.swift
@@ -57,7 +57,7 @@ class AWSPinpointAnalyticsPluginClientBehaviorTests: AWSPinpointAnalyticsPluginT
                                                plan: testPlan,
                                                location: testLocation,
                                                properties: testProperties)
-        let expectedEndpointProfile = PinpointEndpointProfile(applicationId: "appId",
+        var expectedEndpointProfile = PinpointEndpointProfile(applicationId: "appId",
                                                               endpointId: "endpointId")
         expectedEndpointProfile.addUserId(testIdentityId)
         expectedEndpointProfile.addUserProfile(userProfile)
@@ -108,7 +108,7 @@ class AWSPinpointAnalyticsPluginClientBehaviorTests: AWSPinpointAnalyticsPluginT
                                                plan: testPlan,
                                                location: testLocation,
                                                properties: testProperties)
-        let expectedEndpointProfile = PinpointEndpointProfile(applicationId: "appId",
+        var expectedEndpointProfile = PinpointEndpointProfile(applicationId: "appId",
                                                               endpointId: "endpointId")
         expectedEndpointProfile.addUserId(testIdentityId)
         expectedEndpointProfile.addUserProfile(userProfile)

--- a/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginIntegrationTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginIntegrationTests.swift
@@ -75,7 +75,7 @@ class AWSPinpointAnalyticsPluginIntergrationTests: XCTestCase {
 
         // Remove userId from the current endpoint
         let endpointClient = endpointClient()
-        let currentProfile = await endpointClient.currentEndpointProfile()
+        var currentProfile = await endpointClient.currentEndpointProfile()
         currentProfile.addUserId("")
         try await endpointClient.updateEndpointProfile(with: currentProfile)
     }

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Endpoint/EndpointClient.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Endpoint/EndpointClient.swift
@@ -94,6 +94,7 @@ actor EndpointClient: EndpointClientBehaviour {
     }
 
     private func configure(endpointProfile: PinpointEndpointProfile) async -> PinpointEndpointProfile {
+        var endpointProfile = endpointProfile
         var deviceToken: PinpointEndpointProfile.DeviceToken?
         if let tokenData = Self.getStoredData(from: keychain, forKey: Constants.deviceTokenKey, fallbackTo: userDefaults) {
             deviceToken = tokenData.asHexString()
@@ -109,6 +110,7 @@ actor EndpointClient: EndpointClientBehaviour {
     }
 
     private func updateEndpoint(with endpointProfile: PinpointEndpointProfile) async throws {
+        var endpointProfile = endpointProfile
         endpointProfile.effectiveDate = Date()
         let input = createUpdateInput(from: endpointProfile)
         log.verbose("UpdateEndpointInput: \(input)")

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Endpoint/PinpointEndpointProfile.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Endpoint/PinpointEndpointProfile.swift
@@ -10,7 +10,7 @@ import AWSPinpoint
 import Foundation
 
 @_spi(InternalAWSPinpoint)
-public class PinpointEndpointProfile: Codable {
+public struct PinpointEndpointProfile: Codable, Equatable {
     typealias DeviceToken = String
 
     var applicationId: String
@@ -45,11 +45,11 @@ public class PinpointEndpointProfile: Codable {
         self.user = user
     }
 
-    public func addUserId(_ userId: String) {
+    public mutating func addUserId(_ userId: String) {
         user.userId = userId
     }
 
-    public func addUserProfile(_ userProfile: UserProfile) {
+    public mutating func addUserProfile(_ userProfile: UserProfile) {
         if let email = userProfile.email {
             setCustomProperty(email, forKey: Constants.AttributeKeys.email)
         }
@@ -75,18 +75,18 @@ public class PinpointEndpointProfile: Codable {
         }
     }
 
-    public func setAPNsToken(_ apnsToken: Data) {
+    public mutating func setAPNsToken(_ apnsToken: Data) {
         deviceToken = apnsToken.asHexString()
     }
 
-    private func addCustomProperties(_ properties: [String: UserProfilePropertyValue]?) {
+    private mutating func addCustomProperties(_ properties: [String: UserProfilePropertyValue]?) {
         guard let properties = properties else { return }
         for (key, value) in properties {
             setCustomProperty(value, forKey: key)
         }
     }
 
-    private func addUserAttributes(_ attributes: [String: [String]]?) {
+    private mutating func addUserAttributes(_ attributes: [String: [String]]?) {
         guard let attributes = attributes else { return }
         let userAttributes = user.userAttributes ?? [:]
         user.userAttributes = userAttributes.merging(
@@ -95,7 +95,7 @@ public class PinpointEndpointProfile: Codable {
         )
     }
 
-    private func setCustomProperty(_ value: UserProfilePropertyValue,
+    private mutating func setCustomProperty(_ value: UserProfilePropertyValue,
                                    forKey key: String) {
         if let value = value as? String {
             attributes[key] = [value]

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EndpointClientTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EndpointClientTests.swift
@@ -75,7 +75,7 @@ class EndpointClientTests: XCTestCase {
         XCTAssertNotNil(keychain.dataValues[EndpointClient.Constants.endpointProfileKey])
         XCTAssertNotNil(keychain.dataValues[EndpointClient.Constants.deviceTokenKey])
         XCTAssertEqual(archiver.decodeCount, 1)
-        XCTAssertTrue(endpointProfile === storedEndpointProfile, "Expected stored PinpointEndpointProfile object")
+        XCTAssertNotEqual(endpointProfile, storedEndpointProfile, "Expected updated PinpointEndpointProfile object")
         XCTAssertEqual(endpointProfile.applicationId, currentApplicationId)
         XCTAssertEqual(endpointProfile.endpointId, currentEndpointId)
         XCTAssertEqual(endpointProfile.deviceToken, newToken.asHexString())
@@ -104,7 +104,7 @@ class EndpointClientTests: XCTestCase {
         XCTAssertEqual(keychain.dataForKeyCountMap[EndpointClient.Constants.endpointProfileKey], 1)
         XCTAssertEqual(keychain.dataForKeyCountMap[EndpointClient.Constants.deviceTokenKey], 1)
         XCTAssertEqual(archiver.decodeCount, 0)
-        XCTAssertFalse(endpointProfile === storedEndpointProfile, "Expected new PinpointEndpointProfile object")
+        XCTAssertNotEqual(endpointProfile, storedEndpointProfile, "Expected new PinpointEndpointProfile object")
         XCTAssertEqual(endpointProfile.applicationId, currentApplicationId)
         XCTAssertEqual(endpointProfile.endpointId, currentEndpointId)
         XCTAssertEqual(endpointProfile.deviceToken, newToken?.asHexString())
@@ -128,7 +128,7 @@ class EndpointClientTests: XCTestCase {
     func testUpdateEndpointProfile_withAPNsToken_withoutStoredToken_shouldSaveToken() async {
         keychain.resetCounters()
 
-        let endpoint = PinpointEndpointProfile(applicationId: "applicationId",
+        var endpoint = PinpointEndpointProfile(applicationId: "applicationId",
                                                endpointId: "endpointId")
         endpoint.setAPNsToken(Data(hexString: newTokenHex)!)
         try? await endpointClient.updateEndpointProfile(with: endpoint)
@@ -142,7 +142,7 @@ class EndpointClientTests: XCTestCase {
         storeToken("oldToken")
         keychain.resetCounters()
 
-        let endpoint = PinpointEndpointProfile(applicationId: "applicationId",
+        var endpoint = PinpointEndpointProfile(applicationId: "applicationId",
                                                endpointId: "endpointId")
         endpoint.setAPNsToken(Data(hexString: newTokenHex)!)
         try? await endpointClient.updateEndpointProfile(with: endpoint)
@@ -156,7 +156,7 @@ class EndpointClientTests: XCTestCase {
         storeToken(newTokenHex)
         keychain.resetCounters()
 
-        let endpoint = PinpointEndpointProfile(applicationId: "applicationId",
+        var endpoint = PinpointEndpointProfile(applicationId: "applicationId",
                                                endpointId: "endpointId")
         endpoint.setAPNsToken(Data(hexString: newTokenHex)!)
         try? await endpointClient.updateEndpointProfile(with: endpoint)

--- a/AmplifyPlugins/Notifications/Push/Sources/AWSPinpointPushNotificationsPlugin/AWSPinpointPushNotificationsPlugin+ClientBehaviour.swift
+++ b/AmplifyPlugins/Notifications/Push/Sources/AWSPinpointPushNotificationsPlugin/AWSPinpointPushNotificationsPlugin+ClientBehaviour.swift
@@ -20,7 +20,7 @@ import AppKit
 
 extension AWSPinpointPushNotificationsPlugin {
     public func identifyUser(userId: String, userProfile: UserProfile?) async throws {
-        let currentEndpointProfile = await pinpoint.currentEndpointProfile()
+        var currentEndpointProfile = await pinpoint.currentEndpointProfile()
         currentEndpointProfile.addUserId(userId)
         if let userProfile = userProfile {
             currentEndpointProfile.addUserProfile(userProfile)
@@ -30,7 +30,7 @@ extension AWSPinpointPushNotificationsPlugin {
     }
 
     public func registerDevice(apnsToken: Data) async throws {
-        let currentEndpointProfile = await pinpoint.currentEndpointProfile()
+        var currentEndpointProfile = await pinpoint.currentEndpointProfile()
         currentEndpointProfile.setAPNsToken(apnsToken)
         do {
             try await pinpoint.updateEndpoint(with: currentEndpointProfile,

--- a/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginClientBehaviourTests.swift
+++ b/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginClientBehaviourTests.swift
@@ -25,7 +25,8 @@ class AWSPinpointPushNotificationsPluginClientBehaviourTests: AWSPinpointPushNot
         
         XCTAssertEqual(mockPinpoint.currentEndpointProfileCount, 1)
         XCTAssertEqual(mockPinpoint.updateEndpointCount, 1)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.user.userId, "newUserId")
+        let updatedEndpoint = try XCTUnwrap(mockPinpoint.updatedPinpointEndpointProfile)
+        XCTAssertEqual(updatedEndpoint.user.userId, "newUserId")
     }
 
     func testIdentifyUser_withProfile_shouldUpdateUserProfile() async throws {
@@ -38,13 +39,14 @@ class AWSPinpointPushNotificationsPluginClientBehaviourTests: AWSPinpointPushNot
 
         XCTAssertEqual(mockPinpoint.currentEndpointProfileCount, 1)
         XCTAssertEqual(mockPinpoint.updateEndpointCount, 1)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.user.userId, "newUserId")
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.attributes.count, 3)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.attributes["name"]?.first, "Name")
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.attributes["email"]?.first, "Email")
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.attributes["plan"]?.first, "Plan")
-        XCTAssertTrue(mockPinpoint.mockedPinpointEndpointProfile.metrics.isEmpty)
-        XCTAssertNil(mockPinpoint.mockedPinpointEndpointProfile.user.userAttributes)
+        let updatedEndpoint = try XCTUnwrap(mockPinpoint.updatedPinpointEndpointProfile)
+        XCTAssertEqual(updatedEndpoint.user.userId, "newUserId")
+        XCTAssertEqual(updatedEndpoint.attributes.count, 3)
+        XCTAssertEqual(updatedEndpoint.attributes["name"]?.first, "Name")
+        XCTAssertEqual(updatedEndpoint.attributes["email"]?.first, "Email")
+        XCTAssertEqual(updatedEndpoint.attributes["plan"]?.first, "Plan")
+        XCTAssertTrue(updatedEndpoint.metrics.isEmpty)
+        XCTAssertNil(updatedEndpoint.user.userAttributes)
     }
 
     func testIdentifyUser_withAnalyticsProfile_shouldUpdateUserProfile() async throws {
@@ -60,14 +62,15 @@ class AWSPinpointPushNotificationsPluginClientBehaviourTests: AWSPinpointPushNot
 
         XCTAssertEqual(mockPinpoint.currentEndpointProfileCount, 1)
         XCTAssertEqual(mockPinpoint.updateEndpointCount, 1)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.user.userId, "newUserId")
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.attributes.count, 2)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.attributes["attribute"]?.first, "string")
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.attributes["boolAttribute"]?.first, "true")
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.metrics["metric"], 2.0)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.metrics["intMetric"], 1)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.metrics.count, 2)
-        XCTAssertNil(mockPinpoint.mockedPinpointEndpointProfile.user.userAttributes)
+        let updatedEndpoint = try XCTUnwrap(mockPinpoint.updatedPinpointEndpointProfile)
+        XCTAssertEqual(updatedEndpoint.user.userId, "newUserId")
+        XCTAssertEqual(updatedEndpoint.attributes.count, 2)
+        XCTAssertEqual(updatedEndpoint.attributes["attribute"]?.first, "string")
+        XCTAssertEqual(updatedEndpoint.attributes["boolAttribute"]?.first, "true")
+        XCTAssertEqual(updatedEndpoint.metrics["metric"], 2.0)
+        XCTAssertEqual(updatedEndpoint.metrics["intMetric"], 1)
+        XCTAssertEqual(updatedEndpoint.metrics.count, 2)
+        XCTAssertNil(updatedEndpoint.user.userAttributes)
     }
 
     func testIdentifyUser_withBasicProfile_shouldUpdateUserProfile() async throws {
@@ -83,14 +86,15 @@ class AWSPinpointPushNotificationsPluginClientBehaviourTests: AWSPinpointPushNot
 
         XCTAssertEqual(mockPinpoint.currentEndpointProfileCount, 1)
         XCTAssertEqual(mockPinpoint.updateEndpointCount, 1)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.user.userId, "newUserId")
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.attributes.count, 2)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.attributes["attribute"]?.first, "string")
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.attributes["boolAttribute"]?.first, "true")
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.metrics["metric"], 2.0)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.metrics["intMetric"], 1)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.metrics.count, 2)
-        XCTAssertNil(mockPinpoint.mockedPinpointEndpointProfile.user.userAttributes)
+        let updatedEndpoint = try XCTUnwrap(mockPinpoint.updatedPinpointEndpointProfile)
+        XCTAssertEqual(updatedEndpoint.user.userId, "newUserId")
+        XCTAssertEqual(updatedEndpoint.attributes.count, 2)
+        XCTAssertEqual(updatedEndpoint.attributes["attribute"]?.first, "string")
+        XCTAssertEqual(updatedEndpoint.attributes["boolAttribute"]?.first, "true")
+        XCTAssertEqual(updatedEndpoint.metrics["metric"], 2.0)
+        XCTAssertEqual(updatedEndpoint.metrics["intMetric"], 1)
+        XCTAssertEqual(updatedEndpoint.metrics.count, 2)
+        XCTAssertNil(updatedEndpoint.user.userAttributes)
     }
 
     func testIdentifyUser_withPinpointProfile_shouldUpdateUserProfile() async throws {
@@ -110,26 +114,29 @@ class AWSPinpointPushNotificationsPluginClientBehaviourTests: AWSPinpointPushNot
 
         XCTAssertEqual(mockPinpoint.currentEndpointProfileCount, 1)
         XCTAssertEqual(mockPinpoint.updateEndpointCount, 1)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.attributes["attribute"]?.first, "string")
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.attributes["attributes"]?.count, 2)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.attributes["attributes"]?.first, "string")
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.attributes["boolAttribute"]?.first, "true")
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.metrics["metric"], 2)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.metrics["intMetric"], 1)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.user.userId, "newUserId")
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.user.userAttributes?["roles"]?.count, 2)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.user.userAttributes?["roles"]?.first, "Test")
+        let updatedEndpoint = try XCTUnwrap(mockPinpoint.updatedPinpointEndpointProfile)
+        XCTAssertEqual(updatedEndpoint.attributes["attribute"]?.first, "string")
+        XCTAssertEqual(updatedEndpoint.attributes["attributes"]?.count, 2)
+        XCTAssertEqual(updatedEndpoint.attributes["attributes"]?.first, "string")
+        XCTAssertEqual(updatedEndpoint.attributes["boolAttribute"]?.first, "true")
+        XCTAssertEqual(updatedEndpoint.metrics["metric"], 2)
+        XCTAssertEqual(updatedEndpoint.metrics["intMetric"], 1)
+        XCTAssertEqual(updatedEndpoint.user.userId, "newUserId")
+        XCTAssertEqual(updatedEndpoint.user.userAttributes?["roles"]?.count, 2)
+        XCTAssertEqual(updatedEndpoint.user.userAttributes?["roles"]?.first, "Test")
     }
 
     func testIdentifyUser_withPinpointProfileOptedOutOfMessages_shouldUpdateUserProfileOptOutValue() async throws {
         try await plugin.identifyUser(userId: "newUserId", userProfile: nil)
-        let updatedEndpoint = try XCTUnwrap(mockPinpoint.updatedPinpointEndpointProfile)
+        var updatedEndpoint = try XCTUnwrap(mockPinpoint.updatedPinpointEndpointProfile)
         XCTAssertFalse(updatedEndpoint.isOptOut)
 
         try await plugin.identifyUser(userId: "newUserId", userProfile: PinpointUserProfile(optedOutOfMessages: true))
+        updatedEndpoint = try XCTUnwrap(mockPinpoint.updatedPinpointEndpointProfile)
         XCTAssertTrue(updatedEndpoint.isOptOut)
 
         try await plugin.identifyUser(userId: "newUserId", userProfile: PinpointUserProfile(name: "User"))
+        updatedEndpoint = try XCTUnwrap(mockPinpoint.updatedPinpointEndpointProfile)
         XCTAssertTrue(updatedEndpoint.isOptOut)
     }
     
@@ -140,7 +147,8 @@ class AWSPinpointPushNotificationsPluginClientBehaviourTests: AWSPinpointPushNot
         
         XCTAssertEqual(mockPinpoint.currentEndpointProfileCount, 1)
         XCTAssertEqual(mockPinpoint.updateEndpointCount, 1)
-        XCTAssertEqual(mockPinpoint.mockedPinpointEndpointProfile.deviceToken, apnsToken.asHexString())
+        let updatedEndpoint = try XCTUnwrap(mockPinpoint.updatedPinpointEndpointProfile)
+        XCTAssertEqual(updatedEndpoint.deviceToken, apnsToken.asHexString())
     }
     
     // MARK: - Record Notification received tests

--- a/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/Mocks/MockAWSPinpoint.swift
+++ b/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/Mocks/MockAWSPinpoint.swift
@@ -43,7 +43,7 @@ class MockAWSPinpoint: AWSPinpointBehavior {
     )
     func currentEndpointProfile() async -> PinpointEndpointProfile {
         currentEndpointProfileCount += 1
-        return mockedPinpointEndpointProfile
+        return updatedPinpointEndpointProfile ?? mockedPinpointEndpointProfile
     }
 
     var updateEndpointCount = 0


### PR DESCRIPTION
## Issue \#
- https://github.com/aws-amplify/amplify-swift/issues/3439

## Description
This PR makes the `PinpointEndpointProfile` a `struct` to prevent race conditions crashes when two different `identifyUser` invocations attempt to modify it.

## General Checklist
- [ ] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
  - [PushNotifications](https://github.com/aws-amplify/amplify-swift/actions/runs/7450866796)
  - [Analytics](https://github.com/aws-amplify/amplify-swift/actions/runs/7451233515)
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
