### PR TITLE
test(storage): gen2 integ tests

### DIFF
--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginAccessLevelTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginAccessLevelTests.swift
@@ -16,8 +16,6 @@ class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase {
         let label: String
         let key: String
         let accessLevel: StorageAccessLevel
-        let user1: (String, String) // (username/email and password)
-        let user2: (String, String) // (username/email and password)
     }
 
     /// Given: An unauthenticated user
@@ -51,17 +49,8 @@ class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase {
     func testUploadAndRemoveForGuestOnly() async throws {
         let logger = Amplify.Logging.logger(forCategory: "Storage", logLevel: .verbose)
 
-        let username: String
-        let password: String
-        if useGen2Configuration {
-            username = "\(UUID().uuidString)@amazon.com"
-            password = "Pp123!@\(UUID().uuidString)"
-            _ = try await Amplify.Auth.signUp(username: username, password: password)
-        } else {
-            username = AWSS3StoragePluginTestBase.user1.lowercased()
-            password = AWSS3StoragePluginTestBase.password
-        }
-
+        let username = AWSS3StoragePluginTestBase.user1.lowercased()
+        let password = AWSS3StoragePluginTestBase.password
         let accessLevel: StorageAccessLevel = .guest
 
         do {
@@ -112,21 +101,13 @@ class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase {
             .guest
         ]
 
-        let username: String
-        let password: String
-        if useGen2Configuration {
-            username = "\(UUID().uuidString)@amazon.com"
-            password = "Pp123!@\(UUID().uuidString)"
-            _ = try await Amplify.Auth.signUp(username: username, password: password)
-        } else {
-            username = AWSS3StoragePluginTestBase.user1.lowercased()
-            password = AWSS3StoragePluginTestBase.password
-        }
+        let username = AWSS3StoragePluginTestBase.user1.lowercased()
+        let password = AWSS3StoragePluginTestBase.password
         logger.debug("Signing in as user1")
         let result = try await Amplify.Auth.signIn(username: username, password: password)
         XCTAssertTrue(result.isSignedIn)
         let currentUser = try await Amplify.Auth.getCurrentUser()
-         XCTAssertEqual(username, currentUser.username)
+        XCTAssertEqual(username, currentUser.username)
         let isSignedIn = result.isSignedIn
 
         // must be signed in to continue
@@ -176,39 +157,13 @@ class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase {
     func testAccessLevelsBetweenTwoUsers() async throws {
         let logger = Amplify.Logging.logger(forCategory: "Storage", logLevel: .verbose)
 
-        let username1: String
-        let username2: String
-        let password: String
-        if useGen2Configuration {
-            username1 = "\(UUID().uuidString)@amazon.com"
-            password = "Pp123!@\(UUID().uuidString)"
-            _ = try await Amplify.Auth.signUp(username: username1, password: password)
-            username2 = "\(UUID().uuidString)@amazon.com"
-            _ = try await Amplify.Auth.signUp(username: username2, password: password)
-        } else {
-            username1 = AWSS3StoragePluginTestBase.user1
-            username2 = AWSS3StoragePluginTestBase.user2
-            password = AWSS3StoragePluginTestBase.password
-        }
         let testRuns: [StorageAccessLevelsTestRun] = [
             // user 2 can read upload by user 1 with guest access
-            .init(label: "Guest",
-                  key: UUID().uuidString,
-                  accessLevel: .guest,
-                  user1: (username1, password),
-                  user2: (username2, password)),
+            .init(label: "Guest", key: UUID().uuidString, accessLevel: .guest),
             // user 2 can read upload by user 1 with protected access
-            .init(label: "Protected", 
-                  key: UUID().uuidString,
-                  accessLevel: .protected,
-                  user1: (username1, password),
-                  user2: (username2, password)),
+            .init(label: "Protected", key: UUID().uuidString, accessLevel: .protected),
             // user 2 can get access denied error from upload by user 1 with private access
-            .init(label: "Private", 
-                  key: UUID().uuidString,
-                  accessLevel: .private,
-                  user1: (username1, password),
-                  user2: (username2, password)),
+            .init(label: "Private", key: UUID().uuidString, accessLevel: .private),
         ]
 
         for testRun in testRuns {
@@ -218,8 +173,7 @@ class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase {
                     await signOut()
 
                     logger.debug("Signing in user1")
-                    let user1SignedIn = try await Amplify.Auth.signIn(username: testRun.user1.0,
-                                                                      password: testRun.user1.1).isSignedIn
+                    let user1SignedIn = try await Amplify.Auth.signIn(username: AWSS3StoragePluginTestBase.user1, password: AWSS3StoragePluginTestBase.password).isSignedIn
                     XCTAssertTrue(user1SignedIn)
 
                     logger.debug("Getting identity for user1")
@@ -242,8 +196,7 @@ class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase {
                     await signOut()
 
                     logger.debug("Signing in as user2")
-                    let user2SignedIn = try await Amplify.Auth.signIn(username: testRun.user2.0,
-                                                                      password: testRun.user2.1).isSignedIn
+                    let user2SignedIn = try await Amplify.Auth.signIn(username: AWSS3StoragePluginTestBase.user2, password: AWSS3StoragePluginTestBase.password).isSignedIn
                     XCTAssertTrue(user2SignedIn)
 
                     logger.debug("Getting identity for user2")

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginTestBase.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginTestBase.swift
@@ -118,27 +118,31 @@ class AWSS3StoragePluginTestBase: XCTestCase {
     func getBucketFromConfig(forResource: String) throws -> String {
         let data = try TestConfigHelper.retrieve(forResource: forResource)
         let json = try JSONDecoder().decode(JSONValue.self, from: data)
-        if useGen2Configuration {
-            guard let bucket = json["storage"]?["bucket_name"] else {
-                throw "Could not retrieve bucket from config"
-            }
 
-            guard case let .string(bucketValue) = bucket else {
-                throw "bucket is not a string value"
-            }
-
-            return bucketValue
-        } else {
-            guard let bucket = json["storage"]?["plugins"]?["awsS3StoragePlugin"]?["bucket"] else {
-                throw "Could not retrieve bucket from config"
-            }
-
-            guard case let .string(bucketValue) = bucket else {
-                throw "bucket is not a string value"
-            }
-
-            return bucketValue
+        guard let bucket = json["storage"]?["plugins"]?["awsS3StoragePlugin"]?["bucket"] else {
+            throw "Could not retrieve bucket from config"
         }
+
+        guard case let .string(bucketValue) = bucket else {
+            throw "bucket is not a string value"
+        }
+
+        return bucketValue
+    }
+
+    func getBucketFromAmplifyOutputs(forResource: String) throws -> String {
+        let data = try TestConfigHelper.retrieve(forResource: forResource)
+        let json = try JSONDecoder().decode(JSONValue.self, from: data)
+
+        guard let bucket = json["storage"]?["bucket_name"] else {
+            throw "Could not retrieve bucket from config"
+        }
+
+        guard case let .string(bucketValue) = bucket else {
+            throw "bucket is not a string value"
+        }
+
+        return bucketValue
     }
 
     func signUp() async {
@@ -149,15 +153,9 @@ class AWSS3StoragePluginTestBase: XCTestCase {
         let registerFirstUserComplete = expectation(description: "register firt user completed")
         Task {
             do {
-                if useGen2Configuration {
-                    try await AuthSignInHelper.signUpUser(username: AWSS3StoragePluginTestBase.email1,
-                                                          password: AWSS3StoragePluginTestBase.password,
-                                                          email: AWSS3StoragePluginTestBase.email1)
-                } else {
-                    try await AuthSignInHelper.signUpUser(username: AWSS3StoragePluginTestBase.user1,
-                                                          password: AWSS3StoragePluginTestBase.password,
-                                                          email: AWSS3StoragePluginTestBase.email1)
-                }
+                try await AuthSignInHelper.signUpUser(username: AWSS3StoragePluginTestBase.user1,
+                                                      password: AWSS3StoragePluginTestBase.password,
+                                                      email: AWSS3StoragePluginTestBase.email1)
                 Self.isFirstUserSignedUp = true
                 registerFirstUserComplete.fulfill()
             } catch {
@@ -169,15 +167,9 @@ class AWSS3StoragePluginTestBase: XCTestCase {
         let registerSecondUserComplete = expectation(description: "register second user completed")
         Task {
             do {
-                if useGen2Configuration {
-                    try await AuthSignInHelper.signUpUser(username: AWSS3StoragePluginTestBase.email2,
-                                                          password: AWSS3StoragePluginTestBase.password,
-                                                          email: AWSS3StoragePluginTestBase.email2)
-                } else {
-                    try await AuthSignInHelper.signUpUser(username: AWSS3StoragePluginTestBase.user2,
-                                                          password: AWSS3StoragePluginTestBase.password,
-                                                          email: AWSS3StoragePluginTestBase.email2)
-                }
+                try await AuthSignInHelper.signUpUser(username: AWSS3StoragePluginTestBase.user2,
+                                                      password: AWSS3StoragePluginTestBase.password,
+                                                      email: AWSS3StoragePluginTestBase.email2)
                 Self.isSecondUserSignedUp = true
                 registerSecondUserComplete.fulfill()
             } catch {

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginUploadMetadataTestCase.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginUploadMetadataTestCase.swift
@@ -240,7 +240,7 @@ class AWSS3StoragePluginUploadMetadataTestCase: AWSS3StoragePluginTestBase {
         let s3Client = storagePlugin.getEscapeHatch()
         let bucket: String
         if useGen2Configuration {
-            bucket = try getBucketFromConfig(
+            bucket = try getBucketFromAmplifyOutputs(
                 forResource: "amplify_outputs"
             )
         } else {

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/README.md
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/README.md
@@ -115,18 +115,18 @@ At the time this was written, it follows the steps from here https://docs.amplif
 {
   ...
   "devDependencies": {
-    "@aws-amplify/backend": "^0.13.0-beta.14",
-    "@aws-amplify/backend-cli": "^0.12.0-beta.16",
-    "aws-cdk": "^2.134.0",
-    "aws-cdk-lib": "^2.134.0",
+    "@aws-amplify/backend": "^0.15.0",
+    "@aws-amplify/backend-cli": "^0.15.0",
+    "aws-cdk": "^2.139.0",
+    "aws-cdk-lib": "^2.139.0",
     "constructs": "^10.3.0",
     "esbuild": "^0.20.2",
-    "tsx": "^4.7.1",
-    "typescript": "^5.4.3"
+    "tsx": "^4.7.3",
+    "typescript": "^5.4.5"
   },
   "dependencies": {
-    "aws-amplify": "^6.0.25"
-  }
+    "aws-amplify": "^6.2.0"
+  },
 }
 
 
@@ -241,5 +241,5 @@ If you want to be able utilize Git commits for deployments
 10. Generate the `amplify_outputs.json` configuration file
 
 ```
-npx amplify generate config --branch main --app-id [APP_ID] --profile [AWS_PROFILE] --config-version 1
+npx amplify generate outputs --branch main --app-id [APP_ID] --profile [AWS_PROFILE] --config-version 1
 ```


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
This mostly reverts some changes that were applied in the original config PR https://github.com/aws-amplify/amplify-swift/pull/3567

The provisioning steps were updated to use username as the username rather than email. So the test code that pivot on username or email is no longer needed (code that was added during the config PR). The same code works with both Gen1 and Gen2 provisioned backends.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
