### PR TITLE
fix(datastore): decode optimistically with paginated list response type

### DIFF
--- a/Amplify/Categories/API/Response/GraphQLError.swift
+++ b/Amplify/Categories/API/Response/GraphQLError.swift
@@ -44,3 +44,5 @@ extension GraphQLError {
         public let column: Int
     }
 }
+
+extension GraphQLError: Error { }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/PaginatedList.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/PaginatedList.swift
@@ -12,4 +12,35 @@ public struct PaginatedList<ModelType: Model>: Decodable {
     public let items: [MutationSync<ModelType>]
     public let nextToken: String?
     public let startedAt: Int64?
+
+    enum CodingKeys: CodingKey {
+        case items
+        case nextToken
+        case startedAt
+    }
+
+    public init(items: [MutationSync<ModelType>], nextToken: String?, startedAt: Int64?) {
+        self.items = items
+        self.nextToken = nextToken
+        self.startedAt = startedAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let optimisticDecodedResults = try values.decode([OptimisticDecoded<MutationSync<ModelType>>].self, forKey: .items)
+        items = optimisticDecodedResults.compactMap { try? $0.result.get() }
+        nextToken = try values.decode(String?.self, forKey: .nextToken)
+        startedAt = try values.decode(Int64?.self, forKey: .startedAt)
+    }
+}
+
+
+fileprivate struct OptimisticDecoded<T: Decodable>: Decodable {
+    let result: Result<T, Error>
+
+    init(from decoder: Decoder) throws {
+        result = Result(catching: {
+            try T(from: decoder)
+        })
+    }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/PaginatedListTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/PaginatedListTests.swift
@@ -95,10 +95,11 @@ class PaginatedListTests: XCTestCase {
         }
     }
 
-    func testDecodePaginatedListOptimastically() {
+    func testDecodePaginatedListOptimistically() {
         let syncQueryJSON = """
         {
           "items": [
+            null,
             {
               "id": "post-id",
               "createdAt": "2019-11-27T23:35:39Z",

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/PaginatedListTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/PaginatedListTests.swift
@@ -69,6 +69,7 @@ class PaginatedListTests: XCTestCase {
             XCTAssertNotNil(paginatedList.startedAt)
             XCTAssertNotNil(paginatedList.nextToken)
             XCTAssertNotNil(paginatedList.items)
+            XCTAssertEqual(paginatedList.items.count, 2)
             XCTAssert(!paginatedList.items.isEmpty)
             XCTAssert(paginatedList.items[0].model.title == "title")
             XCTAssert(paginatedList.items[0].syncMetadata.version == 10)
@@ -89,6 +90,48 @@ class PaginatedListTests: XCTestCase {
             XCTAssertNotNil(paginatedList.nextToken)
             XCTAssert(paginatedList.nextToken == "token")
             XCTAssert(paginatedList.items.isEmpty)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func testDecodePaginatedListOptimastically() {
+        let syncQueryJSON = """
+        {
+          "items": [
+            {
+              "id": "post-id",
+              "createdAt": "2019-11-27T23:35:39Z",
+              "_version": 10,
+              "_lastChangedAt": 1574897753341,
+              "_deleted": null
+            },
+            {
+              "id": "post-id",
+              "title": "title",
+              "content": "post content",
+              "createdAt": "2019-11-27T23:35:39Z",
+              "_version": 11,
+              "_lastChangedAt": 1574897753341,
+              "_deleted": null
+            }
+          ],
+          "startedAt": 1575322600038,
+          "nextToken": "token"
+        }
+        """
+        do {
+            let decoder = JSONDecoder(dateDecodingStrategy: ModelDateFormatting.decodingStrategy)
+            let data = Data(syncQueryJSON.utf8)
+            let paginatedList = try decoder.decode(PaginatedList<Post>.self, from: data)
+            XCTAssertNotNil(paginatedList)
+            XCTAssertNotNil(paginatedList.startedAt)
+            XCTAssertNotNil(paginatedList.nextToken)
+            XCTAssertNotNil(paginatedList.items)
+            XCTAssertEqual(paginatedList.items.count, 1)
+            XCTAssert(paginatedList.items[0].model.title == "title")
+            XCTAssert(paginatedList.items[0].syncMetadata.version == 11)
+            XCTAssert(paginatedList.items[0].syncMetadata.lastChangedAt == 1_574_897_753_341)
         } catch {
             XCTFail(error.localizedDescription)
         }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/PaginatedListTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/PaginatedListTests.swift
@@ -95,6 +95,12 @@ class PaginatedListTests: XCTestCase {
         }
     }
 
+    /// - Given: a `Post` Sync query with items, nextToken, and with sync data (startedAt, _version, etc)
+    /// - When:
+    ///   - some of the JSON items are not able to be decoded to Post
+    ///   - the JSON is decoded into `PaginatedList<Post>`
+    /// - Then:
+    ///   - the result should contain only valid items of type MutationSync<Post>, startedAt, nextToken.
     func testDecodePaginatedListOptimistically() {
         let syncQueryJSON = """
         {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/3259

## Description
<!-- Why is this change required? What problem does it solve? -->

- decoding the `PaginatedList` optimistically

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
