### PR TITLE
fix(api): AWSGraphQLSubscriptionTaskRunner failing to cancel AppSyncRealTimeSubscription

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
@@ -46,10 +46,7 @@ public class AWSGraphQLSubscriptionTaskRunner<R: Decodable>: InternalTaskRunner,
 
     public func cancel() {
         self.send(GraphQLSubscriptionEvent<R>.connection(.disconnected))
-        Task { [weak self] in
-            guard let self else {
-                return
-            }
+        Task {
             guard let appSyncClient = self.appSyncClient else {
                 return
             }


### PR DESCRIPTION
## Description
<!-- Why is this change required? What problem does it solve? -->
Amplify fails to cancel/deallocate `AppSyncRealTimeSubscription` because `AWSGraphQLSubscriptionTaskRunner` gets released before it has a chance to tell `AppSyncRealTimeClient` to unsubscribe the subscription. 
If you keep cancelling and creating new subscriptions (for example when you minimize and open the app) at some point the number of active subscriptions reaches 100 and the app starts to crash.

edit: 
- this is reproducible in `2.29.1`


## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
