### PR TITLE
ci: use alias latest and minimum to represent xcode cmd tool version

### DIFF
--- a/.github/composite_actions/get_platform_parameters/action.yml
+++ b/.github/composite_actions/get_platform_parameters/action.yml
@@ -5,62 +5,99 @@ inputs:
     required: true
     type: string
   xcode_version:
-    description: 'The version of Xcode. Valid values are 14.3 and 15.0'
-    required: true
+    description: "The version of Xcode. Available aliases are 'latest' and 'minimum'"
+    default: 'latest'
     type: string
+  destination:
+    description: "The destination associated with the given platform and Xcode version"
+    default: ''
+    type: string
+
 outputs:
   destination:
     description: "The destination associated with the given platform and Xcode version"
-    value: ${{ steps.platform.outputs.destination }}
+    value: ${{ steps.get-destination.outputs.destination }}
   sdk:
     description: "The SDK associated with the given platform"
-    value: ${{ steps.platform.outputs.sdk }}
+    value: ${{ steps.get-sdk.outputs.sdk }}
+  xcode-version:
+    description: "The Xcode version to build with"
+    value: ${{ steps.get-xcode-version.outputs.xcode-version }}
+
 runs:
   using: "composite"
   steps:
-    - id: platform
+    - name: Validate platform
       run: |
-        PLATFORM=${{ inputs.platform }}
-        case $PLATFORM in
+        INPUT_PLATFORM=${{ inputs.platform }}
+        case $INPUT_PLATFORM in
           iOS|tvOS|watchOS|macOS) ;;
-          *) echo "Unsupported platform: $PLATFORM"; exit 1 ;;
+          *) echo "Unsupported platform: $INPUT_PLATFORM"; exit 1 ;;
         esac
+      shell: bash
 
-        XCODE_VERSION=${{ inputs.xcode_version }}
-        case $XCODE_VERSION in
-          14.0.1|14.3|15.0) ;;
-          *) echo "Unsupported Xcode version: $XCODE_VERSION"; exit 1 ;;
+    - id: get-xcode-version
+      run: |
+        LATEST_XCODE_VERSION=14.3.1
+        MINIMUM_XCODE_VERSION=14.0.1
+
+        INPUT_XCODE_VERSION=${{ inputs.xcode_version }}
+
+        case $INPUT_XCODE_VERSION in
+          latest)
+            XCODE_VERSION=$LATEST_XCODE_VERSION ;;
+          minimum)
+            XCODE_VERSION=$MINIMUM_XCODE_VERSION ;;
+          *)
+            XCODE_VERSION=$INPUT_XCODE_VERSION ;;
         esac
+        echo "xcode-version=$XCODE_VERSION" >> $GITHUB_OUTPUT
+
+      shell: bash
+
+    - id: get-destination
+      run: |
+        INPUT_PLATFORM=${{ inputs.platform }}
+        INPUT_DESTINATION='${{ inputs.destination }}'
+        INPUT_XCODE_VERSION=${{ inputs.xcode_version }}
 
         DESTINATION_MAPPING='{
-          "14.0.1": {
+          "minimum": {
             "iOS": "platform=iOS Simulator,name=iPhone 14,OS=16.0",
             "tvOS": "platform=tvOS Simulator,name=Apple TV 4K (2nd generation),OS=16.0",
             "watchOS": "platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=9.0",
             "macOS": "platform=macOS,arch=x86_64"
           },
-          "14.3": {
+          "latest": {
             "iOS": "platform=iOS Simulator,name=iPhone 14,OS=16.4",
             "tvOS": "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=16.4",
             "watchOS": "platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=9.4",
             "macOS": "platform=macOS,arch=x86_64"
-          },
-          "15.0": {
-            "iOS": "platform=iOS Simulator,name=iPhone 15,OS=latest",
-            "tvOS": "platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=latest",
-            "watchOS": "platform=watchOS Simulator,name=Apple Watch Series 9 (45mm),OS=latest",
-            "macOS": "platform=macOS,arch=x86_64"
           }
         }'
 
+        if [ -z "$INPUT_DESTINATION" ]; then
+          DESTINATION=$(echo $DESTINATION_MAPPING | jq -r ".\"$INPUT_XCODE_VERSION\".$INPUT_PLATFORM")
+        else
+          DESTINATION=$INPUT_DESTINATION
+        fi
+
+        if [ -z "$DESTINATION" ]; then
+          echo "No available destination to build for"
+          exit 1
+        fi
+        echo "destination=$DESTINATION" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - id: get-sdk
+      run: |
+        INPUT_PLATFORM=${{ inputs.platform }}
         SDK_MAPPING='{
           "iOS": "iphonesimulator",
           "tvOS": "appletvsimulator",
           "watchOS": "watchsimulator",
           "macOS": "macosx"
         }'
