### PR TITLE
chore(storage): align storage validation exception message with Amplify Android

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StoragePath+Extensions.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StoragePath+Extensions.swift
@@ -41,15 +41,9 @@ extension StoragePath {
     }
 
     func validate(_ path: String) throws {
-        guard !path.isEmpty else {
-            let errorDescription = "Invalid StoragePath specified."
-            let recoverySuggestion = "Please specify a valid StoragePath"
-            throw StorageError.validation("path", errorDescription, recoverySuggestion, nil)
-        }
-
-        if path.hasPrefix("/") {
-            let errorDescription = "Invalid StoragePath specified."
-            let recoverySuggestion = "Please specify a valid StoragePath that does not contain the prefix / "
+        if path.isEmpty || path.hasPrefix("/") {
+            let errorDescription = "Invalid StoragePath provided."
+            let recoverySuggestion = "StoragePath must not be empty or start with /"
             throw StorageError.validation("path", errorDescription, recoverySuggestion, nil)
         }
     }


### PR DESCRIPTION

## Issue \#
Aligning `StoragePath` validation exception message with Amplify Android.

## Description
<!-- Why is this change required? What problem does it solve? -->

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
