### PR TITLE
chore(storage): update storage path validation rule

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StoragePath+Extensions.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StoragePath+Extensions.swift
@@ -41,9 +41,9 @@ extension StoragePath {
     }
 
     func validate(_ path: String) throws {
-        if !path.hasPrefix("/") {
+        if path.hasPrefix("/") {
             let errorDescription = "Invalid StoragePath specified."
-            let recoverySuggestion = "Please specify a valid StoragePath that contains the prefix / "
+            let recoverySuggestion = "Please specify a valid StoragePath that does not contain the prefix / "
             throw StorageError.validation("path", errorDescription, recoverySuggestion, nil)
         }
     }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageDownloadFileOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageDownloadFileOperationTests.swift
@@ -186,7 +186,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
     /// When: The operation is executed with a request that has an invalid StringStoragePath
     /// Then: The operation will fail with a validation error
     func testDownloadFileOperationStringStoragePathValidationError() {
-        let path = StringStoragePath(resolve: { _ in return "my/path" })
+        let path = StringStoragePath(resolve: { _ in return "/my/path" })
         let request = StorageDownloadFileRequest(path: path,
                                                  local: testURL,
                                                  options: StorageDownloadFileRequest.Options())
@@ -218,7 +218,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
     /// When: The operation is executed with a request that has an invalid IdentityIDStoragePath
     /// Then: The operation will fail with a validation error
     func testDownloadFileOperationIdentityIDStoragePathValidationError() {
-        let path = IdentityIDStoragePath(resolve: { _ in return "my/path" })
+        let path = IdentityIDStoragePath(resolve: { _ in return "/my/path" })
         let request = StorageDownloadFileRequest(path: path,
                                                  local: testURL,
                                                  options: StorageDownloadFileRequest.Options())
@@ -282,7 +282,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
     /// When: The operation is executed with a request that has an valid StringStoragePath
     /// Then: The operation will succeed
     func testDownloadFileOperationWithStringStoragePathSucceeds() async throws {
-        let path = StringStoragePath(resolve: { _ in return "/public/\(self.testKey)" })
+        let path = StringStoragePath(resolve: { _ in return "public/\(self.testKey)" })
         let task = StorageTransferTask(transferType: .download(onEvent: { _ in }), bucket: "bucket", key: "key")
         mockStorageService.storageServiceDownloadEvents = [
             StorageEvent.initiated(StorageTaskReference(task)),
@@ -314,7 +314,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
 
         await waitForExpectations(timeout: 1)
         XCTAssertTrue(operation.isFinished)
-        mockStorageService.verifyDownload(serviceKey: "/public/\(self.testKey)", fileURL: url)
+        mockStorageService.verifyDownload(serviceKey: "public/\(self.testKey)", fileURL: url)
     }
 
     /// Given: Storage Download File Operation
@@ -322,7 +322,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
     /// Then: The operation will succeed
     func testDownloadFileOperationWithIdentityIDStoragePathSucceeds() async throws {
         mockAuthService.identityId = testIdentityId
-        let path = IdentityIDStoragePath(resolve: { id in return "/public/\(id)/\(self.testKey)" })
+        let path = IdentityIDStoragePath(resolve: { id in return "public/\(id)/\(self.testKey)" })
         let task = StorageTransferTask(transferType: .download(onEvent: { _ in }), bucket: "bucket", key: "key")
         mockStorageService.storageServiceDownloadEvents = [
             StorageEvent.initiated(StorageTaskReference(task)),
@@ -354,7 +354,7 @@ class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
 
         await waitForExpectations(timeout: 1)
         XCTAssertTrue(operation.isFinished)
-        mockStorageService.verifyDownload(serviceKey: "/public/\(testIdentityId)/\(self.testKey)", fileURL: url)
+        mockStorageService.verifyDownload(serviceKey: "public/\(testIdentityId)/\(self.testKey)", fileURL: url)
     }
 
     // TODO: missing unit tests for pause resume and cancel. do we create a mock of the StorageTaskReference?

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageGetDataOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageGetDataOperationTests.swift
@@ -178,7 +178,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
     /// When: The operation is executed with a request that has an invalid StringStoragePath
     /// Then: The operation will fail with a validation error
     func testDownloadDataOperationStringStoragePathValidationError() {
-        let path = StringStoragePath(resolve: { _ in return "my/path" })
+        let path = StringStoragePath(resolve: { _ in return "/my/path" })
         let request = StorageDownloadDataRequest(path: path, options: StorageDownloadDataRequest.Options())
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageDownloadDataOperation(request,
@@ -208,7 +208,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
     /// When: The operation is executed with a request that has an invalid IdentityIDStoragePath
     /// Then: The operation will fail with a validation error
     func testDownloadDataOperationIdentityIdStoragePathValidationError() {
-        let path = IdentityIDStoragePath(resolve: { _ in return "my/path" })
+        let path = IdentityIDStoragePath(resolve: { _ in return "/my/path" })
         let request = StorageDownloadDataRequest(path: path, options: StorageDownloadDataRequest.Options())
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let operation = AWSS3StorageDownloadDataOperation(request,
@@ -271,7 +271,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
             StorageEvent.initiated(StorageTaskReference(task)),
             StorageEvent.inProcess(Progress()),
             StorageEvent.completed(Data())]
-        let path = StringStoragePath(resolve: { _ in return "/public/\(self.testKey)" })
+        let path = StringStoragePath(resolve: { _ in return "public/\(self.testKey)" })
         let request = StorageDownloadDataRequest(path: path, options: StorageDownloadDataRequest.Options())
 
         let inProcessInvoked = expectation(description: "inProgress was invoked on operation")
@@ -296,7 +296,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
 
         await fulfillment(of: [inProcessInvoked, completeInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
-        mockStorageService.verifyDownload(serviceKey: "/public/\(self.testKey)", fileURL: nil)
+        mockStorageService.verifyDownload(serviceKey: "public/\(self.testKey)", fileURL: nil)
     }
 
     /// Given: Storage Download Data Operation
@@ -309,7 +309,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
             StorageEvent.initiated(StorageTaskReference(task)),
             StorageEvent.inProcess(Progress()),
             StorageEvent.completed(Data())]
-        let path = IdentityIDStoragePath(resolve: { id in return "/public/\(id)/\(self.testKey)" })
+        let path = IdentityIDStoragePath(resolve: { id in return "public/\(id)/\(self.testKey)" })
         let request = StorageDownloadDataRequest(path: path, options: StorageDownloadDataRequest.Options())
 
         let inProcessInvoked = expectation(description: "inProgress was invoked on operation")
@@ -334,7 +334,7 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
 
         await fulfillment(of: [inProcessInvoked, completeInvoked], timeout: 1)
         XCTAssertTrue(operation.isFinished)
-        mockStorageService.verifyDownload(serviceKey: "/public/\(testIdentityId)/\(self.testKey)", fileURL: nil)
+        mockStorageService.verifyDownload(serviceKey: "public/\(testIdentityId)/\(self.testKey)", fileURL: nil)
     }
 
     // TODO: missing unit tets for pause resume and cancel. do we create a mock of the StorageTaskReference?

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StoragePutDataOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StoragePutDataOperationTests.swift
@@ -223,7 +223,7 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
     /// When: The operation is executed with a request that has an invalid StringStoragePath
     /// Then: The operation will fail with a validation error
     func testUploadDataOperationStringStoragePathValidationError() {
-        let path = StringStoragePath(resolve: { _ in return "my/path" })
+        let path = StringStoragePath(resolve: { _ in return "/my/path" })
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let options = StorageUploadDataRequest.Options(accessLevel: .protected)
         let request = StorageUploadDataRequest(path: path, data: testData, options: options)
@@ -254,7 +254,7 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
     /// When: The operation is executed with a request that has an invalid IdentityIDStoragePath
     /// Then: The operation will fail with a validation error
     func testUploadDataOperationIdentityIDStoragePathValidationError() {
-        let path = IdentityIDStoragePath(resolve: { _ in return "my/path" })
+        let path = IdentityIDStoragePath(resolve: { _ in return "/my/path" })
         let failedInvoked = expectation(description: "failed was invoked on operation")
         let options = StorageUploadDataRequest.Options(accessLevel: .protected)
         let request = StorageUploadDataRequest(path: path, data: testData, options: options)
@@ -316,7 +316,7 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
     /// When: The operation is executed with a request that has an valid StringStoragePath
     /// Then: The operation will succeed
     func testUploadDataOperationWithStringStoragePathSucceeds() async throws {
-        let path = StringStoragePath(resolve: { _ in return "/public/\(self.testKey)" })
+        let path = StringStoragePath(resolve: { _ in return "public/\(self.testKey)" })
         let task = StorageTransferTask(transferType: .upload(onEvent: { _ in }), bucket: "bucket", key: "key")
         mockStorageService.storageServiceUploadEvents = [
             StorageEvent.initiated(StorageTaskReference(task)),
@@ -354,7 +354,7 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
         await waitForExpectations(timeout: 1)
         XCTAssertTrue(operation.isFinished)
         XCTAssertEqual(mockStorageService.uploadCalled, 1)
-        mockStorageService.verifyUpload(serviceKey: "/public/\(self.testKey)",
+        mockStorageService.verifyUpload(serviceKey: "public/\(self.testKey)",
                                         key: testKey,
                                         uploadSource: expectedUploadSource,
                                         contentType: testContentType,
@@ -366,7 +366,7 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
     /// Then: The operation will succeed
     func testUploadDataOperationWithIdentityIDStoragePathSucceeds() async throws {
         mockAuthService.identityId = testIdentityId
-        let path = IdentityIDStoragePath(resolve: { id in return "/public/\(id)/\(self.testKey)" })
+        let path = IdentityIDStoragePath(resolve: { id in return "public/\(id)/\(self.testKey)" })
         let task = StorageTransferTask(transferType: .upload(onEvent: { _ in }), bucket: "bucket", key: "key")
         mockStorageService.storageServiceUploadEvents = [
             StorageEvent.initiated(StorageTaskReference(task)),
@@ -403,7 +403,7 @@ class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
         await waitForExpectations(timeout: 1)
         XCTAssertTrue(operation.isFinished)
         XCTAssertEqual(mockStorageService.uploadCalled, 1)
-        mockStorageService.verifyUpload(serviceKey: "/public/\(testIdentityId)/\(testKey)",
+        mockStorageService.verifyUpload(serviceKey: "public/\(testIdentityId)/\(testKey)",
                                         key: testKey,
                                         uploadSource: expectedUploadSource,
                                         contentType: testContentType,

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests.swift
@@ -259,7 +259,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
     /// When: The operation is executed with a request that has an invalid StringStoragePath
     /// Then: The operation will fail with a validation error
     func testUploadFileOperationStringStoragePathValidationError() {
-        let path = StringStoragePath(resolve: { _ in return "my/path" })
+        let path = StringStoragePath(resolve: { _ in return "/my/path" })
         mockAuthService.identityId = testIdentityId
         let task = StorageTransferTask(transferType: .upload(onEvent: { _ in }), bucket: "bucket", key: "key")
         mockStorageService.storageServiceUploadEvents = [
@@ -305,7 +305,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
     /// When: The operation is executed with a request that has an invalid IdentityIDStoragePath
     /// Then: The operation will fail with a validation error
     func testUploadFileOperationIdentityIDStoragePathValidationError() {
-        let path = IdentityIDStoragePath(resolve: { _ in return "my/path" })
+        let path = IdentityIDStoragePath(resolve: { _ in return "/my/path" })
         mockAuthService.identityId = testIdentityId
         let task = StorageTransferTask(transferType: .upload(onEvent: { _ in }), bucket: "bucket", key: "key")
         mockStorageService.storageServiceUploadEvents = [
@@ -397,7 +397,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
     /// When: The operation is executed with a request that has an valid StringStoragePath
     /// Then: The operation will succeed
     func testUploadFileOperationWithStringStoragePathSucceeds() async throws {
-        let path = StringStoragePath(resolve: { _ in return "/public/\(self.testKey)" })
+        let path = StringStoragePath(resolve: { _ in return "public/\(self.testKey)" })
         mockAuthService.identityId = testIdentityId
         let task = StorageTransferTask(transferType: .upload(onEvent: { _ in }), bucket: "bucket", key: "key")
         mockStorageService.storageServiceUploadEvents = [
@@ -439,7 +439,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
         await waitForExpectations(timeout: 1)
         XCTAssertTrue(operation.isFinished)
         XCTAssertEqual(mockStorageService.uploadCalled, 1)
-        mockStorageService.verifyUpload(serviceKey: "/public/\(testKey)",
+        mockStorageService.verifyUpload(serviceKey: "public/\(testKey)",
                                         key: testKey,
                                         uploadSource: expectedUploadSource,
                                         contentType: testContentType,
@@ -450,7 +450,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
     /// When: The operation is executed with a request that has an valid IdentityIDStoragePath
     /// Then: The operation will succeed
     func testUploadFileOperationWithIdentityIDStoragePathSucceeds() async throws {
-        let path = IdentityIDStoragePath(resolve: { id in return "/public/\(id)/\(self.testKey)" })
+        let path = IdentityIDStoragePath(resolve: { id in return "public/\(id)/\(self.testKey)" })
         mockAuthService.identityId = testIdentityId
         let task = StorageTransferTask(transferType: .upload(onEvent: { _ in }), bucket: "bucket", key: "key")
         mockStorageService.storageServiceUploadEvents = [
@@ -491,7 +491,7 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
         await waitForExpectations(timeout: 1)
         XCTAssertTrue(operation.isFinished)
         XCTAssertEqual(mockStorageService.uploadCalled, 1)
-        mockStorageService.verifyUpload(serviceKey: "/public/\(testIdentityId)/\(testKey)",
+        mockStorageService.verifyUpload(serviceKey: "public/\(testIdentityId)/\(testKey)",
                                         key: testKey,
                                         uploadSource: expectedUploadSource,
                                         contentType: testContentType,

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageGetURLTaskTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageGetURLTaskTests.swift
@@ -21,7 +21,7 @@ class AWSS3StorageGetURLTaskTests: XCTestCase {
     /// - Then: A URL should be returned.
     func testRemoveTaskSuccess() async throws {
 
-        let somePath = "/path"
+        let somePath = "path"
         let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
 
         let serviceMock = MockAWSS3StorageService()
@@ -43,7 +43,7 @@ class AWSS3StorageGetURLTaskTests: XCTestCase {
     /// - When: AWSS3StorageGetURLTask value is invoked
     /// - Then: A storage service error should be returned, with an underlying service error
     func testRemoveTaskNoBucket() async throws {
-        let somePath = "/path"
+        let somePath = "path"
 
         let serviceMock = MockAWSS3StorageService()
         serviceMock.getPreSignedURLHandler = { _, _, _ in
@@ -74,7 +74,7 @@ class AWSS3StorageGetURLTaskTests: XCTestCase {
     /// - When: AWSS3StorageGetURLTask value is invoked
     /// - Then: A storage validation error should be returned
     func testGetURLTaskWithInvalidPath() async throws {
-        let somePath = "path"
+        let somePath = "/path"
         let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
 
         let serviceMock = MockAWSS3StorageService()

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageGetURLTaskTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageGetURLTaskTests.swift
@@ -21,7 +21,7 @@ class AWSS3StorageGetURLTaskTests: XCTestCase {
     /// - Then: A URL should be returned.
     func testGetURLTaskSuccess() async throws {
 
-        let somePath = "/path"
+        let somePath = "path"
         let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
 
         let serviceMock = MockAWSS3StorageService()
@@ -43,7 +43,7 @@ class AWSS3StorageGetURLTaskTests: XCTestCase {
     /// - When: AWSS3StorageGetURLTask value is invoked
     /// - Then: A storage service error should be returned, with an underlying service error
     func testGetURLTaskNoBucket() async throws {
-        let somePath = "/path"
+        let somePath = "path"
 
         let serviceMock = MockAWSS3StorageService()
         serviceMock.getPreSignedURLHandler = { _, _, _ in
@@ -74,7 +74,7 @@ class AWSS3StorageGetURLTaskTests: XCTestCase {
     /// - When: AWSS3StorageGetURLTask value is invoked
     /// - Then: A storage validation error should be returned
     func testGetURLTaskWithInvalidPath() async throws {
-        let somePath = "path"
+        let somePath = "/path"
         let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
 
         let serviceMock = MockAWSS3StorageService()

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageListObjectsTaskTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageListObjectsTaskTests.swift
@@ -31,7 +31,7 @@ class AWSS3StorageListObjectsTaskTests: XCTestCase {
         }
 
         let request = StorageListRequest(
-            path: StringStoragePath.fromString("/path"), options: .init())
+            path: StringStoragePath.fromString("path"), options: .init())
         let task = AWSS3StorageListObjectsTask(
             request,
             storageConfiguration: AWSS3StoragePluginConfiguration(),
@@ -56,7 +56,7 @@ class AWSS3StorageListObjectsTaskTests: XCTestCase {
         }
 
         let request = StorageListRequest(
-            path: StringStoragePath.fromString("/path"), options: .init())
+            path: StringStoragePath.fromString("path"), options: .init())
         let task = AWSS3StorageListObjectsTask(
             request,
             storageConfiguration: AWSS3StoragePluginConfiguration(),
@@ -83,7 +83,7 @@ class AWSS3StorageListObjectsTaskTests: XCTestCase {
         let serviceMock = MockAWSS3StorageService()
 
         let request = StorageListRequest(
-            path: StringStoragePath.fromString("path"), options: .init())
+            path: StringStoragePath.fromString("/path"), options: .init())
         let task = AWSS3StorageListObjectsTask(
             request,
             storageConfiguration: AWSS3StoragePluginConfiguration(),

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageRemoveTaskTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageRemoveTaskTests.swift
@@ -27,13 +27,13 @@ class AWSS3StorageRemoveTaskTests: XCTestCase {
         }
 
         let request = StorageRemoveRequest(
-            path: StringStoragePath.fromString("/path"), options: .init())
+            path: StringStoragePath.fromString("path"), options: .init())
         let task = AWSS3StorageRemoveTask(
             request,
             storageConfiguration: AWSS3StoragePluginConfiguration(),
             storageBehaviour: serviceMock)
         let value = try await task.value
-        XCTAssertEqual(value, "/path")
+        XCTAssertEqual(value, "path")
     }
 
     /// - Given: A configured Storage Remove Task with mocked service, throwing `NoSuchKey` exception
@@ -47,7 +47,7 @@ class AWSS3StorageRemoveTaskTests: XCTestCase {
         }
 
         let request = StorageRemoveRequest(
-            path: StringStoragePath.fromString("/path"), options: .init())
+            path: StringStoragePath.fromString("path"), options: .init())
         let task = AWSS3StorageRemoveTask(
             request,
             storageConfiguration: AWSS3StoragePluginConfiguration(),
@@ -74,7 +74,7 @@ class AWSS3StorageRemoveTaskTests: XCTestCase {
         let serviceMock = MockAWSS3StorageService()
 
         let request = StorageRemoveRequest(
-            path: StringStoragePath.fromString("path"), options: .init())
+            path: StringStoragePath.fromString("/path"), options: .init())
         let task = AWSS3StorageRemoveTask(
             request,
             storageConfiguration: AWSS3StoragePluginConfiguration(),


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
* Update `StoragePath` validation rule to not allow leading `/` in the path
* Update related unit tests based on the new validation rule change

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
