### PR TITLE
fix(datastore): propagate remote mutationEvents to Hub for sync received

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -337,7 +337,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
     }
 
     enum ApplyRemoteModelResult {
-        case applied(RemoteModel)
+        case applied(RemoteModel, AppliedModel)
         case dropped
     }
 
@@ -363,7 +363,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
                         promise(.failure(dataStoreError))
                     }
                 case .success:
-                    promise(.success(.applied(remoteModel)))
+                    promise(.success(.applied(remoteModel, remoteModel)))
                 }
             }
         }
@@ -387,14 +387,13 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
                     let anyModel: AnyModel
                     do {
                         anyModel = try savedModel.eraseToAnyModel()
+                        let appliedModel = MutationSync(model: anyModel, syncMetadata: remoteModel.syncMetadata)
+                        promise(.success(.applied(remoteModel, appliedModel)))
                     } catch {
                         let dataStoreError = DataStoreError(error: error)
                         self.notifyDropped(error: dataStoreError)
                         promise(.failure(dataStoreError))
-                        return
                     }
-                    let inProcessModel = MutationSync(model: anyModel, syncMetadata: remoteModel.syncMetadata)
-                    promise(.success(.applied(inProcessModel)))
                 }
             }
         }
@@ -417,21 +416,15 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
         result: ApplyRemoteModelResult,
         mutationType: MutationEvent.MutationType
     ) -> AnyPublisher<Void, DataStoreError> {
-        if case let .applied(inProcessModel) = result {
-            return self.saveMetadata(storageAdapter: storageAdapter, remoteModel: inProcessModel, mutationType: mutationType)
-                .handleEvents( receiveOutput: { syncMetadata in
-                    let appliedModel = MutationSync(model: inProcessModel.model, syncMetadata: syncMetadata)
-                    self.notify(savedModel: appliedModel, mutationType: mutationType)
-                }, receiveCompletion: { completion in
-                    if case .failure(let error) = completion {
-                        self.notifyDropped(error: error)
-                    }
-                })
-                .map { _ in () }
+        switch result {
+        case .applied(let remoteModel, let appliedModel):
+            return self.saveMetadata(storageAdapter: storageAdapter, remoteModel: remoteModel, mutationType: mutationType)
+                .map { MutationSync(model: appliedModel.model, syncMetadata: $0) }
+                .map { [weak self] in self?.notify(appliedModel: $0, mutationType: mutationType) }
                 .eraseToAnyPublisher()
-
+        case .dropped:
+            return Just(()).setFailureType(to: DataStoreError.self).eraseToAnyPublisher()
         }
-        return Just(()).setFailureType(to: DataStoreError.self).eraseToAnyPublisher()
     }
 
     private func saveMetadata(
@@ -440,9 +433,17 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
         mutationType: MutationEvent.MutationType
     ) -> Future<MutationSyncMetadata, DataStoreError> {
         Future { promise in
-            storageAdapter.save(remoteModel.syncMetadata,
-                                condition: nil,
-                                eagerLoad: self.isEagerLoad) { result in
+            storageAdapter.save(
+                remoteModel.syncMetadata,
+                condition: nil,
+                eagerLoad: self.isEagerLoad
+            ) { result in
+                switch result {
+                case .failure(let error):
+                    self.notifyDropped(error: error)
+                case .success:
+                    self.notifyHub(remoteModel: remoteModel, mutationType: mutationType)
+                }
                 promise(result)
             }
         }
@@ -454,28 +455,46 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation {
         }
     }
 
-    private func notify(savedModel: AppliedModel,
-                        mutationType: MutationEvent.MutationType) {
-        let version = savedModel.syncMetadata.version
-
-        // TODO: Dispatch/notify error if we can't erase to any model? Would imply an error in JSON decoding,
-        // which shouldn't be possible this late in the process. Possibly notify global conflict/error handler?
-        guard let json = try? savedModel.model.instance.toJSON() else {
+    /// Inform the mutationEvents subscribers about the updated model,
+    /// which incorporates lazy loading information if applicable.
+    private func notify(appliedModel: AppliedModel, mutationType: MutationEvent.MutationType) {
+        guard let json = try? appliedModel.model.instance.toJSON() else {
             log.error("Could not notify mutation event")
             return
         }
-        let modelIdentifier = savedModel.model.instance.identifier(schema: modelSchema).stringValue
+
+        let modelIdentifier = appliedModel.model.instance.identifier(schema: modelSchema).stringValue
         let mutationEvent = MutationEvent(modelId: modelIdentifier,
                                           modelName: modelSchema.name,
                                           json: json,
                                           mutationType: mutationType,
-                                          version: version)
+                                          version: appliedModel.syncMetadata.version)
+        mutationEventPublisher.send(.mutationEvent(mutationEvent))
+    }
+
+    /// Inform the remote mutationEvents to Hub event subscribers,
+    /// which only contains information received from AppSync server.
+    private func notifyHub(
+        remoteModel: RemoteModel,
+        mutationType: MutationEvent.MutationType
+    ) {
+        // TODO: Dispatch/notify error if we can't erase to any model? Would imply an error in JSON decoding,
+        // which shouldn't be possible this late in the process. Possibly notify global conflict/error handler?
+        guard let json = try? remoteModel.model.instance.toJSON() else {
+            log.error("Could not notify Hub mutation event")
+            return
+        }
+
+        let modelIdentifier = remoteModel.model.instance.identifier(schema: modelSchema).stringValue
+        let mutationEvent = MutationEvent(modelId: modelIdentifier,
+                                          modelName: modelSchema.name,
+                                          json: json,
+                                          mutationType: mutationType,
+                                          version: remoteModel.syncMetadata.version)
 
         let payload = HubPayload(eventName: HubPayload.EventName.DataStore.syncReceived,
                                  data: mutationEvent)
         Amplify.Hub.dispatch(to: .dataStore, payload: payload)
-
-        mutationEventPublisher.send(.mutationEvent(mutationEvent))
     }
 
     private func notifyFinished() {


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-swift/pull/2684

## Description
<!-- Why is this change required? What problem does it solve? -->

As we introduce lazy loading support in Datastore v2, the observe API requires the model instance in the stream to have accurate information for data related to lazy loading. However, the syncReceived hub event should still propagate the mutation event data from AppSync, which includes metadata such as `_version`, `_deleted`, and `_lastChangedAt`.


## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
