### PR TITLE
fix(DataStore): save and syncMutation under transaction

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
@@ -208,31 +208,38 @@ final class StorageEngine: StorageEngineBehavior {
             completion(.failure(causedBy: dataStoreError))
         }
 
-        let wrappedCompletion: DataStoreCallback<M> = { result in
-            guard modelSchema.isSyncable, let syncEngine = self.syncEngine else {
-                completion(result)
-                return
-            }
+        do {
+            try storageAdapter.transaction {
+                let wrappedCompletion: DataStoreCallback<M> = { result in
+                    guard modelSchema.isSyncable, let syncEngine = self.syncEngine else {
+                        completion(result)
+                        return
+                    }
 
-            guard case .success(let savedModel) = result else {
-                completion(result)
-                return
-            }
+                    guard case .success(let savedModel) = result else {
+                        completion(result)
+                        return
+                    }
 
-            self.log.verbose("\(#function) syncing mutation for \(savedModel)")
-            self.syncMutation(of: savedModel,
-                              modelSchema: modelSchema,
-                              mutationType: mutationType,
-                              predicate: condition,
-                              syncEngine: syncEngine,
-                              completion: completion)
+                    self.log.verbose("\(#function) syncing mutation for \(savedModel)")
+                    self.syncMutation(of: savedModel,
+                                      modelSchema: modelSchema,
+                                      mutationType: mutationType,
+                                      predicate: condition,
+                                      syncEngine: syncEngine,
+                                      completion: completion)
+                }
+
+                storageAdapter.save(model,
+                                    modelSchema: modelSchema,
+                                    condition: condition,
+                                    eagerLoad: eagerLoad,
+                                    completion: wrappedCompletion)
+            }
+        } catch {
+            completion(.failure(causedBy: error))
         }
 
-        storageAdapter.save(model,
-                            modelSchema: modelSchema,
-                            condition: condition,
-                            eagerLoad: eagerLoad,
-                            completion: wrappedCompletion)
     }
 
     func save<M: Model>(_ model: M,


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
Continuation from https://github.com/aws-amplify/amplify-swift/issues/3259#issuecomment-1921637958

## Description
<!-- Why is this change required? What problem does it solve? -->
When `DataStore.save()` is called, it will perform a sequence of reads and writes. If this sequence is interrupted by `DataStore.stop()` then not all data that would have been written is committed.

For example, `SQLiteStorageEngineAdapter.save()` will check if the model exists, decide whether to create an Insert/update, perform the write, and query the model and return it. 

On completion, `StorageEngine.save()` checks if sync is enabled, and saves the MutationEvent through `syncMutation(of: savedModel)`.

If the process is interrupted before the MutationEvent is persisted, then the local data will never be synced to AppSync. 

This causes subsequent issues for models with associations, ie. Comment belongs to a Post. If the post is never synced to AppSync, then saving the comment will result in 
1. Save comment to local database is fine, since there's a local post
2. Sync comment to AppSync fails when the schema enforces required association. Post does not exist in AppSync.


## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