-
-        echo "destination=$(echo $DESTINATION_MAPPING | jq -r ."\"$XCODE_VERSION\"".$PLATFORM)" >> $GITHUB_OUTPUT
-        echo "sdk=$(echo $SDK_MAPPING | jq -r .$PLATFORM)" >> $GITHUB_OUTPUT
+        echo "sdk=$(echo $SDK_MAPPING | jq -r .$INPUT_PLATFORM)" >> $GITHUB_OUTPUT
       shell: bash
 

--- a/.github/composite_actions/run_xcodebuild_test/action.yml
+++ b/.github/composite_actions/run_xcodebuild_test/action.yml
@@ -12,9 +12,8 @@ inputs:
     required: false
     type: string
   destination:
-    required: false
+    required: true
     type: string
-    default: 'platform=iOS Simulator,name=iPhone 13,OS=latest'
   sdk:
     required: false
     type: string

--- a/.github/workflows/build_amplify_swift.yml
+++ b/.github/workflows/build_amplify_swift.yml
@@ -8,7 +8,7 @@ on:
 
       xcode-version:
         type: string
-        default: '14.3'
+        default: 'latest'
 
       os-runner:
         type: string
@@ -43,7 +43,7 @@ jobs:
         id: dependencies-cache
         if: inputs.cacheable
         timeout-minutes: 4
-        continue-on-error: true
+        continue-on-error: ${{ inputs.cacheable }}
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
@@ -55,7 +55,7 @@ jobs:
         id: build-cache
         if: inputs.cacheable
         timeout-minutes: 4
-        continue-on-error: true
+        continue-on-error: ${{ inputs.cacheable }}
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -63,13 +63,13 @@ jobs:
 
       - name: Build Amplify for Swift
         id: build-package
-        continue-on-error: true
+        continue-on-error: ${{ inputs.cacheable }}
         uses: ./.github/composite_actions/run_xcodebuild
         with:
           scheme: Amplify-Package
           destination: ${{ steps.platform.outputs.destination }}
           sdk: ${{ steps.platform.outputs.sdk }}
-          xcode_path: /Applications/Xcode_${{ inputs.xcode-version }}.app
+          xcode_path: /Applications/Xcode_${{ steps.platform.outputs.xcode-version }}.app
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.dependencies-cache.outputs.cache-hit }}
@@ -85,7 +85,7 @@ jobs:
         if: inputs.cacheable && steps.build-cache.outputs.cache-hit && github.ref_name == 'main'
         env:
           GH_TOKEN: ${{ github.token }}
-        continue-on-error: true
+        continue-on-error: ${{ inputs.cacheable }}
         run: |
           gh cache delete ${{ steps.build-cache.outputs.cache-primary-key }}
 

--- a/.github/workflows/build_minimum_supported_swift_platforms.yml
+++ b/.github/workflows/build_minimum_supported_swift_platforms.yml
@@ -15,27 +15,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os-runner: macos-12
-            xcode-version: 14.0.1
-            platform: iOS
-
-          - os-runner: macos-12
-            xcode-version: 14.0.1
-            platform: macOS
-
-          - os-runner: macos-12
-            xcode-version: 14.0.1
-            platform: tvOS
-
-          - os-runner: macos-12
-            xcode-version: 14.0.1
-            platform: watchOS
+        platform: [iOS, macOS, tvOS, watchOS]
 
     uses: ./.github/workflows/build_amplify_swift.yml
     with:
-      os-runner: ${{ matrix.os-runner }}
-      xcode-version: ${{ matrix.xcode-version }}
+      os-runner: macos-12
+      xcode-version: 'minimum'
       platform: ${{ matrix.platform }}
       cacheable: false
 

