### PR TITLE
fix(Auth): Fixing a retain cycle when configuring Auth and listening for updates

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/StateMachineSupport/AWSCognitoAuthPlugin+StateMachine.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/StateMachineSupport/AWSCognitoAuthPlugin+StateMachine.swift
@@ -11,10 +11,10 @@ extension AWSCognitoAuthPlugin {
 
     func listenToStateMachineChanges() {
 
-        Task {
-            let stateSequences = await authStateMachine.listen()
+        Task { [weak self] in
+            guard let stateSequences = await self?.authStateMachine.listen() else { return }
             for await state in stateSequences {
-                self.log.verbose("""
+                Self.log.verbose("""
                 Auth state change:
 
                 \(state)
@@ -22,10 +22,10 @@ extension AWSCognitoAuthPlugin {
                 """)
             }
         }
-        Task {
-            let stateSequences = await credentialStoreStateMachine.listen()
+        Task { [weak self] in
+            guard let stateSequences = await self?.credentialStoreStateMachine.listen() else { return }
             for await state in stateSequences {
-                self.log.verbose("""
+                Self.log.verbose("""
                 Credential Store state change:
 
                 \(state)


### PR DESCRIPTION
## Description
This PR addresses a retain cycle that happened when the Auth plugin was added due to the fact that `Task` retains `self` and we were iterating through a never-ending `AsyncSequence`.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
  - https://github.com/aws-amplify/amplify-swift/actions/runs/8574210531
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
