### PR TITLE
chore: clarify wording in closed issue visibility comment

### DIFF
--- a/.github/workflows/issue_closed.yml
+++ b/.github/workflows/issue_closed.yml
@@ -30,5 +30,5 @@ jobs:
           message: |
                     ### ⚠️COMMENT VISIBILITY WARNING⚠️
                     Comments on closed issues are hard for our team to see.
-                    If you need more assistance, please either tag a team member or open a new issue that references this one.
+                    If you need more assistance, please open a new issue that references this one.
                     If you wish to keep having a conversation with other community members under this issue feel free to do so.


### PR DESCRIPTION
## Description
Remove "tag a team member" wording in closed issue visibility comment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
