### PR TITLE
chore: Adding workflow to build Amplify for minimum Xcode

### DIFF
--- a/.github/composite_actions/get_platform_parameters/action.yml
+++ b/.github/composite_actions/get_platform_parameters/action.yml
@@ -39,7 +39,8 @@ runs:
     - id: get-xcode-version
       run: |
         LATEST_XCODE_VERSION=14.3.1
-        MINIMUM_XCODE_VERSION=14.0.1
+        MINIMUM_XCODE_VERSION_IOS_MAC=14.1.0
+        MINIMUM_XCODE_VERSION_WATCH_TV=14.3.1
 
         INPUT_XCODE_VERSION=${{ inputs.xcode_version }}
 
@@ -47,7 +48,13 @@ runs:
           latest)
             XCODE_VERSION=$LATEST_XCODE_VERSION ;;
           minimum)
-            XCODE_VERSION=$MINIMUM_XCODE_VERSION ;;
+            INPUT_PLATFORM=${{ inputs.platform }}
+            case $INPUT_PLATFORM in
+              iOS|macOS)
+                XCODE_VERSION=$MINIMUM_XCODE_VERSION_IOS_MAC ;;
+              tvOS|watchOS)
+                XCODE_VERSION=$MINIMUM_XCODE_VERSION_WATCH_TV ;;
+            esac ;;
           *)
             XCODE_VERSION=$INPUT_XCODE_VERSION ;;
         esac
@@ -63,7 +70,7 @@ runs:
 
         DESTINATION_MAPPING='{
           "minimum": {
-            "iOS": "platform=iOS Simulator,name=iPhone 14,OS=16.0",
+            "iOS": "platform=iOS Simulator,name=iPhone 14,OS=16.1",
             "tvOS": "platform=tvOS Simulator,name=Apple TV 4K (2nd generation),OS=16.0",
             "watchOS": "platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=9.0",
             "macOS": "platform=macOS,arch=x86_64"

--- a/.github/composite_actions/get_platform_parameters/action.yml
+++ b/.github/composite_actions/get_platform_parameters/action.yml
@@ -71,8 +71,8 @@ runs:
         DESTINATION_MAPPING='{
           "minimum": {
             "iOS": "platform=iOS Simulator,name=iPhone 14,OS=16.1",
-            "tvOS": "platform=tvOS Simulator,name=Apple TV 4K (2nd generation),OS=16.0",
-            "watchOS": "platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=9.0",
+            "tvOS": "platform=tvOS Simulator,name=Apple TV 4K (2nd generation),OS=16.1",
+            "watchOS": "platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=9.1",
             "macOS": "platform=macOS,arch=x86_64"
           },
           "latest": {

--- a/.github/workflows/build_amplify_swift_platforms.yml
+++ b/.github/workflows/build_amplify_swift_platforms.yml
@@ -52,8 +52,9 @@ jobs:
           - platform: ${{ github.event.inputs.macos == 'false' && 'macOS' || 'None' }}
           - platform: ${{ github.event.inputs.tvos == 'false' && 'tvOS' || 'None' }}
           - platform: ${{ github.event.inputs.watchos == 'false' && 'watchOS' || 'None' }}
-    uses: ./.github/workflows/build_amplify_swift.yml
+    uses: ./.github/workflows/build_scheme.yml
     with:
+      scheme: Amplify-Package
       platform: ${{ matrix.platform }}
 
   confirm-pass:

--- a/.github/workflows/build_minimum_supported_swift_platforms.yml
+++ b/.github/workflows/build_minimum_supported_swift_platforms.yml
@@ -12,6 +12,10 @@ permissions:
   contents: read
   actions: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'main'}}
+
 jobs:
   build-amplify-with-minimum-supported-xcode:
     name: Build Amplify Swift for ${{ matrix.platform }}

--- a/.github/workflows/build_minimum_supported_swift_platforms.yml
+++ b/.github/workflows/build_minimum_supported_swift_platforms.yml
@@ -1,6 +1,12 @@
 name: Build with Minimum Supported Xcode Versions
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -14,12 +20,13 @@ jobs:
       matrix:
         platform: [iOS, macOS, tvOS, watchOS]
 