--- a/.github/workflows/integ_test_analytics.yml
+++ b/.github/workflows/integ_test_analytics.yml
@@ -39,7 +39,6 @@ jobs:
       scheme: ${{ matrix.platform == 'watchOS' && 'AWSPinpointAnalyticsPluginIntegrationTestsWatch' || 'AWSPinpointAnalyticsPluginIntegrationTests' }}
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/Analytics/Tests/AnalyticsHostApp
-      xcode_version: '14.3'
       resource_subfolder: analytics
       timeout-minutes: 30
     secrets: inherit

--- a/.github/workflows/integ_test_api_functional.yml
+++ b/.github/workflows/integ_test_api_functional.yml
@@ -39,7 +39,6 @@ jobs:
       scheme: ${{ matrix.platform == 'watchOS' && 'AWSAPIPluginFunctionalTestsWatch' || 'AWSAPIPluginFunctionalTests' }}
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/API/Tests/APIHostApp
-      xcode_version: '14.3'
       resource_subfolder: api
       timeout-minutes: 45
     secrets: inherit

--- a/.github/workflows/integ_test_api_graphql_auth_directive.yml
+++ b/.github/workflows/integ_test_api_graphql_auth_directive.yml
@@ -33,7 +33,6 @@ jobs:
       scheme: AWSAPIPluginGraphQLAuthDirectiveTests
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/API/Tests/APIHostApp
-      xcode_version: '14.3'
       resource_subfolder: api
       timeout-minutes: 45
     secrets: inherit

--- a/.github/workflows/integ_test_api_graphql_iam.yml
+++ b/.github/workflows/integ_test_api_graphql_iam.yml
@@ -33,7 +33,6 @@ jobs:
       scheme: AWSAPIPluginGraphQLIAMTests
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/API/Tests/APIHostApp
-      xcode_version: '14.3'
       resource_subfolder: api
       timeout-minutes: 45
     secrets: inherit

--- a/.github/workflows/integ_test_api_graphql_lambda_auth.yml
+++ b/.github/workflows/integ_test_api_graphql_lambda_auth.yml
@@ -39,7 +39,6 @@ jobs:
       scheme: ${{ matrix.platform == 'watchOS' && 'AWSAPIPluginGraphQLLambdaAuthTestsWatch' || 'AWSAPIPluginGraphQLLambdaAuthTests' }}
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/API/Tests/APIHostApp
-      xcode_version: '14.3'
       resource_subfolder: api
       timeout-minutes: 45
     secrets: inherit

--- a/.github/workflows/integ_test_api_graphql_lazy_load.yml
+++ b/.github/workflows/integ_test_api_graphql_lazy_load.yml
@@ -33,7 +33,6 @@ jobs:
       scheme: AWSAPIPluginLazyLoadTests
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/API/Tests/APIHostApp
-      xcode_version: '14.3'
       resource_subfolder: api
       timeout-minutes: 45
     secrets: inherit

--- a/.github/workflows/integ_test_api_graphql_user_pool.yml
+++ b/.github/workflows/integ_test_api_graphql_user_pool.yml
@@ -33,7 +33,6 @@ jobs:
       scheme: AWSAPIPluginGraphQLUserPoolTests
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/API/Tests/APIHostApp
-      xcode_version: '14.3'
       resource_subfolder: api
       timeout-minutes: 45
     secrets: inherit

--- a/.github/workflows/integ_test_api_rest_iam.yml
+++ b/.github/workflows/integ_test_api_rest_iam.yml
@@ -39,7 +39,6 @@ jobs:
       scheme: ${{ matrix.platform == 'watchOS' && 'AWSAPIPluginRESTIAMTestsWatch' || 'AWSAPIPluginRESTIAMTests' }}
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/API/Tests/APIHostApp
-      xcode_version: '14.3'
       resource_subfolder: api
       timeout-minutes: 45
     secrets: inherit

--- a/.github/workflows/integ_test_api_rest_user_pool.yml
+++ b/.github/workflows/integ_test_api_rest_user_pool.yml
@@ -33,7 +33,6 @@ jobs:
       scheme: AWSAPIPluginRESTUserPoolTests
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/API/Tests/APIHostApp
-      xcode_version: '14.3'
       resource_subfolder: api
       timeout-minutes: 45
     secrets: inherit

