### PR TITLE
fix(core): potential memory leak in WebSocketClient

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/WebSocket/WebSocketClient.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/WebSocket/WebSocketClient.swift
@@ -265,7 +265,7 @@ extension WebSocketClient: URLSessionWebSocketDelegate {
 extension WebSocketClient {
     /// Monitor network status. Disconnect or reconnect when the network drops or comes back online.
     private func startNetworkMonitor() {
-        networkMonitor.publisher.sink(receiveValue: { stateChange in
+        networkMonitor.publisher.sink(receiveValue: { [weak self] stateChange in
             Task { [weak self] in
                 await self?.onNetworkStateChange(stateChange)
             }
@@ -304,7 +304,7 @@ extension WebSocketClient {
             return closeCode
         }
         .compactMap { $0 }
-        .sink(receiveCompletion: { _ in }) { closeCode in
+        .sink(receiveCompletion: { _ in }) { [weak self] closeCode in
             Task { [weak self] in await self?.retryOnCloseCode(closeCode) }
         }
         .store(in: &cancelables)
@@ -319,7 +319,7 @@ extension WebSocketClient {
             }
             return false
         }
-        .sink(receiveCompletion: { _ in }) { _ in
+        .sink(receiveCompletion: { _ in }) { [weak self] _ in
             Task { [weak self] in
                 await self?.retryWithJitter.reset()
             }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
In Swift, even if you declare an inner closure with a weak reference to self, the outer closure still has a strong reference to self, which can cause the strong reference cycle.

ref: https://github.com/apple/swift/issues/72391

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