-    uses: ./.github/workflows/build_amplify_swift.yml
+    uses: ./.github/workflows/build_scheme.yml
     with:
-      os-runner: macos-12
+      scheme: Amplify
+      os-runner: ${{ (matrix.platform == 'tvOS' || matrix.platform == 'watchOS') && 'macos-13' || 'macos-12' }}
       xcode-version: 'minimum'
       platform: ${{ matrix.platform }}
-      cacheable: false
+      use_cache: false
 
   confirm-pass:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_minimum_supported_swift_platforms.yml
+++ b/.github/workflows/build_minimum_supported_swift_platforms.yml
@@ -22,7 +22,7 @@ jobs:
 
     uses: ./.github/workflows/build_scheme.yml
     with:
-      scheme: Amplify
+      scheme: Amplify-Build
       os-runner: ${{ (matrix.platform == 'tvOS' || matrix.platform == 'watchOS') && 'macos-13' || 'macos-12' }}
       xcode-version: 'minimum'
       platform: ${{ matrix.platform }}

--- a/.github/workflows/build_minimum_supported_swift_platforms.yml
+++ b/.github/workflows/build_minimum_supported_swift_platforms.yml
@@ -26,7 +26,7 @@ jobs:
       os-runner: ${{ (matrix.platform == 'tvOS' || matrix.platform == 'watchOS') && 'macos-13' || 'macos-12' }}
       xcode-version: 'minimum'
       platform: ${{ matrix.platform }}
-      use_cache: false
+      save_build_cache: false
 
   confirm-pass:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_minimum_supported_swift_platforms.yml
+++ b/.github/workflows/build_minimum_supported_swift_platforms.yml
@@ -1,4 +1,4 @@
-name: Build with Minimum Supported Xcode Versions
+name: Build with minimum Xcode version | Amplify Swift
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/build_scheme.yml
+++ b/.github/workflows/build_scheme.yml
@@ -18,7 +18,7 @@ on:
         type: string
         default: 'macos-13'
 
-      use_cache:
+      save_build_cache:
         type: boolean
         default: true
 
@@ -45,7 +45,6 @@ jobs:
 
       - name: Attempt to use the dependencies cache
         id: dependencies-cache
-        if: inputs.use_cache
         timeout-minutes: 4
         continue-on-error: true
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -57,7 +56,6 @@ jobs:
 
       - name: Attempt to restore the build cache from main
         id: build-cache
-        if: inputs.use_cache
         timeout-minutes: 4
         continue-on-error: true
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -67,7 +65,6 @@ jobs:
 
       - name: Build ${{ inputs.scheme }}
         id: build-package
-        continue-on-error: true
         uses: ./.github/composite_actions/run_xcodebuild
         with:
           scheme: ${{ inputs.scheme }}
@@ -79,14 +76,14 @@ jobs:
           disable_package_resolution: ${{ steps.dependencies-cache.outputs.cache-hit }}
 
       - name: Save the dependencies cache in main
-        if: inputs.use_cache && steps.dependencies-cache.outputs.cache-hit != 'true' && github.ref_name == 'main'
+        if: inputs.save_build_cache && steps.dependencies-cache.outputs.cache-hit != 'true' && github.ref_name == 'main'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: ${{ steps.dependencies-cache.outputs.cache-primary-key }}
 
       - name: Delete the old build cache
-        if: inputs.use_cache && steps.build-cache.outputs.cache-hit && github.ref_name == 'main'
+        if: inputs.save_build_cache && steps.build-cache.outputs.cache-hit && github.ref_name == 'main'
         env:
           GH_TOKEN: ${{ github.token }}
         continue-on-error: true
@@ -94,7 +91,7 @@ jobs:
           gh cache delete ${{ steps.build-cache.outputs.cache-primary-key }}
 
       - name: Save the build cache
