### PR TITLE
fix(API): pass authMode used for lazy loading functionality

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListDecoder.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListDecoder.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Amplify
+import AWSPluginsCore
 
 /// This decoder is registered and used to detect various data payloads objects to store
 /// inside an AppSyncListProvider when decoding to the Lazy `List` type as a "not yet loaded" List. If the data payload
@@ -18,6 +19,7 @@ public struct AppSyncListDecoder: ModelListDecoder {
         let appSyncAssociatedIdentifiers: [String]
         let appSyncAssociatedFields: [String]
         let apiName: String?
+        let authMode: AWSAuthorizationType?
     }
 
     /// Used by the custom decoder implemented in the `List` type to detect if the payload can be

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListPayload.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListPayload.swift
@@ -46,7 +46,7 @@ public struct AppSyncListPayload: Codable {
         // `GraphQLFilter`.
         guard let filterVariablesData = try? encoder.encode(filterValue),
               let filterVariablesJSON = try? JSONSerialization.jsonObject(with: filterVariablesData)
-                as? [String: Any] else {
+                as? GraphQLFilter else {
 
             assertionFailure("Filter variables is not a valid JSON object: \(filterValue)")
             return nil

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListPayload.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListPayload.swift
@@ -16,11 +16,14 @@ public struct AppSyncListPayload: Codable {
 
     let graphQLData: JSONValue
     let apiName: String?
+    let authMode: AWSAuthorizationType?
 
     public init(graphQLData: JSONValue,
                 apiName: String?,
+                authMode: AWSAuthorizationType?,
                 variables: [String: JSONValue]?) {
         self.apiName = apiName
+        self.authMode = authMode
         self.variables = variables
         self.graphQLData = graphQLData
     }
@@ -43,7 +46,7 @@ public struct AppSyncListPayload: Codable {
         // `GraphQLFilter`.
         guard let filterVariablesData = try? encoder.encode(filterValue),
               let filterVariablesJSON = try? JSONSerialization.jsonObject(with: filterVariablesData)
-                as? GraphQLFilter else {
+                as? [String: Any] else {
 
             assertionFailure("Filter variables is not a valid JSON object: \(filterValue)")
             return nil

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListResponse.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListResponse.swift
@@ -7,6 +7,7 @@
 
 import Amplify
 import Foundation
+import AWSPluginsCore
 
 /// Resembles the AppSync's GraphQL response for a list operation.
 struct AppSyncListResponse<Element: Model>: Codable {
@@ -25,10 +26,14 @@ extension AppSyncListResponse {
     /// model metadata on its array associations.
     static func initWithMetadata(type: Element.Type,
                                  graphQLData: JSONValue,
-                                 apiName: String?) throws -> AppSyncListResponse<Element> {
+                                 apiName: String?,
+                                 authMode: AWSAuthorizationType?) throws -> AppSyncListResponse<Element> {
         var elements = [Element]()
         if case let .array(jsonArray) = graphQLData["items"] {
-            let jsonArrayWithMetadata = AppSyncModelMetadataUtils.addMetadata(toModelArray: jsonArray, apiName: apiName)
+            let jsonArrayWithMetadata = AppSyncModelMetadataUtils.addMetadata(
+                toModelArray: jsonArray,
+                apiName: apiName,
+                authMode: authMode)
 
             let encoder = JSONEncoder()
             encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncModelDecoder.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncModelDecoder.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Amplify
+import AWSPluginsCore
 
 /// This decoder is registered and used to detect various data payloads to store
 /// inside an `AppSyncModelProvider` when decoding to the `LazyReference` as a "not yet loaded" Reference. If the data payload
@@ -17,11 +18,16 @@ public struct AppSyncModelDecoder: ModelProviderDecoder {
     struct Metadata: Codable {
         let identifiers: [LazyReferenceIdentifier]
         let apiName: String?
+        let authMode: AWSAuthorizationType?
         let source: String
 
-        init(identifiers: [LazyReferenceIdentifier], apiName: String?, source: String = ModelProviderRegistry.DecoderSource.appSync) {
+        init(identifiers: [LazyReferenceIdentifier],
+             apiName: String?,
+             authMode: AWSAuthorizationType?,
+             source: String = ModelProviderRegistry.DecoderSource.appSync) {
             self.identifiers = identifiers
             self.apiName = apiName
+            self.authMode = authMode
             self.source = source
         }
     }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncModelMetadata.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncModelMetadata.swift
@@ -7,6 +7,7 @@
 
 import Amplify
 import Foundation
+import AWSPluginsCore
 
 /// Holds the methods to traverse and maniupulate the response data object by injecting
 public struct AppSyncModelMetadataUtils {
@@ -25,15 +26,17 @@ public struct AppSyncModelMetadataUtils {
     }
 
     static func addMetadata(toModelArray graphQLDataArray: [JSONValue],
-                            apiName: String?) -> [JSONValue] {
+                            apiName: String?,
+                            authMode: AWSAuthorizationType?) -> [JSONValue] {
         return graphQLDataArray.map { (graphQLData) -> JSONValue in
-            addMetadata(toModel: graphQLData, apiName: apiName)
+            addMetadata(toModel: graphQLData, apiName: apiName, authMode: authMode)
         }
     }
 
     static func addMetadata(
         toModel graphQLData: JSONValue,
         apiName: String?,
+        authMode: AWSAuthorizationType?,
         source: String = ModelProviderRegistry.DecoderSource.appSync) -> JSONValue {
             
         guard case var .object(modelJSON) = graphQLData else {
@@ -89,6 +92,7 @@ public struct AppSyncModelMetadataUtils {
                 if let modelIdentifierMetadata = createModelIdentifierMetadata(associatedModelType,
                                                                                modelObject: modelObject,
                                                                                apiName: apiName,
+                                                                               authMode: authMode,
                                                                                source: source) {
                     if let serializedMetadata = try? encoder.encode(modelIdentifierMetadata),
                        let metadataJSON = try? decoder.decode(JSONValue.self, from: serializedMetadata) {
@@ -104,7 +108,9 @@ public struct AppSyncModelMetadataUtils {
                 // add metadata to its fields, to create not loaded LazyReference objects
                 // only if the model type allowsfor lazy loading functionality
                 else if associatedModelType.rootPath != nil {
-                    let nestedModelWithMetadata = addMetadata(toModel: nestedModelJSON, apiName: apiName)
+                    let nestedModelWithMetadata = addMetadata(toModel: nestedModelJSON, 
+                                                              apiName: apiName, 
+                                                              authMode: authMode)
                     modelJSON.updateValue(nestedModelWithMetadata, forKey: modelField.name)
                 }
                 // otherwise do nothing to the data.
@@ -120,7 +126,8 @@ public struct AppSyncModelMetadataUtils {
                 if modelJSON[modelField.name] == nil {
                     let appSyncModelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: identifiers,
                                                                            appSyncAssociatedFields: modelField.associatedFieldNames,
-                                                                           apiName: apiName)
+                                                                           apiName: apiName, 
+                                                                           authMode: authMode)
                     if let serializedMetadata = try? encoder.encode(appSyncModelMetadata),
                        let metadataJSON = try? decoder.decode(JSONValue.self, from: serializedMetadata) {
                         log.verbose("Adding [\(modelField.name): \(metadataJSON)]")
@@ -141,13 +148,16 @@ public struct AppSyncModelMetadataUtils {
                    associatedModelType.rootPath != nil {
 
                     for (index, item) in graphQLDataArray.enumerated() {
-                        let modelJSON = AppSyncModelMetadataUtils.addMetadata(toModel: item, apiName: apiName)
+                        let modelJSON = AppSyncModelMetadataUtils.addMetadata(toModel: item, 
+                                                                              apiName: apiName,
+                                                                              authMode: authMode)
                         graphQLDataArray[index] = modelJSON
                     }
 
                     graphQLDataObject["items"] = JSONValue.array(graphQLDataArray)
                     let payload = AppSyncListPayload(graphQLData: JSONValue.object(graphQLDataObject),
                                                      apiName: apiName,
+                                                     authMode: authMode,
                                                      variables: nil)
 
                     if let serializedPayload = try? encoder.encode(payload),
@@ -171,6 +181,7 @@ public struct AppSyncModelMetadataUtils {
     static func createModelIdentifierMetadata(_ associatedModel: Model.Type,
                                               modelObject: [String: JSONValue],
                                               apiName: String?,
+                                              authMode: AWSAuthorizationType?,
                                               source: String) -> AppSyncModelDecoder.Metadata? {
         let primarykeys = associatedModel.schema.primaryKey
         var identifiers = [LazyReferenceIdentifier]()
@@ -188,6 +199,7 @@ public struct AppSyncModelMetadataUtils {
             return AppSyncModelDecoder.Metadata(
                 identifiers: identifiers,
                 apiName: apiName,
+                authMode: authMode,
                 source: source)
         } else {
             return nil

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncModelProvider.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncModelProvider.swift
@@ -12,6 +12,7 @@ import AWSPluginsCore
 public class AppSyncModelProvider<ModelType: Model>: ModelProvider {
 
     let apiName: String?
+    let authMode: AWSAuthorizationType?
     let source: String
     var loadedState: ModelProviderState<ModelType>
 
@@ -20,12 +21,14 @@ public class AppSyncModelProvider<ModelType: Model>: ModelProvider {
         self.loadedState = .notLoaded(identifiers: metadata.identifiers)
         self.apiName = metadata.apiName
         self.source = metadata.source
+        self.authMode = metadata.authMode
     }
 
     // Creates a "loaded" provider
     init(model: ModelType?) {
         self.loadedState = .loaded(model: model)
         self.apiName = nil
+        self.authMode = nil
         self.source = ModelProviderRegistry.DecoderSource.appSync
     }
 
@@ -41,7 +44,8 @@ public class AppSyncModelProvider<ModelType: Model>: ModelProvider {
             }
             let request = GraphQLRequest<ModelType?>.getRequest(ModelType.self,
                                                                 byIdentifiers: identifiers,
-                                                                apiName: apiName)
+                                                                apiName: apiName, 
+                                                                authMode: authMode)
             log.verbose("Loading \(ModelType.modelName) with \(identifiers)")
             let graphQLResponse = try await Amplify.API.query(request: request)
             switch graphQLResponse {
@@ -67,6 +71,7 @@ public class AppSyncModelProvider<ModelType: Model>: ModelProvider {
             let metadata = AppSyncModelDecoder.Metadata(
                 identifiers: identifiers ?? [],
                 apiName: apiName,
+                authMode: authMode,
                 source: source)
             try metadata.encode(to: encoder)
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Decode/GraphQLResponseDecoder+DecodeData.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Decode/GraphQLResponseDecoder+DecodeData.swift
@@ -52,22 +52,26 @@ extension GraphQLResponseDecoder {
                     modelJSON = AppSyncModelMetadataUtils.addMetadata(
                         toModel: item,
                         apiName: request.apiName,
+                        authMode: request.authMode as? AWSAuthorizationType,
                         source: ModelProviderRegistry.DecoderSource.dataStore)
                 } else {
                     modelJSON = AppSyncModelMetadataUtils.addMetadata(
                         toModel: item,
-                        apiName: request.apiName)
+                        apiName: request.apiName,
+                        authMode: request.authMode as? AWSAuthorizationType)
                 }
                 graphQLDataArray[index] = modelJSON
             }
             graphQLDataObject["items"] = JSONValue.array(graphQLDataArray)
             let payload = AppSyncListPayload(graphQLData: JSONValue.object(graphQLDataObject),
                                              apiName: request.apiName,
+                                             authMode: request.authMode as? AWSAuthorizationType,
                                              variables: try getVariablesJSON())
             serializedJSON = try encoder.encode(payload)
         } else if AppSyncModelMetadataUtils.shouldAddMetadata(toModel: graphQLData) { // 4
             let modelJSON = AppSyncModelMetadataUtils.addMetadata(toModel: graphQLData,
-                                                                  apiName: request.apiName)
+                                                                  apiName: request.apiName,
+                                                                  authMode: request.authMode as? AWSAuthorizationType)
             serializedJSON = try encoder.encode(modelJSON)
         } else { // 5
             serializedJSON = try encoder.encode(graphQLData)

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/GraphQLRequest+toListQuery.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Support/Utils/GraphQLRequest+toListQuery.swift
@@ -16,7 +16,8 @@ extension GraphQLRequest {
                                                    filter: [String: Any]? = nil,
                                                    limit: Int? = nil,
                                                    nextToken: String? = nil,
-                                                   apiName: String? = nil) -> GraphQLRequest<ResponseType> {
+                                                   apiName: String? = nil,
+                                                   authMode: AWSAuthorizationType?) -> GraphQLRequest<ResponseType> {
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelSchema,
                                                                operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))
@@ -29,12 +30,14 @@ extension GraphQLRequest {
                                             document: document.stringValue,
                                             variables: document.variables,
                                             responseType: responseType.self,
-                                            decodePath: document.name)
+                                            decodePath: document.name,
+                                            authMode: authMode)
     }
 
     static func getRequest<M: Model>(_ modelType: M.Type,
                                      byIdentifiers identifiers: [LazyReferenceIdentifier],
-                                     apiName: String?) -> GraphQLRequest<M?> {
+                                     apiName: String?,
+                                     authMode: AWSAuthorizationType?) -> GraphQLRequest<M?> {
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
                                                                operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
@@ -46,6 +49,7 @@ extension GraphQLRequest {
                                   document: document.stringValue,
                                   variables: document.variables,
                                   responseType: M?.self,
-                                  decodePath: document.name)
+                                  decodePath: document.name,
+                                  authMode: authMode)
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListDecoderTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListDecoderTests.swift
@@ -42,7 +42,7 @@ class AppSyncListDecoderTests: XCTestCase {
             ],
             "nextToken": "nextToken"
         ]
-        let appSyncPayload = AppSyncListPayload(graphQLData: json, apiName: nil, variables: nil)
+        let appSyncPayload = AppSyncListPayload(graphQLData: json, apiName: nil, authMode: nil, variables: nil)
         let data = try encoder.encode(appSyncPayload)
 
         let harness = try decoder.decode(AppSyncListDecoderHarness<Post4>.self, from: data)
@@ -70,7 +70,7 @@ class AppSyncListDecoderTests: XCTestCase {
             ],
             "nextToken": "nextToken"
         ]
-        let appSyncPayload = AppSyncListPayload(graphQLData: json, apiName: nil, variables: nil)
+        let appSyncPayload = AppSyncListPayload(graphQLData: json, apiName: nil, authMode: nil, variables: nil)
         let data = try encoder.encode(appSyncPayload)
         let result = try decoder.decode(AppSyncListDecoderHarness<Post4>.self, from: data)
         XCTAssertNil(result.listProvider)
@@ -79,7 +79,8 @@ class AppSyncListDecoderTests: XCTestCase {
     func testShouldDecodeFromModelMetadata() throws {
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
                                                         appSyncAssociatedFields: ["post"],
-                                                        apiName: "apiName")
+                                                        apiName: "apiName", 
+                                                        authMode: nil)
         let data = try encoder.encode(modelMetadata)
         let harness = try decoder.decode(AppSyncListDecoderHarness<Comment4>.self, from: data)
         XCTAssertNotNil(harness.listProvider)

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListPayloadTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListPayloadTests.swift
@@ -22,6 +22,7 @@ class AppSyncListPayloadTests: XCTestCase {
         ]
         let payload = AppSyncListPayload(graphQLData: JSONValue.null,
                                          apiName: "apiName",
+                                         authMode: nil,
                                          variables: variables)
 
         guard let limit = payload.limit else {
@@ -51,7 +52,8 @@ class AppSyncListPayloadTests: XCTestCase {
             "missingLimit": 500
         ]
         let payload = AppSyncListPayload(graphQLData: JSONValue.null,
-                                         apiName: "apiName",
+                                         apiName: "apiName", 
+                                         authMode: nil,
                                          variables: variables)
 
         XCTAssertNil(payload.graphQLFilter)
@@ -60,7 +62,8 @@ class AppSyncListPayloadTests: XCTestCase {
 
     func testRetrieveNilFilterAndLimit_MissingVariables() {
         let payload = AppSyncListPayload(graphQLData: JSONValue.null,
-                                         apiName: "apiName",
+                                         apiName: "apiName", 
+                                         authMode: nil,
                                          variables: nil)
 
         XCTAssertNil(payload.graphQLFilter)

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListProviderPaginationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListProviderPaginationTests.swift
@@ -36,7 +36,8 @@ extension AppSyncListProviderTests {
     func testNotLoadedStateHasNextPageFalse() {
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
                                                         appSyncAssociatedFields: ["post"],
-                                                        apiName: "apiName")
+                                                        apiName: "apiName", 
+                                                        authMode: nil)
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
@@ -109,13 +110,16 @@ extension AppSyncListProviderTests {
 
     func testLoadedStateGetNextPageFailure_GraphQLErrorResponse() async {
         mockAPIPlugin.responders[.queryRequestResponse] =
-            QueryRequestResponder<List<Comment4>> { _ in
+            QueryRequestResponder<List<Comment4>> { request in
+
+                XCTAssertEqual(request.apiName, "apiName")
+                XCTAssertEqual(request.authMode as? AWSAuthorizationType, .amazonCognitoUserPools)
                 let event: GraphQLOperation<List<Comment4>>.OperationResult = .success(
                     .failure(GraphQLResponseError.error([GraphQLError]())))
                 return event
         }
         let elements = [Comment4(content: "content")]
-        let provider = AppSyncListProvider(elements: elements, nextToken: "nextToken")
+        let provider = AppSyncListProvider(elements: elements, nextToken: "nextToken", apiName: "apiName", authMode: .amazonCognitoUserPools)
         guard case .loaded = provider.loadedState else {
             XCTFail("Should be loaded")
             return
@@ -138,7 +142,8 @@ extension AppSyncListProviderTests {
     func testNotLoadedStateGetNextPageFailure() async {
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
                                                         appSyncAssociatedFields: ["post"],
-                                                        apiName: "apiName")
+                                                        apiName: "apiName", 
+                                                        authMode: nil)
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListProviderTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListProviderTests.swift
@@ -59,7 +59,10 @@ class AppSyncListProviderTests: XCTestCase {
             ],
             "limit": 500
         ]
-        let appSyncPayload = AppSyncListPayload(graphQLData: json, apiName: "apiName", variables: variables)
+        let appSyncPayload = AppSyncListPayload(graphQLData: json, 
+                                                apiName: "apiName", 
+                                                authMode: nil,
+                                                variables: variables)
         let provider = try AppSyncListProvider<Post4>(payload: appSyncPayload)
         guard case .loaded(let elements, let nextToken, let filter) = provider.loadedState else {
             XCTFail("Should be in loaded state")
@@ -82,7 +85,10 @@ class AppSyncListProviderTests: XCTestCase {
             ],
             "nextToken": "nextToken"
         ]
-        let appSyncPayload = AppSyncListPayload(graphQLData: json, apiName: nil, variables: nil)
+        let appSyncPayload = AppSyncListPayload(graphQLData: json, 
+                                                apiName: nil, 
+                                                authMode: nil,
+                                                variables: nil)
         do {
             _ = try AppSyncListProvider<Post4>(payload: appSyncPayload)
         } catch _ as DecodingError {
@@ -95,7 +101,8 @@ class AppSyncListProviderTests: XCTestCase {
     func testInitWithModelMetadataShouldBeNotLoadedState() throws {
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
                                                         appSyncAssociatedFields: ["post"],
-                                                        apiName: "apiName")
+                                                        apiName: "apiName", 
+                                                        authMode: nil)
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded(let associatedIdentifiers, let associatedFields) = provider.loadedState else {
             XCTFail("Should be in not loaded state")
@@ -120,7 +127,9 @@ class AppSyncListProviderTests: XCTestCase {
 
     func testNotLoadedStateLoadSuccess() async throws {
         mockAPIPlugin.responders[.queryRequestResponse] =
-        QueryRequestResponder<JSONValue> { _ in
+        QueryRequestResponder<JSONValue> { request in
+            XCTAssertEqual(request.apiName, "apiName")
+            XCTAssertEqual(request.authMode as? AWSAuthorizationType, .amazonCognitoUserPools)
             let json: JSONValue = [
                 "items": [
                     [
@@ -138,7 +147,8 @@ class AppSyncListProviderTests: XCTestCase {
         }
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
                                                         appSyncAssociatedFields: ["post"],
-                                                        apiName: "apiName")
+                                                        apiName: "apiName", 
+                                                        authMode: .amazonCognitoUserPools)
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
@@ -175,7 +185,8 @@ class AppSyncListProviderTests: XCTestCase {
         }
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
                                                         appSyncAssociatedFields: ["post"],
-                                                        apiName: "apiName")
+                                                        apiName: "apiName", 
+                                                        authMode: nil)
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
@@ -222,7 +233,8 @@ class AppSyncListProviderTests: XCTestCase {
         }
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
                                                         appSyncAssociatedFields: ["post"],
-                                                        apiName: "apiName")
+                                                        apiName: "apiName", 
+                                                        authMode: nil)
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
@@ -259,7 +271,8 @@ class AppSyncListProviderTests: XCTestCase {
         }
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
                                                         appSyncAssociatedFields: ["post"],
-                                                        apiName: "apiName")
+                                                        apiName: "apiName", 
+                                                        authMode: nil)
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
@@ -294,8 +307,9 @@ class AppSyncListProviderTests: XCTestCase {
             return event
         }
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
-                                                 appSyncAssociatedFields: ["post"],
-                                                 apiName: "apiName")
+                                                        appSyncAssociatedFields: ["post"],
+                                                        apiName: "apiName",
+                                                        authMode: nil)
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")
@@ -344,7 +358,8 @@ class AppSyncListProviderTests: XCTestCase {
         }
         let modelMetadata = AppSyncListDecoder.Metadata(appSyncAssociatedIdentifiers: ["postId"],
                                                         appSyncAssociatedFields: ["post"],
-                                                        apiName: "apiName")
+                                                        apiName: "apiName", 
+                                                        authMode: nil)
         let provider = AppSyncListProvider<Comment4>(metadata: modelMetadata)
         guard case .notLoaded = provider.loadedState else {
             XCTFail("Should not be loaded")

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListResponseTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListResponseTests.swift
@@ -38,7 +38,8 @@ class AppSyncListResponseTests: XCTestCase {
         ]
         let listResponse = try AppSyncListResponse.initWithMetadata(type: Post4.self,
                                                                     graphQLData: graphQLData,
-                                                                    apiName: "apiName")
+                                                                    apiName: "apiName", 
+                                                                    authMode: nil)
 
         XCTAssertEqual(listResponse.items.count, 2)
         XCTAssertEqual(listResponse.nextToken, "nextToken")
@@ -59,8 +60,9 @@ class AppSyncListResponseTests: XCTestCase {
             ]
         ]
         let listResponse = try AppSyncListResponse.initWithMetadata(type: Comment4.self,
-                                                                graphQLData: graphQLData,
-                                                                apiName: "apiName")
+                                                                    graphQLData: graphQLData,
+                                                                    apiName: "apiName", 
+                                                                    authMode: nil)
 
         XCTAssertEqual(listResponse.items.count, 2)
         XCTAssertNil(listResponse.nextToken)

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncModelMetadataTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncModelMetadataTests.swift
@@ -54,19 +54,23 @@ class ModelMetadataTests: XCTestCase {
                 "__typename": "Post4"
             ]
         ]
-        let posts = AppSyncModelMetadataUtils.addMetadata(toModelArray: jsonArray, apiName: "apiName")
+        let posts = AppSyncModelMetadataUtils.addMetadata(toModelArray: jsonArray, 
+                                                          apiName: "apiName",
+                                                          authMode: .amazonCognitoUserPools)
         XCTAssertEqual(posts.count, 2)
         for post in posts {
             guard case .object(let associationData) = post["comments"],
                   case .array(let associatedFields) = associationData["appSyncAssociatedFields"],
                   case .array(let associatedIdentifiers) = associationData["appSyncAssociatedIdentifiers"],
-                  case .string(let apiName) = associationData["apiName"] else {
+                  case .string(let apiName) = associationData["apiName"],
+                  case .string(let authMode) = associationData["authMode"] else {
                 XCTFail("Missing association metadata for comments")
                 return
             }
             XCTAssertEqual(associatedIdentifiers[0], "postId")
             XCTAssertEqual(associatedFields, ["post"])
             XCTAssertEqual(apiName, "apiName")
+            XCTAssertEqual(authMode, "AMAZON_COGNITO_USER_POOLS")
         }
     }
 
@@ -77,22 +81,24 @@ class ModelMetadataTests: XCTestCase {
             "__typename": "Post4"
         ]
 
-        let post = AppSyncModelMetadataUtils.addMetadata(toModel: json, apiName: "apiName")
+        let post = AppSyncModelMetadataUtils.addMetadata(toModel: json, apiName: "apiName", authMode: .apiKey)
         guard case .object(let associationData) = post["comments"],
               case .array(let associatedFields) = associationData["appSyncAssociatedFields"],
               case .array(let associatedIdentifiers) = associationData["appSyncAssociatedIdentifiers"],
-              case .string(let apiName) = associationData["apiName"] else {
+              case .string(let apiName) = associationData["apiName"],
+              case .string(let authMode) = associationData["authMode"] else {
             XCTFail("Missing association metadata for comments")
             return
         }
         XCTAssertEqual(associatedIdentifiers[0], "postId")
         XCTAssertEqual(associatedFields, ["post"])
         XCTAssertEqual(apiName, "apiName")
+        XCTAssertEqual(authMode, "API_KEY")
     }
 
     func testAddMetadataToModelNoOp_NotAnObject() {
         let json: JSONValue = "notAnObject"
-        let result = AppSyncModelMetadataUtils.addMetadata(toModel: json, apiName: "apiName")
+        let result = AppSyncModelMetadataUtils.addMetadata(toModel: json, apiName: "apiName", authMode: nil)
         XCTAssertEqual(result, "notAnObject")
     }
 
@@ -102,7 +108,7 @@ class ModelMetadataTests: XCTestCase {
             "title": JSONValue.init(stringLiteral: "title")
         ]
 
-        let post = AppSyncModelMetadataUtils.addMetadata(toModel: json, apiName: "apiName")
+        let post = AppSyncModelMetadataUtils.addMetadata(toModel: json, apiName: "apiName", authMode: nil)
         guard case .object(let postObject) = post,
               case .string = postObject["id"],
               case .string = postObject["title"] else {
@@ -119,7 +125,7 @@ class ModelMetadataTests: XCTestCase {
             "__typename": "InvalidModelName"
         ]
 
-        let post = AppSyncModelMetadataUtils.addMetadata(toModel: json, apiName: "apiName")
+        let post = AppSyncModelMetadataUtils.addMetadata(toModel: json, apiName: "apiName", authMode: nil)
         guard case .object(let postObject) = post,
               case .string = postObject["id"],
               case .string = postObject["title"],
@@ -136,7 +142,7 @@ class ModelMetadataTests: XCTestCase {
             "__typename": "Post4"
         ]
 
-        let post = AppSyncModelMetadataUtils.addMetadata(toModel: json, apiName: "apiName")
+        let post = AppSyncModelMetadataUtils.addMetadata(toModel: json, apiName: "apiName", authMode: nil)
         guard case .object(let postObject) = post,
               case .string = postObject["title"],
               case .string = postObject["__typename"] else {
@@ -159,7 +165,7 @@ class ModelMetadataTests: XCTestCase {
             ]
         ]
 
-        let post = AppSyncModelMetadataUtils.addMetadata(toModel: json, apiName: "apiName")
+        let post = AppSyncModelMetadataUtils.addMetadata(toModel: json, apiName: "apiName", authMode: nil)
         guard case .object(let associationData) = post["comments"],
               associationData["appSyncAssociatedField"] == nil,
               associationData["appSyncAssociatedIdentifiers"] == nil,

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/GraphQLRequestToListQueryTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/GraphQLRequestToListQueryTests.swift
@@ -28,7 +28,8 @@ class GraphQLRequestToListQueryTests: XCTestCase {
                                                           modelSchema: Comment4.schema,
                                                           filter: predicate.graphQLFilter(for: Comment4.schema),
                                                           limit: 1_000,
-                                                          apiName: "apiName")
+                                                          apiName: "apiName",
+                                                          authMode: .awsIAM)
         XCTAssertNotNil(request)
         let expectedDocument = """
         query ListComment4s($filter: ModelComment4FilterInput, $limit: Int) {
@@ -50,6 +51,7 @@ class GraphQLRequestToListQueryTests: XCTestCase {
         XCTAssertEqual(request.document, expectedDocument)
         XCTAssertEqual(request.decodePath, "listComment4s")
         XCTAssertEqual(request.apiName, "apiName")
+        XCTAssertEqual(request.authMode as? AWSAuthorizationType, .awsIAM)
         guard let variables = request.variables else {
             XCTFail("The document doesn't contain variables")
             return
@@ -76,7 +78,8 @@ class GraphQLRequestToListQueryTests: XCTestCase {
         let request = GraphQLRequest<JSONValue>.listQuery(responseType: List<Comment4>.self,
                                                           modelSchema: Comment4.schema,
                                                           nextToken: "nextToken",
-                                                          apiName: "apiName")
+                                                          apiName: "apiName",
+                                                          authMode: .amazonCognitoUserPools)
         XCTAssertNotNil(request)
         let expectedDocument = """
         query ListComment4s($limit: Int, $nextToken: String) {
@@ -98,6 +101,7 @@ class GraphQLRequestToListQueryTests: XCTestCase {
         XCTAssertEqual(request.document, expectedDocument)
         XCTAssertEqual(request.decodePath, "listComment4s")
         XCTAssertEqual(request.apiName, "apiName")
+        XCTAssertEqual(request.authMode as? AWSAuthorizationType, .amazonCognitoUserPools)
         guard let variables = request.variables else {
             XCTFail("The document doesn't contain variables")
             return
@@ -119,7 +123,8 @@ class GraphQLRequestToListQueryTests: XCTestCase {
                                                           filter: previousFilter,
                                                           limit: 1_000,
                                                           nextToken: "nextToken",
-                                                          apiName: "apiName")
+                                                          apiName: "apiName",
+                                                          authMode: .function)
         XCTAssertNotNil(request)
         let expectedDocument = """
         query ListComment4s($filter: ModelComment4FilterInput, $limit: Int, $nextToken: String) {
@@ -141,6 +146,7 @@ class GraphQLRequestToListQueryTests: XCTestCase {
         XCTAssertEqual(request.document, expectedDocument)
         XCTAssertEqual(request.decodePath, "listComment4s")
         XCTAssertEqual(request.apiName, "apiName")
+        XCTAssertEqual(request.authMode as? AWSAuthorizationType, .function)
         guard let variables = request.variables else {
             XCTFail("The document doesn't contain variables")
             return

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthorizationType.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthorizationType.swift
@@ -46,6 +46,8 @@ public enum AWSAuthorizationType: String, AuthorizationMode {
 
 extension AWSAuthorizationType: CaseIterable { }
 
+extension AWSAuthorizationType: Codable { }
+
 /// Indicates whether the authotization type requires the auth plugin to operate.
 extension AWSAuthorizationType {
     public var requiresAuthPlugin: Bool {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/issues/3677

## Description
<!-- Why is this change required? What problem does it solve? -->
Lazy Loading functionality is built on metadata passed to it during decoding. For example, the hasMany list will contain the parent's identifiers and the apiName to reconstruct the request when lazy loading. The belongsTo lazy model will contain its identifiers and the apiName used to when the child model was retrieved. 

The issue is with the new `authMode` parameter, the `authMode` was not being passed down to the lazy types (https://github.com/aws-amplify/amplify-swift/issues/3677#issuecomment-2108404457)

```swift
// default auth type is APIKey.
let message = try await Amplify.API.query(request: .get(Message.self, byId: id, authMode: .amazonCognitoUserPools)).get() // use userPool auth
let sender = try await message.sender  // with fix, uses user pool auth. without fix, uses default API key auth from config
let space = try await message.space // with fix, uses user pool auth. without fix, uses default API key auth from config
```

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
