### PR TITLE
add support for GraphQL filter attributeExists

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/Persistable.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Persistable.swift
@@ -65,6 +65,12 @@ struct PersistableHelper {
             return lhs == rhs
         case let (lhs, rhs) as (String, String):
             return lhs == rhs
+        case let (lhs, rhs) as (any EnumPersistable, String):
+            return lhs.rawValue == rhs
+        case let (lhs, rhs) as (String, any EnumPersistable):
+            return lhs == rhs.rawValue
+        case let (lhs, rhs) as (any EnumPersistable, any EnumPersistable):
+            return lhs.rawValue == rhs.rawValue
         default:
             return false
         }
@@ -94,6 +100,12 @@ struct PersistableHelper {
             return lhs == Double(rhs)
         case let (lhs, rhs) as (String, String):
             return lhs == rhs
+        case let (lhs, rhs) as (any EnumPersistable, String):
+            return lhs.rawValue == rhs
+        case let (lhs, rhs) as (String, any EnumPersistable):
+            return lhs == rhs.rawValue
+        case let (lhs, rhs) as (any EnumPersistable, any EnumPersistable):
+            return lhs.rawValue == rhs.rawValue
         default:
             return false
         }
@@ -122,6 +134,12 @@ struct PersistableHelper {
             return lhs <= Double(rhs)
         case let (lhs, rhs) as (String, String):
             return lhs <= rhs
+        case let (lhs, rhs) as (any EnumPersistable, String):
+            return lhs.rawValue <= rhs
+        case let (lhs, rhs) as (String, any EnumPersistable):
+            return lhs <= rhs.rawValue
+        case let (lhs, rhs) as (any EnumPersistable, any EnumPersistable):
+            return lhs.rawValue <= rhs.rawValue
         default:
             return false
         }
@@ -150,6 +168,12 @@ struct PersistableHelper {
             return lhs < Double(rhs)
         case let (lhs, rhs) as (String, String):
             return lhs < rhs
+        case let (lhs, rhs) as (any EnumPersistable, String):
+            return lhs.rawValue < rhs
+        case let (lhs, rhs) as (String, any EnumPersistable):
+            return lhs < rhs.rawValue
+        case let (lhs, rhs) as (any EnumPersistable, any EnumPersistable):
+            return lhs.rawValue < rhs.rawValue
         default:
             return false
         }
@@ -178,6 +202,12 @@ struct PersistableHelper {
             return lhs >= Double(rhs)
         case let (lhs, rhs) as (String, String):
             return lhs >= rhs
+        case let (lhs, rhs) as (any EnumPersistable, String):
+            return lhs.rawValue >= rhs
+        case let (lhs, rhs) as (String, any EnumPersistable):
+            return lhs >= rhs.rawValue
+        case let (lhs, rhs) as (any EnumPersistable, any EnumPersistable):
+            return lhs.rawValue >= rhs.rawValue
         default:
             return false
         }
@@ -206,6 +236,12 @@ struct PersistableHelper {
             return Double(lhs) > rhs
         case let (lhs, rhs) as (String, String):
             return lhs > rhs
+        case let (lhs, rhs) as (any EnumPersistable, String):
+            return lhs.rawValue > rhs
+        case let (lhs, rhs) as (String, any EnumPersistable):
+            return lhs > rhs.rawValue
+        case let (lhs, rhs) as (any EnumPersistable, any EnumPersistable):
+            return lhs.rawValue > rhs.rawValue
         default:
             return false
         }