-        if: inputs.use_cache && github.ref_name == 'main'
+        if: inputs.save_build_cache && github.ref_name == 'main'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build

--- a/.github/workflows/build_scheme.yml
+++ b/.github/workflows/build_scheme.yml
@@ -1,7 +1,11 @@
-name: Build Amplify-Package for the given platform
+name: Build scheme for the given platform and other parameters
 on:
   workflow_call:
     inputs:
+      scheme:
+        type: string
+        required: true
+
       platform:
         type: string
         required: true
@@ -14,7 +18,7 @@ on:
         type: string
         default: 'macos-13'
 
-      cacheable:
+      use_cache:
         type: boolean
         default: true
 
@@ -23,8 +27,8 @@ permissions:
     actions: write
 
 jobs:
-  build-amplify-swift:
-    name: Build Amplify-Package | ${{ inputs.platform }}
+  build-scheme:
+    name: Build ${{ inputs.scheme }} | ${{ inputs.platform }}
     runs-on: ${{ inputs.os-runner }}
     steps:
       - name: Checkout repository
@@ -41,9 +45,9 @@ jobs:
 
       - name: Attempt to use the dependencies cache
         id: dependencies-cache
-        if: inputs.cacheable
+        if: inputs.use_cache
         timeout-minutes: 4
-        continue-on-error: ${{ inputs.cacheable }}
+        continue-on-error: ${{ inputs.use_cache }}
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
@@ -53,20 +57,20 @@ jobs:
 
       - name: Attempt to restore the build cache from main
         id: build-cache
-        if: inputs.cacheable
+        if: inputs.use_cache
         timeout-minutes: 4
-        continue-on-error: ${{ inputs.cacheable }}
+        continue-on-error: ${{ inputs.use_cache }}
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
           key: Amplify-${{ inputs.platform }}-build-cache
 
-      - name: Build Amplify for Swift
+      - name: Build ${{ inputs.scheme }}
         id: build-package
-        continue-on-error: ${{ inputs.cacheable }}
+        continue-on-error: ${{ inputs.use_cache }}
         uses: ./.github/composite_actions/run_xcodebuild
         with:
-          scheme: Amplify-Package
+          scheme: ${{ inputs.scheme }}
           destination: ${{ steps.platform.outputs.destination }}
           sdk: ${{ steps.platform.outputs.sdk }}
           xcode_path: /Applications/Xcode_${{ steps.platform.outputs.xcode-version }}.app
@@ -75,22 +79,22 @@ jobs:
           disable_package_resolution: ${{ steps.dependencies-cache.outputs.cache-hit }}
 
       - name: Save the dependencies cache in main
-        if: inputs.cacheable && steps.dependencies-cache.outputs.cache-hit != 'true' && github.ref_name == 'main'
+        if: inputs.use_cache && steps.dependencies-cache.outputs.cache-hit != 'true' && github.ref_name == 'main'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: ${{ steps.dependencies-cache.outputs.cache-primary-key }}
 
       - name: Delete the old build cache
-        if: inputs.cacheable && steps.build-cache.outputs.cache-hit && github.ref_name == 'main'
+        if: inputs.use_cache && steps.build-cache.outputs.cache-hit && github.ref_name == 'main'
         env:
           GH_TOKEN: ${{ github.token }}
-        continue-on-error: ${{ inputs.cacheable }}
+        continue-on-error: ${{ inputs.use_cache }}
         run: |
           gh cache delete ${{ steps.build-cache.outputs.cache-primary-key }}
 
       - name: Save the build cache
-        if: inputs.cacheable && github.ref_name == 'main'
+        if: inputs.use_cache && github.ref_name == 'main'
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build

--- a/.github/workflows/build_scheme.yml
+++ b/.github/workflows/build_scheme.yml
@@ -47,7 +47,7 @@ jobs:
         id: dependencies-cache
         if: inputs.use_cache
         timeout-minutes: 4
-        continue-on-error: ${{ inputs.use_cache }}
+        continue-on-error: true
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
@@ -59,7 +59,7 @@ jobs:
         id: build-cache
         if: inputs.use_cache
         timeout-minutes: 4
