### PR TITLE
chore: require admin approval for codeowners and CI/CD versions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,8 @@
-* @aws-amplify/amplify-ios 
+# Amplify iOS / Swift team has general approval permissions.
+* @aws-amplify/amplify-ios
+
+# Changes to this file requires admin approval.
+/.github/CODEOWNERS @aws-amplify/amplify-ios-admins
+
+# Changes to Xcode / OS runtime versions run in CI/CD requires admin approval.
+/.github/composite_actions/get_platform_parameters/action.yml @aws-amplify/amplify-ios-admins


### PR DESCRIPTION
## Issue \#
N/A

## Description
- Updates CODEOWNERS file to require admin approval for changing CODEOWNERS file (`/.github/CODEOWNERS`).
- Updates CODEOWNERS file to require admin approval for changing Xcode / OS runtime versions in CI/CD (`/.github/composite_actions/get_platform_parameters/action.yml`).

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] ~Added new tests to cover change, if needed~
- [ ] ~Build succeeds with all target using Swift Package Manager~
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style
- [ ] ~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~
- [ ] ~If breaking change, documentation/changelog update with migration instructions~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
