### PR TITLE
[Flutter-DataStore-V2] fix: resolve plugins build issues

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/AWSPluginsSDKCore.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AWSPluginsSDKCore.xcscheme
@@ -26,8 +26,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:AmplifyPlugins/Core/AWSPluginsSDKCoreTests/AWSPluginsSDKCore.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
@@ -755,6 +755,16 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AWSPluginsSDKCoreTests"
+               BuildableName = "AWSPluginsSDKCoreTests"
+               BlueprintName = "AWSPluginsSDKCoreTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -781,15 +791,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "Amplify"
-            BuildableName = "Amplify"
-            BlueprintName = "Amplify"
-            ReferencedContainer = "container:">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin+Configure.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin+Configure.swift
@@ -7,6 +7,7 @@
 
 @_spi(InternalAmplifyConfiguration) import Amplify
 import AWSPluginsCore
+import AWSPluginsSDKCore
 import AwsCommonRuntimeKit
 
 public extension AWSAPIPlugin {
@@ -55,7 +56,7 @@ extension AWSAPIPlugin {
     /// A holder for AWSAPIPlugin dependencies that provides sane defaults for
     /// production
     struct ConfigurationDependencies {
-        let authService: AWSAuthServiceBehavior
+        let authService: AWSAuthCredentialsProviderBehavior
         let pluginConfig: AWSAPICategoryPluginConfiguration
         let appSyncRealTimeClientFactory: AppSyncRealTimeClientFactoryProtocol
         let logLevel: Amplify.LogLevel
@@ -63,7 +64,7 @@ extension AWSAPIPlugin {
         init(
             configurationValues: JSONValue,
             apiAuthProviderFactory: APIAuthProviderFactory,
-            authService: AWSAuthServiceBehavior? = nil,
+            authService: AWSAuthCredentialsProviderBehavior? = nil,
             appSyncRealTimeClientFactory: AppSyncRealTimeClientFactoryProtocol? = nil,
             logLevel: Amplify.LogLevel? = nil
         ) throws {
@@ -90,7 +91,7 @@ extension AWSAPIPlugin {
         init(
             configuration: AmplifyOutputsData,
             apiAuthProviderFactory: APIAuthProviderFactory,
-            authService: AWSAuthServiceBehavior = AWSAuthService(),
+            authService: AWSAuthCredentialsProviderBehavior = AWSAuthService(),
             appSyncRealTimeClientFactory: AppSyncRealTimeClientFactoryProtocol? = nil,
             logLevel: Amplify.LogLevel = Amplify.Logging.logLevel
         ) throws {
@@ -111,7 +112,7 @@ extension AWSAPIPlugin {
 
         init(
             pluginConfig: AWSAPICategoryPluginConfiguration,
-            authService: AWSAuthServiceBehavior,
+            authService: AWSAuthCredentialsProviderBehavior,
             appSyncRealTimeClientFactory: AppSyncRealTimeClientFactoryProtocol,
             logLevel: Amplify.LogLevel
         ) {

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin.swift
@@ -7,6 +7,7 @@
 
 import Amplify
 import AWSPluginsCore
+import AWSPluginsSDKCore
 import Foundation
 
 final public class AWSAPIPlugin: NSObject, APICategoryPlugin, AWSAPIAuthInformation {
@@ -25,7 +26,7 @@ final public class AWSAPIPlugin: NSObject, APICategoryPlugin, AWSAPIAuthInformat
 
     /// The provider for Auth services required to access protected APIs. This will be
     /// populated during the configuration phase, and is clearable by `reset()`.
-    var authService: AWSAuthServiceBehavior!
+    var authService: AWSAuthCredentialsProviderBehavior!
 
     /// The provider for network connections and operations. This will be populated
     /// during initialization, and is clearable by `reset()`.

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPICategoryPluginConfiguration.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPICategoryPluginConfiguration.swift
@@ -8,6 +8,7 @@
 @_spi(InternalAmplifyConfiguration) import Amplify
 import Foundation
 import AWSPluginsCore
+import AWSPluginsSDKCore
 
 // Convenience typealias
 typealias APIEndpointName = String
@@ -17,11 +18,11 @@ public struct AWSAPICategoryPluginConfiguration {
     private var interceptors: [APIEndpointName: AWSAPIEndpointInterceptors]
 
     private var apiAuthProviderFactory: APIAuthProviderFactory?
-    private var authService: AWSAuthServiceBehavior?
+    private var authService: AWSAuthCredentialsProviderBehavior?
 
     init(jsonValue: JSONValue,
          apiAuthProviderFactory: APIAuthProviderFactory,
-         authService: AWSAuthServiceBehavior) throws {
+         authService: AWSAuthCredentialsProviderBehavior) throws {
         guard case .object(let config) = jsonValue else {
             throw PluginError.pluginConfigurationError(
                 "Could not cast incoming configuration to a JSONValue `.object`",
@@ -50,7 +51,7 @@ public struct AWSAPICategoryPluginConfiguration {
 
     init(configuration: AmplifyOutputsData,
          apiAuthProviderFactory: APIAuthProviderFactory,
-         authService: AWSAuthServiceBehavior) throws {
+         authService: AWSAuthCredentialsProviderBehavior) throws {
 
         guard let data = configuration.data else {
             throw PluginError.pluginConfigurationError(
@@ -95,7 +96,7 @@ public struct AWSAPICategoryPluginConfiguration {
     internal init(endpoints: [APIEndpointName: EndpointConfig],
                   interceptors: [APIEndpointName: AWSAPIEndpointInterceptors] = [:],
                   apiAuthProviderFactory: APIAuthProviderFactory,
-                  authService: AWSAuthServiceBehavior) {
+                  authService: AWSAuthCredentialsProviderBehavior) {
         self.endpoints = endpoints
         self.interceptors = interceptors
         self.apiAuthProviderFactory = apiAuthProviderFactory
@@ -215,7 +216,7 @@ public struct AWSAPICategoryPluginConfiguration {
     /// - Returns: dictionary of AWSAPIEndpointInterceptors indexed by API endpoint name
     private static func makeInterceptors(forEndpoints endpoints: [APIEndpointName: EndpointConfig],
                                          apiAuthProviderFactory: APIAuthProviderFactory,
-                                         authService: AWSAuthServiceBehavior) throws -> [APIEndpointName: AWSAPIEndpointInterceptors] {
+                                         authService: AWSAuthCredentialsProviderBehavior) throws -> [APIEndpointName: AWSAPIEndpointInterceptors] {
         var interceptors: [APIEndpointName: AWSAPIEndpointInterceptors] = [:]
         for (name, config) in endpoints {
             var interceptorsConfig = AWSAPIEndpointInterceptors(endpointName: name,

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPIEndpointInterceptors.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Configuration/AWSAPIEndpointInterceptors.swift
@@ -8,6 +8,7 @@
 import Amplify
 import Foundation
 import AWSPluginsCore
+import AWSPluginsSDKCore
 
 /// The order of interceptor decoration is as follows:
 /// 1. **prelude interceptors**
@@ -22,7 +23,7 @@ struct AWSAPIEndpointInterceptors {
     let apiEndpointName: APIEndpointName
 
     let apiAuthProviderFactory: APIAuthProviderFactory
-    let authService: AWSAuthServiceBehavior?
+    let authService: AWSAuthCredentialsProviderBehavior?
 
     var preludeInterceptors: [URLRequestInterceptor] = []
 
@@ -46,7 +47,7 @@ struct AWSAPIEndpointInterceptors {
     
     init(endpointName: APIEndpointName,
          apiAuthProviderFactory: APIAuthProviderFactory,
-         authService: AWSAuthServiceBehavior? = nil) {
+         authService: AWSAuthCredentialsProviderBehavior? = nil) {
         self.apiEndpointName = endpointName
         self.apiAuthProviderFactory = apiAuthProviderFactory
         self.authService = authService

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/APIKeyURLRequestInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/APIKeyURLRequestInterceptor.swift
@@ -7,6 +7,7 @@
 
 import Amplify
 import AWSPluginsCore
+import AWSPluginsSDKCore
 import Foundation
 
 struct APIKeyURLRequestInterceptor: URLRequestInterceptor {

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenProviderWrapper.swift
@@ -7,6 +7,7 @@
 
 import Amplify
 import AWSPluginsCore
+import AWSPluginsSDKCore
 import Foundation
 
 class AuthTokenProviderWrapper: AuthTokenProvider {

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenURLRequestInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/AuthTokenURLRequestInterceptor.swift
@@ -7,6 +7,7 @@
 
 import Amplify
 import AWSPluginsCore
+import AWSPluginsSDKCore
 import Foundation
 
 struct AuthTokenURLRequestInterceptor: URLRequestInterceptor {

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/IAMURLRequestInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/RequestInterceptor/IAMURLRequestInterceptor.swift
@@ -7,6 +7,7 @@
 
 import Amplify
 import AWSPluginsCore
+import AWSPluginsSDKCore
 import Foundation
 import ClientRuntime
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 @_spi(WebSocket) import AWSPluginsCore
+import AWSPluginsSDKCore
 import Amplify
 import AWSClientRuntime
 import ClientRuntime

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
@@ -8,6 +8,7 @@
 import Amplify
 import Foundation
 import AWSPluginsCore
+import AWSPluginsSDKCore
 import Combine
 
 public class AWSGraphQLSubscriptionTaskRunner<R: Decodable>: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel {
@@ -25,7 +26,7 @@ public class AWSGraphQLSubscriptionTaskRunner<R: Decodable>: InternalTaskRunner,
     }
     let appSyncClientFactory: AppSyncRealTimeClientFactoryProtocol
     let pluginConfig: AWSAPICategoryPluginConfiguration
-    let authService: AWSAuthServiceBehavior
+    let authService: AWSAuthCredentialsProviderBehavior
     var apiAuthProviderFactory: APIAuthProviderFactory
     private let userAgent = AmplifyAWSServiceConfiguration.userAgentLib
     private let subscriptionId = UUID().uuidString
@@ -35,7 +36,7 @@ public class AWSGraphQLSubscriptionTaskRunner<R: Decodable>: InternalTaskRunner,
     init(request: Request,
          pluginConfig: AWSAPICategoryPluginConfiguration,
          appSyncClientFactory: AppSyncRealTimeClientFactoryProtocol,
-         authService: AWSAuthServiceBehavior,
+         authService: AWSAuthCredentialsProviderBehavior,
          apiAuthProviderFactory: APIAuthProviderFactory) {
         self.request = request
         self.pluginConfig = pluginConfig
@@ -185,7 +186,7 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
 
     let pluginConfig: AWSAPICategoryPluginConfiguration
     let appSyncRealTimeClientFactory: AppSyncRealTimeClientFactoryProtocol
-    let authService: AWSAuthServiceBehavior
+    let authService: AWSAuthCredentialsProviderBehavior
     private let userAgent = AmplifyAWSServiceConfiguration.userAgentLib
 
     var appSyncRealTimeClient: AppSyncRealTimeClientProtocol?
@@ -201,7 +202,7 @@ final public class AWSGraphQLSubscriptionOperation<R: Decodable>: GraphQLSubscri
     init(request: GraphQLOperationRequest<R>,
          pluginConfig: AWSAPICategoryPluginConfiguration,
          appSyncRealTimeClientFactory: AppSyncRealTimeClientFactoryProtocol,
-         authService: AWSAuthServiceBehavior,
+         authService: AWSAuthCredentialsProviderBehavior,
          apiAuthProviderFactory: APIAuthProviderFactory,
          inProcessListener: AWSGraphQLSubscriptionOperation.InProcessListener?,
          resultListener: AWSGraphQLSubscriptionOperation.ResultListener?) {

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AppSyncRealTimeClientFactory.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AppSyncRealTimeClientFactory.swift
@@ -9,13 +9,14 @@
 import Foundation
 import Amplify
 import Combine
+import AWSPluginsSDKCore
 @_spi(WebSocket) import AWSPluginsCore
 
 protocol AppSyncRealTimeClientFactoryProtocol {
     func getAppSyncRealTimeClient(
         for endpointConfig: AWSAPICategoryPluginConfiguration.EndpointConfig,
         endpoint: URL,
-        authService: AWSAuthServiceBehavior,
+        authService: AWSAuthCredentialsProviderBehavior,
         authType: AWSAuthorizationType?,
         apiAuthProviderFactory: APIAuthProviderFactory
     ) async throws -> AppSyncRealTimeClientProtocol
@@ -40,7 +41,7 @@ actor AppSyncRealTimeClientFactory: AppSyncRealTimeClientFactoryProtocol {
     public func getAppSyncRealTimeClient(
         for endpointConfig: AWSAPICategoryPluginConfiguration.EndpointConfig,
         endpoint: URL,
-        authService: AWSAuthServiceBehavior,
+        authService: AWSAuthCredentialsProviderBehavior,
         authType: AWSAuthorizationType? = nil,
         apiAuthProviderFactory: APIAuthProviderFactory
     ) throws -> AppSyncRealTimeClientProtocol {
@@ -90,7 +91,7 @@ actor AppSyncRealTimeClientFactory: AppSyncRealTimeClientFactoryProtocol {
 
     private func getInterceptor(
         for authorizationConfiguration: AWSAuthorizationConfiguration,
-        authService: AWSAuthServiceBehavior,
+        authService: AWSAuthCredentialsProviderBehavior,
         apiAuthProviderFactory: APIAuthProviderFactory
     ) throws -> AppSyncRequestInterceptor & WebSocketInterceptor {
         switch authorizationConfiguration {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/AppSyncRealTimeClientTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/AppSyncRealTimeClientTests.swift
@@ -11,6 +11,7 @@ import Combine
 @testable import Amplify
 @testable import AWSAPIPlugin
 @testable @_spi(WebSocket) import AWSPluginsCore
+@testable import AWSPluginsSDKCore
 
 class AppSyncRealTimeClientTests: XCTestCase {
     let subscriptionRequest = """

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+InterceptorBehaviorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+InterceptorBehaviorTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import AWSAPIPlugin
 import AWSPluginsCore
+import AWSPluginsSDKCore
 
 // swiftlint:disable:next type_name
 class AWSAPICategoryPluginInterceptorBehaviorTests: AWSAPICategoryPluginTestBase {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -12,6 +12,7 @@ import Foundation
 @testable import AWSAPIPlugin
 @testable import AWSPluginsTestCommon
 import AWSPluginsCore
+import AWSPluginsSDKCore
 
 class AWSAPICategoryPluginConfigurationTests: XCTestCase {
     let graphQLAPI = "graphQLAPI"

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPIEndpointInterceptorsTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPIEndpointInterceptorsTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 import Amplify
 import AWSPluginsCore
+import AWSPluginsSDKCore
 @testable import AmplifyTestCommon
 @testable import AWSAPIPlugin
 @testable import AWSPluginsTestCommon
@@ -102,7 +103,7 @@ class AWSAPIEndpointInterceptorsTests: XCTestCase {
     
     // MARK: - Test Helpers
 
-    func createAPIInterceptorConfig(authService: AWSAuthServiceBehavior = MockAWSAuthService()) -> AWSAPIEndpointInterceptors {
+    func createAPIInterceptorConfig(authService: AWSAuthCredentialsProviderBehavior = MockAWSAuthService()) -> AWSAPIEndpointInterceptors {
         return AWSAPIEndpointInterceptors(
             endpointName: endpointName,
             apiAuthProviderFactory: APIAuthProviderFactory(),

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -7,6 +7,7 @@
 
 import XCTest
 import AWSPluginsCore
+import AWSPluginsSDKCore
 @testable import Amplify
 @testable import AmplifyTestCommon
 @testable import AWSAPIPlugin

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Mocks/MockSubscription.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Mocks/MockSubscription.swift
@@ -11,14 +11,14 @@ import Amplify
 import Combine
 @testable import AWSAPIPlugin
 @_spi(WebSocket) import AWSPluginsCore
+import AWSPluginsSDKCore
 
 struct MockSubscriptionConnectionFactory: AppSyncRealTimeClientFactoryProtocol {
-    
 
     typealias OnGetOrCreateConnection = (
         AWSAPICategoryPluginConfiguration.EndpointConfig,
         URL,
-        AWSAuthServiceBehavior,
+        AWSAuthCredentialsProviderBehavior,
         AWSAuthorizationType?,
         APIAuthProviderFactory
     ) async throws -> AppSyncRealTimeClientProtocol
@@ -32,7 +32,7 @@ struct MockSubscriptionConnectionFactory: AppSyncRealTimeClientFactoryProtocol {
     func getAppSyncRealTimeClient(
         for endpointConfig: AWSAPICategoryPluginConfiguration.EndpointConfig,
         endpoint: URL,
-        authService: AWSAuthServiceBehavior,
+        authService: AWSAuthCredentialsProviderBehavior,
         authType: AWSAuthorizationType?,
         apiAuthProviderFactory: APIAuthProviderFactory
     ) async throws -> AppSyncRealTimeClientProtocol {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -13,7 +13,7 @@ import AWSCognitoIdentityProvider
 import AWSPluginsCore
 import ClientRuntime
 import AWSClientRuntime
-@_spi(PluginHTTPClientEngine) import AWSPluginsCore
+@_spi(PluginHTTPClientEngine) import AWSPluginsSDKCore
 @_spi(InternalHttpEngineProxy) import AWSPluginsCore
 
 extension AWSCognitoAuthPlugin {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+PluginExtension.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+PluginExtension.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(InternalAmplifyPluginExtension) import AWSPluginsCore
+@_spi(InternalAmplifyPluginExtension) import AWSPluginsSDKCore
 import Foundation
 import ClientRuntime
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/HttpClientEngineProxy.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/HttpClientEngineProxy.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(InternalHttpEngineProxy) @_spi(InternalAmplifyPluginExtension) import AWSPluginsCore
+@_spi(InternalHttpEngineProxy) @_spi(InternalAmplifyPluginExtension) import AWSPluginsSDKCore
 import ClientRuntime
 import Foundation
 

--- a/AmplifyPlugins/Core/AWSPluginsSDKCore/AWSAuthCredentialsProviderBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsSDKCore/AWSAuthCredentialsProviderBehavior.swift
@@ -8,7 +8,10 @@
 import Foundation
 import Amplify
 import AWSClientRuntime
+import AWSPluginsCore
 
-public protocol AWSAuthCredentialsProviderBehavior {
+public protocol AWSAuthCredentialsProviderBehavior: AWSAuthServiceBehavior {
     func getCredentialsProvider() -> CredentialsProviding
 }
+
+

--- a/AmplifyPlugins/Core/AWSPluginsSDKCore/AWSAuthService+CredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsSDKCore/AWSAuthService+CredentialsProvider.swift
@@ -8,9 +8,10 @@
 import Foundation
 import Amplify
 import AWSClientRuntime
+import AWSPluginsCore
 
-public class AWSAuthCredentialsProvider: AWSAuthCredentialsProviderBehavior {
-    public func getCredentialsProvider() -> CredentialsProviding {
+extension AWSAuthService: AWSAuthCredentialsProviderBehavior {
+    public func getCredentialsProvider() -> AWSClientRuntime.CredentialsProviding {
         return AmplifyAWSCredentialsProvider()
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsSDKCore/AmplifyAWSCredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsSDKCore/AmplifyAWSCredentialsProvider.swift
@@ -8,6 +8,7 @@
 import Amplify
 import AWSClientRuntime
 import AwsCommonRuntimeKit
+import AWSPluginsCore
 import Foundation
 
 public class AmplifyAWSCredentialsProvider: AWSClientRuntime.CredentialsProviding {
@@ -24,7 +25,7 @@ public class AmplifyAWSCredentialsProvider: AWSClientRuntime.CredentialsProvidin
     }
 }
 
-extension AWSCredentials {
+extension AWSPluginsCore.AWSCredentials {
 
     func toAWSSDKCredentials() -> AWSClientRuntime.AWSCredentials {
         if let tempCredentials = self as? AWSTemporaryCredentials {

--- a/AmplifyPlugins/Core/AWSPluginsSDKCore/AuthTokenProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsSDKCore/AuthTokenProvider.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Amplify
+import AWSPluginsCore
 
 public protocol AuthTokenProvider {
     func getUserPoolAccessToken() async throws -> String

--- a/AmplifyPlugins/Core/AWSPluginsSDKCore/IAMCredentialProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsSDKCore/IAMCredentialProvider.swift
@@ -8,15 +8,16 @@
 import Foundation
 import Amplify
 import AWSClientRuntime
+import AWSPluginsCore
 
 public protocol IAMCredentialsProvider {
     func getCredentialsProvider() -> CredentialsProviding
 }
 
 public struct BasicIAMCredentialsProvider: IAMCredentialsProvider {
-    let authService: AWSAuthServiceBehavior
+    let authService: AWSAuthCredentialsProviderBehavior
 
-    public init(authService: AWSAuthServiceBehavior) {
+    public init(authService: AWSAuthCredentialsProviderBehavior) {
         self.authService = authService
     }
 

--- a/AmplifyPlugins/Core/AWSPluginsSDKCoreTests/AWSPluginsSDKCore.xctestplan
+++ b/AmplifyPlugins/Core/AWSPluginsSDKCoreTests/AWSPluginsSDKCore.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "9D7C41C1-F847-4136-AB74-D1E17831BCDD",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "AWSPluginsSDKCoreTests",
+        "name" : "AWSPluginsSDKCoreTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/AmplifyPlugins/Core/AWSPluginsSDKCoreTests/Auth/AWSAuthServiceTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsSDKCoreTests/Auth/AWSAuthServiceTests.swift
@@ -9,6 +9,7 @@ import XCTest
 
 @testable import Amplify
 @testable import AWSPluginsCore
+@testable import AWSPluginsSDKCore
 import AWSClientRuntime
 
 class AWSAuthServiceTests: XCTestCase {

--- a/AmplifyPlugins/Core/AWSPluginsSDKCoreTests/Utils/UserAgentSettingClientEngineTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsSDKCoreTests/Utils/UserAgentSettingClientEngineTests.swift
@@ -8,7 +8,7 @@
 @_spi(InternalAmplifyPluginExtension) 
 @_spi(PluginHTTPClientEngine)
 @_spi(InternalHttpEngineProxy)
-import AWSPluginsCore
+import AWSPluginsSDKCore
 import ClientRuntime
 import XCTest
 

--- a/AmplifyPlugins/Core/AWSPluginsSDKCoreTests/Utils/UserAgentSuffixAppenderTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsSDKCoreTests/Utils/UserAgentSuffixAppenderTests.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(InternalAmplifyPluginExtension) @_spi(InternalHttpEngineProxy) import AWSPluginsCore
+@_spi(InternalAmplifyPluginExtension) @_spi(InternalHttpEngineProxy) import AWSPluginsSDKCore
 import ClientRuntime
 import XCTest
 

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -8,9 +8,9 @@
 import ClientRuntime
 import AWSClientRuntime
 import Amplify
-import AWSPluginsCore
+import AWSPluginsSDKCore
 
-public class MockAWSAuthService: AWSAuthServiceBehavior {
+public class MockAWSAuthService: AWSAuthCredentialsProviderBehavior {
 
     var interactions: [String] = []
     var getIdentityIdError: AuthError?

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSSignatureV4Signer.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSSignatureV4Signer.swift
@@ -8,6 +8,7 @@
 import AWSPluginsCore
 import ClientRuntime
 import AWSClientRuntime
+import AWSPluginsSDKCore
 import Foundation
 
 class MockAWSSignatureV4Signer: AWSSignatureV4Signer {

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
@@ -284,7 +284,7 @@ class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
         listenerDelay: TimeInterval
     ) -> MutateRequestResponder<MutationSync<AnyModel>> {
         MutateRequestResponder<MutationSync<AnyModel>> { _ in
-            try! await Task.sleep(seconds: listenerDelay)
+            try? await Task.sleep(seconds: listenerDelay)
             return .failure(.unknown("", "", self.connectionError))
         }
     }

--- a/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/AWSLocationGeoPlugin+Configure.swift
+++ b/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/AWSLocationGeoPlugin+Configure.swift
@@ -8,7 +8,7 @@
 import Foundation
 @_spi(InternalAmplifyConfiguration) import Amplify
 import AWSPluginsCore
-@_spi(PluginHTTPClientEngine) import AWSPluginsCore
+@_spi(PluginHTTPClientEngine) import AWSPluginsSDKCore
 import AWSLocation
 import AWSClientRuntime
 

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/PinpointEvent+PinpointClientTypes.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/PinpointEvent+PinpointClientTypes.swift
@@ -7,6 +7,7 @@
 
 import AWSPinpoint
 import AWSPluginsCore
+import AWSPluginsSDKCore
 import Foundation
 
 extension PinpointEvent {

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Extensions/PinpointClient+CredentialsProvider.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Extensions/PinpointClient+CredentialsProvider.swift
@@ -8,7 +8,7 @@
 import AWSClientRuntime
 import AWSPluginsCore
 import AWSPinpoint
-@_spi(PluginHTTPClientEngine) import AWSPluginsCore
+@_spi(PluginHTTPClientEngine) import AWSPluginsSDKCore
 
 extension PinpointClient {
     convenience init(region: String, credentialsProvider: CredentialsProviding) throws {

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Support/Utils/PinpointRequestsRegistry.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Support/Utils/PinpointRequestsRegistry.swift
@@ -8,8 +8,7 @@
 import Foundation
 import AWSPinpoint
 import ClientRuntime
-@_spi(PluginHTTPClientEngine)
-import AWSPluginsCore
+@_spi(PluginHTTPClientEngine) import AWSPluginsSDKCore
 
 @globalActor actor PinpointRequestsRegistry {
     static let shared = PinpointRequestsRegistry()

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
@@ -6,7 +6,7 @@
 //
 
 import AWSPluginsCore
-@_spi(PluginHTTPClientEngine) import AWSPluginsCore
+@_spi(PluginHTTPClientEngine) import AWSPluginsSDKCore
 import Amplify
 import Combine
 import Foundation

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Configuration/DefaultRemoteLoggingConstraintsProvider.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Configuration/DefaultRemoteLoggingConstraintsProvider.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Amplify
 import AWSPluginsCore
+import AWSPluginsSDKCore
 import AWSClientRuntime
 import ClientRuntime
 

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService.swift
@@ -12,7 +12,7 @@ import AWSTextract
 import AWSComprehend
 import AWSPolly
 import AWSPluginsCore
-@_spi(PluginHTTPClientEngine) import AWSPluginsCore
+@_spi(PluginHTTPClientEngine) import AWSPluginsSDKCore
 import Foundation
 import ClientRuntime
 import AWSClientRuntime

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
@@ -9,14 +9,14 @@ import Foundation
 import AWSS3
 import Amplify
 import AWSPluginsCore
-@_spi(PluginHTTPClientEngine) import AWSPluginsCore
 import ClientRuntime
+@_spi(PluginHTTPClientEngine) import AWSPluginsSDKCore
 
 /// - Tag: AWSS3StorageService
 class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy {
 
     // resettable values
-    private var authService: AWSAuthServiceBehavior?
+    private var authService: AWSAuthCredentialsProviderBehavior?
     var logger: Logger!
     var preSignedURLBuilder: AWSS3PreSignedURLBuilderBehavior!
     var awsS3: AWSS3Behavior!
@@ -48,7 +48,7 @@ class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy {
         storageConfiguration.sessionIdentifier
     }
 
-    convenience init(authService: AWSAuthServiceBehavior,
+    convenience init(authService: AWSAuthCredentialsProviderBehavior,
                      region: String,
                      bucket: String,
                      httpClientEngineProxy: HttpClientEngineProxy? = nil,
@@ -107,7 +107,7 @@ class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy {
                   bucket: bucket)
     }
 
-    init(authService: AWSAuthServiceBehavior,
+    init(authService: AWSAuthCredentialsProviderBehavior,
          storageConfiguration: StorageConfiguration = .default,
          storageTransferDatabase: StorageTransferDatabase = .default,
          fileSystem: FileSystem = .default,

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/DefaultStorageTransferDatabaseTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/DefaultStorageTransferDatabaseTests.swift
@@ -204,7 +204,7 @@ class DefaultStorageTransferDatabaseTests: XCTestCase {
     /// Given: A DefaultStorageTransferDatabase
     /// When: recover is invoked with a StorageURLSession that returns a session
     /// Then: A .success is returned
-    func testLoadPersistableTasks() {
+    func testLoadPersistableTasks() async {
         let urlSession = MockStorageURLSession(
             sessionTasks: [
                 session
@@ -217,18 +217,18 @@ class DefaultStorageTransferDatabaseTests: XCTestCase {
             }
             expectation.fulfill()
         }
-        waitForExpectations(timeout: 1)
+        await fulfillment(of: [expectation], timeout: 1)
     }
 
     /// Given: A DefaultStorageTransferDatabase
     /// When: prepareForBackground is invoked
     /// Then: A callback is invoked
-    func testPrepareForBackground() {
+    func testPrepareForBackground() async {
         let expectation = self.expectation(description: "Prepare for Background")
         database.prepareForBackground() {
             expectation.fulfill()
         }
-        waitForExpectations(timeout: 1)
+        await fulfillment(of: [expectation], timeout: 1)
     }
 
     /// Given: The StorageTransferDatabase Type

--- a/AmplifyTestCommon/Mocks/MockCredentialsProvider.swift
+++ b/AmplifyTestCommon/Mocks/MockCredentialsProvider.swift
@@ -5,11 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AWSPluginsCore
 import AWSClientRuntime
 import Foundation
 
-class MockCredentialsProvider: CredentialsProviding {
-    func getCredentials() async throws -> AWSCredentials {
+class MockCredentialsProvider: AWSClientRuntime.CredentialsProviding {
+    func getCredentials() async throws -> AWSClientRuntime.AWSCredentials {
         return AWSCredentials(
             accessKey: "accessKey",
             secret: "secret",

--- a/Package.swift
+++ b/Package.swift
@@ -44,12 +44,10 @@ let amplifyTargets: [Target] = [
         name: "AWSPluginsSDKCore",
         dependencies: [
             "Amplify",
+            "AWSPluginsCore",
             .product(name: "AWSClientRuntime", package: "aws-sdk-swift")
         ],
         path: "AmplifyPlugins/Core/AWSPluginsSDKCore",
-        exclude: [
-            "Info.plist"
-        ],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
         ]
@@ -59,7 +57,7 @@ let amplifyTargets: [Target] = [
         dependencies: [
             "Amplify",
             "CwlPreconditionTesting",
-            "AWSPluginsCore"
+            "AWSPluginsSDKCore"
         ],
         path: "AmplifyTestCommon",
         exclude: [
@@ -102,6 +100,7 @@ let amplifyTargets: [Target] = [
         dependencies: [
             "Amplify",
             "AWSPluginsCore",
+            "AWSPluginsSDKCore",
             .product(name: "AWSClientRuntime", package: "aws-sdk-swift")
         ],
         path: "AmplifyPlugins/Core/AWSPluginsTestCommon",
@@ -113,13 +112,21 @@ let amplifyTargets: [Target] = [
         name: "AWSPluginsCoreTests",
         dependencies: [
             "AWSPluginsCore",
-            "AmplifyTestCommon",
-            .product(name: "AWSClientRuntime", package: "aws-sdk-swift")
+            "AmplifyTestCommon"
         ],
         path: "AmplifyPlugins/Core/AWSPluginsCoreTests",
         exclude: [
             "Info.plist"
         ]
+    ),
+    .testTarget(
+        name: "AWSPluginsSDKCoreTests",
+        dependencies: [
+            "AWSPluginsSDKCore",
+            "AmplifyTestCommon",
+            .product(name: "AWSClientRuntime", package: "aws-sdk-swift")
+        ],
+        path: "AmplifyPlugins/Core/AWSPluginsSDKCoreTests"
     )
 ]
 
@@ -128,7 +135,7 @@ let apiTargets: [Target] = [
         name: "AWSAPIPlugin",
         dependencies: [
             .target(name: "Amplify"),
-            .target(name: "AWSPluginsCore")
+            .target(name: "AWSPluginsSDKCore")
         ],
         path: "AmplifyPlugins/API/Sources/AWSAPIPlugin",
         exclude: [


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
- change `AWSAuthCredentialsProviderBehavior` to inherit from `AWSAuthServiceBehavior` in PluginsCore
- extend `AWSAuthService` to implement `AWSAuthCredentialsProviderBehavior` in PluginsSDKCore

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [x] All unit tests [pass](https://github.com/aws-amplify/amplify-swift/actions?query=branch%3A5d%2Fsdk-core-rebase)
- [x] All integration tests [pass](https://github.com/aws-amplify/amplify-swift/actions?query=branch%3A5d%2Fsdk-core-rebase)
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
