### PR TITLE
chore(storage): add new upload and download integration tests

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+AsyncClientBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+AsyncClientBehavior.swift
@@ -151,8 +151,7 @@ extension AWSS3StoragePlugin {
         options: StorageUploadDataOperation.Request.Options? = nil
     ) -> StorageUploadDataTask {
         let options = options ?? StorageUploadDataRequest.Options()
-        let path = "" //TODO: resolve path
-        let request = StorageUploadDataRequest(key: path, data: data, options: options)
+        let request = StorageUploadDataRequest(path: path, data: data, options: options)
         let operation = AWSS3StorageUploadDataOperation(request,
                                                         storageConfiguration: storageConfiguration,
                                                         storageService: storageService,
@@ -188,8 +187,7 @@ extension AWSS3StoragePlugin {
         options: StorageUploadFileOperation.Request.Options? = nil
     ) -> StorageUploadFileTask {
         let options = options ?? StorageUploadFileRequest.Options()
-        let path = "" //TODO: resolve path
-        let request = StorageUploadFileRequest(key: path, local: local, options: options)
+        let request = StorageUploadFileRequest(path: path, local: local, options: options)
         let operation = AWSS3StorageUploadFileOperation(request,
                                                         storageConfiguration: storageConfiguration,
                                                         storageService: storageService,

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginDownloadIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginDownloadIntegrationTests.swift
@@ -1,0 +1,61 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import Amplify
+
+import AWSS3StoragePlugin
+import ClientRuntime
+import CryptoKit
+import XCTest
+
+class AWSS3StoragePluginDownloadIntegrationTests: AWSS3StoragePluginTestBase {
+    /// Given: An object in storage
+    /// When: Call the downloadData API
+    /// Then: The operation completes successfully with the data retrieved
+    func testDownloadDataToMemory() async throws {
+        let key = UUID().uuidString
+        try await uploadData(key: key, data: Data(key.utf8))
+        _ = try await Amplify.Storage.downloadData(path: .fromString("public/\(key)"), options: .init()).value
+        _ = try await Amplify.Storage.remove(path: .fromString("public/\(key)"))
+    }
+    /// Given: An object in storage
+    /// When: Call the downloadFile API
+    /// Then: The operation completes successfully the local file containing the data from the object
+    func testDownloadFile() async throws {
+        let key = UUID().uuidString
+        let timestamp = String(Date().timeIntervalSince1970)
+        let timestampData = Data(timestamp.utf8)
+        try await uploadData(key: key, data: timestampData)
+        let filePath = NSTemporaryDirectory() + key + ".tmp"
+        let fileURL = URL(fileURLWithPath: filePath)
+        removeIfExists(fileURL)
+
+        _ = try await Amplify.Storage.downloadFile(path: .fromString("public/\(key)"), local: fileURL, options: .init()).value
+
+        let fileExists = FileManager.default.fileExists(atPath: fileURL.path)
+        XCTAssertTrue(fileExists)
+        do {
+            let result = try String(contentsOf: fileURL, encoding: .utf8)
+            XCTAssertEqual(result, timestamp)
+        } catch {
+            XCTFail("Failed to read file that has been downloaded to")
+        }
+        removeIfExists(fileURL)
+        _ = try await Amplify.Storage.remove(key: key)
+    }
+
+    func removeIfExists(_ fileURL: URL) {
+        let fileExists = FileManager.default.fileExists(atPath: fileURL.path)
+        if fileExists {
+            do {
+                try FileManager.default.removeItem(at: fileURL)
+            } catch {
+                XCTFail("Failed to delete file at \(fileURL)")
+            }
+        }
+    }
+}

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginUploadIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginUploadIntegrationTests.swift
@@ -1,0 +1,201 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import Amplify
+
+import AWSS3StoragePlugin
+import ClientRuntime
+import CryptoKit
+import XCTest
+
+class AWSS3StoragePluginUploadIntegrationTests: AWSS3StoragePluginTestBase {
+
+    var uploadedKeys: [String]!
+
+    /// Represents expected pieces of the User-Agent header of an SDK http request.
+    ///
+    /// Example SDK User-Agent:
+    /// ```
+    /// User-Agent: aws-sdk-swift/1.0 api/s3/1.0 os/iOS/16.4.0 lang/swift/5.8
+    /// ```
+    /// - Tag: SdkUserAgentComponent
+    private enum SdkUserAgentComponent: String, CaseIterable {
+        case api = "api/s3"
+        case lang = "lang/swift"
+        case os = "os/"
+        case sdk = "aws-sdk-swift/"
+    }
+
+    /// Represents expected pieces of the User-Agent header of an URLRequest used for uploading or
+    /// downloading.
+    ///
+    /// Example SDK User-Agent:
+    /// ```
+    /// User-Agent: lib/amplify-swift
+    /// ```
+    /// - Tag: SdkUserAgentComponent
+    private enum URLUserAgentComponent: String, CaseIterable {
+        case lib = "lib/amplify-swift"
+        case os = "os/"
+    }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        uploadedKeys = []
+    }
+
+    override func tearDown() async throws {
+        for key in uploadedKeys {
+            _ = try await Amplify.Storage.remove(path: .fromString("public/\(key)"))
+        }
+        uploadedKeys = nil
+        try await super.tearDown()
+    }
+
+    /// Given: An data object
+    /// When: Upload the data
+    /// Then: The operation completes successfully
+    func testUploadData() async throws {
+        let key = UUID().uuidString
+        let data = Data(key.utf8)
+
+        _ = try await Amplify.Storage.uploadData(path: .fromString("public/\(key)"), data: data, options: nil).value
+        _ = try await Amplify.Storage.remove(path: .fromString("public/\(key)"))
+
+        // Only the remove operation results in an SDK request
+        XCTAssertEqual(requestRecorder.sdkRequests.map { $0.method } , [.delete])
+        try assertUserAgentComponents(sdkRequests: requestRecorder.sdkRequests)
+
+        XCTAssertEqual(requestRecorder.urlRequests.map { $0.httpMethod }, ["PUT"])
+        try assertUserAgentComponents(urlRequests: requestRecorder.urlRequests)
+    }
+
+    /// Given: A empty data object
+    /// When: Upload the data
+    /// Then: The operation completes successfully
+    func testUploadEmptyData() async throws {
+        let key = UUID().uuidString
+        let data = Data("".utf8)
+        _ = try await Amplify.Storage.uploadData(path: .fromString("public/\(key)"), data: data, options: nil).value
+        _ = try await Amplify.Storage.remove(path: .fromString("public/\(key)"))
+
+        XCTAssertEqual(requestRecorder.urlRequests.map { $0.httpMethod }, ["PUT"])
+        try assertUserAgentComponents(urlRequests: requestRecorder.urlRequests)
+    }
+
+    /// Given: A file with contents
+    /// When: Upload the file
+    /// Then: The operation completes successfully and all URLSession and SDK requests include a user agent
+    func testUploadFile() async throws {
+        let key = UUID().uuidString
+        let filePath = NSTemporaryDirectory() + key + ".tmp"
+
+        let fileURL = URL(fileURLWithPath: filePath)
+        FileManager.default.createFile(atPath: filePath, contents: Data(key.utf8), attributes: nil)
+
+        _ = try await Amplify.Storage.uploadFile(path: .fromString("public/\(key)"), local: fileURL, options: nil).value
+        _ = try await Amplify.Storage.remove(path: .fromString("public/\(key)"))
+
+        // Only the remove operation results in an SDK request
+        XCTAssertEqual(requestRecorder.sdkRequests.map { $0.method} , [.delete])
+        try assertUserAgentComponents(sdkRequests: requestRecorder.sdkRequests)
+
+        XCTAssertEqual(requestRecorder.urlRequests.map { $0.httpMethod }, ["PUT"])
+        try assertUserAgentComponents(urlRequests: requestRecorder.urlRequests)
+    }
+
+    /// Given: A file with empty contents
+    /// When: Upload the file
+    /// Then: The operation completes successfully
+    func testUploadFileEmptyData() async throws {
+        let key = UUID().uuidString
+        let filePath = NSTemporaryDirectory() + key + ".tmp"
+        let fileURL = URL(fileURLWithPath: filePath)
+        FileManager.default.createFile(atPath: filePath, contents: Data("".utf8), attributes: nil)
+
+        _ = try await Amplify.Storage.uploadFile(path: .fromString("public/\(key)"), local: fileURL, options: nil).value
+        _ = try await Amplify.Storage.remove(path: .fromString("public/\(key)"))
+
+        XCTAssertEqual(requestRecorder.urlRequests.map { $0.httpMethod }, ["PUT"])
+        try assertUserAgentComponents(urlRequests: requestRecorder.urlRequests)
+    }
+
+    /// Given: A large  data object
+    /// When: Upload the data
+    /// Then: The operation completes successfully
+    func testUploadLargeData() async throws {
+        let key = "public/" + UUID().uuidString
+
+        let uploadKey = try await Amplify.Storage.uploadData(path: .fromString(key),
+                                                             data: AWSS3StoragePluginTestBase.largeDataObject,
+                                                             options: nil).value
+        XCTAssertEqual(uploadKey, key)
+
+        try await Amplify.Storage.remove(path: .fromString(key))
+
+        let userAgents = requestRecorder.urlRequests.compactMap { $0.allHTTPHeaderFields?["User-Agent"] }
+        XCTAssertGreaterThan(userAgents.count, 1)
+        for userAgent in userAgents {
+            let expectedComponent = "MultiPart/UploadPart"
+            XCTAssertTrue(userAgent.contains(expectedComponent), "\(userAgent) does not contain \(expectedComponent)")
+        }
+    }
+
+    /// Given: A large file
+    /// When: Upload the file
+    /// Then: The operation completes successfully
+    func testUploadLargeFile() async throws {
+        let key = UUID().uuidString
+        let filePath = NSTemporaryDirectory() + key + ".tmp"
+        let fileURL = URL(fileURLWithPath: filePath)
+
+        FileManager.default.createFile(atPath: filePath,
+                                       contents: AWSS3StoragePluginTestBase.largeDataObject,
+                                       attributes: nil)
+
+        _ = try await Amplify.Storage.uploadFile(path: .fromString("public/\(key)"), local: fileURL, options: nil).value
+        _ = try await Amplify.Storage.remove(path: .fromString("public/\(key)"))
+
+        let userAgents = requestRecorder.urlRequests.compactMap { $0.allHTTPHeaderFields?["User-Agent"] }
+        XCTAssertGreaterThan(userAgents.count, 1)
+        for userAgent in userAgents {
+            let expectedComponent = "MultiPart/UploadPart"
+            XCTAssertTrue(userAgent.contains(expectedComponent), "\(userAgent) does not contain \(expectedComponent)")
+        }
+    }
+
+    func removeIfExists(_ fileURL: URL) {
+        let fileExists = FileManager.default.fileExists(atPath: fileURL.path)
+        if fileExists {
+            do {
+                try FileManager.default.removeItem(at: fileURL)
+            } catch {
+                XCTFail("Failed to delete file at \(fileURL)")
+            }
+        }
+    }
+
+    private func assertUserAgentComponents(sdkRequests: [SdkHttpRequest], file: StaticString = #filePath, line: UInt = #line) throws {
+        for request in sdkRequests {
+            let headers = request.headers.dictionary
+            let userAgent = try XCTUnwrap(headers["User-Agent"]?.joined(separator:","))
+            for component in SdkUserAgentComponent.allCases {
+                XCTAssertTrue(userAgent.contains(component.rawValue), "\(userAgent.description) does not contain \(component)", file: file, line: line)
+            }
+        }
+    }
+
+    private func assertUserAgentComponents(urlRequests: [URLRequest], file: StaticString = #filePath, line: UInt = #line) throws {
+        for request in urlRequests {
+            let headers = try XCTUnwrap(request.allHTTPHeaderFields)
+            let userAgent = try XCTUnwrap(headers["User-Agent"])
+            for component in URLUserAgentComponent.allCases {
+                XCTAssertTrue(userAgent.contains(component.rawValue), "\(userAgent.description) does not contain \(component)", file: file, line: line)
+            }
+        }
+    }
+}

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj/project.pbxproj
@@ -59,6 +59,8 @@
 		68828E4628C2736C006E7C0A /* AWSS3StoragePluginProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB08C28BEAF8E00C8A6EB /* AWSS3StoragePluginProgressTests.swift */; };
 		68828E4728C27745006E7C0A /* AWSS3StoragePluginPutDataResumabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB08828BEAF8E00C8A6EB /* AWSS3StoragePluginPutDataResumabilityTests.swift */; };
 		68828E4828C2AAA6006E7C0A /* AWSS3StoragePluginGetDataResumabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB08B28BEAF8E00C8A6EB /* AWSS3StoragePluginGetDataResumabilityTests.swift */; };
