### PR TITLE
test(storage): fix copy_configuration script early exit

### DIFF
--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/copy_configuration.sh
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/copy_configuration.sh
@@ -27,19 +27,15 @@ fi
 
 if [ -f "$SOURCE_DIR/AWSS3StoragePluginTests-amplifyconfiguration.json" ]; then
     cp "$SOURCE_DIR/AWSS3StoragePluginTests-amplifyconfiguration.json" "$DESTINATION_DIR/amplifyconfiguration.json"
-    exit 0
 fi
     touch "$DESTINATION_DIR/amplifyconfiguration.json"
 fi
 
 if [ -f "$SOURCE_DIR/AWSS3StoragePluginTests-amplify_outputs.json" ]; then
     cp "$SOURCE_DIR/AWSS3StoragePluginTests-amplify_outputs.json" "$DESTINATION_DIR/amplify_outputs.json"
-    exit 0
 else
     touch "$DESTINATION_DIR/amplify_outputs.json"
 fi
-
-
 
 exit 0
 

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/copy_configuration.sh
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/copy_configuration.sh
@@ -27,7 +27,7 @@ fi
 
 if [ -f "$SOURCE_DIR/AWSS3StoragePluginTests-amplifyconfiguration.json" ]; then
     cp "$SOURCE_DIR/AWSS3StoragePluginTests-amplifyconfiguration.json" "$DESTINATION_DIR/amplifyconfiguration.json"
-fi
+else
     touch "$DESTINATION_DIR/amplifyconfiguration.json"
 fi
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
We require both files to be present, which is why the `else` block exists now to touch the file. The exit after copying the `amplifyconfiguration.json` cause it to finish and not run the block that copies/touch the `amplify_outputs.json` file

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
