### PR TITLE
test(storage): fix copy_configuration script

### DIFF
--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/copy_configuration.sh
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/copy_configuration.sh
@@ -25,6 +25,13 @@ else
     touch "$DESTINATION_DIR/amplifyconfiguration.json"
 fi
 
+if [ -f "$SOURCE_DIR/AWSS3StoragePluginTests-amplifyconfiguration.json" ]; then
+    cp "$SOURCE_DIR/AWSS3StoragePluginTests-amplifyconfiguration.json" "$DESTINATION_DIR/amplifyconfiguration.json"
+    exit 0
+fi
+    touch "$DESTINATION_DIR/amplifyconfiguration.json"
+fi
+
 if [ -f "$SOURCE_DIR/AWSS3StoragePluginTests-amplify_outputs.json" ]; then
     cp "$SOURCE_DIR/AWSS3StoragePluginTests-amplify_outputs.json" "$DESTINATION_DIR/amplify_outputs.json"
     exit 0


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
This fixes the copy configuration script, which was modified to copy the outputs file. but replaced the previous `amplifyconfiguration.json` instead of it being an addition

The change that introduced the issue https://github.com/aws-amplify/amplify-swift/pull/3567/files#diff-afbd7f754fa78d6674c0136cafca4f962448f9cea32199a51f5e354694dfb75d

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