+		734605222BACB5CC0039F0EB /* AWSS3StoragePluginUploadIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734605212BACB5CC0039F0EB /* AWSS3StoragePluginUploadIntegrationTests.swift */; };
+		734605242BACB60E0039F0EB /* AWSS3StoragePluginDownloadIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734605232BACB60E0039F0EB /* AWSS3StoragePluginDownloadIntegrationTests.swift */; };
 		901AB3E92AE2C2DC000F825B /* AWSS3StoragePluginUploadMetadataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901AB3E82AE2C2DC000F825B /* AWSS3StoragePluginUploadMetadataTestCase.swift */; };
 		97914BA32955798D002000EA /* AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEAF28E748270000C36A /* AsyncTesting.swift */; };
 		97914BA52955798D002000EA /* AsyncExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEB028E748270000C36A /* AsyncExpectation.swift */; };
@@ -128,6 +130,8 @@
 		684FB0A928BEB07200C8A6EB /* AWSS3StoragePluginIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSS3StoragePluginIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		684FB0C228BEB45600C8A6EB /* AuthSignInHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSignInHelper.swift; sourceTree = "<group>"; };
 		684FB0C528BEB84800C8A6EB /* StorageHostApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StorageHostApp.entitlements; sourceTree = "<group>"; };
+		734605212BACB5CC0039F0EB /* AWSS3StoragePluginUploadIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3StoragePluginUploadIntegrationTests.swift; sourceTree = "<group>"; };
+		734605232BACB60E0039F0EB /* AWSS3StoragePluginDownloadIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3StoragePluginDownloadIntegrationTests.swift; sourceTree = "<group>"; };
 		901AB3E82AE2C2DC000F825B /* AWSS3StoragePluginUploadMetadataTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3StoragePluginUploadMetadataTestCase.swift; sourceTree = "<group>"; };
 		97914B972955797E002000EA /* StorageStressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageStressTests.swift; sourceTree = "<group>"; };
 		97914BB92955798D002000EA /* StorageStressTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StorageStressTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -269,6 +273,8 @@
 				562B9AA32A0D703700A96FC6 /* AWSS3StoragePluginRequestRecorder.swift */,
 				901AB3E82AE2C2DC000F825B /* AWSS3StoragePluginUploadMetadataTestCase.swift */,
 				684FB08728BEAF8E00C8A6EB /* ResumabilityTests */,
