### PR TITLE
fix(api): add user-agent header to appsync websocket handshake request

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AppSyncRealTimeClientFactory.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AppSyncRealTimeClientFactory.swift
@@ -61,7 +61,10 @@ actor AppSyncRealTimeClientFactory: AppSyncRealTimeClientFactoryProtocol {
                 requestInterceptor: authInterceptor,
                 webSocketClient: WebSocketClient(
                     url: Self.appSyncRealTimeEndpoint(endpoint),
-                    protocols: ["graphql-ws"],
+                    handshakeHttpHeaders: [
+                        URLRequestConstants.Header.webSocketSubprotocols: "graphql-ws",
+                        URLRequestConstants.Header.userAgent: AmplifyAWSServiceConfiguration.userAgentLib
+                    ],
                     interceptor: authInterceptor
                 )
             )

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Constants/URLRequestConstants.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Constants/URLRequestConstants.swift
@@ -18,6 +18,7 @@ struct URLRequestConstants {
         static let userAgent = "User-Agent"
         static let xApiKey = "x-api-key"
         static let host = "Host"
+        static let webSocketSubprotocols = "Sec-WebSocket-Protocol"
     }
 
     struct ContentType {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/AppSyncRealTimeClientTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/AppSyncRealTimeClientTests.swift
@@ -47,7 +47,10 @@ class AppSyncRealTimeClientTests: XCTestCase {
 
             let webSocketClient = WebSocketClient(
                 url: AppSyncRealTimeClientFactory.appSyncRealTimeEndpoint(URL(string: endpoint)!),
-                protocols: ["graphql-ws"],
+                handshakeHttpHeaders: [
+                    URLRequestConstants.Header.webSocketSubprotocols: "graphql-ws",
+                    URLRequestConstants.Header.userAgent: AmplifyAWSServiceConfiguration.userAgentLib + " (intg-test)"
+                ],
                 interceptor: APIKeyAuthInterceptor(apiKey: apiKey)
             )
             appSyncRealTimeClient = AppSyncRealTimeClient(


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
- add library `user-agent` value for appsync handshake request

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
