### PR TITLE
feat(storage): add new storage gen2 APIs

### DIFF
--- a/Amplify/Categories/Storage/Operation/Request/StorageDownloadDataRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageDownloadDataRequest.swift
@@ -40,11 +40,13 @@ public extension StorageDownloadDataRequest {
         /// Access level of the storage system. Defaults to `public`
         ///
         /// - Tag: StorageDownloadDataRequestOptions.accessLevel
+        @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let accessLevel: StorageAccessLevel
 
         /// Target user to apply the action on.
         ///
         /// - Tag: StorageDownloadDataRequestOptions.targetIdentityId
+        @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let targetIdentityId: String?
 
         /// Extra plugin specific options, only used in special circumstances when the existing options do not provide

--- a/Amplify/Categories/Storage/Operation/Request/StorageDownloadFileRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageDownloadFileRequest.swift
@@ -46,11 +46,13 @@ public extension StorageDownloadFileRequest {
         /// Access level of the storage system. Defaults to `public`
         ///
         /// - Tag: StorageDownloadFileRequestOptions.accessLevel
+        @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let accessLevel: StorageAccessLevel
 
         /// Target user to apply the action on.
         ///
         /// - Tag: StorageDownloadFileRequestOptions.targetIdentityId
+        @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let targetIdentityId: String?
 
         /// Extra plugin specific options, only used in special circumstances when the existing options do not provide

--- a/Amplify/Categories/Storage/Operation/Request/StorageGetURLRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageGetURLRequest.swift
@@ -43,11 +43,13 @@ public extension StorageGetURLRequest {
         /// Access level of the storage system. Defaults to `public`
         ///
         /// - Tag: StorageListRequestOptions.accessLevel
+        @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let accessLevel: StorageAccessLevel
 
         /// Target user to apply the action on.
         ///
         /// - Tag: StorageListRequestOptions.targetIdentityId
+        @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let targetIdentityId: String?
 
         /// Number of seconds before the URL expires. Defaults to

--- a/Amplify/Categories/Storage/Operation/Request/StorageListRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageListRequest.swift
@@ -32,16 +32,19 @@ public extension StorageListRequest {
         /// Access level of the storage system. Defaults to `public`
         ///
         /// - Tag: StorageListRequestOptions.accessLevel
+        @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let accessLevel: StorageAccessLevel
 
         /// Target user to apply the action on
         ///
         /// - Tag: StorageListRequestOptions.targetIdentityId
+        @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let targetIdentityId: String?
 
         /// Path to the keys
         ///
         /// - Tag: StorageListRequestOptions.path
+        @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let path: String?
 
         /// Number between 1 and 1,000 that indicates the limit of how many entries to fetch when

--- a/Amplify/Categories/Storage/Operation/Request/StorageRemoveRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageRemoveRequest.swift
@@ -38,6 +38,7 @@ public extension StorageRemoveRequest {
         /// Access level of the storage system. Defaults to `public`
         ///
         /// - Tag: StorageRemoveRequestOptions.accessLevel
+        @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let accessLevel: StorageAccessLevel
 
         /// Extra plugin specific options, only used in special circumstances when the existing options do not provide

--- a/Amplify/Categories/Storage/Operation/Request/StorageUploadDataRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageUploadDataRequest.swift
@@ -46,11 +46,13 @@ public extension StorageUploadDataRequest {
         /// Access level of the storage system. Defaults to `public`
         ///
         /// - Tag: StorageUploadDataRequestOptions.accessLevel
+        @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let accessLevel: StorageAccessLevel
 
         /// Target user to apply the action on.
         ///
         /// - Tag: StorageUploadDataRequestOptions.targetIdentityId
+        @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let targetIdentityId: String?
 
         /// Metadata for the object to store

--- a/Amplify/Categories/Storage/Operation/Request/StorageUploadFileRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageUploadFileRequest.swift
@@ -43,11 +43,13 @@ public extension StorageUploadFileRequest {
         /// Access level of the storage system. Defaults to `public`
         ///
         /// - Tag: StorageUploadFileRequestOptions.accessLevel
+        @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let accessLevel: StorageAccessLevel
 
         /// Target user to apply the action on.
         ///
         /// - Tag: StorageUploadFileRequestOptions.targetIdentityId
+        @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let targetIdentityId: String?
 
         /// Metadata for the object to store

--- a/Amplify/Categories/Storage/Result/StorageListResult.swift
+++ b/Amplify/Categories/Storage/Result/StorageListResult.swift
@@ -42,6 +42,11 @@ extension StorageListResult {
     /// - Tag: StorageListResultItem
     public struct Item {
 
+        /// The path of the object in storage.
+        ///
+        /// - Tag: StorageListResultItem.path
+        public let path: StoragePath
+
         /// The unique identifier of the object in storage.
         ///
         /// - Tag: StorageListResultItem.key
@@ -72,11 +77,31 @@ extension StorageListResult {
         /// [StorageCategoryBehavior.list](x-source-tag://StorageCategoryBehavior.list).
         ///
         /// - Tag: StorageListResultItem.init
-        public init(key: String,
-                    size: Int? = nil,
-                    eTag: String? = nil,
-                    lastModified: Date? = nil,
-                    pluginResults: Any? = nil) {
+        @available(*, deprecated, message: "Use init(path:key:size:lastModifiedDate:eTag:pluginResults)")
+        public init(
+            key: String,
+            size: Int? = nil,
+            eTag: String? = nil,
+            lastModified: Date? = nil,
+            pluginResults: Any? = nil
+        ) {
+            self.key = key
+            self.size = size
+            self.eTag = eTag
+            self.lastModified = lastModified
+            self.pluginResults  = pluginResults
+            self.path = StringStoragePath(pathResolver: { _ in return "" })
+        }
+
+        public init(
+            path: StoragePath,
+            key: String,
+            size: Int? = nil,
+            eTag: String? = nil,
+            lastModified: Date? = nil,
+            pluginResults: Any? = nil
+        ) {
+            self.path = path
             self.key = key
             self.size = size
             self.eTag = eTag

--- a/Amplify/Categories/Storage/StorageAccessLevel.swift
+++ b/Amplify/Categories/Storage/StorageAccessLevel.swift
@@ -11,6 +11,7 @@ import Foundation
 /// See https://aws-amplify.github.io/docs/ios/storage#storage-access
 ///
 /// - Tag: StorageAccessLevel
+@available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
 public enum StorageAccessLevel: String {
 
     /// Objects can be read or written by any user without authentication

--- a/Amplify/Categories/Storage/StorageCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Storage/StorageCategory+ClientBehavior.swift
@@ -18,11 +18,27 @@ extension StorageCategory: StorageCategoryBehavior {
     }
 
     @discardableResult
+    public func getURL(
+        path: StoragePath,
+        options: StorageGetURLOperation.Request.Options? = nil
+    ) async throws -> URL {
+        try await plugin.getURL(path: path, options: options)
+    }
+
+    @discardableResult
     public func downloadData(
         key: String,
         options: StorageDownloadDataOperation.Request.Options? = nil
     ) -> StorageDownloadDataTask {
         plugin.downloadData(key: key, options: options)
+    }
+
+    @discardableResult
+    public func downloadData(
+        path: StoragePath,
+        options: StorageDownloadDataOperation.Request.Options? = nil
+    ) -> StorageDownloadDataTask {
+        plugin.downloadData(path: path, options: options)
     }
 
     @discardableResult
@@ -35,12 +51,30 @@ extension StorageCategory: StorageCategoryBehavior {
     }
 
     @discardableResult
+    public func downloadFile(
+        path: StoragePath,
+        local: URL,
+        options: StorageDownloadFileOperation.Request.Options? = nil
+    ) -> StorageDownloadFileTask {
+        plugin.downloadFile(path: path, local: local, options: options)
+    }
+
+    @discardableResult
     public func uploadData(
         key: String,
         data: Data,
         options: StorageUploadDataOperation.Request.Options? = nil
     ) -> StorageUploadDataTask {
         plugin.uploadData(key: key, data: data, options: options)
+    }
+
+    @discardableResult
+    public func uploadData(
+        path: StoragePath,
+        data: Data,
+        options: StorageUploadDataOperation.Request.Options? = nil
+    ) -> StorageUploadDataTask {
+        plugin.uploadData(path: path, data: data, options: options)
     }
 
     @discardableResult
@@ -53,6 +87,15 @@ extension StorageCategory: StorageCategoryBehavior {
     }
 
     @discardableResult
+    public func uploadFile(
+        path: StoragePath,
+        local: URL,
+        options: StorageUploadFileOperation.Request.Options? = nil
+    ) -> StorageUploadFileTask {
+        plugin.uploadFile(path: path, local: local, options: options)
+    }
+
+    @discardableResult
     public func remove(
         key: String,
         options: StorageRemoveRequest.Options? = nil
@@ -61,10 +104,26 @@ extension StorageCategory: StorageCategoryBehavior {
     }
 
     @discardableResult
+    public func remove(
+        path: StoragePath,
+        options: StorageRemoveRequest.Options? = nil
+    ) async throws -> String {
+        try await plugin.remove(path: path, options: options)
+    }
+
+    @discardableResult
     public func list(
         options: StorageListOperation.Request.Options? = nil
     ) async throws -> StorageListResult {
         try await plugin.list(options: options)
+    }
+
+    @discardableResult
+    public func list(
+        path: StoragePath,
+        options: StorageListOperation.Request.Options? = nil
+    ) async throws -> StorageListResult {
+        try await plugin.list(path: path, options: options)
     }
 
     public func handleBackgroundEvents(identifier: String) async -> Bool {

--- a/Amplify/Categories/Storage/StorageCategoryBehavior.swift
+++ b/Amplify/Categories/Storage/StorageCategoryBehavior.swift
@@ -22,9 +22,26 @@ public protocol StorageCategoryBehavior {
     /// - Returns: requested Get URL
     ///
     /// - Tag: StorageCategoryBehavior.getURL
+    @available(*, deprecated, message: "Use getURL(path:options:)")
     @discardableResult
-    func getURL(key: String,
-                options: StorageGetURLOperation.Request.Options?) async throws -> URL
+    func getURL(
+        key: String,
+        options: StorageGetURLOperation.Request.Options?
+    ) async throws -> URL
+
+    /// Retrieve the remote URL for the object from storage.
+    ///
+    /// - Parameters:
+    ///   - path: the path to the object in storage.
+    ///   - options: Parameters to specific plugin behavior
+    /// - Returns: requested Get URL
+    ///
+    /// - Tag: StorageCategoryBehavior.getURL
+    @discardableResult
+    func getURL(
+        path: StoragePath,
+        options: StorageGetURLOperation.Request.Options?
+    ) async throws -> URL
 
     /// Retrieve the object from storage into memory.
     ///
@@ -34,9 +51,23 @@ public protocol StorageCategoryBehavior {
     /// - Returns: A task that provides progress updates and the key which was used to download
     ///
     /// - Tag: StorageCategoryBehavior.downloadData
+    @available(*, deprecated, message: "Use downloadData(path:options:)")
     @discardableResult
     func downloadData(key: String,
                       options: StorageDownloadDataOperation.Request.Options?) -> StorageDownloadDataTask
+
+    /// Retrieve the object from storage into memory.
+    ///
+    /// - Parameters:
+    ///   - path: The path for the object in storage
+    ///   - options: Options to adjust the behavior of this request, including plugin-options
+    /// - Returns: A task that provides progress updates and the key which was used to download
+    ///
+    /// - Tag: StorageCategoryBehavior.downloadData
+    func downloadData(
+        path: StoragePath,
+        options: StorageDownloadDataOperation.Request.Options?
+    ) -> StorageDownloadDataTask
 
     /// Download to file the object from storage.
     ///
@@ -47,10 +78,29 @@ public protocol StorageCategoryBehavior {
     /// - Returns: A task that provides progress updates and the key which was used to download
     ///
     /// - Tag: StorageCategoryBehavior.downloadFile
+    @available(*, deprecated, message: "Use downloadFile(path:options:)")
     @discardableResult
-    func downloadFile(key: String,
-                      local: URL,
-                      options: StorageDownloadFileOperation.Request.Options?) -> StorageDownloadFileTask
+    func downloadFile(
+        key: String,
+        local: URL,
+        options: StorageDownloadFileOperation.Request.Options?
+    ) -> StorageDownloadFileTask
+
+    /// Download to file the object from storage.
+    ///
+    /// - Parameters:
+    ///   - path: The path for the object in storage.
+    ///   - local: The local file to download destination
+    ///   - options: Parameters to specific plugin behavior
+    /// - Returns: A task that provides progress updates and the key which was used to download
+    ///
+    /// - Tag: StorageCategoryBehavior.downloadFile
+    @discardableResult
+    func downloadFile(
+        path: StoragePath,
+        local: URL,
+        options: StorageDownloadFileOperation.Request.Options?
+    ) -> StorageDownloadFileTask
 
     /// Upload data to storage
     ///
@@ -61,10 +111,30 @@ public protocol StorageCategoryBehavior {
     /// - Returns: A task that provides progress updates and the key which was used to upload
     ///
     /// - Tag: StorageCategoryBehavior.uploadData
+    @available(*, deprecated, message: "Use uploadData(path:options:)")
     @discardableResult
-    func uploadData(key: String,
-                    data: Data,
-                    options: StorageUploadDataOperation.Request.Options?) -> StorageUploadDataTask
+    func uploadData(
+        key: String,
+        data: Data,
+        options: StorageUploadDataOperation.Request.Options?
+    ) -> StorageUploadDataTask
+
+    /// Upload data to storage
+    ///
+    /// - Parameters:
+    ///   - path: The path of the object in storage.
+    ///   - data: The data in memory to be uploaded
+    ///   - options: Parameters to specific plugin behavior
+    /// - Returns: A task that provides progress updates and the key which was used to upload
+    ///
+    /// - Tag: StorageCategoryBehavior.uploadData
+    @discardableResult
+    func uploadData(
+        path: StoragePath,
+        data: Data,
+        options: StorageUploadDataOperation.Request.Options?
+    ) -> StorageUploadDataTask
+
 
     /// Upload local file to storage
     ///
@@ -75,10 +145,29 @@ public protocol StorageCategoryBehavior {
     /// - Returns: A task that provides progress updates and the key which was used to upload
     ///
     /// - Tag: StorageCategoryBehavior.uploadFile
+    @available(*, deprecated, message: "Use uploadFile(path:options:)")
     @discardableResult
-    func uploadFile(key: String,
-                    local: URL,
-                    options: StorageUploadFileOperation.Request.Options?) -> StorageUploadFileTask
+    func uploadFile(
+        key: String,
+        local: URL,
+        options: StorageUploadFileOperation.Request.Options?
+    ) -> StorageUploadFileTask
+
+    /// Upload local file to storage
+    ///
+    /// - Parameters:
+    ///   - path: The path of the object in storage.
+    ///   - local: The path to a local file.
+    ///   - options: Parameters to specific plugin behavior
+    /// - Returns: A task that provides progress updates and the key which was used to upload
+    ///
+    /// - Tag: StorageCategoryBehavior.uploadFile
+    @discardableResult
+    func uploadFile(
+        path: StoragePath,
+        local: URL,
+        options: StorageUploadFileOperation.Request.Options?
+    ) -> StorageUploadFileTask
 
     /// Delete object from storage
     ///
@@ -88,20 +177,51 @@ public protocol StorageCategoryBehavior {
     /// - Returns: An operation object that provides notifications and actions related to the execution of the work
     ///
     /// - Tag: StorageCategoryBehavior.remove
+    @available(*, deprecated, message: "Use remove(path:options:)")
     @discardableResult
-    func remove(key: String,
-                options: StorageRemoveOperation.Request.Options?) async throws -> String
+    func remove(
+        key: String,
+        options: StorageRemoveOperation.Request.Options?
+    ) async throws -> String
+
+    /// Delete object from storage
+    ///
+    /// - Parameters:
+    ///   - path: The path of the object in storage.
+    ///   - options: Parameters to specific plugin behavior
+    /// - Returns: An operation object that provides notifications and actions related to the execution of the work
+    ///
+    /// - Tag: StorageCategoryBehavior.remove
+    @discardableResult
+    func remove(
+        path: StoragePath,
+        options: StorageRemoveOperation.Request.Options?
+    ) async throws -> String
 
     /// List the object identifiers under the hierarchy specified by the path, relative to access level, from storage
     ///
     /// - Parameters:
     ///   - options: Parameters to specific plugin behavior
-    ///   - resultListener: Triggered when the list is complete
+    /// - Returns: An operation object that provides notifications and actions related to the execution of the work
+    ///
+    /// - Tag: StorageCategoryBehavior.list
+    @available(*, deprecated, message: "Use list(path:options:)")
+    @discardableResult
+    func list(options: StorageListOperation.Request.Options?) async throws -> StorageListResult
+
+    /// List the object identifiers under the hierarchy specified by the path, relative to access level, from storage
+    ///
+    /// - Parameters:
+    ///   - path: The path of the object in storage.
+    ///   - options: Parameters to specific plugin behavior
     /// - Returns: An operation object that provides notifications and actions related to the execution of the work
     ///
     /// - Tag: StorageCategoryBehavior.list
     @discardableResult
-    func list(options: StorageListOperation.Request.Options?) async throws -> StorageListResult
+    func list(
+        path: StoragePath,
+        options: StorageListOperation.Request.Options?
+    ) async throws -> StorageListResult
 
     /// Handles background events which are related to URLSession
     /// - Parameter identifier: identifier

--- a/Amplify/Categories/Storage/StoragePath.swift
+++ b/Amplify/Categories/Storage/StoragePath.swift
@@ -1,0 +1,30 @@
+
+
+import Foundation
+
+public typealias StoragePathResolver = (String) -> String
+
+public protocol StoragePath {
+    var pathResolver: StoragePathResolver { get }
+}
+
+public extension StoragePath where Self == StringStoragePath {
+    static func fromString(_ path: String) -> Self {
+        return StringStoragePath(pathResolver: { _ in return path })
+    }
+}
+
+public extension StoragePath where Self == IdentityIdStoragePath  {
+    static func fromIdentityId(_ identityIdPathResolver: @escaping StoragePathResolver) -> Self {
+        return IdentityIdStoragePath(pathResolver: identityIdPathResolver)
+    }
+}
+
+public struct StringStoragePath: StoragePath {
+    public let pathResolver: StoragePathResolver
+}
+
+public struct IdentityIdStoragePath: StoragePath {
+    public let pathResolver: StoragePathResolver
+}
+

--- a/Amplify/Categories/Storage/StoragePath.swift
+++ b/Amplify/Categories/Storage/StoragePath.swift
@@ -1,9 +1,17 @@
-
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 
 import Foundation
 
 public typealias StoragePathResolver = (String) -> String
 
+/// Protocol that provides a closure to resolve the storage path.
+///
+/// - Tag: StoragePath
 public protocol StoragePath {
     var pathResolver: StoragePathResolver { get }
 }
@@ -20,10 +28,17 @@ public extension StoragePath where Self == IdentityIdStoragePath  {
     }
 }
 
+/// Conforms to StoragePath protocol.  Provides a storage path based on a string storage path.
+///
+/// - Tag: StringStoragePath
 public struct StringStoragePath: StoragePath {
     public let pathResolver: StoragePathResolver
 }
 
+/// Conforms to StoragePath protocol.
+/// Provides a storage path constructed from an unique identity identifer.
+///
+/// - Tag: IdentityStoragePath
 public struct IdentityIdStoragePath: StoragePath {
     public let pathResolver: StoragePathResolver
 }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+AsyncClientBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+AsyncClientBehavior.swift
@@ -45,6 +45,55 @@ extension AWSS3StoragePlugin {
         return result
     }
 
+    public func getURL(
+        path: StoragePath,
+        options: StorageGetURLOperation.Request.Options? = nil
+    ) async throws -> URL {
+        let options = options ?? StorageGetURLRequest.Options()
+        let path = "" //TODO: resolve path
+        let request = StorageGetURLRequest(key: path, options: options)
+        if let error = request.validate() {
+            throw error
+        }
+        let prefixResolver = storageConfiguration.prefixResolver ?? StorageAccessLevelAwarePrefixResolver(authService: authService)
+        let prefix = try await prefixResolver.resolvePrefix(for: options.accessLevel,
+                                                            targetIdentityId: options.targetIdentityId)
+        let serviceKey = prefix + request.key
+        if let pluginOptions = options.pluginOptions as? AWSStorageGetURLOptions, pluginOptions.validateObjectExistence {
+            try await storageService.validateObjectExistence(serviceKey: serviceKey)
+        }
+        let accelerate = try AWSS3PluginOptions.accelerateValue(
+            pluginOptions: options.pluginOptions)
+        let result = try await storageService.getPreSignedURL(
+            serviceKey: serviceKey,
+            signingOperation: .getObject,
+            metadata: nil,
+            accelerate: accelerate,
+            expires: options.expires)
+
+        let channel = HubChannel(from: categoryType)
+        let payload = HubPayload(eventName: HubPayload.EventName.Storage.getURL, context: options, data: result)
+        Amplify.Hub.dispatch(to: channel, payload: payload)
+        return result
+    }
+
+    public func downloadData(
+        path: StoragePath,
+        options: StorageDownloadDataOperation.Request.Options? = nil
+    ) -> StorageDownloadDataTask {
+        let options = options ?? StorageDownloadDataRequest.Options()
+        let path = "" //TODO: resolve path
+        let request = StorageDownloadDataRequest(key: path, options: options)
+        let operation = AWSS3StorageDownloadDataOperation(request,
+                                                          storageConfiguration: storageConfiguration,
+                                                          storageService: storageService,
+                                                          authService: authService)
+        let taskAdapter = AmplifyInProcessReportingOperationTaskAdapter(operation: operation)
+        queue.addOperation(operation)
+
+        return taskAdapter
+    }
+
     @discardableResult
     public func downloadData(
         key: String,
@@ -81,6 +130,25 @@ extension AWSS3StoragePlugin {
     }
 
     @discardableResult
+    public func downloadFile(
+        path: StoragePath,
+        local: URL,
+        options: StorageDownloadFileOperation.Request.Options? = nil
+    ) -> StorageDownloadFileTask {
+        let options = options ?? StorageDownloadFileRequest.Options()
+        let path = "" //TODO: resolve path
+        let request = StorageDownloadFileRequest(key: path, local: local, options: options)
+        let operation = AWSS3StorageDownloadFileOperation(request,
+                                                          storageConfiguration: storageConfiguration,
+                                                          storageService: storageService,
+                                                          authService: authService)
+        let taskAdapter = AmplifyInProcessReportingOperationTaskAdapter(operation: operation)
+        queue.addOperation(operation)
+
+        return taskAdapter
+    }
+
+    @discardableResult
     public func uploadData(
         key: String,
         data: Data,
@@ -88,6 +156,25 @@ extension AWSS3StoragePlugin {
     ) -> StorageUploadDataTask {
         let options = options ?? StorageUploadDataRequest.Options()
         let request = StorageUploadDataRequest(key: key, data: data, options: options)
+        let operation = AWSS3StorageUploadDataOperation(request,
+                                                        storageConfiguration: storageConfiguration,
+                                                        storageService: storageService,
+                                                        authService: authService)
+        let taskAdapter = AmplifyInProcessReportingOperationTaskAdapter(operation: operation)
+        queue.addOperation(operation)
+
+        return taskAdapter
+    }
+
+    @discardableResult
+    public func uploadData(
+        path: StoragePath,
+        data: Data,
+        options: StorageUploadDataOperation.Request.Options? = nil
+    ) -> StorageUploadDataTask {
+        let options = options ?? StorageUploadDataRequest.Options()
+        let path = "" //TODO: resolve path
+        let request = StorageUploadDataRequest(key: path, data: data, options: options)
         let operation = AWSS3StorageUploadDataOperation(request,
                                                         storageConfiguration: storageConfiguration,
                                                         storageService: storageService,
@@ -117,6 +204,25 @@ extension AWSS3StoragePlugin {
     }
 
     @discardableResult
+    public func uploadFile(
+        path: StoragePath,
+        local: URL,
+        options: StorageUploadFileOperation.Request.Options? = nil
+    ) -> StorageUploadFileTask {
+        let options = options ?? StorageUploadFileRequest.Options()
+        let path = "" //TODO: resolve path
+        let request = StorageUploadFileRequest(key: path, local: local, options: options)
+        let operation = AWSS3StorageUploadFileOperation(request,
+                                                        storageConfiguration: storageConfiguration,
+                                                        storageService: storageService,
+                                                        authService: authService)
+        let taskAdapter = AmplifyInProcessReportingOperationTaskAdapter(operation: operation)
+        queue.addOperation(operation)
+
+        return taskAdapter
+    }
+
+    @discardableResult
     public func remove(
         key: String,
         options: StorageRemoveOperation.Request.Options? = nil
@@ -133,12 +239,45 @@ extension AWSS3StoragePlugin {
         return try await taskAdapter.value
     }
 
+    @discardableResult
+    public func remove(
+        path: StoragePath,
+        options: StorageRemoveOperation.Request.Options? = nil
+    ) async throws -> String {
+        let options = options ?? StorageRemoveRequest.Options()
+        let path = "" //TODO: resolve path
+        let request = StorageRemoveRequest(key: path, options: options)
+        let operation = AWSS3StorageRemoveOperation(request,
+                                                    storageConfiguration: storageConfiguration,
+                                                    storageService: storageService,
+                                                    authService: authService)
+        let taskAdapter = AmplifyOperationTaskAdapter(operation: operation)
+        queue.addOperation(operation)
+
+        return try await taskAdapter.value
+    }
+
     public func list(
         options: StorageListRequest.Options? = nil
     ) async throws -> StorageListResult {
         let options = options ?? StorageListRequest.Options()
         let prefixResolver = storageConfiguration.prefixResolver ?? StorageAccessLevelAwarePrefixResolver(authService: authService)
         let prefix = try await prefixResolver.resolvePrefix(for: options.accessLevel, targetIdentityId: options.targetIdentityId)
+        let result = try await storageService.list(prefix: prefix, options: options)
+
+        let channel = HubChannel(from: categoryType)
+        let payload = HubPayload(eventName: HubPayload.EventName.Storage.list, context: options, data: result)
+        Amplify.Hub.dispatch(to: channel, payload: payload)
+
+        return result
+    }
+
+    public func list(
+        path: StoragePath,
+        options: StorageListRequest.Options? = nil
+    ) async throws -> StorageListResult {
+        let options = options ?? StorageListRequest.Options()
+        let prefix = "" //TODO: resolve path
         let result = try await storageService.list(prefix: prefix, options: options)
 
         let channel = HubChannel(from: categoryType)

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
@@ -25,6 +25,7 @@ final public class AWSS3StoragePlugin: StorageCategoryPlugin {
     var queue: OperationQueue!
 
     /// The default access level used for API calls.
+    @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
     var defaultAccessLevel: StorageAccessLevel!
 
     /// The unique key of the plugin within the storage category.

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Configuration/AWSS3PluginPrefixResolver.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Configuration/AWSS3PluginPrefixResolver.swift
@@ -12,6 +12,7 @@ import AWSPluginsCore
 /// Resolves the final prefix prepended to the S3 key for a given request.
 ///
 /// - Tag: AWSS3PluginPrefixResolver
+@available(*, deprecated, message: "Use `StoragePath` instead")
 public protocol AWSS3PluginPrefixResolver {
     /// - Tag: AWSS3PluginPrefixResolver.resolvePrefix
     func resolvePrefix(for accessLevel: StorageAccessLevel,
@@ -21,6 +22,7 @@ public protocol AWSS3PluginPrefixResolver {
 /// Convenience resolver. Resolves the provided key as-is, with no manipulation
 ///
 /// - Tag: PassThroughPrefixResolver
+@available(*, deprecated, message: "Use `StoragePath` instead")
 public struct PassThroughPrefixResolver: AWSS3PluginPrefixResolver {
     public func resolvePrefix(for accessLevel: StorageAccessLevel,
                               targetIdentityId: String?) async throws -> String {
@@ -31,6 +33,7 @@ public struct PassThroughPrefixResolver: AWSS3PluginPrefixResolver {
 /// AWSS3StoragePlugin default logic
 ///
 /// - Tag: StorageAccessLevelAwarePrefixResolver
+@available(*, deprecated, message: "Use `StoragePath` instead")
 struct StorageAccessLevelAwarePrefixResolver {
     let authService: AWSAuthServiceBehavior
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Configuration/AWSS3StoragePluginConfiguration.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Configuration/AWSS3StoragePluginConfiguration.swift
@@ -13,6 +13,7 @@ import Foundation
 public struct AWSS3StoragePluginConfiguration {
 
     /// - Tag: AWSS3StoragePluginConfiguration.prefixResolver
+    @available(*, deprecated)
     public let prefixResolver: AWSS3PluginPrefixResolver?
 
     /// - Tag: AWSS3StoragePluginConfiguration.init
@@ -21,6 +22,7 @@ public struct AWSS3StoragePluginConfiguration {
     }
 
     /// - Tag: AWSS3StoragePluginConfiguration.prefixResolverFunc
+    @available(*, deprecated, message: "Use `StoragePath` instead")
     public static func prefixResolver(
         _ prefixResolver: AWSS3PluginPrefixResolver) -> AWSS3StoragePluginConfiguration {
         .init(prefixResolver: prefixResolver)

--- a/AmplifyTestCommon/Mocks/MockStorageCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockStorageCategoryPlugin.swift
@@ -180,6 +180,68 @@ class MockStorageCategoryPlugin: MessageReporter, StorageCategoryPlugin {
         false
     }
 
+    func getURL(path: StoragePath, options: StorageGetURLRequest.Options?) async throws -> URL {
+        notify("getURL")
+        let options = options ?? StorageGetURLRequest.Options()
+        let request = StorageGetURLRequest(key: key, options: options)
+        let operation = MockStorageGetURLOperation(request: request)
+        let taskAdapter = AmplifyOperationTaskAdapter(operation: operation)
+        return try await taskAdapter.value
+    }
+
+    func downloadData(path: StoragePath, options: StorageDownloadDataRequest.Options?) -> StorageDownloadDataTask {
+        notify("downloadData")
+        let options = options ?? StorageDownloadDataRequest.Options()
+        let request = StorageDownloadDataRequest(key: key, options: options)
+        let operation = MockStorageDownloadDataOperation(request: request)
+        let taskAdapter = AmplifyInProcessReportingOperationTaskAdapter(operation: operation)
+        return taskAdapter
+    }
+
+    func downloadFile(path: StoragePath, local: URL, options: StorageDownloadFileRequest.Options?) -> StorageDownloadFileTask {
+        notify("downloadFile")
+        let options = options ?? StorageDownloadFileRequest.Options()
+        let request = StorageDownloadFileRequest(key: key, local: local, options: options)
+        let operation = MockStorageDownloadFileOperation(request: request)
+        let taskAdapter = AmplifyInProcessReportingOperationTaskAdapter(operation: operation)
+        return taskAdapter
+    }
+
+    func uploadData(path: StoragePath, data: Data, options: StorageUploadDataRequest.Options?) -> StorageUploadDataTask {
+        notify("uploadData")
+        let options = options ?? StorageUploadDataRequest.Options()
+        let request = StorageUploadDataRequest(key: key, data: data, options: options)
+        let operation = MockStorageUploadDataOperation(request: request)
+        let taskAdapter = AmplifyInProcessReportingOperationTaskAdapter(operation: operation)
+        return taskAdapter
+    }
+
+    func uploadFile(path: StoragePath, local: URL, options: StorageUploadFileRequest.Options?) -> StorageUploadFileTask {
+        notify("uploadFile")
+        let options = options ?? StorageUploadFileRequest.Options()
+        let request = StorageUploadFileRequest(key: key, local: local, options: options)
+        let operation =  MockStorageUploadFileOperation(request: request)
+        let taskAdapter = AmplifyInProcessReportingOperationTaskAdapter(operation: operation)
+        return taskAdapter
+    }
+
+    func remove(path: StoragePath, options: StorageRemoveRequest.Options?) async throws -> String {
+        notify("remove")
+        let options = options ?? StorageRemoveRequest.Options()
+        let request = StorageRemoveRequest(key: key, options: options)
+        let operation = MockStorageRemoveOperation(request: request)
+        let taskAdapter = AmplifyOperationTaskAdapter(operation: operation)
+        return try await taskAdapter.value
+    }
+
+    func list(path: StoragePath, options: StorageListRequest.Options?) async throws -> StorageListResult {
+        notify("list")
+        let options = options ?? StorageListRequest.Options()
+        let request = StorageListRequest(options: options)
+        let operation = MockStorageListOperation(request: request)
+        let taskAdapter = AmplifyOperationTaskAdapter(operation: operation)
+        return try await taskAdapter.value
+    }
 }
 
 class MockSecondStorageCategoryPlugin: MockStorageCategoryPlugin {


### PR DESCRIPTION
## Issue \#

## Description
* Add new APIs for Storage that takes in a `StoragePath`
* stubbed out current implementation in AWSS3StoragePlugin to be implemented next
* mark existing APIs that takes in key as deprecated

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
