### PR TITLE
fix(api): add collection type casting in swift 5.7

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
@@ -379,14 +379,14 @@ fileprivate func toAPIError<R: Decodable>(_ errors: [Error], type: R.Type) -> AP
     }
 
 #if swift(<5.8)
-    if let errors = castArray(errors, withElementType: AppSyncRealTimeRequest.Error.self) {
+    if let errors = errors.cast(to: AppSyncRealTimeRequest.Error.self) {
         let hasAuthorizationError = errors.contains(where: { $0 == .unauthorized})
         return APIError.operationError(
             errorDescription(hasAuthorizationError),
             "",
             errors.first
         )
-    } else if let errors = castArray(errors, withElementType: GraphQLError.self) {
+    } else if let errors = errors.cast(to: GraphQLError.self) {
         let hasAuthorizationError = errors.map(\.extensions)
             .compactMap { $0.flatMap { $0["errorType"]?.stringValue } }
             .contains(where: { AppSyncErrorType($0) == .unauthorized })
@@ -429,14 +429,3 @@ fileprivate func toAPIError<R: Decodable>(_ errors: [Error], type: R.Type) -> AP
     }
 #endif
 }
-
-#if swift(<5.8)
-fileprivate func castArray<T>(_ arr: Array<Any>, withElementType: T.Type) -> [T]? {
-    arr.reduce([]) { result, ele in
-        if let result, let ele = ele as? T {
-            return result + [ele]
-        }
-        return nil
-    }
-}
-#endif

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
@@ -378,6 +378,31 @@ fileprivate func toAPIError<R: Decodable>(_ errors: [Error], type: R.Type) -> AP
         (hasAuthorizationError ? ": \(APIError.UnauthorizedMessageString)" : "")
     }
 
+#if swift(<5.8)
+    if let errors = castArray(errors, withElementType: AppSyncRealTimeRequest.Error.self) {
+        let hasAuthorizationError = errors.contains(where: { $0 == .unauthorized})
+        return APIError.operationError(
+            errorDescription(hasAuthorizationError),
+            "",
+            errors.first
+        )
+    } else if let errors = castArray(errors, withElementType: GraphQLError.self) {
+        let hasAuthorizationError = errors.map(\.extensions)
+            .compactMap { $0.flatMap { $0["errorType"]?.stringValue } }
+            .contains(where: { AppSyncErrorType($0) == .unauthorized })
+        return APIError.operationError(
+            errorDescription(hasAuthorizationError),
+            "",
+            GraphQLResponseError<R>.error(errors)
+        )
+    } else {
+        return APIError.operationError(
+            errorDescription(),
+            "",
+            errors.first
+        )
+    }
+#else
     switch errors {
     case let errors as [AppSyncRealTimeRequest.Error]:
         let hasAuthorizationError = errors.contains(where: { $0 == .unauthorized})
@@ -402,5 +427,16 @@ fileprivate func toAPIError<R: Decodable>(_ errors: [Error], type: R.Type) -> AP
             errors.first
         )
     }
-
+#endif
 }
+
+#if swift(<5.8)
+fileprivate func castArray<T>(_ arr: Array<Any>, withElementType: T.Type) -> [T]? {
+    arr.reduce([]) { result, ele in
+        if let result, let ele = ele as? T {
+            return result + [ele]
+        }
+        return nil
+    }
+}
+#endif

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/Array+Error+TypeCast.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/Array+Error+TypeCast.swift
@@ -1,0 +1,21 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+
+@_spi(AmplifyAPI)
+extension Array where Element == Error {
+    func cast<T>(to type: T.Type) -> [T]? {
+        self.reduce([]) { partialResult, ele in
+            if let partialResult, let ele = ele as? T {
+                return partialResult + [ele]
+            }
+            return nil
+        }
+    }
+}

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/Array+Error+TypeCastTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/Array+Error+TypeCastTests.swift
@@ -1,0 +1,48 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import XCTest
+@testable @_spi(AmplifyAPI) import AWSAPIPlugin
+
+class ArrayWithErrorElementExtensionTests: XCTestCase {
+
+
+
+    func testCast_toCorrectErrorType_returnCastedErrorType() {
+        let errors: [Error] = [
+            Error1(), Error1(), Error1()
+        ]
+
+        let error1s = errors.cast(to: Error1.self)
+        XCTAssertNotNil(error1s)
+        XCTAssertTrue(!error1s!.isEmpty)
+        XCTAssertEqual(errors.count, error1s!.count)
+    }
+
+    func testCast_toWrongErrorType_returnNil() {
+        let errors: [Error] = [
+            Error1(), Error1(), Error1()
+        ]
+
+        let error2s = errors.cast(to: Error2.self)
+        XCTAssertNil(error2s)
+    }
+
+    func testCast_partiallyToWrongErrorType_returnNil() {
+        let errors: [Error] = [
+            Error2(), Error2(), Error1()
+        ]
+
+        let error2s = errors.cast(to: Error2.self)
+        XCTAssertNil(error2s)
+    }
+
+    struct Error1: Error { }
+
+    struct Error2: Error { }
+}

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/Array+Error+TypeCastTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/Array+Error+TypeCastTests.swift
@@ -11,8 +11,11 @@ import XCTest
 
 class ArrayWithErrorElementExtensionTests: XCTestCase {
 
-
-
+    /**
+     Given: errors with generic protocol type
+     When: cast to the correct underlying concrete type
+     Then: successfully casted to underlying concrete type
+     */
     func testCast_toCorrectErrorType_returnCastedErrorType() {
         let errors: [Error] = [
             Error1(), Error1(), Error1()
@@ -24,6 +27,11 @@ class ArrayWithErrorElementExtensionTests: XCTestCase {
         XCTAssertEqual(errors.count, error1s!.count)
     }
 
+    /**
+     Given: errors with generic protocol type
+     When: cast to the wong underlying concrete type
+     Then: return nil
+     */
     func testCast_toWrongErrorType_returnNil() {
         let errors: [Error] = [
             Error1(), Error1(), Error1()
@@ -32,6 +40,12 @@ class ArrayWithErrorElementExtensionTests: XCTestCase {
         let error2s = errors.cast(to: Error2.self)
         XCTAssertNil(error2s)
     }
+
+    /**
+     Given: errors with generic protocol type
+     When: some of the elements failed to cast to the underlying concrete type
+     Then: return nil
+     */
 
     func testCast_partiallyToWrongErrorType_returnNil() {
         let errors: [Error] = [


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

Swift Collection type casting is introduced in `Swift 5.8`. As our library is still supporting `Swift 5.7`, adding backward compatibility support for collection casting.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
