### PR TITLE
fix(DataStore): retry MutationEvents on signed-out and token expired errors

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenURLRequestInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenURLRequestInterceptor.swift
@@ -48,8 +48,8 @@ struct AuthTokenURLRequestInterceptor: URLRequestInterceptor {
         if isTokenExpired?(token) ?? false {
             // If the access token has expired, we send back the underlying "AuthError.sessionExpired" error.
             // Without a more specific AuthError case like "tokenExpired", this is the closest representation.
-            throw APIError.operationError("Authorization token has expired.",
-                                          "",
+            throw APIError.operationError("Auth Token Provider returned a expired token.",
+                                          "Please call `Amplify.Auth.fetchAuthSession()` or sign in again.",
                                           AuthError.sessionExpired("", "", nil))
         }
 

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -45,13 +45,11 @@ class AuthTokenURLRequestInterceptorTests: XCTestCase {
         do {
             _ = try await interceptor.intercept(request).allHTTPHeaderFields
         } catch {
-            XCTAssertNotNil(error)
-            if case .operationError(let description, _, let underlyingError) = error as? APIError,
+            guard case .operationError(let description, _, let underlyingError) = error as? APIError,
                let authError = underlyingError as? AuthError,
-               case .sessionExpired = authError {
-                XCTAssertEqual(description, "Authorization token has expired.")
-            } else {
+               case .sessionExpired = authError else {
                 XCTFail("Should be API.operationError with underlying AuthError.sessionExpired")
+                return
             }
         }
     }


### PR DESCRIPTION
## Issue \#
Continuation from https://github.com/aws-amplify/amplify-swift/issues/3259#issuecomment-1910524131

## Description
<!-- Why is this change required? What problem does it solve? -->
This PR is a change in DataStore's SyncMutationToCloudOperation to determine whether mutation events are retryable.
1. A mutation event is deemed retryable when the underlying auth error is `AuthError.signedOut`. If the user is signed out, we could not attempt the request and therefore, should be retried. 
2. A mutation event should be retried on session expired. Changes to API plugin returns `API.operationError` with underlying `AuthError.sessionExpired` when the token is expired. If authService provides APIPlugin with an expired token, it will fail fast during the request interception, and pass this error back. No additional changes necessary needed in DataStore since it is already retrying on session expired from a previous PR.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
