### PR TITLE
fix(datastore): fix syncQuery for partial success-error responses and update retry mechanism for error codes

### DIFF
--- a/Amplify/Categories/API/Response/GraphQLError.swift
+++ b/Amplify/Categories/API/Response/GraphQLError.swift
@@ -44,3 +44,5 @@ extension GraphQLError {
         public let column: Int
     }
 }
+
+extension GraphQLError: Error { }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/PaginatedList.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/PaginatedList.swift
@@ -12,4 +12,35 @@ public struct PaginatedList<ModelType: Model>: Decodable {
     public let items: [MutationSync<ModelType>]
     public let nextToken: String?
     public let startedAt: Int64?
+
+    enum CodingKeys: CodingKey {
+        case items
+        case nextToken
+        case startedAt
+    }
+
+    public init(items: [MutationSync<ModelType>], nextToken: String?, startedAt: Int64?) {
+        self.items = items
+        self.nextToken = nextToken
+        self.startedAt = startedAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let optimisticDecodedResults = try values.decode([OptimisticDecoded<MutationSync<ModelType>>].self, forKey: .items)
+        items = optimisticDecodedResults.compactMap { try? $0.result.get() }
+        nextToken = try values.decode(String?.self, forKey: .nextToken)
+        startedAt = try values.decode(Int64?.self, forKey: .startedAt)
+    }
+}
+
+
+fileprivate struct OptimisticDecoded<T: Decodable>: Decodable {
+    let result: Result<T, Error>
+
+    init(from decoder: Decoder) throws {
+        result = Result(catching: {
+            try T(from: decoder)
+        })
+    }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/PaginatedListTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/PaginatedListTests.swift
@@ -69,6 +69,7 @@ class PaginatedListTests: XCTestCase {
             XCTAssertNotNil(paginatedList.startedAt)
             XCTAssertNotNil(paginatedList.nextToken)
             XCTAssertNotNil(paginatedList.items)
+            XCTAssertEqual(paginatedList.items.count, 2)
             XCTAssert(!paginatedList.items.isEmpty)
             XCTAssert(paginatedList.items[0].model.title == "title")
             XCTAssert(paginatedList.items[0].syncMetadata.version == 10)
@@ -89,6 +90,55 @@ class PaginatedListTests: XCTestCase {
             XCTAssertNotNil(paginatedList.nextToken)
             XCTAssert(paginatedList.nextToken == "token")
             XCTAssert(paginatedList.items.isEmpty)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    /// - Given: a `Post` Sync query with items, nextToken, and with sync data (startedAt, _version, etc)
+    /// - When:
+    ///   - some of the JSON items are not able to be decoded to Post
+    ///   - the JSON is decoded into `PaginatedList<Post>`
+    /// - Then:
+    ///   - the result should contain only valid items of type MutationSync<Post>, startedAt, nextToken.
+    func testDecodePaginatedListOptimistically() {
+        let syncQueryJSON = """
+        {
+          "items": [
+            null,
+            {
+              "id": "post-id",
+              "createdAt": "2019-11-27T23:35:39Z",
+              "_version": 10,
+              "_lastChangedAt": 1574897753341,
+              "_deleted": null
+            },
+            {
+              "id": "post-id",
+              "title": "title",
+              "content": "post content",
+              "createdAt": "2019-11-27T23:35:39Z",
+              "_version": 11,
+              "_lastChangedAt": 1574897753341,
+              "_deleted": null
+            }
+          ],
+          "startedAt": 1575322600038,
+          "nextToken": "token"
+        }
+        """
+        do {
+            let decoder = JSONDecoder(dateDecodingStrategy: ModelDateFormatting.decodingStrategy)
+            let data = Data(syncQueryJSON.utf8)
+            let paginatedList = try decoder.decode(PaginatedList<Post>.self, from: data)
+            XCTAssertNotNil(paginatedList)
+            XCTAssertNotNil(paginatedList.startedAt)
+            XCTAssertNotNil(paginatedList.nextToken)
+            XCTAssertNotNil(paginatedList.items)
+            XCTAssertEqual(paginatedList.items.count, 1)
+            XCTAssert(paginatedList.items[0].model.title == "title")
+            XCTAssert(paginatedList.items[0].syncMetadata.version == 11)
+            XCTAssert(paginatedList.items[0].syncMetadata.lastChangedAt == 1_574_897_753_341)
         } catch {
             XCTFail(error.localizedDescription)
         }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RequestRetryablePolicy.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RequestRetryablePolicy.swift
@@ -40,7 +40,8 @@ class RequestRetryablePolicy: RequestRetryable {
              .timedOut,
              .dataNotAllowed,
              .cannotParseResponse,
-             .networkConnectionLost:
+             .networkConnectionLost,
+             .userAuthenticationRequired:
             let waitMillis = retryDelayInMillseconds(for: attemptNumber)
             return RequestRetryAdvice(shouldRetry: true, retryInterval: .milliseconds(waitMillis))
         default:

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RequestRetryablePolicy.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RequestRetryablePolicy.swift
@@ -41,6 +41,7 @@ class RequestRetryablePolicy: RequestRetryable {
              .dataNotAllowed,
              .cannotParseResponse,
              .networkConnectionLost,
+             .secureConnectionFailed,
              .userAuthenticationRequired:
             let waitMillis = retryDelayInMillseconds(for: attemptNumber)
             return RequestRetryAdvice(shouldRetry: true, retryInterval: .milliseconds(waitMillis))

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RequestRetryablePolicyTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RequestRetryablePolicyTests.swift
@@ -199,6 +199,17 @@ class RequestRetryablePolicyTests: XCTestCase {
         assertMilliseconds(retryAdvice.retryInterval, greaterThan: 200, lessThan: 300)
     }
 
+    func testUserAuthenticationRequiredError() {
+        let retryableErrorCode = URLError.init(.userAuthenticationRequired)
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: retryableErrorCode,
+                                                         httpURLResponse: nil,
+                                                         attemptNumber: 1)
+
+        XCTAssert(retryAdvice.shouldRetry)
+        assertMilliseconds(retryAdvice.retryInterval, greaterThan: 200, lessThan: 300)
+    }
+
     func testHTTPTooManyRedirectsError() {
         let nonRetryableErrorCode = URLError.init(.httpTooManyRedirects)
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RequestRetryablePolicyTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RequestRetryablePolicyTests.swift
@@ -210,6 +210,17 @@ class RequestRetryablePolicyTests: XCTestCase {
         XCTAssertEqual(retryAdvice.retryInterval, defaultTimeout)
     }
 
+    func testSecureConnectionFailedError() {
+        let retryableErrorCode = URLError.init(.secureConnectionFailed)
+
+        let retryAdvice = retryPolicy.retryRequestAdvice(urlError: retryableErrorCode,
+                                                         httpURLResponse: nil,
+                                                         attemptNumber: 1)
+
+        XCTAssert(retryAdvice.shouldRetry)
+        assertMilliseconds(retryAdvice.retryInterval, greaterThan: 200, lessThan: 300)
+    }
+
     func testMaxValueRetryDelay() {
         let retryableErrorCode = URLError.init(.timedOut)
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/3259

## Description
<!-- Why is this change required? What problem does it solve? -->
This PR combines the the three PRs below:
https://github.com/aws-amplify/amplify-swift/pull/3474
https://github.com/aws-amplify/amplify-swift/pull/3475
https://github.com/aws-amplify/amplify-swift/pull/3477

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
