### PR TITLE
chore: deprecate key field in StorageListResult.Item

### DIFF
--- a/Amplify/Categories/Storage/Result/StorageListResult.swift
+++ b/Amplify/Categories/Storage/Result/StorageListResult.swift
@@ -50,6 +50,7 @@ extension StorageListResult {
         /// The unique identifier of the object in storage.
         ///
         /// - Tag: StorageListResultItem.key
+        @available(*, deprecated, message: "Use `path` instead.")
         public let key: String
 
         /// Size in bytes of the object
@@ -77,7 +78,7 @@ extension StorageListResult {
         /// [StorageCategoryBehavior.list](x-source-tag://StorageCategoryBehavior.list).
         ///
         /// - Tag: StorageListResultItem.init
-        @available(*, deprecated, message: "Use init(path:key:size:lastModifiedDate:eTag:pluginResults)")
+        @available(*, deprecated, message: "Use init(path:size:lastModifiedDate:eTag:pluginResults)")
         public init(
             key: String,
             size: Int? = nil,
@@ -95,14 +96,13 @@ extension StorageListResult {
 
         public init(
             path: String,
-            key: String,
             size: Int? = nil,
             eTag: String? = nil,
             lastModified: Date? = nil,
             pluginResults: Any? = nil
         ) {
             self.path = path
-            self.key = key
+            self.key = path
             self.size = size
             self.eTag = eTag
             self.lastModified = lastModified

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Tasks/AWSS3StorageListObjectsTask.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Tasks/AWSS3StorageListObjectsTask.swift
@@ -38,7 +38,7 @@ class AWSS3StorageListObjectsTask: StorageListObjectsTask, DefaultLogger {
         guard let path = try await request.path?.resolvePath() else {
             throw StorageError.validation(
                 "path",
-                "`path` is required for removing an object",
+                "`path` is required for listing objects",
                 "Make sure that a valid `path` is passed for removing an object")
         }
         let input = ListObjectsV2Input(bucket: storageBehaviour.bucket,
@@ -51,12 +51,11 @@ class AWSS3StorageListObjectsTask: StorageListObjectsTask, DefaultLogger {
             let response = try await storageBehaviour.client.listObjectsV2(input: input)
             let contents: S3BucketContents = response.contents ?? []
             let items = try contents.map { s3Object in
-                guard let key = s3Object.key else {
+                guard let path = s3Object.key else {
                     throw StorageError.unknown("Missing key in response")
                 }
                 return StorageListResult.Item(
                     path: path,
-                    key: key,
                     eTag: s3Object.eTag,
                     lastModified: s3Object.lastModified)
             }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageListObjectsTaskTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageListObjectsTaskTests.swift
@@ -41,6 +41,7 @@ class AWSS3StorageListObjectsTaskTests: XCTestCase {
         XCTAssertEqual(value.nextToken, "continuationToken")
         XCTAssertEqual(value.items[0].eTag, "tag")
         XCTAssertEqual(value.items[0].key, "key")
+        XCTAssertEqual(value.items[0].path, "key")
         XCTAssertNotNil(value.items[0].lastModified)
 
     }

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginListObjectsIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginListObjectsIntegrationTests.swift
@@ -29,14 +29,16 @@ class AWSS3StoragePluginListObjectsIntegrationTests: AWSS3StoragePluginTestBase 
         let firstListResult = try await Amplify.Storage.list(path: .fromString(uniqueStringPath))
 
         // Validate the item was uploaded.
-        XCTAssertEqual(firstListResult.items.filter({ $0.path == uniqueStringPath}).count, 1)
+        XCTAssertEqual(firstListResult.items.filter({ $0.path.contains(uniqueStringPath)
+        }).count, 1)
 
         _ = try await Amplify.Storage.uploadData(path: .fromString(uniqueStringPath + "/test2"), data: data, options: nil).value
 
         let secondListResult = try await Amplify.Storage.list(path: .fromString(uniqueStringPath))
 
         // Validate the item was uploaded.
-        XCTAssertEqual(secondListResult.items.filter({ $0.path == uniqueStringPath}).count, 2)
+        XCTAssertEqual(secondListResult.items.filter({ $0.path.contains(uniqueStringPath)
+        }).count, 2)
 
         // Clean up
         _ = try await Amplify.Storage.remove(path: .fromString(uniqueStringPath + "/test1"))
@@ -65,7 +67,8 @@ class AWSS3StoragePluginListObjectsIntegrationTests: AWSS3StoragePluginTestBase 
         let firstListResult = try await Amplify.Storage.list(path: .fromString(uniqueStringPath))
 
         // Validate the item was uploaded.
-        XCTAssertEqual(firstListResult.items.filter({ $0.path == uniqueStringPath}).count, 1)
+        XCTAssertEqual(firstListResult.items.filter({ $0.path.contains(uniqueStringPath)
+        }).count, 1)
 
         _ = try await Amplify.Storage.uploadData(
             path: .fromIdentityID({ identityId in
@@ -78,7 +81,8 @@ class AWSS3StoragePluginListObjectsIntegrationTests: AWSS3StoragePluginTestBase 
         let secondListResult = try await Amplify.Storage.list(path: .fromString(uniqueStringPath))
 
         // Validate the item was uploaded.
-        XCTAssertEqual(secondListResult.items.filter({ $0.path == uniqueStringPath}).count, 2)
+        XCTAssertEqual(secondListResult.items.filter({ $0.path.contains(uniqueStringPath)
+        }).count, 2)
 
         // clean up
         _ = try await Amplify.Storage.remove(path: .fromString(uniqueStringPath + "test1"))
@@ -108,7 +112,8 @@ class AWSS3StoragePluginListObjectsIntegrationTests: AWSS3StoragePluginTestBase 
         let firstListResult = try await Amplify.Storage.list(path: .fromString(uniqueStringPath))
 
         // Validate the item was uploaded.
-        XCTAssertEqual(firstListResult.items.filter({ $0.path == uniqueStringPath}).count, 1)
+        XCTAssertEqual(firstListResult.items.filter({ $0.path.contains(uniqueStringPath)
+        }).count, 1)
 
         _ = try await Amplify.Storage.uploadData(
             path: .fromIdentityID({ identityId in
@@ -121,7 +126,8 @@ class AWSS3StoragePluginListObjectsIntegrationTests: AWSS3StoragePluginTestBase 
         let secondListResult = try await Amplify.Storage.list(path: .fromString(uniqueStringPath))
 
         // Validate the item was uploaded.
-        XCTAssertEqual(secondListResult.items.filter({ $0.path == uniqueStringPath}).count, 2)
+        XCTAssertEqual(secondListResult.items.filter({ $0.path.contains(uniqueStringPath)
+        }).count, 2)
 
         // clean up
         _ = try await Amplify.Storage.remove(path: .fromString(uniqueStringPath + "test1"))


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
* Update `StorageListResult.Item` to deprecate key 
* Update associated unit tests and integration tests

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
