### PR TITLE
fix(storage): retrieve accesslevel before storage service

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+Configure.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+Configure.swift
@@ -37,6 +37,7 @@ extension AWSS3StoragePlugin {
 
         do {
             let authService = AWSAuthService()
+            let defaultAccessLevel = try configClosures.retrieveDefaultAccessLevel()
             let storageService = try AWSS3StorageService(authService: authService,
                                                          region: configClosures.retrieveRegion(),
                                                          bucket: configClosures.retrieveBucket(),
@@ -45,7 +46,7 @@ extension AWSS3StoragePlugin {
 
             configure(storageService: storageService, 
                       authService: authService,
-                      defaultAccessLevel: try configClosures.retrieveDefaultAccessLevel())
+                      defaultAccessLevel: defaultAccessLevel)
         } catch let storageError as StorageError {
             throw storageError
         } catch {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
During AWSS3StoragePlugin's `configure()`, it will validate the `defaultAccessLevel` value from the JSONValue configuration (amplifyconfiguration.json). This was previously done first before creating an `AWSS3StorageService`. When the Gen2 configuration logic was added, the refactoring resulted in a flipped sequence; create the `AWSS3StorageService` and then validate the `defaultAccessLevel`. This is an issue when the `defaultAccessLevel` is invalid and it throws an error after an instance of `AWSS3StorageService` has been created.

The issue:
1. `Amplify.configure()` with an invalid `defaultAccessLevel`. Internally it will create the `AWSS3StorageService`, and then throw.
2. The next test will call `Amplify.reset()`. It will do nothing since `storageService: AWS3StorageService` was never added to the plugin. `reset()`  calls `storageService.reset()` to clean things up.
3. `Amplify.configure()` creates another `AWSS3StorageService`. 
4. Then hangs, logs indicate it looks like an storage.upload and underlying URLSession client hangs

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
