### PR TITLE
chore: fixing coverage token not accessible on releases [skip ci]

### DIFF
--- a/.github/workflows/deploy_package.yml
+++ b/.github/workflows/deploy_package.yml
@@ -25,6 +25,7 @@ jobs:
     uses: ./.github/workflows/unit_test.yml
     with:
       identifier: 'workflow-call-unit-test'
+    secrets: inherit
 
   fortify:
     name: Run Fortify Scan

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -21,6 +21,7 @@ jobs:
     uses: ./.github/workflows/unit_test.yml
     with:
       identifier: 'workflow-call-unit-test'
+    secrets: inherit
 
   fortify:
     name: Run Fortify Scan

--- a/.github/workflows/deploy_unstable.yml
+++ b/.github/workflows/deploy_unstable.yml
@@ -21,6 +21,7 @@ jobs:
     uses: ./.github/workflows/unit_test.yml
     with:
       identifier: 'workflow-call-unit-test'
+    secrets: inherit
 
   fortify:
     name: Run Fortify Scan


### PR DESCRIPTION
## Description
Reusable workflows don't have access to secrets unless they are explicitly inherited, which caused the coverage during release workflows to not work.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
