### PR TITLE
chore(logging): update logging remote constraint ETag caching

### DIFF
--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Configuration/DefaultRemoteLoggingConstraintsProvider.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Configuration/DefaultRemoteLoggingConstraintsProvider.swift
@@ -58,7 +58,9 @@ public class DefaultRemoteLoggingConstraintsProvider: RemoteLoggingConstraintsPr
         let loggingConstraint = try JSONDecoder().decode(LoggingConstraints.self, from: data)
         loggingConstraintsLocalStore.setLocalLoggingConstraints(loggingConstraints: loggingConstraint)
 
-        if let etag = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "If-None-Match") {
+        if let etag = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "ETag") {
+            loggingConstraintsLocalStore.setLocalLoggingConstraintsEtag(etag: etag)
+        } else if let etag = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "If-None-Match") {
             loggingConstraintsLocalStore.setLocalLoggingConstraintsEtag(etag: etag)
         }
         return loggingConstraint

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Configuration/DefaultRemoteLoggingConstraintsProvider.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Configuration/DefaultRemoteLoggingConstraintsProvider.swift
@@ -58,6 +58,11 @@ public class DefaultRemoteLoggingConstraintsProvider: RemoteLoggingConstraintsPr
         let loggingConstraint = try JSONDecoder().decode(LoggingConstraints.self, from: data)
         loggingConstraintsLocalStore.setLocalLoggingConstraints(loggingConstraints: loggingConstraint)
 
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
+        // the response header should only use the ETag header field in accordance with Http protocol spec
+        // but we need to also look at `If-None-Match` due to the initial/old lambda documentation recommending to
+        // `If-None-Match` to return the ETag
         if let etag = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "ETag") {
             loggingConstraintsLocalStore.setLocalLoggingConstraintsEtag(etag: etag)
         } else if let etag = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "If-None-Match") {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
Update the Logging remote constraint provider to fetch the configuration and look up the `ETag` in the response header.  `If-None-Match` should only be in the request header not the response header, keeping this logic in so that it is not a breaking change to existing customers.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