+				734605212BACB5CC0039F0EB /* AWSS3StoragePluginUploadIntegrationTests.swift */,
+				734605232BACB60E0039F0EB /* AWSS3StoragePluginDownloadIntegrationTests.swift */,
 			);
 			path = AWSS3StoragePluginIntegrationTests;
 			sourceTree = "<group>";
@@ -616,6 +622,7 @@
 				68828E4628C2736C006E7C0A /* AWSS3StoragePluginProgressTests.swift in Sources */,
 				684FB0B528BEB08900C8A6EB /* AWSS3StoragePluginAccessLevelTests.swift in Sources */,
 				68828E4028C1549E006E7C0A /* AWSS3StoragePluginDownloadFileResumabilityTests.swift in Sources */,
+				734605242BACB60E0039F0EB /* AWSS3StoragePluginDownloadIntegrationTests.swift in Sources */,
 				68828E4528C26D2D006E7C0A /* AWSS3StoragePluginPrefixKeyResolverTests.swift in Sources */,
 				684FB0B328BEB08900C8A6EB /* AWSS3StoragePluginTestBase.swift in Sources */,
 				68828E3F28C1549B006E7C0A /* AWSS3StoragePluginUploadFileResumabilityTests.swift in Sources */,
@@ -623,6 +630,7 @@
 				68828E3E28C1546F006E7C0A /* AWSS3StoragePluginConfigurationTests.swift in Sources */,
 				68828E4728C27745006E7C0A /* AWSS3StoragePluginPutDataResumabilityTests.swift in Sources */,
 				68828E4128C154E5006E7C0A /* AWSS3StoragePluginNegativeTests.swift in Sources */,
+				734605222BACB5CC0039F0EB /* AWSS3StoragePluginUploadIntegrationTests.swift in Sources */,
 				68828E3D28C136EB006E7C0A /* AWSS3StoragePluginBasicIntegrationTests.swift in Sources */,
 				681DFEB428E748270000C36A /* XCTestCase+AsyncTesting.swift in Sources */,
 				68828E4228C15B8B006E7C0A /* AWSS3StoragePluginOptionsUsabilityTests.swift in Sources */,


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
* Add storage integration tests that uploads and downloads to S3 using new `StoragePath` APIs
* Update upload operations to use `StoragePath` and return the path on completion of operation

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
