### PR TITLE
fix(datastore): memory leak in ModelSyncedEventEmitter

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
@@ -65,7 +65,7 @@ final class ModelSyncedEventEmitter {
         self.syncOrchestratorSink = initialSyncOrchestrator?
             .publisher
             .receive(on: queue)
-            .filter{ [weak self] in self?.filterSyncOperationEvent($0) == true }
+            .filter { [weak self] in self?.filterSyncOperationEvent($0) == true }
             .sink(receiveCompletion: { _ in },
                   receiveValue: { [weak self] value in
                     self?.onReceiveSyncOperationEvent(value: value)
@@ -74,7 +74,7 @@ final class ModelSyncedEventEmitter {
         self.reconciliationQueueSink = reconciliationQueue?
             .publisher
             .receive(on: queue)
-            .filter{ [weak self] in self?.filterReconciliationQueueEvent($0) == true }
+            .filter { [weak self] in self?.filterReconciliationQueueEvent($0) == true }
             .sink(receiveCompletion: { _ in },
                   receiveValue: { [weak self] value in
                     self?.onReceiveReconciliationEvent(value: value)

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/ModelSyncedEventEmitter.swift
@@ -65,7 +65,7 @@ final class ModelSyncedEventEmitter {
         self.syncOrchestratorSink = initialSyncOrchestrator?
             .publisher
             .receive(on: queue)
-            .filter(filterSyncOperationEvent(_:))
+            .filter{ [weak self] in self?.filterSyncOperationEvent($0) == true }
             .sink(receiveCompletion: { _ in },
                   receiveValue: { [weak self] value in
                     self?.onReceiveSyncOperationEvent(value: value)
@@ -74,7 +74,7 @@ final class ModelSyncedEventEmitter {
         self.reconciliationQueueSink = reconciliationQueue?
             .publisher
             .receive(on: queue)
-            .filter(filterReconciliationQueueEvent(_:))
+            .filter{ [weak self] in self?.filterReconciliationQueueEvent($0) == true }
             .sink(receiveCompletion: { _ in },
                   receiveValue: { [weak self] value in
                     self?.onReceiveReconciliationEvent(value: value)


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
#3510 

## Description
<!-- Why is this change required? What problem does it solve? -->
- capturing `self` with weak reference in filter operator.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
