### PR TITLE
chore: Control coverage reporting through a repository variable

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -41,7 +41,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'main'}}
 
 jobs:
-  unit-tests-without-coverage:
+  targets-without-coverage:
     name: ${{ matrix.scheme }} Unit Tests
     strategy:
       fail-fast: false
@@ -54,7 +54,7 @@ jobs:
       scheme: ${{ matrix.scheme }}
       generate_coverage_report: false
 
-  unit-tests-with-coverage:
+  targets-with-coverage:
     name: ${{ matrix.scheme }} Unit Tests
     strategy:
       fail-fast: false
@@ -76,40 +76,41 @@ jobs:
     uses: ./.github/workflows/run_unit_tests_platforms.yml
     with:
       scheme: ${{ matrix.scheme }}
-      generate_coverage_report: true
+      generate_coverage_report: ${{ vars.DISABLE_COVERAGE_REPORT != 'true' }}
 
-  # report-coverage:
-  #   name: ${{ matrix.file.scheme }} Unit Tests
-  #   needs: [unit-tests-with-coverage]
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       file: [
-  #         { scheme: Amplify, flags: 'Amplify,unit_tests' },
-  #         { scheme: AWSPluginsCore, flags: 'AWSPluginsCore,unit_tests' },
-  #         { scheme: AWSAPIPlugin, flags: 'API_plugin_unit_test,unit_tests' },
-  #         { scheme: AWSCloudWatchLoggingPlugin, flags: 'Logging_plugin_unit_test,unit_tests' },
-  #         { scheme: AWSCognitoAuthPlugin, flags: 'Auth_plugin_unit_test,unit_tests' },
-  #         { scheme: AWSDataStorePlugin, flags: 'DataStore_plugin_unit_test,unit_tests' },
-  #         { scheme: AWSLocationGeoPlugin, flags: 'Geo_plugin_unit_test,unit_tests' },
-  #         { scheme: AWSPredictionsPlugin, flags: 'Predictions_plugin_unit_test,unit_tests' },
-  #         { scheme: AWSPinpointAnalyticsPlugin, flags: 'Analytics_plugin_unit_test,unit_tests' },
-  #         { scheme: AWSPinpointPushNotificationsPlugin, flags: 'PushNotifications_plugin_unit_test,unit_tests' },
-  #         { scheme: AWSS3StoragePlugin, flags: 'Storage_plugin_unit_test,unit_tests' },
-  #         { scheme: CoreMLPredictionsPlugin, flags: 'CoreMLPredictions_plugin_unit_test,unit_tests' }
-  #       ]
-  #   uses: ./.github/workflows/upload_coverage_report.yml
-  #   with:
-  #     scheme: ${{ matrix.file.scheme }}
-  #     flags: ${{ matrix.file.flags }}
+  report-coverage:
+    if: ${{ vars.DISABLE_COVERAGE_REPORT != 'true' }}
+    name: ${{ matrix.file.scheme }} Unit Tests
+    needs: [targets-with-coverage]
+    strategy:
+      fail-fast: false
+      matrix:
+        file: [
+          { scheme: Amplify, flags: 'Amplify,unit_tests' },
+          { scheme: AWSPluginsCore, flags: 'AWSPluginsCore,unit_tests' },
+          { scheme: AWSAPIPlugin, flags: 'API_plugin_unit_test,unit_tests' },
+          { scheme: AWSCloudWatchLoggingPlugin, flags: 'Logging_plugin_unit_test,unit_tests' },
+          { scheme: AWSCognitoAuthPlugin, flags: 'Auth_plugin_unit_test,unit_tests' },
+          { scheme: AWSDataStorePlugin, flags: 'DataStore_plugin_unit_test,unit_tests' },
+          { scheme: AWSLocationGeoPlugin, flags: 'Geo_plugin_unit_test,unit_tests' },
+          { scheme: AWSPredictionsPlugin, flags: 'Predictions_plugin_unit_test,unit_tests' },
+          { scheme: AWSPinpointAnalyticsPlugin, flags: 'Analytics_plugin_unit_test,unit_tests' },
+          { scheme: AWSPinpointPushNotificationsPlugin, flags: 'PushNotifications_plugin_unit_test,unit_tests' },
+          { scheme: AWSS3StoragePlugin, flags: 'Storage_plugin_unit_test,unit_tests' },
+          { scheme: CoreMLPredictionsPlugin, flags: 'CoreMLPredictions_plugin_unit_test,unit_tests' }
+        ]
+    uses: ./.github/workflows/upload_coverage_report.yml
+    with:
+      scheme: ${{ matrix.file.scheme }}
+      flags: ${{ matrix.file.flags }}
 
   unit-test-pass-confirmation:
     runs-on: ubuntu-latest
     name: Confirm Passing Unit Tests
     if: ${{ !cancelled() }}
     needs: [
-      unit-tests-with-coverage,
-      unit-tests-without-coverage
+      targets-with-coverage,
+      targets-without-coverage
     ]
     env:
       EXIT_CODE: ${{ contains(needs.*.result, 'failure') && 1 || 0 }}


### PR DESCRIPTION
## Description
This PR updates the unit test workflow to determine whether to gather and report coverage based on the value of a repository variable.
This allows us to enable/disable it without having to edit the files.

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
