### PR TITLE
fix(API): make sure unsubscribe is invoked when subscription cancelled

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeClient.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeClient.swift
@@ -54,6 +54,10 @@ actor AppSyncRealTimeClient: AppSyncRealTimeClientProtocol {
         self.state.value == .connected
     }
 
+    internal var numOfSubscriptions: Int {
+        self.subscriptions.count
+    }
+
     /**
      Creates a new AppSyncRealTimeClient with endpoint, requestInterceptor and webSocketClient.
      - Parameters:

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeClient.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeClient.swift
@@ -54,7 +54,7 @@ actor AppSyncRealTimeClient: AppSyncRealTimeClientProtocol {
         self.state.value == .connected
     }
 
-    internal var numOfSubscriptions: Int {
+    internal var numberOfSubscriptions: Int {
         self.subscriptions.count
     }
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
@@ -44,6 +44,9 @@ public class AWSGraphQLSubscriptionTaskRunner<R: Decodable>: InternalTaskRunner,
         self.apiAuthProviderFactory = apiAuthProviderFactory
     }
 
+    /// When the top-level AmplifyThrowingSequence is canceled, this cancel method is invoked.
+    /// In this situation, we need to send the disconnected event because
+    /// the top-level AmplifyThrowingSequence is terminated immediately upon cancellation.
     public func cancel() {
         self.send(GraphQLSubscriptionEvent<R>.connection(.disconnected))
         Task {
@@ -210,12 +213,7 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
 
     override public func cancel() {
         super.cancel()
-
-        Task { [weak self] in
-            guard let self else {
-                return
-            }
-
+        Task {
             guard let appSyncRealTimeClient = self.appSyncRealTimeClient else {
                 return
             }

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
@@ -494,12 +494,12 @@ class GraphQLModelBasedTests: XCTestCase {
            let appSyncRealTimeClient =
             await appSyncRealTimeClientFactory.apiToClientCache.values.first as? AppSyncRealTimeClient
         {
-            var appSyncSubscriptions = await appSyncRealTimeClient.numOfSubscriptions
+            var appSyncSubscriptions = await appSyncRealTimeClient.numberOfSubscriptions
             XCTAssertEqual(appSyncSubscriptions, numberOfSubscription)
 
             subscriptions.forEach { $0.cancel() }
             try await Task.sleep(seconds: 2)
-            appSyncSubscriptions = await appSyncRealTimeClient.numOfSubscriptions
+            appSyncSubscriptions = await appSyncRealTimeClient.numberOfSubscriptions
             XCTAssertEqual(appSyncSubscriptions, 0)
 
         } else {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

This PR addresses a similar issue to PR #3615, it fixes the `AWSGraphQLSubscriptionOperation` to ensure that the unsubscribe method is called during the cancellation of the operation. Additionally, an integration test case has been added to verify that subscriptions are properly unsubscribed and removed from the AppSyncRealTimeClient.

## General Checklist
<!-- Check or cross out if not relevant -->

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