--- a/.github/workflows/integ_test_auth.yml
+++ b/.github/workflows/integ_test_auth.yml
@@ -44,7 +44,6 @@ jobs:
       scheme: ${{ matrix.platform == 'watchOS' && 'AuthIntegrationTestsWatch' || 'AuthIntegrationTests' }}
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/Auth/Tests/AuthHostApp/
-      xcode_version: '14.3'
       resource_subfolder: auth
       timeout-minutes: 30
     secrets: inherit
@@ -56,7 +55,6 @@ jobs:
       scheme: AuthHostedUIApp
       platform: iOS
       project_path: ./AmplifyPlugins/Auth/Tests/AuthHostedUIApp/
-      xcode_version: '14.3'
       resource_subfolder: auth
       timeout-minutes: 30
     secrets: inherit

--- a/.github/workflows/integ_test_datastore_auth_cognito.yml
+++ b/.github/workflows/integ_test_datastore_auth_cognito.yml
@@ -39,7 +39,6 @@ jobs:
       scheme: ${{ matrix.platform == 'watchOS' && 'AWSDataStorePluginAuthCognitoTestsWatch' || 'AWSDataStorePluginAuthCognitoTests' }}
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
-      xcode_version: '14.3'
       resource_subfolder: datastore
       timeout-minutes: 120
     secrets: inherit

--- a/.github/workflows/integ_test_datastore_auth_iam.yml
+++ b/.github/workflows/integ_test_datastore_auth_iam.yml
@@ -39,7 +39,6 @@ jobs:
       scheme: ${{ matrix.platform == 'watchOS' && 'AWSDataStorePluginAuthIAMTestsWatch' || 'AWSDataStorePluginAuthIAMTests' }}
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
-      xcode_version: '14.3'
       resource_subfolder: datastore
       timeout-minutes: 120
     secrets: inherit

--- a/.github/workflows/integ_test_datastore_base.yml
+++ b/.github/workflows/integ_test_datastore_base.yml
@@ -39,7 +39,6 @@ jobs:
       scheme: ${{ matrix.platform == 'watchOS' && 'AWSDataStorePluginIntegrationTestsWatch' || 'AWSDataStorePluginIntegrationTests' }}
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
-      xcode_version: '14.3'
       resource_subfolder: datastore
       timeout-minutes: 120
     secrets: inherit

--- a/.github/workflows/integ_test_datastore_cpk.yml
+++ b/.github/workflows/integ_test_datastore_cpk.yml
@@ -39,7 +39,6 @@ jobs:
       scheme: ${{ matrix.platform == 'watchOS' && 'AWSDataStorePluginCPKTestsWatch' || 'AWSDataStorePluginCPKTests' }}
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
-      xcode_version: '14.3'
       resource_subfolder: datastore
       timeout-minutes: 120
     secrets: inherit

--- a/.github/workflows/integ_test_datastore_lazy_load.yml
+++ b/.github/workflows/integ_test_datastore_lazy_load.yml
@@ -39,7 +39,6 @@ jobs:
       scheme: ${{ matrix.platform == 'watchOS' && 'AWSDataStorePluginLazyLoadTestsWatch' || 'AWSDataStorePluginLazyLoadTests' }}
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
-      xcode_version: '14.3'
       resource_subfolder: datastore
       timeout-minutes: 120
     secrets: inherit

--- a/.github/workflows/integ_test_datastore_multi_auth.yml
+++ b/.github/workflows/integ_test_datastore_multi_auth.yml
@@ -39,7 +39,6 @@ jobs:
       scheme: ${{ matrix.platform == 'watchOS' && 'AWSDataStorePluginMultiAuthTestsWatch' || 'AWSDataStorePluginMultiAuthTests' }}
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
-      xcode_version: '14.3'
       resource_subfolder: datastore
       timeout-minutes: 120
     secrets: inherit

--- a/.github/workflows/integ_test_datastore_v2.yml
+++ b/.github/workflows/integ_test_datastore_v2.yml
@@ -39,7 +39,6 @@ jobs:
       scheme: ${{ matrix.platform == 'watchOS' && 'AWSDataStorePluginV2TestsWatch' || 'AWSDataStorePluginV2Tests' }}
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
-      xcode_version: '14.3'
       resource_subfolder: datastore
       timeout-minutes: 120
     secrets: inherit

