### PR TITLE
test(storage): fix copy_configuration script for stress test

### DIFF
--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/copy_configuration.sh
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/copy_configuration.sh
@@ -20,9 +20,8 @@ mkdir -p "$DESTINATION_DIR"
 
 if [ -f "$SOURCE_DIR/AWSAmplifyStressTests-amplifyconfiguration.json" ]; then
     cp "$SOURCE_DIR/AWSAmplifyStressTests-amplifyconfiguration.json" "$DESTINATION_DIR/amplifyconfiguration.json"
+    touch "$DESTINATION_DIR/amplify_outputs.json"
     exit 0
-else
-    touch "$DESTINATION_DIR/amplifyconfiguration.json"
 fi
 
 if [ -f "$SOURCE_DIR/AWSS3StoragePluginTests-amplifyconfiguration.json" ]; then


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

For the stress test workflow, we have not yet updated this to run against amplify_outputs config. However the test exits after it copies the configuration file. The script is written in a way that it looks like either only `AWSAmplifyStressTests-amplifyconfiguration.json` exists or `AWSS3StoragePluginTests-amplifyconfiguration.json` but not both. One easy fix here is to touch the outputs file when running in the context of the stress test (when `AWSAmplifyStressTests-amplifyconfiguration.json` exists)



## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