-        continue-on-error: ${{ inputs.use_cache }}
+        continue-on-error: true
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
         with:
           path: ${{ github.workspace }}/Build
@@ -67,7 +67,7 @@ jobs:
 
       - name: Build ${{ inputs.scheme }}
         id: build-package
-        continue-on-error: ${{ inputs.use_cache }}
+        continue-on-error: true
         uses: ./.github/composite_actions/run_xcodebuild
         with:
           scheme: ${{ inputs.scheme }}
@@ -89,7 +89,7 @@ jobs:
         if: inputs.use_cache && steps.build-cache.outputs.cache-hit && github.ref_name == 'main'
         env:
           GH_TOKEN: ${{ github.token }}
-        continue-on-error: ${{ inputs.use_cache }}
+        continue-on-error: true
         run: |
           gh cache delete ${{ steps.build-cache.outputs.cache-primary-key }}
 

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Build.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Build.xcscheme
@@ -4,8 +4,7 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      buildArchitectures = "Automatic">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "NO"
@@ -201,15 +200,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "Amplify"
-            BuildableName = "Amplify"
-            BlueprintName = "Amplify"
-            ReferencedContainer = "container:">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Build.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Build.xcscheme
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Amplify"
+               BuildableName = "Amplify"
+               BlueprintName = "Amplify"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AWSCognitoAuthPlugin"
+               BuildableName = "AWSCognitoAuthPlugin"
+               BlueprintName = "AWSCognitoAuthPlugin"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AWSDataStorePlugin"
+               BuildableName = "AWSDataStorePlugin"
+               BlueprintName = "AWSDataStorePlugin"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AWSCloudWatchLoggingPlugin"
+               BuildableName = "AWSCloudWatchLoggingPlugin"
+               BlueprintName = "AWSCloudWatchLoggingPlugin"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CoreMLPredictionsPlugin"
+               BuildableName = "CoreMLPredictionsPlugin"
+               BlueprintName = "CoreMLPredictionsPlugin"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AWSS3StoragePlugin"
+               BuildableName = "AWSS3StoragePlugin"
+               BlueprintName = "AWSS3StoragePlugin"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AWSPredictionsPlugin"
+               BuildableName = "AWSPredictionsPlugin"
+               BlueprintName = "AWSPredictionsPlugin"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AWSPinpointPushNotificationsPlugin"
+               BuildableName = "AWSPinpointPushNotificationsPlugin"
+               BlueprintName = "AWSPinpointPushNotificationsPlugin"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AWSPinpointAnalyticsPlugin"
+               BuildableName = "AWSPinpointAnalyticsPlugin"
+               BlueprintName = "AWSPinpointAnalyticsPlugin"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AWSAPIPlugin"
+               BuildableName = "AWSAPIPlugin"
+               BlueprintName = "AWSAPIPlugin"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AWSLocationGeoPlugin"
+               BuildableName = "AWSLocationGeoPlugin"
+               BlueprintName = "AWSLocationGeoPlugin"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AWSPluginsCore"
+               BuildableName = "AWSPluginsCore"
+               BlueprintName = "AWSPluginsCore"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Amplify"
+            BuildableName = "Amplify"
+            BlueprintName = "Amplify"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Description
This PR fixes the `build_minimum_supported_swift_platforms.yml` workflow so that we build each platform for the minimum supported Xcode version on each PR and push to the `main` branch:
- For iOS and macOS, the minimum supported Xcode version is 14.1.
- For watchOS and tvOS, the minimum supported Xcode version is 14.3 We're using **14.3.1** as that is the one available in the [macos-13 GitHub runner](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#xcode).

Summary of changes:
- Creating a new target called `Amplify-Build` that only includes the Amplify plugins and no tests.
- Renaming `build-amplify-package` to `build-scheme` and making the scheme an argument
- Removing `continue-on-error` on the build step, as otherwise the workflow would report a success even if it failed.



## General Checklist
- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