--- a/Amplify/Categories/DataStore/Query/ModelKey.swift
+++ b/Amplify/Categories/DataStore/Query/ModelKey.swift
@@ -36,6 +36,11 @@ public protocol ModelKey: CodingKey, CaseIterable, QueryFieldOperation {}
 
 extension CodingKey where Self: ModelKey {
 
+    // MARK: - attributeExists
+    public func attributeExists(_ value: Bool) -> QueryPredicateOperation {
+        return field(stringValue).attributeExists(value)
+    }
+
     // MARK: - beginsWith
     public func beginsWith(_ value: String) -> QueryPredicateOperation {
         return field(stringValue).beginsWith(value)

--- a/Amplify/Categories/DataStore/Query/QueryField.swift
+++ b/Amplify/Categories/DataStore/Query/QueryField.swift
@@ -30,7 +30,7 @@ public func field(_ name: String) -> QueryField {
 /// - seealso: `ModelKey`
 public protocol QueryFieldOperation {
     // MARK: - Functions
-
+    func attributeExists(_ value: Bool) -> QueryPredicateOperation
     func beginsWith(_ value: String) -> QueryPredicateOperation
     func between(start: Persistable, end: Persistable) -> QueryPredicateOperation
     func contains(_ value: String) -> QueryPredicateOperation
@@ -60,6 +60,11 @@ public protocol QueryFieldOperation {
 public struct QueryField: QueryFieldOperation {
 
     public let name: String
+
+    // MARK: - attributeExists
+    public func attributeExists(_ value: Bool) -> QueryPredicateOperation {
+        return QueryPredicateOperation(field: name, operator: .attributeExists(value))
+    }
 
     // MARK: - beginsWith
     public func beginsWith(_ value: String) -> QueryPredicateOperation {

--- a/Amplify/Categories/DataStore/Query/QueryPredicate.swift
+++ b/Amplify/Categories/DataStore/Query/QueryPredicate.swift
@@ -155,34 +155,6 @@ public class QueryPredicateOperation: QueryPredicate, Encodable {
     }
 
     public func evaluate(target: Model) -> Bool {
-        guard let fieldValue = target[field] else {
-            return false
-        }
-
-        guard let value = fieldValue else {
-            return false
-        }
-
-        if let booleanValue = value as? Bool {
-            return self.operator.evaluate(target: booleanValue)
-        }
-
-        if let doubleValue = value as? Double {
-            return self.operator.evaluate(target: doubleValue)
-        }
-
-        if let intValue = value as? Int {
-            return self.operator.evaluate(target: intValue)
-        }
-
-        if let timeValue = value as? Temporal.Time {
-            return self.operator.evaluate(target: timeValue)
-        }
-
-        if let enumValue = value as? EnumPersistable {
-            return self.operator.evaluate(target: enumValue.rawValue)
-        }
-
-        return self.operator.evaluate(target: value)
+        return self.operator.evaluate(target: target[field]?.flatMap { $0 })
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/QueryPredicate+GraphQL.swift
@@ -187,6 +187,8 @@ extension QueryOperator {
             return "beginsWith"
         case .notContains:
             return "notContains"
+        case .attributeExists:
+            return "attributeExists"
         }
     }
 
@@ -211,6 +213,8 @@ extension QueryOperator {
         case .beginsWith(let value):
             return value
         case .notContains(let value):
+            return value
+        case .attributeExists(let value):
             return value
         }
     }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLListQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLListQueryTests.swift
@@ -218,4 +218,88 @@ class GraphQLListQueryTests: XCTestCase {
         XCTAssertEqual(variables["limit"] as? Int, 1_000)
         XCTAssertNotNil(variables["filter"])
     }
+
+    /**
+     - Given: 
+        - A Post schema with optional field 'draft'
+     - When:
+        - Using list query to filter records that either don't have 'draft' field or have 'null' value
+     - Then:
+        - the query document as expected
+        - the filter is encoded correctly
+     */
+    func test_listQuery_withAttributeExistsFilter_correctlyBuildGraphQLQueryStatement() {
+        let post = Post.keys
+        let predicate = post.id.eq("id")
+        && (post.draft.attributeExists(false) || post.draft.eq("null"))
+
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: Post.schema, operationType: .query)
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
+        documentBuilder.add(decorator: PaginationDecorator())
+        documentBuilder.add(decorator: FilterDecorator(filter: predicate.graphQLFilter(for: Post.schema)))
+        let document = documentBuilder.build()
+        let expectedQueryDocument = """
+        query ListPosts($filter: ModelPostFilterInput, $limit: Int) {
+          listPosts(filter: $filter, limit: $limit) {
+            items {
+              id
+              content
+              createdAt
+              draft
+              rating
+              status
+              title
+              updatedAt
+              __typename
+            }
+            nextToken
+          }
+        }
+        """
+        XCTAssertEqual(document.name, "listPosts")
+        XCTAssertEqual(document.stringValue, expectedQueryDocument)
+        guard let variables = document.variables else {
+            XCTFail("The document doesn't contain variables")
+            return
+        }
+        XCTAssertNotNil(variables["limit"])
+        XCTAssertEqual(variables["limit"] as? Int, 1_000)
+
+        guard let filter = variables["filter"] as? GraphQLFilter else {
+            XCTFail("variables should contain a valid filter")
+            return
+        }
+
+        // Test filter for a valid JSON format
+        let filterJSON = try? JSONSerialization.data(withJSONObject: filter,
+                                                     options: .prettyPrinted)
+        XCTAssertNotNil(filterJSON)
+
+        let expectedFilterJSON = """
+        {
+          "and" : [
+            {
+              "id" : {
+                "eq" : "id"
+              }
+            },
+            {
+              "or" : [
+                {
+                  "draft" : {
+                    "attributeExists" : false
+                  }
+                },
+                {
+                  "draft" : {
+                    "eq" : "null"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+        """
+        XCTAssertEqual(String(data: filterJSON!, encoding: .utf8), expectedFilterJSON)
+    }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedBoolTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedBoolTests.swift
@@ -41,7 +41,7 @@ class QueryPredicateEvaluateGeneratedBoolTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testBoolfalsenotEqualBooltrue() throws {
@@ -70,7 +70,7 @@ class QueryPredicateEvaluateGeneratedBoolTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testBooltrueequalsBooltrue() throws {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTests.swift
@@ -60,7 +60,7 @@ class QueryPredicateEvaluateGeneratedDateTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testTemporalDateTemporal_Date_now_addvalue1to_daynotEqualTemporalDateTemporal_Date_now() throws {
@@ -109,7 +109,7 @@ class QueryPredicateEvaluateGeneratedDateTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testTemporalDateTemporal_Date_now_addvalue2to_daynotEqualTemporalDateTemporal_Date_now() throws {
@@ -158,7 +158,7 @@ class QueryPredicateEvaluateGeneratedDateTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testTemporalDateTemporal_Date_now_addvalue3to_daynotEqualTemporalDateTemporal_Date_now() throws {
@@ -207,7 +207,7 @@ class QueryPredicateEvaluateGeneratedDateTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testTemporalDateTemporal_Date_nowequalsTemporalDateTemporal_Date_now() throws {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTimeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTimeTests.swift
@@ -66,7 +66,7 @@ class QueryPredicateEvaluateGeneratedDateTimeTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testTemporalDateTimeTemporal_DateTime_now_addvalue1to_hournotEqualTemporalDateTimeTemporal_DateTime_now() throws {
@@ -120,7 +120,7 @@ class QueryPredicateEvaluateGeneratedDateTimeTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testTemporalDateTimeTemporal_DateTime_now_addvalue2to_hournotEqualTemporalDateTimeTemporal_DateTime_now() throws {
@@ -174,7 +174,7 @@ class QueryPredicateEvaluateGeneratedDateTimeTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testTemporalDateTimeTemporal_DateTime_now_addvalue3to_hournotEqualTemporalDateTimeTemporal_DateTime_now() throws {
@@ -228,7 +228,7 @@ class QueryPredicateEvaluateGeneratedDateTimeTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testTemporalDateTimeTemporal_DateTime_nowequalsTemporalDateTimeTemporal_DateTime_now() throws {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleIntTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleIntTests.swift
@@ -50,7 +50,7 @@ class QueryPredicateEvaluateGeneratedDoubleIntTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testDouble2_1notEqualInt1() throws {
@@ -89,7 +89,7 @@ class QueryPredicateEvaluateGeneratedDoubleIntTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testDouble3_1notEqualInt1() throws {
@@ -128,7 +128,7 @@ class QueryPredicateEvaluateGeneratedDoubleIntTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testDouble1notEqualInt1() throws {
@@ -167,7 +167,7 @@ class QueryPredicateEvaluateGeneratedDoubleIntTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testDouble2notEqualInt1() throws {
@@ -206,7 +206,7 @@ class QueryPredicateEvaluateGeneratedDoubleIntTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testDouble3notEqualInt1() throws {
@@ -245,7 +245,7 @@ class QueryPredicateEvaluateGeneratedDoubleIntTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testDouble1_1equalsInt1() throws {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleTests.swift
@@ -80,7 +80,7 @@ class QueryPredicateEvaluateGeneratedDoubleTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testDouble2_1notEqualDouble1_1() throws {
@@ -149,7 +149,7 @@ class QueryPredicateEvaluateGeneratedDoubleTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testDouble3_1notEqualDouble1_1() throws {
@@ -218,7 +218,7 @@ class QueryPredicateEvaluateGeneratedDoubleTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testDouble1notEqualDouble1_1() throws {
@@ -287,7 +287,7 @@ class QueryPredicateEvaluateGeneratedDoubleTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testDouble2notEqualDouble1_1() throws {
@@ -356,7 +356,7 @@ class QueryPredicateEvaluateGeneratedDoubleTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testDouble3notEqualDouble1_1() throws {
@@ -425,7 +425,7 @@ class QueryPredicateEvaluateGeneratedDoubleTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testDouble1_1equalsDouble1_1() throws {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntTests.swift
@@ -54,7 +54,7 @@ class QueryPredicateEvaluateGeneratedIntBetweenTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testInt2notEqualInt1() throws {
@@ -93,7 +93,7 @@ class QueryPredicateEvaluateGeneratedIntBetweenTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testInt3notEqualInt1() throws {
@@ -132,7 +132,7 @@ class QueryPredicateEvaluateGeneratedIntBetweenTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testInt1equalsInt1() throws {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedStringTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedStringTests.swift
@@ -64,7 +64,7 @@ class QueryPredicateEvaluateGeneratedStringTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testStringbbnotEqualStringa() throws {
@@ -113,7 +113,7 @@ class QueryPredicateEvaluateGeneratedStringTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testStringaanotEqualStringa() throws {
@@ -162,7 +162,7 @@ class QueryPredicateEvaluateGeneratedStringTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testStringcnotEqualStringa() throws {
@@ -211,7 +211,7 @@ class QueryPredicateEvaluateGeneratedStringTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testStringaequalsStringa() throws {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedTimeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedTimeTests.swift
@@ -69,7 +69,7 @@ class QueryPredicateEvaluateGeneratedTimeTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testTemporalTimeTemporal_Time_now_addvalue1to_hournotEqualTemporalTimeTemporal_Time_now() throws {
@@ -123,7 +123,7 @@ class QueryPredicateEvaluateGeneratedTimeTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testTemporalTimeTemporal_Time_now_addvalue2to_hournotEqualTemporalTimeTemporal_Time_now() throws {
@@ -177,7 +177,7 @@ class QueryPredicateEvaluateGeneratedTimeTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testTemporalTimeTemporal_Time_now_addvalue3to_hournotEqualTemporalTimeTemporal_Time_now() throws {
@@ -231,7 +231,7 @@ class QueryPredicateEvaluateGeneratedTimeTests: XCTestCase {
 
         let evaluation = try predicate.evaluate(target: instance.eraseToAnyModel().instance)
 
-        XCTAssertFalse(evaluation)
+        XCTAssertTrue(evaluation)
     }
 
     func testTemporalTimeTemporal_Time_nowequalsTemporalTimeTemporal_Time_now() throws {

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/QueryPredicate+SQLite.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/QueryPredicate+SQLite.swift
@@ -33,6 +33,8 @@ extension QueryOperator {
             return "instr(\(column), ?) > 0"
         case .notContains:
             return "instr(\(column), ?) = 0"
+        case .attributeExists(let value):
+            return "\(column) is \(value ? "not" : "") null"
         }
     }
 
@@ -51,6 +53,8 @@ extension QueryOperator {
             .beginsWith(let value),
             .notContains(let value):
             return [value.asBinding()]
+        case .attributeExists:
+            return []
         }
     }
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

- add support for AppSync GraphQL filter `attributeExists`
- fix query filter with `nil` value.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
