### PR TITLE
fix(auth): gen2 config oauth domain

### DIFF
--- a/Amplify/Core/Configuration/AmplifyOutputsData.swift
+++ b/Amplify/Core/Configuration/AmplifyOutputsData.swift
@@ -66,8 +66,7 @@ public struct AmplifyOutputsData: Codable {
         @_spi(InternalAmplifyConfiguration)
         public struct OAuth: Codable {
             public let identityProviders: [String]
-            public let cognitoDomain: String
-            public let customDomain: String?
+            public let domain: String
             public let scopes: [String]
             public let redirectSignInUri: [String]
             public let redirectSignOutUri: [String]

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ConfigurationHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Helpers/ConfigurationHelper.swift
@@ -159,7 +159,7 @@ struct ConfigurationHelper {
 
         return createHostedConfiguration(appClientId: configuration.userPoolClientId,
                                          clientSecret: nil,
-                                         domain: oauth.customDomain ?? oauth.cognitoDomain,
+                                         domain: oauth.domain,
                                          scopes: oauth.scopes,
                                          signInRedirectURI: signInRedirectURI,
                                          signOutRedirectURI: signOutRedirectURI)

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/ConfigurationHelperTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/ConfigurationHelperTests.swift
@@ -46,8 +46,7 @@ final class ConfigurationHelperTests: XCTestCase {
             userPoolId: "poolId",
             userPoolClientId: "clientId",
             oauth: AmplifyOutputsData.Auth.OAuth(identityProviders: ["provider1", "provider2"],
-                                                 cognitoDomain: "cognitoDomain",
-                                                 customDomain: nil,
+                                                 domain: "domain",
                                                  scopes: ["scope1", "scope2"],
                                                  redirectSignInUri: ["redirect1", "redirect2"],
                                                  redirectSignOutUri: ["signOut1", "signOut2"],
@@ -62,35 +61,7 @@ final class ConfigurationHelperTests: XCTestCase {
         XCTAssertEqual(hostedUIConfig.clientId, "clientId")
         XCTAssertNil(hostedUIConfig.clientSecret, "Client secret should be nil as its not supported in Gen2")
         XCTAssertEqual(hostedUIConfig.oauth.scopes, ["scope1", "scope2"])
-        XCTAssertEqual(hostedUIConfig.oauth.domain, "cognitoDomain")
-        XCTAssertEqual(hostedUIConfig.oauth.signInRedirectURI, "redirect1")
-        XCTAssertEqual(hostedUIConfig.oauth.signOutRedirectURI, "signOut1")
-    }
-
-    /// Test Oauth section's `customDomain` overwrites `cognitoDomain`
-    func testParseUserPoolData_WithOAuth_CustomDomain() throws {
-        let config = AmplifyOutputsData.Auth(
-            awsRegion: "us-east-1",
-            userPoolId: "poolId",
-            userPoolClientId: "clientId",
-            oauth: AmplifyOutputsData.Auth.OAuth(identityProviders: ["provider1", "provider2"],
-                                                 cognitoDomain: "cognitoDomain",
-                                                 customDomain: "customDomain",
-                                                 scopes: ["scope1", "scope2"],
-                                                 redirectSignInUri: ["redirect1", "redirect2"],
-                                                 redirectSignOutUri: ["signOut1", "signOut2"],
-                                                 responseType: "responseType"))
-
-        guard let config = ConfigurationHelper.parseUserPoolData(config),
-              let hostedUIConfig = config.hostedUIConfig else {
-            XCTFail("Expected to parse UserPoolData into object")
-            return
-        }
-
-        XCTAssertEqual(hostedUIConfig.clientId, "clientId")
-        XCTAssertNil(hostedUIConfig.clientSecret)
-        XCTAssertEqual(hostedUIConfig.oauth.scopes, ["scope1", "scope2"])
-        XCTAssertEqual(hostedUIConfig.oauth.domain, "customDomain")
+        XCTAssertEqual(hostedUIConfig.oauth.domain, "domain")
         XCTAssertEqual(hostedUIConfig.oauth.signInRedirectURI, "redirect1")
         XCTAssertEqual(hostedUIConfig.oauth.signOutRedirectURI, "signOut1")
     }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
Related Android change https://github.com/aws-amplify/amplify-android/pull/2785
Schema https://github.com/aws-amplify/amplify-backend/blob/main/packages/client-config/src/client-config-schema/schema_v1.json#L102C1-L105C15

## Description
<!-- Why is this change required? What problem does it solve? -->
Backend reverted `cognitoDomain` and `customDomain` back to  `domain`.



## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
