### PR TITLE
fix(Auth): Fixing the Gen2 json configuration used by the Authenticator

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ConfigurationHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ConfigurationHelper.swift
@@ -220,7 +220,7 @@ struct ConfigurationHelper {
                 AuthPluginErrorConstants.configurationMissingError
             )
         }
-        let userPoolConfig = try parseUserPoolData(config)
+        let userPoolConfig = parseUserPoolData(config)
         let identityPoolConfig = parseIdentityPoolData(config)
 
         return try createAuthConfiguration(userPoolConfig: userPoolConfig,
@@ -281,11 +281,10 @@ struct ConfigurationHelper {
                  "verificationMechanism": .array(verificationMechanisms)])
         }
 
-        return JSONValue.object(
-            ["auth": .object(
-                ["plugins": .object(
-                    ["awsCognitoAuthPlugin": .object(
-                        ["Auth": .object(
-                            ["Default": authConfigObject])])])])])
+        return JSONValue.object([
+            "Auth": .object([
+                "Default": authConfigObject
+            ])
+        ])
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/ConfigurationHelperTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/ConfigurationHelperTests.swift
@@ -246,7 +246,7 @@ final class ConfigurationHelperTests: XCTestCase {
                 ]))
         let json = ConfigurationHelper.createUserPoolJsonConfiguration(config)
 
-        guard let authConfig = json.auth?.plugins?.awsCognitoAuthPlugin?.Auth?.Default else {
+        guard let authConfig = json.Auth?.Default else {
             XCTFail("Could not retrieve auth configuration from json")
             return
         }


### PR DESCRIPTION
## Description
The JSON configuration expected by the Authenticator does not include the `"auth.plugin.awsCognitoAuthPlugin"` levels, so I'm removing them.

Also removing an unnecessary `try` that generated an Xcode warning. 

## General Checklist
- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
