### PR TITLE
chore: update set-up ruby 1.171.0

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -39,7 +39,7 @@ jobs:
         run: amplify init --quickstart --frontend ios
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
         with:
           ruby-version: '3.2.1'
           bundler-cache: true

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -39,7 +39,7 @@ jobs:
         run: amplify init --quickstart --frontend ios
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
+        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
         with:
           ruby-version: '3.2.1'
           bundler-cache: true

--- a/.github/workflows/deploy_package.yml
+++ b/.github/workflows/deploy_package.yml
@@ -66,7 +66,7 @@ jobs:
           token: ${{steps.retrieve-token.outputs.token}}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
         with:
           ruby-version: '3.2.1'
           bundler-cache: true

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -62,7 +62,7 @@ jobs:
           token: ${{steps.retrieve-token.outputs.token}}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
         with:
           ruby-version: '3.2.1'
           bundler-cache: true

--- a/.github/workflows/deploy_unstable.yml
+++ b/.github/workflows/deploy_unstable.yml
@@ -62,7 +62,7 @@ jobs:
           token: ${{steps.retrieve-token.outputs.token}}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
         with:
           ruby-version: '3.2.1'
           bundler-cache: true

--- a/.github/workflows/release_doc.yml
+++ b/.github/workflows/release_doc.yml
@@ -36,7 +36,7 @@ jobs:
           token: ${{steps.retrieve-token.outputs.token}}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
         with:
           ruby-version: '3.2.1'
           bundler-cache: true


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
The release workflow failed when installing ruby on macos-latest (macos-14)
https://github.com/aws-amplify/amplify-swift/actions/runs/8843689240/job/24299009047

```
Error: The current runner (macos--arm64) was detected as self-hosted because the platform does not match a GitHub-hosted runner image (or that image is deprecated and no longer supported).
```

Related issue https://github.com/ruby/setup-ruby/issues/568 fixed in 1.171.0 https://github.com/ruby/setup-ruby/issues/568#issuecomment-1919283320 


This [test workflow](https://github.com/aws-amplify/amplify-swift/actions/runs/8835798609/job/24260846301) uses 1.171.0 and installs successfully. 

This PR does not update the canary workflow since it's not using macos-14, does not have the problem.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
