### PR TITLE
fix(predictions): Serialize the dispatch of web socket events

### DIFF
--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/FaceLivenessSessionRepresentable.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/FaceLivenessSessionRepresentable.swift
@@ -12,7 +12,7 @@ import Amplify
 public protocol LivenessService {
     func send<T>(
         _ event: LivenessEvent<T>,
-        eventDate: () -> Date
+        eventDate: @escaping () -> Date
     )
 
     var onServiceException: (FaceLivenessSessionError) -> Void { get set }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
Some customer Liveness sessions using the Amplify iOS SDK fail midway through the session with the error:
```
InvalidSignatureException: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
```

## Description
<!-- Why is this change required? What problem does it solve? -->
Video and client events over the web socket from different threads. If a video and client event are sent at identical time, prior signatures may get mixed up, causing an invalid signature event. This PR introduces a change to use a serial dispatch queue to send web socket events.

## Testing
Manual testing done on the `HostApp` in the `amplify-ui-swift-liveness` repo.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
