### PR TITLE
chore: Fixing workflows

### DIFF
--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -1,4 +1,4 @@
-name: Integration Tests
+name: Integration Tests (Except DataStore & API)
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/nightly_repeated_unittest.yml
+++ b/.github/workflows/nightly_repeated_unittest.yml
@@ -37,5 +37,4 @@ jobs:
       scheme: ${{ matrix.scheme }}
       timeout-minutes: 50
       generate_coverage_report: false
-      retry_on_error: false
-      other_flags: -test-iterations 100 -run-tests-until-failure
+      test_iterations_flags: -test-iterations 100 -run-tests-until-failure

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: boolean
         default: false
+      test_iterations_flags:
+        description: 'The xcodebuild flags used when running the test. Defaults to retrying on failure up to 3 times'
+        required: false
+        type: string
+        default: '-test-iterations 3 -retry-tests-on-failure'
 
 permissions:
     contents: read
@@ -82,7 +87,7 @@ jobs:
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: ${{ steps.dependencies-cache.outputs.cache-hit }}
-          other_flags: -test-iterations 3 -retry-tests-on-failure
+          other_flags: ${{ inputs.test_iterations_flags }}
 
       - name: Retry ${{ inputs.platform }} Unit Tests
         if: steps.run-tests.outcome=='failure'
@@ -98,7 +103,7 @@ jobs:
           cloned_source_packages_path: ~/Library/Developer/Xcode/DerivedData/Amplify
           derived_data_path: ${{ github.workspace }}/Build
           disable_package_resolution: true
-          other_flags: -test-iterations 3 -retry-tests-on-failure
+          other_flags: ${{ inputs.test_iterations_flags }}
 
       - name: Store Coverage Report File
         if: ${{ inputs.generate_coverage_report == true }}

--- a/.github/workflows/run_unit_tests_platforms.yml
+++ b/.github/workflows/run_unit_tests_platforms.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: boolean
         default: false
+      test_iterations_flags:
+        description: 'The xcodebuild flags used when running the test. Defaults to retrying on failure up to 3 times'
+        required: false
+        type: string
+        default: '-test-iterations 3 -retry-tests-on-failure'
 
 permissions:
     contents: read
@@ -38,3 +43,4 @@ jobs:
       platform: ${{ matrix.platform }}
       generate_coverage_report: ${{ github.event_name != 'workflow_dispatch' && matrix.platform == 'iOS' && inputs.generate_coverage_report }}
       timeout-minutes: ${{ inputs.timeout-minutes }}
+      test_iterations_flags: ${{ inputs.test_iterations_flags }}

--- a/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/API/Tests/APIHostApp/APIHostApp.xcodeproj/project.pbxproj
@@ -3554,7 +3554,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mattgallagher/CwlPreconditionTesting.git";
 			requirement = {
-				kind = upToNextMinorVersion;
+				kind = upToNextMajorVersion;
 				minimumVersion = 2.1.0;
 			};
 		};


### PR DESCRIPTION
## Description
This PR fixes the following:
- The API Integration Tests not being able to run with the latest dependencies cache. This was caused because the `APIHostApp` project's **CwlPreconditionTesting** dependency was set to "Up to next minor", while the `Amplify-Package` target that caches dependencies has it as "Up to next major". 
- The "Amplify Nightly Repeated Unit Tests" workflow not being able to run. This happened because the reused workflow changed its parameters and it wasn't updated in the nightly workflow, so I've added a new `test_iterations_flags` that can be set accordingly but defaults to the existing behaviour.
- Renamed the "Integration Tests" workflow to "Integration Test (Except DataStore & API)" to prevent confusion. 
  - We still cannot group all the integration tests in just one workflow because then the number of chained workflows becomes higher than the maximum allowed (20) and the workflow fails. More info [here](https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations)

## General Checklist
- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass:
  - https://github.com/aws-amplify/amplify-swift/actions/runs/8022129567
- [ ] All integration tests pass:
  - DataStore: https://github.com/aws-amplify/amplify-swift/actions/runs/8022440937
  - API: https://github.com/aws-amplify/amplify-swift/actions/runs/8022133985
  - Others: https://github.com/aws-amplify/amplify-swift/actions/runs/8022439741
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