--- a/.github/workflows/integ_test_geo.yml
+++ b/.github/workflows/integ_test_geo.yml
@@ -39,7 +39,6 @@ jobs:
       scheme: ${{ matrix.platform == 'watchOS' && 'AWSLocationGeoPluginIntegrationTestsWatch' || 'AWSLocationGeoPluginIntegrationTests' }}
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/Geo/Tests/GeoHostApp/
-      xcode_version: '14.3'
       resource_subfolder: geo
       timeout-minutes: 30
     secrets: inherit

--- a/.github/workflows/integ_test_logging.yml
+++ b/.github/workflows/integ_test_logging.yml
@@ -39,7 +39,8 @@ jobs:
       scheme: ${{ matrix.platform == 'watchOS' && 'AWSCloudWatchLoggingPluginIntegrationTestsWatch' || 'AWSCloudWatchLoggingPluginIntegrationTests' }}
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginHostApp
-      xcode_version: ${{ matrix.platform == 'watchOS' && '15.0' || '14.3' }}
       resource_subfolder: logging
+      xcode_version: ${{ matrix.platform == 'watchOS' && '15.0' || 'latest' }}
+      destination: ${{ matrix.platform == 'watchOS' && 'platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=10.2' || '' }}
       timeout-minutes: 60
     secrets: inherit

--- a/.github/workflows/integ_test_predictions.yml
+++ b/.github/workflows/integ_test_predictions.yml
@@ -39,7 +39,6 @@ jobs:
       scheme: ${{ matrix.platform == 'watchOS' && 'AWSPredictionsPluginIntegrationTestsWatch' || 'AWSPredictionsPluginIntegrationTests' }}
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/Predictions/Tests/PredictionsHostApp
-      xcode_version: '14.3'
       resource_subfolder: predictions
       timeout-minutes: 30
     secrets: inherit

--- a/.github/workflows/integ_test_push_notifications.yml
+++ b/.github/workflows/integ_test_push_notifications.yml
@@ -42,14 +42,13 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
-      
+
       - name: Get build parameters for ${{ matrix.platform}}
         id: platform
         uses: ./.github/composite_actions/get_platform_parameters
         with:
           platform: ${{ matrix.platform }}
-          xcode_version: '14.3'
-      
+
       - name: Create the test configuration directory
         run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
 
@@ -102,7 +101,7 @@ jobs:
           scheme: ${{ matrix.platform == 'watchOS' && 'PushNotificationWatchTests' || 'PushNotificationHostApp' }}
           destination: ${{ steps.platform.outputs.destination }}
           sdk: ${{ steps.platform.outputs.sdk }}
-          xcode_path: /Applications/Xcode_14.3.app
+          xcode_path: /Applications/Xcode_${{ steps.platform.outputs.xcode-version }}.app
           project_path: ./AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp
           generate_coverage: false
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
@@ -117,7 +116,7 @@ jobs:
           scheme: ${{ matrix.platform == 'watchOS' && 'PushNotificationWatchTests' || 'PushNotificationHostApp' }}
           destination: ${{ steps.platform.outputs.destination }}
           sdk: ${{ steps.platform.outputs.sdk }}
-          xcode_path: /Applications/Xcode_14.3.app
+          xcode_path: /Applications/Xcode_${{ steps.platform.outputs.xcode-version }}.app
           project_path: ./AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp
           generate_coverage: false
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify

--- a/.github/workflows/integ_test_storage.yml
+++ b/.github/workflows/integ_test_storage.yml
@@ -39,7 +39,6 @@ jobs:
       scheme: ${{ matrix.platform == 'watchOS' && 'AWSS3StoragePluginIntegrationTestsWatch' || 'AWSS3StoragePluginIntegrationTests' }}
       platform: ${{ matrix.platform }}
       project_path: ./AmplifyPlugins/Storage/Tests/StorageHostApp/
-      xcode_version: '14.3'
       resource_subfolder: storage
       timeout-minutes: 30
     secrets: inherit

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -2,6 +2,9 @@ name: Run tests for the given parameters
 on:
   workflow_call:
     inputs:
