### PR TITLE
fix(datastore): add required fields in selection set for hasOne-belongsTo relationship

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
@@ -53,7 +53,7 @@ extension SelectionSet {
                       let schema = ModelRegistry.modelSchema(from: associatedModelName) {
                 if recursive {
                     var recursive = recursive
-                    if field._isBelongsToOrHasOne {
+                    if field._isBelongsToOrHasOne && !field.isRequired {
                         recursive = false
                     }
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/3259

## Description
<!-- Why is this change required? What problem does it solve? -->
This PR adds the **required** fields(recursively) for an associated model connected to a model with @belongsTo and @hasOne directive.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
