### PR TITLE
test(logging): gen2 integ tests

### DIFF
--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginHostApp/AWSCloudWatchLoggingPluginIntegrationTests/AWSCloudWatchLoggingPluginGen2IntegrationTests.xctestplan
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginHostApp/AWSCloudWatchLoggingPluginIntegrationTests/AWSCloudWatchLoggingPluginGen2IntegrationTests.xctestplan
@@ -17,11 +17,6 @@
   },
   "testTargets" : [
     {
-      "skippedTests" : [
-        "AWSCloudWatchLoggingPluginIntergrationTests\/testFlushLogWithMessages()",
-        "AWSCloudWatchLoggingPluginIntergrationTests\/testFlushLogWithVerboseMessageAfterDisablingPlugin()",
-        "AWSCloudWatchLoggingPluginIntergrationTests\/testFlushLogWithVerboseMessageAfterEnablingPlugin()"
-      ],
       "target" : {
         "containerPath" : "container:CloudWatchLoggingHostApp.xcodeproj",
         "identifier" : "21F762DF2BD6B55F0048845A",

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginHostApp/AWSCloudWatchLoggingPluginIntegrationTests/AWSCloudWatchLoggingPluginIntegrationTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginHostApp/AWSCloudWatchLoggingPluginIntegrationTests/AWSCloudWatchLoggingPluginIntegrationTests.swift
@@ -15,11 +15,11 @@ class AWSCloudWatchLoggingPluginIntergrationTests: XCTestCase {
     let amplifyConfigurationFile = "testconfiguration/AWSCloudWatchLoggingPluginIntegrationTests-amplifyconfiguration"
     let amplifyOutputsFile = "testconfiguration/AWSCloudWatchLoggingPluginIntegrationTests-amplify_outputs"
     #if os(tvOS)
-    let amplifyConfigurationLoggingFile = "testconfiguration/AWSCloudWatchLoggingPluginIntegrationTests-amplifyconfiguration_logging_tvOS"
+    var amplifyConfigurationLoggingFile = "testconfiguration/AWSCloudWatchLoggingPluginIntegrationTests-amplifyconfiguration_logging_tvOS"
     #elseif os(watchOS)
-    let amplifyConfigurationLoggingFile = "testconfiguration/AWSCloudWatchLoggingPluginIntegrationTests-amplifyconfiguration_logging_watchOS"
+    var amplifyConfigurationLoggingFile = "testconfiguration/AWSCloudWatchLoggingPluginIntegrationTests-amplifyconfiguration_logging_watchOS"
     #else
-    let amplifyConfigurationLoggingFile = "testconfiguration/AWSCloudWatchLoggingPluginIntegrationTests-amplifyconfiguration_logging"
+    var amplifyConfigurationLoggingFile = "testconfiguration/AWSCloudWatchLoggingPluginIntegrationTests-amplifyconfiguration_logging"
     #endif
     var loggingConfiguration: AWSCloudWatchLoggingPluginConfiguration?
     
@@ -31,6 +31,11 @@ class AWSCloudWatchLoggingPluginIntergrationTests: XCTestCase {
         continueAfterFailure = false
         do {
             try Amplify.add(plugin: AWSCognitoAuthPlugin())
+
+            if useGen2Configuration {
+                amplifyConfigurationLoggingFile += "_gen2"
+            }
+
             let loggingConfigurationFile = try TestConfigHelper.retrieveLoggingConfiguration(forResource: amplifyConfigurationLoggingFile)
             loggingConfiguration = try AWSCloudWatchLoggingPluginConfiguration.loadConfiguration(from: loggingConfigurationFile)
             let loggingPlugin = AWSCloudWatchLoggingPlugin(loggingPluginConfiguration: loggingConfiguration)

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginHostApp/AWSCloudWatchLoggingPluginIntegrationTests/README.md
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginHostApp/AWSCloudWatchLoggingPluginIntegrationTests/README.md
@@ -10,9 +10,31 @@ The following steps demonstrate how to set up Logging. Auth category is also req
 
 2. Copy `amplifyconfiguration.json` to a new file named `AWSCloudWatchLoggingPluginIntegrationTests-amplifyconfiguration.json` inside `~/.aws-amplify/amplify-ios/testconfiguration/`.
 
+```
+cp amplifyconfiguration.json ~/.aws-amplify/amplify-ios/testconfiguration/AWSCloudWatchLoggingPluginIntegrationTests-amplifyconfiguration.json
+```
+
 3. Configure the `amplifyconfiguration-logging.json` file (https://docs.amplify.aws/swift/build-a-backend/more-features/logging/set-up-logging/#initialize-amplify-logging)
 
-4. Copy `amplifyconfiguration-logging.json` to a new file named `AWSCloudWatchLoggingPluginIntegrationTests-amplifyconfiguration-logging.json` inside `~/.aws-amplify/amplify-ios/testconfiguration/`.
+```json
+{
+    "awsCloudWatchLoggingPlugin": {
+        "enable": true,
+        "logGroupName": "<log-group-name>",
+        "region": "<region>",
+        "localStoreMaxSizeInMB": 1,
+        "flushIntervalInSeconds": 60,
+        "loggingConstraints": {
+            "defaultLogLevel": "VERBOSE"
+        }
+    }
+}
+```
+4. Copy `amplifyconfiguration_logging.json` to a new file named `AWSCloudWatchLoggingPluginIntegrationTests-amplifyconfiguration_logging.json` inside `~/.aws-amplify/amplify-ios/testconfiguration/`.
+
+```
+cp amplifyconfiguration_logging.json ~/.aws-amplify/amplify-ios/testconfiguration/AWSCloudWatchLoggingPluginIntegrationTests-amplifyconfiguration_logging.json
+```
 
 5. You can now run all of the integration tests. 
 
@@ -30,17 +52,17 @@ At the time this was written, it follows the steps from here https://docs.amplif
 {
   ...
   "devDependencies": {
-    "@aws-amplify/backend": "^0.13.0-beta.14",
-    "@aws-amplify/backend-cli": "^0.12.0-beta.16",
-    "aws-cdk": "^2.134.0",
-    "aws-cdk-lib": "^2.134.0",
+    "@aws-amplify/backend": "^0.15.0",
+    "@aws-amplify/backend-cli": "^0.15.0",
+    "aws-cdk": "^2.139.0",
+    "aws-cdk-lib": "^2.139.0",
     "constructs": "^10.3.0",
     "esbuild": "^0.20.2",
-    "tsx": "^4.7.1",
-    "typescript": "^5.4.3"
+    "tsx": "^4.7.3",
+    "typescript": "^5.4.5"
   },
   "dependencies": {
-    "aws-amplify": "^6.0.25"
+    "aws-amplify": "^6.2.0"
   }
 }
 
@@ -58,53 +80,131 @@ import { defineAuth, defineFunction } from '@aws-amplify/backend';
 export const auth = defineAuth({
   loginWith: {
     email: true
-  },
-  triggers: {
-    // configure a trigger to point to a function definition
-    preSignUp: defineFunction({
-      entry: './pre-sign-up-handler.ts'
-    })
   }
 });
 
 ```
 
+3. Create `amplify/custom/RemoteLoggingConstraintsConstruct.resource.ts` and add the following
+
 ```ts
-import type { PreSignUpTriggerHandler } from 'aws-lambda';
+import * as cdk from "aws-cdk-lib"
+import { Construct } from "constructs"
+import * as logs from "aws-cdk-lib/aws-logs"
+import * as iam from "aws-cdk-lib/aws-iam"
 
-export const handler: PreSignUpTriggerHandler = async (event) => {
-  // your code here
-  event.response.autoConfirmUser = true
-  return event;
-};
+export class RemoteLoggingConstraintsConstruct extends Construct {
+  constructor(scope: Construct, id: string, authRoleName: string, unAuthRoleName: string) {
+    super(scope, id)
+
+    const region = cdk.Stack.of(this).region
+    const account = cdk.Stack.of(this).account
+    const logGroupName = "<log-group-name>"
+    
+    new logs.LogGroup(this, 'Log Group', {
+      logGroupName: logGroupName,
+      retention: logs.RetentionDays.INFINITE
+    })
+
+    const authRole = iam.Role.fromRoleName(this, "Auth-Role", authRoleName)
+    const unAuthRole = iam.Role.fromRoleName(this, "UnAuth-Role", unAuthRoleName)
+    const logResource = `arn:aws:logs:${region}:${account}:log-group:${logGroupName}:log-stream:*`
+    const logIAMPolicy = new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      resources: [logResource],
+      actions: ["logs:PutLogEvents", "logs:DescribeLogStreams", "logs:CreateLogStream", "logs:FilterLogEvents"]
+    })
+
+    authRole.addToPrincipalPolicy(logIAMPolicy)
+    unAuthRole.addToPrincipalPolicy(logIAMPolicy)
+
+    new cdk.CfnOutput(this, 'CloudWatchLogGroupName', { value: logGroupName });
+    new cdk.CfnOutput(this, 'CloudWatchRegion', { value: region });
+  }
+}
 ```
 
-3. Commit and push the files to a git repository.
+Update `backend.ts`.
 
-4. Navigate to the AWS Amplify console (https://us-east-1.console.aws.amazon.com/amplify/home?region=us-east-1#/)
+```ts
+import { defineBackend } from '@aws-amplify/backend';
+import { auth } from './auth/resource';
+import { RemoteLoggingConstraintsConstruct } from './custom/RemoteLoggingConstraintsConstruct/resource';
 
-5. Click on "Try Amplify Gen 2" button.
+const backend = defineBackend({
+  auth
+});
 
-6. Choose "Option 2: Start with an existing app", and choose Github, and press Next.
+// Auth - sign in with username
+const { cfnUserPool } = backend.auth.resources.cfnResources
+cfnUserPool.usernameAttributes = []
 
-7. Find the repository and branch, and click Next
+// ============ Logging Stack ===========
 
-8. Click "Save and deploy" and wait for deployment to finish.  
-
-9. Generate the `amplify_outputs.json` configuration file
+const loggingConstruct = new RemoteLoggingConstraintsConstruct(
+  backend.createStack('logging-stack'),
+  'logging-stack',
+  backend.auth.resources.authenticatedUserIamRole.roleName,
+  backend.auth.resources.unauthenticatedUserIamRole.roleName
+);
 
 ```
-npx amplify generate config --branch main --app-id [APP_ID] --profile [AWS_PROFILE] --config-version 1
+
+4. Deploy the backend with npx amplify sandbox
+
+For example, this deploys to a sandbox env and generates the amplify_outputs.json file.
+
+```
+npx amplify sandbox --config-out-dir ./config --profile [PROFILE]
 ```
 
-10. Copy the `amplify_outputs.json` file over to the test directory as `AWSCloudWatchLoggingPluginIntegrationTests-amplify_outputs.json`. The tests will automatically pick this file up. Create the directories in this path first if it currently doesn't exist.
+5. Copy `amplify_outputs.json` to a new file named `AWSCloudWatchLoggingPluginIntegrationTests-amplify_outputs.json` inside `~/.aws-amplify/amplify-ios/testconfiguration/`.
 
 ```
 cp amplify_outputs.json ~/.aws-amplify/amplify-ios/testconfiguration/AWSCloudWatchLoggingPluginIntegrationTests-amplify_outputs.json
 ```
 
-11. Configure the `amplifyconfiguration-logging.json` file (https://docs.amplify.aws/swift/build-a-backend/more-features/logging/set-up-logging/#initialize-amplify-logging)
+6. Configure the `amplifyconfiguration_logging_gen2.json` file (https://docs.amplify.aws/swift/build-a-backend/add-aws-services/logging/set-up-logging/#initialize-amplify-logging)
 
-12. Copy `amplifyconfiguration-logging.json` to a new file named `AWSCloudWatchLoggingPluginIntegrationTests-amplifyconfiguration-logging.json` inside `~/.aws-amplify/amplify-ios/testconfiguration/`.
+```json
+{
+    "awsCloudWatchLoggingPlugin": {
+        "enable": true,
+        "logGroupName": "<log-group-name>",
+        "region": "<region>",
+        "localStoreMaxSizeInMB": 1,
+        "flushIntervalInSeconds": 60,
+        "loggingConstraints": {
+            "defaultLogLevel": "VERBOSE"
+        }
+    }
+}
+```
 
-13. You can now run all of the integration tests. 
+7. Copy `amplifyconfiguration_logging_gen2.json` to a new file named `AWSCloudWatchLoggingPluginIntegrationTests-amplifyconfiguration_logging_gen2.json` inside `~/.aws-amplify/amplify-ios/testconfiguration/`.
+
+```
+cp amplifyconfiguration_logging_gen2.json ~/.aws-amplify/amplify-ios/testconfiguration/AWSCloudWatchLoggingPluginIntegrationTests-amplifyconfiguration_logging_gen2.json
+```
+
+### Deploying from a branch (Optional)
+
+If you want to be able utilize Git commits for deployments
+
+1. Commit and push the files to a git repository.
+
+2. Navigate to the AWS Amplify console (https://us-east-1.console.aws.amazon.com/amplify/home?region=us-east-1#/)
+
+3. Click on "Try Amplify Gen 2" button.
+
+4. Choose "Option 2: Start with an existing app", and choose Github, and press Next.
+
+5. Find the repository and branch, and click Next
+
+6. Click "Save and deploy" and wait for deployment to finish.  
+
+7. Generate the `amplify_outputs.json` configuration file
+
+```
+npx amplify generate outputs --branch main --app-id [APP_ID] --profile [AWS_PROFILE]
+```


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
- Add example of the logging config file (default to Verbose log level for the test to pass)
- Add CDK code of the provisioning for Gen2 backend
- fix configuration file naming and enable the rest of the logging integ tests

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
