### PR TITLE
fix: add collected data types to privacy manifests

### DIFF
--- a/Amplify/Resources/PrivacyInfo.xcprivacy
+++ b/Amplify/Resources/PrivacyInfo.xcprivacy
@@ -2,9 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPrivacyCollectedDataTypes</key>
+    <key>NSPrivacyCollectedDataTypes</key>
     <array/>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
+    <array/>
 </dict>
 </plist>

--- a/Amplify/Resources/PrivacyInfo.xcprivacy
+++ b/Amplify/Resources/PrivacyInfo.xcprivacy
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+    <array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array/>
 </dict>

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Resources/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Resources/PrivacyInfo.xcprivacy
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array/>
 </dict>

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Resources/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/Resources/PrivacyInfo.xcprivacy
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array/>
 </dict>

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Resources/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Resources/PrivacyInfo.xcprivacy
@@ -1,17 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>NSPrivacyAccessedAPITypes</key>
-        <array>
-            <dict>
-                <key>NSPrivacyAccessedAPIType</key>
-                <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-                <key>NSPrivacyAccessedAPITypeReasons</key>
-                <array>
-                    <string>CA92.1</string>
-                </array>
-            </dict>
-        </array>
-    </dict>
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/AmplifyPlugins/Core/AWSPluginsCore/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Resources/PrivacyInfo.xcprivacy
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array/>
 </dict>

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Resources/PrivacyInfo.xcprivacy
@@ -1,17 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>NSPrivacyAccessedAPITypes</key>
-        <array>
-            <dict>
-                <key>NSPrivacyAccessedAPIType</key>
-                <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-                <key>NSPrivacyAccessedAPITypeReasons</key>
-                <array>
-                    <string>CA92.1</string>
-                </array>
-            </dict>
-        </array>
-    </dict>
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+</dict>
 </plist>

--- a/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/Resources/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/Resources/PrivacyInfo.xcprivacy
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array/>
 </dict>

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Resources/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Resources/PrivacyInfo.xcprivacy
@@ -1,17 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>NSPrivacyAccessedAPITypes</key>
-        <array>
-            <dict>
-                <key>NSPrivacyAccessedAPIType</key>
-                <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-                <key>NSPrivacyAccessedAPITypeReasons</key>
-                <array>
-                    <string>CA92.1</string>
-                </array>
-            </dict>
-        </array>
-    </dict>
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Resources/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Resources/PrivacyInfo.xcprivacy
@@ -1,17 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>NSPrivacyAccessedAPITypes</key>
-        <array>
-            <dict>
-                <key>NSPrivacyAccessedAPIType</key>
-                <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-                <key>NSPrivacyAccessedAPITypeReasons</key>
-                <array>
-                    <string>CA92.1</string>
-                </array>
-            </dict>
-        </array>
-    </dict>
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/AmplifyPlugins/Notifications/Push/Sources/AWSPinpointPushNotificationsPlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Notifications/Push/Sources/AWSPinpointPushNotificationsPlugin/Resources/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AmplifyPlugins/Notifications/Push/Sources/AWSPinpointPushNotificationsPlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Notifications/Push/Sources/AWSPinpointPushNotificationsPlugin/Resources/PrivacyInfo.xcprivacy
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array/>
 </dict>

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Resources/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Resources/PrivacyInfo.xcprivacy
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array/>
 </dict>

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Resources/PrivacyInfo.xcprivacy
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array/>
 </dict>

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Resources/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Resources/PrivacyInfo.xcprivacy
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Resources/PrivacyInfo.xcprivacy
@@ -2,6 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array/>
 </dict>


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
Docs Update required for this change: https://github.com/aws-amplify/docs/pull/6938
Customer issue related to missing key in privacy manfiest: https://github.com/aws-amplify/amplify-swift/issues/3552

## Description
<!-- Why is this change required? What problem does it solve? -->
This PR adds the data collected section in the privacy manifests. In each target are the following reasons

- **Amplify**: no corresponding AWS service, no data is collected
- **AWSAPIPlugin** - adds Amplify's user-agent to AppSync / APIGateway requests
- **AWSPinpointAnalyticsPlugin** - adds Amplify's user-agent to Amazon Pinpoint requests
- **AWSCognitoAuthPlugin** - adds Amplify's user-agent to Cognito requests
- **AWSPluginsCore** - no corresponding AWS service, no data is collected
- **AWSDataStorePlugin** - Makes calls through AWSAPIPlugin, thus it's privacy manifest is reflected by AWSAPIPlugin
- **AWSLocationGeoPlugin** - adds Amplify's user-agent to AWS Location requests
- **InternalAWSPinpoint** - adds Amplify's user-agent to Amazon Pinpoint requests
- **AWSCloudWatchLoggingPlugin** - adds Amplify's user-agent to AWS Cloudwatch requests
- **AWSPinpointPushNotification** - adds Amplify's user-agent to Amazon Pinpoint requests
- **AWSPredictionsPlugin** - adds Amplify's user-agent to various AWS services, depending on which is utilized.
- **CoreMLPredictionsPlugin** - no corresponding AWS service, no data is collected
- **AWSS3StoragePlugin** - adds Amplify's user-agent to AWS S3 requests

The user agent information contains the Amplify version, OS name and version which corresponds to Other Data types (https://docs.amplify.aws/swift/build-a-backend/auth/data-usage-policy/). 

In the current version of the privacy manifest format, there isn't a way to specify in more detail the type of "other data type", which is why I have opened a question in the Apple Developer Forums to ask about this: https://developer.apple.com/forums/thread/743559

Tracking is set to false, despite the current version of our docs shows tracking is true for certain data types, however I have a separate proposal based on my understanding of AppTrackingTransparency Framework that defines what tracking is. We may wait for that proposal to finalize on the Tracking value for the data types listed here (either set `NSPrivacyCollectedDataTypeTracking` to true or leave it as false).

This PR also fixes a problem with generating the privacy manifest report, without this PR, the privacy report shows errors expecting the CollectedDataType key to exist: 
<img width="1116" alt="image" src="https://github.com/aws-amplify/amplify-swift/assets/1365977/95275fc5-a90a-4245-95f7-ee9dcfd5fb74">

To generate a privacy report, Archive the app which consumes the library, and then in Xcode -> Window -> Organizer -> Under Archives, right click on the archive -> Generate Privacy Report. The privacy report only shows tracking related information, thus with this change the privacy report will be an empty file.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
