### PR TITLE
test(auth): fix Gen1 hostedUI textfield check

### DIFF
--- a/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIAppUITests/Screen/SignInScreen.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIAppUITests/Screen/SignInScreen.swift
@@ -11,6 +11,10 @@ struct SignInScreen: Screen {
 
     let app: XCUIApplication
 
+    var useGen2Configuration: Bool {
+        ProcessInfo.processInfo.arguments.contains("GEN2")
+    }
+
     private enum Identifiers {
         static let signUpNav = "hostedUI_signUp_view_nav"
         static let signInButton = "hostedUI_signIn_button"
@@ -45,10 +49,24 @@ struct SignInScreen: Screen {
         return self
     }
 
+
     func signIn(username: String, password: String) -> Self {
-        _ = app.webViews.textFields["Email Email"].waitForExistence(timeout: 60)
-        app.webViews.textFields["Email Email"].tap()
-        app.webViews.textFields["Email Email"].typeText(username)
+        let signInTextFieldName: String
+        // Ideally we align the provisioning of Gen1 and Gen2 backends
+        // to create a HostedUI endpoint that has the same username text field.
+        // The Gen1 steps are updated in the README already, we re-provision the backend
+        // in Gen1 according to those steps, this check can be removed and expect
+        // "Email Email" to be the text field.
+        if useGen2Configuration {
+            signInTextFieldName = "Email Email"
+        } else {
+            signInTextFieldName = "Username"
+        }
+
+        _ = app.webViews.textFields[signInTextFieldName].waitForExistence(timeout: 60)
+        app.webViews.textFields[signInTextFieldName].tap()
+        app.webViews.textFields[signInTextFieldName].typeText(username)
+
 
         app.webViews.secureTextFields["Password"].tap()
         app.webViews.secureTextFields["Password"].typeText(password)


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
There are some differences in how the auth with hostedUI was provisioned, compared to the latest steps in the README.md. The latest Gen1 and Gen2 provisioning resulted in a HostedUI webview that has "Email" as the textfield for the username input. We can either
1. Update Gen2 provisioning steps that results in the HostedUI view with Username as the textfield (unsure of how to do this).
2. Update Gen1 provisioning steps in the README.md that results in a HostedUI view that has Email as the text field. (this was done already in the README.md). And reprovision the Gen1 backend in the integration test account to apply these changes.

Since we have not yet reprovisioned the Gen1 backend, the integration tests are failing. This PR reverts the change to check for the Email textfield only for Gen1, so that we can keep the integration tests passing, followed by reprovisioning and reverting this change at the same time.

The Auth UI Integration test with these changes: https://github.com/aws-amplify/amplify-swift/actions/runs/9008090058/job/24749356913

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
