### PR TITLE
feat(api): Expose a constant for the API name used by Gen2 data category

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin.swift
@@ -9,11 +9,11 @@ import Amplify
 import AWSPluginsCore
 import Foundation
 
-/// Used for the default GraphQL API represented by the `data` category in `amplify_outputs.json`
-/// This constant is not used for APIs present in `amplifyconfiguration.json` since they always have names.
-public let defaultGraphQLAPI = "defaultGraphQLAPI"
-
 final public class AWSAPIPlugin: NSObject, APICategoryPlugin, APICategoryGraphQLBehaviorExtended, AWSAPIAuthInformation {
+    /// Used for the default GraphQL API represented by the `data` category in `amplify_outputs.json`
+    /// This constant is not used for APIs present in `amplifyconfiguration.json` since they always have names.
+    public static let defaultGraphQLAPI = "defaultGraphQLAPI"
+
     /// The unique key of the plugin within the API category.
     public var key: PluginKey {
         return "awsAPIPlugin"

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin.swift
@@ -11,7 +11,7 @@ import Foundation
 
 /// Used for the default GraphQL API represented by the `data` category in `amplify_outputs.json`
 /// This constant is not used for APIs present in `amplifyconfiguration.json` since they always have names.
-let defaultGraphQLAPI = "defaultGraphQLAPI"
+public let defaultGraphQLAPI = "defaultGraphQLAPI"
 
 final public class AWSAPIPlugin: NSObject, APICategoryPlugin, APICategoryGraphQLBehaviorExtended, AWSAPIAuthInformation {
     /// The unique key of the plugin within the API category.

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin.swift
@@ -11,7 +11,7 @@ import Foundation
 
 /// Used for the default GraphQL API represented by the `data` category in `amplify_outputs.json`
 /// This constant is not used for APIs present in `amplifyconfiguration.json` since they always have names.
-let defaultGraphQLApi = "defaultGraphQLApi"
+let defaultGraphQLAPI = "defaultGraphQLAPI"
 
 final public class AWSAPIPlugin: NSObject, APICategoryPlugin, APICategoryGraphQLBehaviorExtended, AWSAPIAuthInformation {
     /// The unique key of the plugin within the API category.

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin.swift
@@ -9,6 +9,10 @@ import Amplify
 import AWSPluginsCore
 import Foundation
 
+/// Used for the default GraphQL API represented by the `data` category in `amplify_outputs.json`
+/// This constant is not used for APIs present in `amplifyconfiguration.json` since they always have names.
+let defaultGraphQLApi = "defaultGraphQLApi"
+
 final public class AWSAPIPlugin: NSObject, APICategoryPlugin, APICategoryGraphQLBehaviorExtended, AWSAPIAuthInformation {
     /// The unique key of the plugin within the API category.
     public var key: PluginKey {

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPICategoryPluginConfiguration.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPICategoryPluginConfiguration.swift
@@ -196,7 +196,7 @@ public struct AWSAPICategoryPluginConfiguration {
         authService: AWSAuthServiceBehavior
     ) throws -> [APIEndpointName: EndpointConfig] {
         var endpoints = [APIEndpointName: EndpointConfig]()
-        let name = defaultGraphQLAPI
+        let name = AWSAPIPlugin.defaultGraphQLAPI
         let endpointConfig = try EndpointConfig(name: name,
                                                 config: config,
                                                 apiAuthProviderFactory: apiAuthProviderFactory,

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPICategoryPluginConfiguration.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPICategoryPluginConfiguration.swift
@@ -196,7 +196,7 @@ public struct AWSAPICategoryPluginConfiguration {
         authService: AWSAuthServiceBehavior
     ) throws -> [APIEndpointName: EndpointConfig] {
         var endpoints = [APIEndpointName: EndpointConfig]()
-        let name = "dataCategory"
+        let name = defaultGraphQLApi
         let endpointConfig = try EndpointConfig(name: name,
                                                 config: config,
                                                 apiAuthProviderFactory: apiAuthProviderFactory,

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPICategoryPluginConfiguration.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPICategoryPluginConfiguration.swift
@@ -196,7 +196,7 @@ public struct AWSAPICategoryPluginConfiguration {
         authService: AWSAuthServiceBehavior
     ) throws -> [APIEndpointName: EndpointConfig] {
         var endpoints = [APIEndpointName: EndpointConfig]()
-        let name = defaultGraphQLApi
+        let name = defaultGraphQLAPI
         let endpointConfig = try EndpointConfig(name: name,
                                                 config: config,
                                                 apiAuthProviderFactory: apiAuthProviderFactory,

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+ConfigureTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+ConfigureTests.swift
@@ -66,8 +66,8 @@ class AWSAPICategoryPluginConfigureTests: AWSAPICategoryPluginTestBase {
             XCTFail("Missing endpoint configuration")
             return
         }
-        XCTAssertEqual(endpoint.key, "dataCategory")
-        XCTAssertEqual(endpoint.value.name, "dataCategory")
+        XCTAssertEqual(endpoint.key, defaultGraphQLApi)
+        XCTAssertEqual(endpoint.value.name, defaultGraphQLApi)
         XCTAssertEqual(endpoint.value.endpointType, .graphQL)
         XCTAssertEqual(endpoint.value.apiKey, "apiKey123")
         XCTAssertEqual(endpoint.value.baseURL, URL(string: "http://www.example.com"))

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+ConfigureTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+ConfigureTests.swift
@@ -66,8 +66,8 @@ class AWSAPICategoryPluginConfigureTests: AWSAPICategoryPluginTestBase {
             XCTFail("Missing endpoint configuration")
             return
         }
-        XCTAssertEqual(endpoint.key, defaultGraphQLAPI)
-        XCTAssertEqual(endpoint.value.name, defaultGraphQLAPI)
+        XCTAssertEqual(endpoint.key, AWSAPIPlugin.defaultGraphQLAPI)
+        XCTAssertEqual(endpoint.value.name, AWSAPIPlugin.defaultGraphQLAPI)
         XCTAssertEqual(endpoint.value.endpointType, .graphQL)
         XCTAssertEqual(endpoint.value.apiKey, "apiKey123")
         XCTAssertEqual(endpoint.value.baseURL, URL(string: "http://www.example.com"))

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+ConfigureTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+ConfigureTests.swift
@@ -66,8 +66,8 @@ class AWSAPICategoryPluginConfigureTests: AWSAPICategoryPluginTestBase {
             XCTFail("Missing endpoint configuration")
             return
         }
-        XCTAssertEqual(endpoint.key, defaultGraphQLApi)
-        XCTAssertEqual(endpoint.value.name, defaultGraphQLApi)
+        XCTAssertEqual(endpoint.key, defaultGraphQLAPI)
+        XCTAssertEqual(endpoint.value.name, defaultGraphQLAPI)
         XCTAssertEqual(endpoint.value.endpointType, .graphQL)
         XCTAssertEqual(endpoint.value.apiKey, "apiKey123")
         XCTAssertEqual(endpoint.value.baseURL, URL(string: "http://www.example.com"))


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
Android change https://github.com/aws-amplify/amplify-android/pull/2791

## Description
<!-- Why is this change required? What problem does it solve? -->

Gen2 doesn't have a concept of API names when using `defineData` for the data category configuration. We are hardcoding a default name for customers to use for use cases where the name is required. For example, adding a custom interceptor:

```swift
struct CustomInterceptor: URLRequestInterceptor {
    func intercept(_ request: URLRequest) throws -> URLRequest {
        var request = request
        request.setValue("headerValue", forHTTPHeaderField: "headerKey")
        return request
    }
}
let apiPlugin = try AWSAPIPlugin()
try Amplify.addPlugin(apiPlugin)
try Amplify.configure()
try apiPlugin.add(interceptor: CustomInterceptor(), for: AWSAPIPlugin.defaultGraphQLAPI)
```

The global name is 
```swift
public class AWSAPIPlugin {
   public static let defaultGraphQLAPI = "defaultGraphQLAPI"
}
```

On swift, we will take on 
- camelCasing
- **GraphQL** is capitalized similar to other types like **GraphQLRequest**. 
- **API** is fully caps, similar to the plugin name, AWS**API**Plugin or the plugin key "awsAPIPlugin"

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