+      os-runner:
+        type: string
+        default: 'macos-13'
       scheme:
         description: 'The scheme to run the tests'
         required: true
@@ -15,7 +18,10 @@ on:
         type: string
       xcode_version:
         description: 'The verion of Xcode used to run these tests'
-        required: true
+        default: 'latest'
+        type: string
+      destination:
+        default: ''
         type: string
       resource_subfolder:
         required: true
@@ -33,7 +39,7 @@ permissions:
 jobs:
   integration-tests:
     name: ${{ inputs.platform }} Tests | ${{ inputs.scheme }}
-    runs-on: macos-13
+    runs-on: ${{ inputs.os-runner }}
     if: inputs.platform != 'macOS' # macOS is not supported for Integration Tests
     timeout-minutes: ${{ inputs.timeout-minutes }}
     environment: IntegrationTest
@@ -49,6 +55,7 @@ jobs:
         with:
           platform: ${{ inputs.platform }}
           xcode_version: ${{ inputs.xcode_version }}
+          destination: ${{ inputs.destination }}
 
       - name: Create the test configuration directory
         run: mkdir -p ~/.aws-amplify/amplify-ios/testconfiguration/
@@ -90,7 +97,7 @@ jobs:
           scheme: ${{ inputs.scheme }}
           destination: ${{ steps.platform.outputs.destination }}
           sdk: ${{ steps.platform.outputs.sdk }}
-          xcode_path: /Applications/Xcode_${{ inputs.xcode_version }}.app
+          xcode_path: /Applications/Xcode_${{ steps.platform.outputs.xcode-version }}.app
           project_path: ${{ inputs.project_path }}
           generate_coverage: false
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
@@ -107,7 +114,7 @@ jobs:
           scheme: ${{ inputs.scheme }}
           destination: ${{ steps.platform.outputs.destination }}
           sdk: ${{ steps.platform.outputs.sdk }}
-          xcode_path: /Applications/Xcode_${{ inputs.xcode_version }}.app
+          xcode_path: /Applications/Xcode_${{ steps.platform.outputs.xcode-version }}.app
           project_path: ${{ inputs.project_path }}
           generate_coverage: false
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -15,7 +15,7 @@ on:
         type: string
       xcode_version:
         description: 'The version of Xcode used to run these tests'
-        required: true
+        default: 'latest'
         type: string
       timeout-minutes:
         description: 'The timeout for each execution'
@@ -77,7 +77,7 @@ jobs:
           scheme: ${{ inputs.scheme }}
           destination: ${{ steps.platform.outputs.destination }}
           sdk: ${{ steps.platform.outputs.sdk }}
-          xcode_path: /Applications/Xcode_${{ inputs.xcode_version }}.app
+          xcode_path: /Applications/Xcode_${{ steps.platform.outputs.xcode-version }}.app
           generate_coverage: ${{ inputs.generate_coverage_report }}
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
@@ -92,7 +92,7 @@ jobs:
           scheme: ${{ inputs.scheme }}
           destination: ${{ steps.platform.outputs.destination }}
           sdk: ${{ steps.platform.outputs.sdk }}
-          xcode_path: /Applications/Xcode_${{ inputs.xcode_version }}.app
+          xcode_path: /Applications/Xcode_${{ steps.platform.outputs.xcode-version }}.app
           project_path: ${{ inputs.project_path }}
           generate_coverage: ${{ inputs.generate_coverage_report }}
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify

--- a/.github/workflows/run_unit_tests_platforms.yml
+++ b/.github/workflows/run_unit_tests_platforms.yml
@@ -36,6 +36,5 @@ jobs:
     with:
       scheme: ${{ inputs.scheme }}
       platform: ${{ matrix.platform }}
-      xcode_version: '14.3'
       generate_coverage_report: ${{ github.event_name != 'workflow_dispatch' && matrix.platform == 'iOS' && inputs.generate_coverage_report }}
       timeout-minutes: ${{ inputs.timeout-minutes }}

--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
     id-token: write
-    contents: read 
+    contents: read
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -29,10 +29,25 @@ jobs:
           aws_region: ${{ secrets.AWS_REGION }}
           aws_s3_bucket: ${{ secrets.AWS_S3_BUCKET_INTEG_V2 }}
 
