### PR TITLE
fix(DataStore): serialize IncomingAsyncSubscriptionEventPublisher events

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisherTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisherTests.swift
@@ -1,0 +1,61 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSPluginsCore
+@testable import AWSDataStorePlugin
+
+final class IncomingAsyncSubscriptionEventPublisherTests: XCTestCase {
+    var apiPlugin: MockAPICategoryPlugin!
+    override func setUp() {
+        apiPlugin = MockAPICategoryPlugin()
+    }
+
+    /// This test was written to to reproduce a bug where the subscribe would miss events emitted by the publisher.
+    /// The pattern in this test using the publisher (`IncomingAsyncSubscriptionEventPublisher`) and subscriber
+    /// (`IncomingAsyncSubscriptionEventToAnyModelMapper`) are identical to the usage in `AWSModelReconciliationQueue.init()`.
+    ///
+    /// See the changes in this PR: https://github.com/aws-amplify/amplify-swift/pull/3489
+    ///
+    /// Before the PR changes, the publisher would emit events concurrently which caused some of them to be missed
+    /// by the subscriber even though the subscriber applied back pressure to process one event at a time (demand
+    /// of `max(1)`). For more details regarding back-pressure, see
+    /// https://developer.apple.com/documentation/combine/processing-published-elements-with-subscribers
+    ///
+    /// The change, to publish the events though the same TaskQueue ensures that the events are properly buffered
+    /// and sent only when the subscriber demands for it.
+    func testSubscriberRecievedEvents() async throws {
+        let expectedEvents = expectation(description: "Expected number of ")
+        let numberOfEvents = 50
+        expectedEvents.expectedFulfillmentCount = numberOfEvents
+        let asyncEvents = await IncomingAsyncSubscriptionEventPublisher(
+            modelSchema: Post.schema,
+            api: apiPlugin,
+            modelPredicate: nil,
+            auth: nil,
+            authModeStrategy: AWSDefaultAuthModeStrategy(),
+            awsAuthService: nil)
+        let mapper = IncomingAsyncSubscriptionEventToAnyModelMapper()
+        asyncEvents.subscribe(subscriber: mapper)
+        let sink = mapper
+            .publisher
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { _ in
+                    expectedEvents.fulfill()
+                }
+            )
+        DispatchQueue.concurrentPerform(iterations: numberOfEvents) { index in
+            asyncEvents.send(.connection(.connected))
+        }
+
+        await fulfillment(of: [expectedEvents], timeout: 2)
+        sink.cancel()
+    }
+}

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisherTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisherTests.swift
@@ -15,6 +15,7 @@ final class IncomingAsyncSubscriptionEventPublisherTests: XCTestCase {
     var apiPlugin: MockAPICategoryPlugin!
     override func setUp() {
         apiPlugin = MockAPICategoryPlugin()
+        ModelRegistry.register(modelType: Post.self)
     }
 
     /// This test was written to to reproduce a bug where the subscribe would miss events emitted by the publisher.
@@ -56,6 +57,53 @@ final class IncomingAsyncSubscriptionEventPublisherTests: XCTestCase {
         }
 
         await fulfillment(of: [expectedEvents], timeout: 2)
+        sink.cancel()
+    }
+
+    /// Ensure that the publisher-subscriber with back pressure is receiving all the events in the order in which they were sent.
+    func testSubscriberRecievedEventsInOrder() async throws {
+        let expectedEvents = expectation(description: "Expected number of ")
+        let expectedOrder = AtomicValue<[String]>(initialValue: [])
+        let actualOrder = AtomicValue<[String]>(initialValue: [])
+        let numberOfEvents = 50
+        expectedEvents.expectedFulfillmentCount = numberOfEvents
+        let asyncEvents = await IncomingAsyncSubscriptionEventPublisher(
+            modelSchema: Post.schema,
+            api: apiPlugin,
+            modelPredicate: nil,
+            auth: nil,
+            authModeStrategy: AWSDefaultAuthModeStrategy(),
+            awsAuthService: nil)
+        let mapper = IncomingAsyncSubscriptionEventToAnyModelMapper()
+        asyncEvents.subscribe(subscriber: mapper)
+        let sink = mapper
+            .publisher
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { event in
+                    switch event {
+                    case .payload(let mutationSync):
+                        actualOrder.append(mutationSync.syncMetadata.modelId)
+                    default:
+                        break
+                    }
+                    expectedEvents.fulfill()
+                }
+            )
+
+        for index in 0..<numberOfEvents {
+            let post = Post(id: "\(index)", title: "title", content: "content", createdAt: .now())
+            expectedOrder.append(post.id)
+            asyncEvents.send(.data(.success(.init(model: AnyModel(post),
+                                                  syncMetadata: .init(modelId: post.id,
+                                                                      modelName: "Post",
+                                                                      deleted: false,
+                                                                      lastChangedAt: 0,
+                                                                      version: 0)))))
+        }
+
+        await fulfillment(of: [expectedEvents], timeout: 2)
+        XCTAssertEqual(expectedOrder.get(), actualOrder.get())
         sink.cancel()
     }
 }


### PR DESCRIPTION
## Issue \#
https://github.com/aws-amplify/amplify-swift/issues/2982#issuecomment-1671713659

## Description
Before the PR changes, the publisher would emit events concurrently which caused some of them to be missed by the subscriber even though the subscriber applied back pressure to process one event at a time (demand of `max(1)`). For more details regarding back-pressure, see https://developer.apple.com/documentation/combine/processing-published-elements-with-subscribers

The change, to publish the events though the same TaskQueue ensures that the events are properly buffered and sent only when the subscriber demands for it.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
