### PR TITLE
fix(DataStore): Fixing a crash when attempting to create a model with a predicate

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
@@ -206,6 +206,7 @@ final class StorageEngine: StorageEngineBehavior {
                 "Cannot apply a condition on model which does not exist.",
                 "Save the model instance without a condition first.")
             completion(.failure(causedBy: dataStoreError))
+            return
         }
 
         do {

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsHasOne.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsHasOne.swift
@@ -70,6 +70,28 @@ class StorageEngineTestsHasOne: StorageEngineTestsBase {
         }
     }
 
+    /// Given: A model that does not exist
+    /// When: save is called with a predicate
+    /// Then: A DataStoreError.invalidCondition error is returned
+    func testSaveModelWithPredicate_shouldFail() {
+        let team = Team(name: "Team")
+        let saveFinished = expectation(description: "Save finished")
+        storageEngine.save(team, condition: Team.keys.name.beginsWith("T")) { result in
+            defer {
+                saveFinished.fulfill()
+            }
+            guard case .failure(let error) = result,
+                  case . invalidCondition(let errorDescription, let recoverySuggestion, _) = error else {
+                XCTFail("Expected failure with .invalidCondition, got \(result)")
+                return
+            }
+
+            XCTAssertEqual(errorDescription, "Cannot apply a condition on model which does not exist.")
+            XCTAssertEqual(recoverySuggestion, "Save the model instance without a condition first.")
+        }
+        wait(for: [saveFinished], timeout: defaultTimeout)
+    }
+
     func testBelongsToRelationshipWithoutOwner() {
         let teamA = Team(name: "A-Team")
         let projectA = Project(name: "ProjectA", team: teamA)


### PR DESCRIPTION
## Issue \#
- https://github.com/aws-amplify/amplify-swift/issues/3595

## Description
Setting a predicate on a `save` operation with a model that does not exist is not supported. The `StorageEngine` performs this validation and reports a failure to the completion handler if attempted. However, the execution is not interrupted and then `StorageAdapter` is still invoked, which also fails and also reports a failure.

This results in the plugin's `continuation` being resumed twice, which results in a crash with `SWIFT TASK CONTINUATION MISUSE`.

The fix is simple, we're just missing a `return` statement in the initial validation after we invoke the completion callback.

## General Checklist
- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
  - DataStore: https://github.com/aws-amplify/amplify-swift/actions/runs/8602460009
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