-  auth-stress-test:
+  get-platform-build-params:
+    runs-on: macos-13
     needs: prepare-for-test
+    outputs:
+      platform-params: ${{ steps.platform.outputs }}
+    steps:
+      - name: Get build parameters
+        id: platform
+        uses: ./.github/composite_actions/get_platform_parameters
+        with:
+          platform: 'iOS'
+
+  auth-stress-test:
+    needs: get-platform-build-params
     runs-on: macos-13
     environment: IntegrationTest
+    env:
+      DESTINATION: ${{ needs.get-platform-build-params.outputs.platform-params.destination }}
+      XCODE_VERSION: ${{ needs.get-platform-build-params.outputs.platform-params.xcode-version }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
         with:
@@ -54,13 +69,16 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Auth/Tests/AuthHostApp/
           scheme: AuthStressTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
-          xcode_path: '/Applications/Xcode_14.3.app'
+          destination: ${{ env.DESTINATION }}
+          xcode_path: '/Applications/Xcode_${{ env.XCODE_VERSION }}.app'
 
   geo-stress-test:
-    needs: prepare-for-test
+    needs: get-platform-build-params
     runs-on: macos-13
     environment: IntegrationTest
+    env:
+      DESTINATION: ${{ needs.get-platform-build-params.outputs.platform-params.destination }}
+      XCODE_VERSION: ${{ needs.get-platform-build-params.outputs.platform-params.xcode-version }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
         with:
@@ -82,13 +100,16 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Geo/Tests/GeoHostApp/
           scheme: GeoStressTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
-          xcode_path: '/Applications/Xcode_14.3.app'
+          destination: ${{ env.DESTINATION }}
+          xcode_path: '/Applications/Xcode_${{ env.XCODE_VERSION }}.app'
 
   storage-stress-test:
-    needs: prepare-for-test
+    needs: get-platform-build-params
     runs-on: macos-13
     environment: IntegrationTest
+    env:
+      DESTINATION: ${{ needs.get-platform-build-params.outputs.platform-params.destination }}
+      XCODE_VERSION: ${{ needs.get-platform-build-params.outputs.platform-params.xcode-version }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
         with:
@@ -110,13 +131,16 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/Storage/Tests/StorageHostApp/
           scheme: StorageStressTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
-          xcode_path: '/Applications/Xcode_14.3.app'
-  
+          destination: ${{ env.DESTINATION }}
+          xcode_path: '/Applications/Xcode_${{ env.XCODE_VERSION }}.app'
+
   datastore-stress-test:
-    needs: prepare-for-test
+    needs: get-platform-build-params
     runs-on: macos-13
     environment: IntegrationTest
+    env:
+      DESTINATION: ${{ needs.get-platform-build-params.outputs.platform-params.destination }}
+      XCODE_VERSION: ${{ needs.get-platform-build-params.outputs.platform-params.xcode-version }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
         with:
@@ -138,13 +162,16 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/DataStore/Tests/DataStoreHostApp
           scheme: DatastoreStressTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
-          xcode_path: '/Applications/Xcode_14.3.app'
+          destination: ${{ env.DESTINATION }}
+          xcode_path: '/Applications/Xcode_${{ env.XCODE_VERSION }}.app'
 
   graphql-api-stress-test:
-    needs: prepare-for-test
+    needs: get-platform-build-params
     runs-on: macos-13
     environment: IntegrationTest
+    env:
+      DESTINATION: ${{ needs.get-platform-build-params.outputs.platform-params.destination }}
+      XCODE_VERSION: ${{ needs.get-platform-build-params.outputs.platform-params.xcode-version }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
         with:
@@ -166,5 +193,5 @@ jobs:
         with:
           project_path: ./AmplifyPlugins/API/Tests/APIHostApp
           scheme: GraphQLAPIStressTests
-          destination: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
-          xcode_path: '/Applications/Xcode_14.3.app'
+          destination: ${{ env.DESTINATION }}
+          xcode_path: '/Applications/Xcode_${{ env.XCODE_VERSION }}.app'


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

- add alias `latest` and `minimum` to represent xcode cmd tool version
  - `latest` is xcode 14.3.1
  - `minimum` is xcode 14.0.1

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
