### PR TITLE
chore: add @mainactor attribute to DeviceInfo

### DIFF
--- a/.github/composite_actions/get_platform_parameters/action.yml
+++ b/.github/composite_actions/get_platform_parameters/action.yml
@@ -38,9 +38,9 @@ runs:
 
     - id: get-xcode-version
       run: |
-        LATEST_XCODE_VERSION=14.3.1
-        MINIMUM_XCODE_VERSION_IOS_MAC=14.1.0
-        MINIMUM_XCODE_VERSION_WATCH_TV=14.3.1
+        LATEST_XCODE_VERSION=15.0.1
+        MINIMUM_XCODE_VERSION_IOS_MAC=15.0.1
+        MINIMUM_XCODE_VERSION_WATCH_TV=15.0.1
 
         INPUT_XCODE_VERSION=${{ inputs.xcode_version }}
 

--- a/Amplify/Core/Support/DeviceInfo.swift
+++ b/Amplify/Core/Support/DeviceInfo.swift
@@ -28,6 +28,7 @@ import AppKit
 /// ```
 ///
 /// - Tag: DeviceInfo
+@MainActor
 public struct DeviceInfo {
 
     private init() {}

--- a/Amplify/DevMenu/Data/DeviceInfoHelper.swift
+++ b/Amplify/DevMenu/Data/DeviceInfoHelper.swift
@@ -10,6 +10,7 @@ import Foundation
 import UIKit
 
 /// Helper class to fetch information for Device Information Screen
+@MainActor
 struct DeviceInfoHelper {
 
     static func getDeviceInformation() -> [DeviceInfoItem] {

--- a/Amplify/DevMenu/Data/IssueInfo.swift
+++ b/Amplify/DevMenu/Data/IssueInfo.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 /// Struct consisting of information required to report an issue
+@MainActor
 struct IssueInfo {
 
     private var includeEnvironmentInfo: Bool

--- a/Amplify/DevMenu/Data/IssueInfoHelper.swift
+++ b/Amplify/DevMenu/Data/IssueInfoHelper.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 /// Helper class to generate markdown text for issue reporting
+@MainActor
 struct IssueInfoHelper {
 
     private static let issueDescTitle = "Issue Description"

--- a/Amplify/DevMenu/Trigger/LongPressGestureRecognizer.swift
+++ b/Amplify/DevMenu/Trigger/LongPressGestureRecognizer.swift
@@ -47,13 +47,5 @@ class LongPressGestureRecognizer: NSObject, TriggerRecognizer, UIGestureRecogniz
         uiWindow?.addGestureRecognizer(recognizer)
         recognizer.delegate = self
     }
-
-    deinit {
-        if let window = uiWindow {
-            window.removeGestureRecognizer(recognizer)
-        }
-        uiWindow = nil
-        triggerDelegate = nil
-    }
 }
 #endif

--- a/Amplify/DevMenu/View/IssueReporter.swift
+++ b/Amplify/DevMenu/View/IssueReporter.swift
@@ -172,7 +172,7 @@ final class MultilineTextField: UIViewRepresentable {
         return view
     }
 
-    @MainActor 
+    @MainActor
     @objc func dismissKeyboard() {
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
                                         to: nil, from: nil, for: nil)

--- a/Amplify/DevMenu/View/IssueReporter.swift
+++ b/Amplify/DevMenu/View/IssueReporter.swift
@@ -14,7 +14,6 @@ import AppKit
 
 /// Issue report screen in developer menu
 #if os(iOS)
-@MainActor
 struct IssueReporter: View {
     @State var issueDescription: String = ""
     @State var includeLogs = true
@@ -96,36 +95,42 @@ struct IssueReporter: View {
 
     /// Open Amplify iOS issue logging screen on Github
     private func reportToGithub() {
-        let issueDescriptionMarkdown =
-            IssueInfoHelper.generateMarkdownForIssue(
-                issue: IssueInfo(issueDescription: issueDescription,
-                         includeEnvInfo: includeEnvInfo,
-                         includeDeviceInfo: includeDeviceInfo))
+        Task {
+            let issue = await IssueInfo(issueDescription: issueDescription,
+                                        includeEnvInfo: includeEnvInfo,
+                                        includeDeviceInfo: includeDeviceInfo)
+            let issueDescriptionMarkdown =
+                await IssueInfoHelper.generateMarkdownForIssue(
+                    issue: issue)
 
-        let urlString = amplifyIosNewIssueUrl + issueDescriptionMarkdown
-        guard let url = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
-            showAlertIfInvalidURL = true
-            return
-        }
-        guard let urlToOpen = URL(string: url) else {
-            showAlertIfInvalidURL = true
-            return
+            let urlString = amplifyIosNewIssueUrl + issueDescriptionMarkdown
+            guard let url = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+                showAlertIfInvalidURL = true
+                return
+            }
+            guard let urlToOpen = URL(string: url) else {
+                showAlertIfInvalidURL = true
+                return
+            }
+
+            await UIApplication.shared.open(urlToOpen)
         }
 
-        UIApplication.shared.open(urlToOpen)
     }
 
     /// Copy issue as a markdown string to clipboard
     private func copyToClipboard() {
-        let issue = IssueInfo(issueDescription: issueDescription,
-                              includeEnvInfo: includeEnvInfo,
-                              includeDeviceInfo: includeDeviceInfo)
-        let value = IssueInfoHelper.generateMarkdownForIssue(issue: issue)
-#if os(iOS)
-        UIPasteboard.general.string = value
-#elseif canImport(AppKit)
-        NSPasteboard.general.setString(value, forType: .string)
-#endif
+        Task {
+            let issue = await IssueInfo(issueDescription: issueDescription,
+                                  includeEnvInfo: includeEnvInfo,
+                                  includeDeviceInfo: includeDeviceInfo)
+            let value = await IssueInfoHelper.generateMarkdownForIssue(issue: issue)
+    #if os(iOS)
+            UIPasteboard.general.string = value
+    #elseif canImport(AppKit)
+            NSPasteboard.general.setString(value, forType: .string)
+    #endif
+        }
     }
 }
 
@@ -167,6 +172,7 @@ final class MultilineTextField: UIViewRepresentable {
         return view
     }
 
+    @MainActor 
     @objc func dismissKeyboard() {
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder),
                                         to: nil, from: nil, for: nil)

--- a/Amplify/DevMenu/View/IssueReporter.swift
+++ b/Amplify/DevMenu/View/IssueReporter.swift
@@ -14,6 +14,7 @@ import AppKit
 
 /// Issue report screen in developer menu
 #if os(iOS)
+@MainActor
 struct IssueReporter: View {
     @State var issueDescription: String = ""
     @State var includeLogs = true

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ASF/ASFDeviceInfo.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ASF/ASFDeviceInfo.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Amplify
 
+@MainActor
 struct ASFDeviceInfo: ASFDeviceBehavior {
 
     let id: String

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ASF/AdvancedSecurityBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ASF/AdvancedSecurityBehavior.swift
@@ -15,7 +15,7 @@ protocol AdvancedSecurityBehavior {
                          configuration: UserPoolConfigurationData) throws -> String
 }
 
-protocol ASFDeviceBehavior {
+protocol ASFDeviceBehavior: Sendable {
 
     var id: String { get }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ASF/CognitoUserPoolASF+KeyChain.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ASF/CognitoUserPoolASF+KeyChain.swift
@@ -32,8 +32,8 @@ extension CognitoUserPoolASF {
     static func encodedContext(username: String,
                                asfDeviceId: String,
                                asfClient: AdvancedSecurityBehavior,
-                               userPoolConfiguration: UserPoolConfigurationData) -> String? {
-        let deviceInfo: ASFDeviceBehavior = ASFDeviceInfo(id: asfDeviceId)
+                               userPoolConfiguration: UserPoolConfigurationData) async -> String? {
+        let deviceInfo: ASFDeviceBehavior = await ASFDeviceInfo(id: asfDeviceId)
         let appInfo: ASFAppInfoBehavior = ASFAppInfo()
 
         do {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/RefreshAuthorizationSession/UserPool/RefreshUserPoolTokens.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/RefreshAuthorizationSession/UserPool/RefreshUserPoolTokens.swift
@@ -41,7 +41,7 @@ struct RefreshUserPoolTokens: Action {
                 for: existingSignedIndata.username,
                 credentialStoreClient: authEnv.credentialsClient)
 
-            let input = InitiateAuthInput.refreshAuthInput(
+            let input = await InitiateAuthInput.refreshAuthInput(
                 username: existingSignedIndata.username,
                 refreshToken: existingTokens.refreshToken,
                 clientMetadata: [:],

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/ConfirmDevice.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/ConfirmDevice.swift
@@ -36,7 +36,7 @@ struct ConfirmDevice: Action {
                 deviceKey: deviceMetadata.deviceKey,
                 password: deviceMetadata.deviceSecret)
 
-            let deviceName = DeviceInfo.current.name
+            let deviceName = await DeviceInfo.current.name
 
             let base64EncodedVerifier = passwordVerifier.passwordVerifier.base64EncodedString()
             let base64EncodedSalt = passwordVerifier.salt.base64EncodedString()

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/CustomSignIn/InitiateCustomAuth.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/CustomSignIn/InitiateCustomAuth.swift
@@ -33,7 +33,7 @@ struct InitiateCustomAuth: Action {
             let asfDeviceId = try await CognitoUserPoolASF.asfDeviceID(
                 for: username,
                 credentialStoreClient: authEnv.credentialsClient)
-            let request = InitiateAuthInput.customAuth(
+            let request = await InitiateAuthInput.customAuth(
                 username: username,
                 clientMetadata: clientMetadata,
                 asfDeviceId: asfDeviceId,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/InitiateAuthDeviceSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/InitiateAuthDeviceSRP.swift
@@ -45,7 +45,7 @@ struct InitiateAuthDeviceSRP: Action {
                 srpKeyPair: srpKeyPair,
                 clientTimestamp: Date())
 
-            let request = RespondToAuthChallengeInput.deviceSRP(
+            let request = await RespondToAuthChallengeInput.deviceSRP(
                 username: username,
                 environment: userPoolEnv,
                 deviceMetadata: deviceMetadata,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/VerifyDevicePasswordSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/DeviceSRPAuth/VerifyDevicePasswordSRP.swift
@@ -59,7 +59,7 @@ struct VerifyDevicePasswordSRP: Action {
                 serverPublicBHexString: serverPublicB,
                 srpClient: srpClient)
 
-            let request = RespondToAuthChallengeInput.devicePasswordVerifier(
+            let request = await RespondToAuthChallengeInput.devicePasswordVerifier(
                 username: username,
                 stateData: stateData,
                 session: authResponse.session,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/HostedUI/InitializeHostedUISignIn.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/HostedUI/InitializeHostedUISignIn.swift
@@ -54,7 +54,7 @@ struct InitializeHostedUISignIn: Action {
             let asfDeviceId = try await CognitoUserPoolASF.asfDeviceID(
                 for: username,
                 credentialStoreClient: environment.credentialsClient)
-            let encodedData = CognitoUserPoolASF.encodedContext(
+            let encodedData = await CognitoUserPoolASF.encodedContext(
                 username: username,
                 asfDeviceId: asfDeviceId,
                 asfClient: environment.cognitoUserPoolASFFactory(),

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/MigrateAuth/InitiateMigrateAuth.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/MigrateAuth/InitiateMigrateAuth.swift
@@ -36,7 +36,7 @@ struct InitiateMigrateAuth: Action {
             let asfDeviceId = try await CognitoUserPoolASF.asfDeviceID(
                 for: username,
                 credentialStoreClient: authEnv.credentialsClient)
-            let request = InitiateAuthInput.migrateAuth(
+            let request = await InitiateAuthInput.migrateAuth(
                 username: username,
                 password: password,
                 clientMetadata: clientMetadata,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/InitiateAuthSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/InitiateAuthSRP.swift
@@ -56,7 +56,7 @@ struct InitiateAuthSRP: Action {
                 for: username,
                 credentialStoreClient: authEnv.credentialsClient)
 
-            let request = InitiateAuthInput.srpInput(
+            let request = await InitiateAuthInput.srpInput(
                 username: username,
                 publicSRPAHexValue: srpKeyPair.publicKeyHexValue,
                 authFlowType: authFlowType,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/VerifyPasswordSRP.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SRPAuth/VerifyPasswordSRP.swift
@@ -57,7 +57,7 @@ struct VerifyPasswordSRP: Action {
                                           serverPublicBHexString: serverPublicB,
                                           srpClient: srpClient,
                                           poolId: userPoolEnv.userPoolConfiguration.poolId)
-            let request = RespondToAuthChallengeInput.passwordVerifier(
+            let request = await RespondToAuthChallengeInput.passwordVerifier(
                 username: username,
                 stateData: stateData,
                 session: authResponse.session,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SoftwareTokenSetup/CompleteTOTPSetup.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/SoftwareTokenSetup/CompleteTOTPSetup.swift
@@ -53,7 +53,7 @@ struct CompleteTOTPSetup: Action {
                 credentialStoreClient: authEnv.credentialsClient)
 
             var userContextData: CognitoIdentityProviderClientTypes.UserContextDataType?
-            if let encodedData = CognitoUserPoolASF.encodedContext(
+            if let encodedData = await CognitoUserPoolASF.encodedContext(
                 username: username,
                 asfDeviceId: asfDeviceId,
                 asfClient: userpoolEnv.cognitoUserPoolASFFactory(),

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/VerifySignInChallenge.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/VerifySignInChallenge.swift
@@ -39,7 +39,7 @@ struct VerifySignInChallenge: Action {
                             for: username,
                             with: environment)
 
-            let input = RespondToAuthChallengeInput.verifyChallenge(
+            let input = await RespondToAuthChallengeInput.verifyChallenge(
                 username: username,
                 challengeType: challengeType,
                 session: session,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUIASWebAuthenticationSession.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUIASWebAuthenticationSession.swift
@@ -110,6 +110,7 @@ class HostedUIASWebAuthenticationSession: NSObject, HostedUISessionBehavior {
 #if os(iOS) || os(macOS)
 extension HostedUIASWebAuthenticationSession: ASWebAuthenticationPresentationContextProviding {
 
+    @MainActor
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         return webPresentation ?? ASPresentationAnchor()
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/ConfirmSignUpInput+Amplify.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/ConfirmSignUpInput+Amplify.swift
@@ -15,7 +15,7 @@ extension ConfirmSignUpInput {
          asfDeviceId: String?,
          forceAliasCreation: Bool?,
          environment: UserPoolEnvironment
-    ) {
+    ) async {
 
         let configuration = environment.userPoolConfiguration
         let secretHash = ClientSecretHelper.calculateSecretHash(
@@ -23,7 +23,7 @@ extension ConfirmSignUpInput {
             userPoolConfiguration: configuration)
         var userContextData: CognitoIdentityProviderClientTypes.UserContextDataType?
         if let asfDeviceId = asfDeviceId,
-           let encodedData = CognitoUserPoolASF.encodedContext(
+           let encodedData = await CognitoUserPoolASF.encodedContext(
             username: username,
             asfDeviceId: asfDeviceId,
             asfClient: environment.cognitoUserPoolASFFactory(),

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/InitiateAuthInput+Amplify.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/InitiateAuthInput+Amplify.swift
@@ -16,7 +16,7 @@ extension InitiateAuthInput {
                          clientMetadata: [String: String],
                          asfDeviceId: String,
                          deviceMetadata: DeviceMetadata,
-                         environment: UserPoolEnvironment) -> InitiateAuthInput {
+                         environment: UserPoolEnvironment) async -> InitiateAuthInput {
         var authParameters = [
             "USERNAME": username,
             "SRP_A": publicSRPAHexValue
@@ -28,7 +28,7 @@ extension InitiateAuthInput {
             authParameters["CHALLENGE_NAME"] = "SRP_A"
         }
 
-        return buildInput(username: username,
+        return await buildInput(username: username,
                           authFlowType: authFlowType.getClientFlowType(),
                           authParameters: authParameters,
                           clientMetadata: clientMetadata,
@@ -41,12 +41,12 @@ extension InitiateAuthInput {
                            clientMetadata: [String: String],
                            asfDeviceId: String,
                            deviceMetadata: DeviceMetadata,
-                           environment: UserPoolEnvironment) -> InitiateAuthInput {
+                           environment: UserPoolEnvironment) async -> InitiateAuthInput {
         let authParameters = [
             "USERNAME": username
         ]
 
-        return buildInput(username: username,
+        return await buildInput(username: username,
                           authFlowType: .customAuth,
                           authParameters: authParameters,
                           clientMetadata: clientMetadata,
@@ -60,13 +60,13 @@ extension InitiateAuthInput {
                             clientMetadata: [String: String],
                             asfDeviceId: String,
                             deviceMetadata: DeviceMetadata,
-                            environment: UserPoolEnvironment) -> InitiateAuthInput {
+                            environment: UserPoolEnvironment) async -> InitiateAuthInput {
         let authParameters = [
             "USERNAME": username,
             "PASSWORD": password
         ]
 
-        return buildInput(username: username,
+        return await buildInput(username: username,
                           authFlowType: .userPasswordAuth,
                           authParameters: authParameters,
                           clientMetadata: clientMetadata,
@@ -80,13 +80,13 @@ extension InitiateAuthInput {
                                  clientMetadata: [String: String],
                                  asfDeviceId: String,
                                  deviceMetadata: DeviceMetadata,
-                                 environment: UserPoolEnvironment) -> InitiateAuthInput {
+                                 environment: UserPoolEnvironment) async -> InitiateAuthInput {
 
         let authParameters = [
             "REFRESH_TOKEN": refreshToken
         ]
 
-        return buildInput(username: username,
+        return await buildInput(username: username,
                           authFlowType: .refreshTokenAuth,
                           authParameters: authParameters,
                           clientMetadata: clientMetadata,
@@ -102,7 +102,7 @@ extension InitiateAuthInput {
                            clientMetadata: [String: String],
                            asfDeviceId: String?,
                            deviceMetadata: DeviceMetadata,
-                           environment: UserPoolEnvironment) -> InitiateAuthInput {
+                           environment: UserPoolEnvironment) async -> InitiateAuthInput {
 
         var authParameters = authParameters
         let configuration = environment.userPoolConfiguration
@@ -123,7 +123,7 @@ extension InitiateAuthInput {
 
         var userContextData: CognitoIdentityProviderClientTypes.UserContextDataType?
         if let asfDeviceId = asfDeviceId,
-           let encodedData = CognitoUserPoolASF.encodedContext(
+           let encodedData = await CognitoUserPoolASF.encodedContext(
             username: username,
             asfDeviceId: asfDeviceId,
             asfClient: environment.cognitoUserPoolASFFactory(),

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/RespondToAuthChallengeInput+Amplify.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/RespondToAuthChallengeInput+Amplify.swift
@@ -19,14 +19,14 @@ extension RespondToAuthChallengeInput {
                                  clientMetadata: ClientMetadata,
                                  deviceMetadata: DeviceMetadata,
                                  asfDeviceId: String?,
-                                 environment: UserPoolEnvironment) -> RespondToAuthChallengeInput {
+                                 environment: UserPoolEnvironment) async -> RespondToAuthChallengeInput {
         let dateStr = stateData.clientTimestamp.utcString
         let challengeResponses = [
             "USERNAME": username,
             "TIMESTAMP": dateStr,
             "PASSWORD_CLAIM_SECRET_BLOCK": secretBlock,
             "PASSWORD_CLAIM_SIGNATURE": signature]
-        return buildInput(
+        return await buildInput(
             username: username,
             challengeType: .passwordVerifier,
             challengeResponses: challengeResponses,
@@ -43,12 +43,12 @@ extension RespondToAuthChallengeInput {
                           deviceMetadata: DeviceMetadata,
                           asfDeviceId: String?,
                           session: String?,
-                          publicHexValue: String) -> RespondToAuthChallengeInput {
+                          publicHexValue: String) async -> RespondToAuthChallengeInput {
         let challengeResponses = [
             "USERNAME": username,
             "SRP_A": publicHexValue
         ]
-        return buildInput(
+        return await buildInput(
             username: username,
             challengeType: .deviceSrpAuth,
             challengeResponses: challengeResponses,
@@ -66,7 +66,7 @@ extension RespondToAuthChallengeInput {
                                        signature: String,
                                        deviceMetadata: DeviceMetadata,
                                        asfDeviceId: String?,
-                                       environment: UserPoolEnvironment)
+                                       environment: UserPoolEnvironment) async
     -> RespondToAuthChallengeInput {
         let dateStr = stateData.clientTimestamp.utcString
         let challengeResponses = [
@@ -74,7 +74,7 @@ extension RespondToAuthChallengeInput {
             "TIMESTAMP": dateStr,
             "PASSWORD_CLAIM_SECRET_BLOCK": secretBlock,
             "PASSWORD_CLAIM_SIGNATURE": signature]
-        return buildInput(
+        return await buildInput(
             username: username,
             challengeType: .devicePasswordVerifier,
             challengeResponses: challengeResponses,
@@ -96,7 +96,7 @@ extension RespondToAuthChallengeInput {
         asfDeviceId: String?,
         attributes: [String: String],
         deviceMetadata: DeviceMetadata,
-        environment: UserPoolEnvironment) -> RespondToAuthChallengeInput {
+        environment: UserPoolEnvironment) async -> RespondToAuthChallengeInput {
 
             var challengeResponses = [
                 "USERNAME": username,
@@ -107,7 +107,7 @@ extension RespondToAuthChallengeInput {
             attributes.forEach {
                 challengeResponses[$0.key] = $0.value
             }
-            return buildInput(
+            return await buildInput(
                 username: username,
                 challengeType: challengeType,
                 challengeResponses: challengeResponses,
@@ -126,7 +126,7 @@ extension RespondToAuthChallengeInput {
         clientMetadata: ClientMetadata,
         asfDeviceId: String?,
         deviceMetadata: DeviceMetadata,
-        environment: UserPoolEnvironment) -> RespondToAuthChallengeInput {
+        environment: UserPoolEnvironment) async -> RespondToAuthChallengeInput {
             var challengeResponses = challengeResponses
             let userPoolClientId = environment.userPoolConfiguration.clientId
             if let clientSecret = environment.userPoolConfiguration.clientSecret {
@@ -145,7 +145,7 @@ extension RespondToAuthChallengeInput {
 
             var userContextData: CognitoIdentityProviderClientTypes.UserContextDataType?
             if let asfDeviceId = asfDeviceId,
-               let encodedData = CognitoUserPoolASF.encodedContext(
+               let encodedData = await CognitoUserPoolASF.encodedContext(
                 username: username,
                 asfDeviceId: asfDeviceId,
                 asfClient: environment.cognitoUserPoolASFFactory(),

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/SignUpInput+Amplify.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/SignUpInput+Amplify.swift
@@ -21,7 +21,7 @@ extension SignUpInput {
          validationData: [String: String]?,
          attributes: [String: String],
          asfDeviceId: String?,
-         environment: UserPoolEnvironment) {
+         environment: UserPoolEnvironment) async {
 
         let configuration = environment.userPoolConfiguration
         let secretHash = ClientSecretHelper.calculateSecretHash(username: username,
@@ -30,7 +30,7 @@ extension SignUpInput {
         let convertedAttributes = Self.convertAttributes(attributes)
         var userContextData: CognitoIdentityProviderClientTypes.UserContextDataType?
         if let asfDeviceId = asfDeviceId,
-           let encodedData = CognitoUserPoolASF.encodedContext(
+           let encodedData = await CognitoUserPoolASF.encodedContext(
             username: username,
             asfDeviceId: asfDeviceId,
             asfClient: environment.cognitoUserPoolASFFactory(),

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/SignUpInput+Amplify.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/Utils/SignUpInput+Amplify.swift
@@ -26,7 +26,7 @@ extension SignUpInput {
         let configuration = environment.userPoolConfiguration
         let secretHash = ClientSecretHelper.calculateSecretHash(username: username,
                                                   userPoolConfiguration: configuration)
-        let validationData = Self.getValidationData(with: validationData)
+        let validationData = await Self.getValidationData(with: validationData)
         let convertedAttributes = Self.convertAttributes(attributes)
         var userContextData: CognitoIdentityProviderClientTypes.UserContextDataType?
         if let asfDeviceId = asfDeviceId,
@@ -52,41 +52,47 @@ extension SignUpInput {
     }
 
     private static func getValidationData(with devProvidedData: [String: String]?)
-    -> [CognitoIdentityProviderClientTypes.AttributeType]? {
+    async -> [CognitoIdentityProviderClientTypes.AttributeType]? {
 
         if let devProvidedData = devProvidedData {
             return devProvidedData.compactMap { (key, value) in
                 return CognitoIdentityProviderClientTypes.AttributeType(name: key, value: value)
-            } + (cognitoValidationData ?? [])
+            } + (await cognitoValidationData ?? [])
         }
-        return cognitoValidationData
+        return await cognitoValidationData
     }
 
     private static var cognitoValidationData: [CognitoIdentityProviderClientTypes.AttributeType]? {
-#if canImport(WatchKit)
-        let device = WKInterfaceDevice.current()
-#elseif canImport(UIKit)
-        let device = UIDevice.current
-#endif
+        get async {
+            #if canImport(WatchKit)
+            let device = WKInterfaceDevice.current()
+            #elseif canImport(UIKit)
+            let device = await UIDevice.current
+            #endif
 
-#if canImport(WatchKit) || canImport(UIKit)
-        let bundle = Bundle.main
-        let bundleVersion = bundle.object(forInfoDictionaryKey: String(kCFBundleVersionKey)) as? String
-        let bundleShortVersion = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-
-        return [
-            .init(name: "cognito:iOSVersion", value: device.systemVersion),
-            .init(name: "cognito:systemName", value: device.systemName),
-            .init(name: "cognito:deviceName", value: device.name),
-            .init(name: "cognito:model", value: device.model),
-            .init(name: "cognito:idForVendor", value: device.identifierForVendor?.uuidString ?? ""),
-            .init(name: "cognito:bundleId", value: bundle.bundleIdentifier),
-            .init(name: "cognito:bundleVersion", value: bundleVersion ?? ""),
-            .init(name: "cognito:bundleShortV", value: bundleShortVersion ?? "")
-        ]
-#else
-        return nil
-#endif
+            #if canImport(WatchKit) || canImport(UIKit)
+            let bundle = Bundle.main
+            let bundleVersion = bundle.object(forInfoDictionaryKey: String(kCFBundleVersionKey)) as? String
+            let bundleShortVersion = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+            let systemVersion = await device.systemVersion
+            let systemName = await device.systemName
+            let name = await device.name
+            let model = await device.model
+            let idForVendor = await device.identifierForVendor?.uuidString ?? ""
+            return [
+                .init(name: "cognito:iOSVersion", value: systemVersion),
+                .init(name: "cognito:systemName", value: systemName),
+                .init(name: "cognito:deviceName", value: name),
+                .init(name: "cognito:model", value: model),
+                .init(name: "cognito:idForVendor", value: idForVendor),
+                .init(name: "cognito:bundleId", value: bundle.bundleIdentifier),
+                .init(name: "cognito:bundleVersion", value: bundleVersion ?? ""),
+                .init(name: "cognito:bundleShortV", value: bundleShortVersion ?? "")
+            ]
+            #else
+                    return nil
+            #endif
+        }
     }
 
     private static func convertAttributes(_ attributes: [String: String]) -> [CognitoIdentityProviderClientTypes.AttributeType] {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmResetPasswordTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmResetPasswordTask.swift
@@ -62,7 +62,7 @@ class AWSAuthConfirmResetPasswordTask: AuthConfirmResetPasswordTask, DefaultLogg
         let asfDeviceId = try await CognitoUserPoolASF.asfDeviceID(
             for: request.username,
             credentialStoreClient: environment.credentialsClient)
-        let encodedData = CognitoUserPoolASF.encodedContext(
+        let encodedData = await CognitoUserPoolASF.encodedContext(
             username: request.username,
             asfDeviceId: asfDeviceId,
             asfClient: environment.cognitoUserPoolASFFactory(),

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignUpTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignUpTask.swift
@@ -35,7 +35,7 @@ class AWSAuthConfirmSignUpTask: AuthConfirmSignUpTask, DefaultLogger {
             let metadata = (request.options.pluginOptions as? AWSAuthConfirmSignUpOptions)?.metadata
             let forceAliasCreation = (request.options.pluginOptions as? AWSAuthConfirmSignUpOptions)?.forceAliasCreation
             let client = try userPoolEnvironment.cognitoUserPoolFactory()
-            let input = ConfirmSignUpInput(username: request.username,
+            let input = await ConfirmSignUpInput(username: request.username,
                                            confirmationCode: request.code,
                                            clientMetadata: metadata,
                                            asfDeviceId: asfDeviceId,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResendSignUpCodeTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResendSignUpCodeTask.swift
@@ -62,7 +62,7 @@ class AWSAuthResendSignUpCodeTask: AuthResendSignUpCodeTask, DefaultLogger {
         let asfDeviceId = try await CognitoUserPoolASF.asfDeviceID(
             for: request.username,
             credentialStoreClient: environment.credentialsClient)
-        let encodedData = CognitoUserPoolASF.encodedContext(
+        let encodedData = await CognitoUserPoolASF.encodedContext(
             username: request.username,
             asfDeviceId: asfDeviceId,
             asfClient: environment.cognitoUserPoolASFFactory(),

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResetPasswordTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResetPasswordTask.swift
@@ -62,7 +62,7 @@ class AWSAuthResetPasswordTask: AuthResetPasswordTask, DefaultLogger {
         let asfDeviceId = try await CognitoUserPoolASF.asfDeviceID(
             for: request.username,
             credentialStoreClient: environment.credentialsClient)
-        let encodedData = CognitoUserPoolASF.encodedContext(
+        let encodedData = await CognitoUserPoolASF.encodedContext(
             username: request.username,
             asfDeviceId: asfDeviceId,
             asfClient: environment.cognitoUserPoolASFFactory(),

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignUpTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignUpTask.swift
@@ -41,7 +41,7 @@ class AWSAuthSignUpTask: AuthSignUpTask, DefaultLogger {
                 into: [String: String]()) {
                     $0[$1.key.rawValue] = $1.value
                 } ?? [:]
-            let input = SignUpInput(username: request.username,
+            let input = await SignUpInput(username: request.username,
                                     password: request.password!,
                                     clientMetadata: metaData,
                                     validationData: validationData,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/CognitoASFTests/ASFDeviceInfoTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/CognitoASFTests/ASFDeviceInfoTests.swift
@@ -10,9 +10,9 @@ import XCTest
 
 class ASFDeviceInfoTests: XCTestCase {
 
-    func testdeviceInfo() {
-        let asf = ASFDeviceInfo(id: "mockID")
-        let deviceFingerPrint = asf.deviceInfo()
+    func testdeviceInfo() async {
+        let asf = await ASFDeviceInfo(id: "mockID")
+        let deviceFingerPrint = await asf.deviceInfo()
         XCTAssertNotNil(deviceFingerPrint)
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/CognitoASFTests/CognitoUserPoolASFTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/CognitoASFTests/CognitoUserPoolASFTests.swift
@@ -22,10 +22,11 @@ class CognitoUserPoolASFTests: XCTestCase {
     /// Given: A CognitoUserPoolASF
     /// When: userContextData is invoked
     /// Then: A non-empty string is returned
-    func testUserContextData_shouldReturnData() throws {
+    func testUserContextData_shouldReturnData() async throws {
+        let deviceInfo = await ASFDeviceInfo(id: "mockedDevice")
         let result = try userPool.userContextData(
             for: "TestUser",
-            deviceInfo: ASFDeviceInfo(id: "mockedDevice"),
+            deviceInfo: deviceInfo,
             appInfo: ASFAppInfo(),
             configuration: .testData
         )

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignUpState/ConfirmSignUpInputTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignUpState/ConfirmSignUpInputTests.swift
@@ -13,7 +13,7 @@ import AWSCognitoIdentityProvider
 
 class ConfirmSignUpInputTests: XCTestCase {
 
-    func testConfirmSignUpInputWithClientSecretAndAsfDeviceId() throws {
+    func testConfirmSignUpInputWithClientSecretAndAsfDeviceId() async throws {
         let username = "jeff"
         let clientSecret = UUID().uuidString
         let userPoolConfiguration = UserPoolConfigurationData(poolId: "",
@@ -26,7 +26,7 @@ class ConfirmSignUpInputTests: XCTestCase {
             cognitoUserPoolASFFactory: Defaults.makeDefaultASF,
             cognitoUserPoolAnalyticsHandlerFactory: Defaults.makeUserPoolAnalytics)
 
-        let confirmSignUpInput = ConfirmSignUpInput(
+        let confirmSignUpInput = await ConfirmSignUpInput(
             username: username,
             confirmationCode: "123",
             clientMetadata: [:],
@@ -38,7 +38,7 @@ class ConfirmSignUpInputTests: XCTestCase {
         XCTAssertNotNil(confirmSignUpInput.userContextData)
     }
 
-    func testConfirmSignUpInputWithoutClientSecretAndAsfDeviceId() throws {
+    func testConfirmSignUpInputWithoutClientSecretAndAsfDeviceId() async throws {
         let username = "jeff"
 
         let userPoolConfiguration = UserPoolConfigurationData(poolId: "",
@@ -51,7 +51,7 @@ class ConfirmSignUpInputTests: XCTestCase {
             cognitoUserPoolASFFactory: Defaults.makeDefaultASF,
             cognitoUserPoolAnalyticsHandlerFactory: Defaults.makeUserPoolAnalytics)
 
-        let confirmSignUpInput = ConfirmSignUpInput(
+        let confirmSignUpInput = await ConfirmSignUpInput(
             username: username,
             confirmationCode: "123",
             clientMetadata: [:],

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignUpState/RespondToAuthInputTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignUpState/RespondToAuthInputTests.swift
@@ -13,7 +13,7 @@ import AWSCognitoIdentityProvider
 
 class RespondToAuthInputTests: XCTestCase {
 
-    func testDevicePasswordVerifierInput() throws {
+    func testDevicePasswordVerifierInput() async throws {
         let username = "jeff"
         let clientSecret = UUID().uuidString
         let userPoolConfiguration = UserPoolConfigurationData(poolId: "",
@@ -26,7 +26,7 @@ class RespondToAuthInputTests: XCTestCase {
             cognitoUserPoolASFFactory: Defaults.makeDefaultASF,
             cognitoUserPoolAnalyticsHandlerFactory: Defaults.makeUserPoolAnalytics)
 
-        let respondToAuthChallengeInput = RespondToAuthChallengeInput.devicePasswordVerifier(
+        let respondToAuthChallengeInput = await RespondToAuthChallengeInput.devicePasswordVerifier(
             username: username,
             stateData: .testData,
             session: "session",
@@ -40,7 +40,7 @@ class RespondToAuthInputTests: XCTestCase {
         XCTAssertNotNil(respondToAuthChallengeInput.userContextData)
     }
 
-    func testVerifyChallengeInput() throws {
+    func testVerifyChallengeInput() async throws {
         let username = "jeff"
         let clientSecret = UUID().uuidString
         let userPoolConfiguration = UserPoolConfigurationData(poolId: "",
@@ -53,7 +53,7 @@ class RespondToAuthInputTests: XCTestCase {
             cognitoUserPoolASFFactory: Defaults.makeDefaultASF,
             cognitoUserPoolAnalyticsHandlerFactory: Defaults.makeUserPoolAnalytics)
 
-        let respondToAuthChallengeInput = RespondToAuthChallengeInput.verifyChallenge(
+        let respondToAuthChallengeInput = await RespondToAuthChallengeInput.verifyChallenge(
             username: username,
             challengeType: .smsMfa,
             session: "session",
@@ -69,7 +69,7 @@ class RespondToAuthInputTests: XCTestCase {
         XCTAssertNotNil(respondToAuthChallengeInput.userContextData)
     }
 
-    func testPasswordVerifierInput() throws {
+    func testPasswordVerifierInput() async throws {
         let username = "jeff"
         let clientSecret = UUID().uuidString
         let userPoolConfiguration = UserPoolConfigurationData(poolId: "",
@@ -82,7 +82,7 @@ class RespondToAuthInputTests: XCTestCase {
             cognitoUserPoolASFFactory: Defaults.makeDefaultASF,
             cognitoUserPoolAnalyticsHandlerFactory: Defaults.makeUserPoolAnalytics)
 
-        let respondToAuthChallengeInput = RespondToAuthChallengeInput.passwordVerifier(
+        let respondToAuthChallengeInput = await RespondToAuthChallengeInput.passwordVerifier(
             username: username,
             stateData: .testData,
             session: "session",
@@ -98,7 +98,7 @@ class RespondToAuthInputTests: XCTestCase {
         XCTAssertNotNil(respondToAuthChallengeInput.userContextData)
     }
 
-    func testDeviceSrpInput() throws {
+    func testDeviceSrpInput() async throws {
         let username = "jeff"
         let clientSecret = UUID().uuidString
         let userPoolConfiguration = UserPoolConfigurationData(poolId: "",
@@ -111,7 +111,7 @@ class RespondToAuthInputTests: XCTestCase {
             cognitoUserPoolASFFactory: Defaults.makeDefaultASF,
             cognitoUserPoolAnalyticsHandlerFactory: Defaults.makeUserPoolAnalytics)
 
-        let respondToAuthChallengeInput = RespondToAuthChallengeInput.deviceSRP(
+        let respondToAuthChallengeInput = await RespondToAuthChallengeInput.deviceSRP(
             username: username,
             environment: environment,
             deviceMetadata: .metadata(.init(deviceKey: "", deviceGroupKey: "")),

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignUpState/SignUpInputTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignUpState/SignUpInputTests.swift
@@ -13,7 +13,7 @@ import AWSCognitoIdentityProvider
 
 class SignUpInputTests: XCTestCase {
 
-    func testSignUpInputWithClientSecret() throws {
+    func testSignUpInputWithClientSecret() async throws {
         let username = "jeff"
         let password = "a2z"
         let clientSecret = UUID().uuidString
@@ -26,7 +26,7 @@ class SignUpInputTests: XCTestCase {
             cognitoUserPoolFactory: Defaults.makeDefaultUserPool,
             cognitoUserPoolASFFactory: Defaults.makeDefaultASF,
             cognitoUserPoolAnalyticsHandlerFactory: Defaults.makeUserPoolAnalytics)
-        let input = SignUpInput(username: username,
+        let input = await SignUpInput(username: username,
                                 password: password,
                                 clientMetadata: [:],
                                 validationData: [:],
@@ -38,7 +38,7 @@ class SignUpInputTests: XCTestCase {
         XCTAssertNotNil(input.userContextData)
     }
 
-    func testSignUpInputWithoutClientSecret() throws {
+    func testSignUpInputWithoutClientSecret() async throws {
         let username = "jeff"
         let password = "a2z"
 
@@ -51,7 +51,7 @@ class SignUpInputTests: XCTestCase {
             cognitoUserPoolFactory: Defaults.makeDefaultUserPool,
             cognitoUserPoolASFFactory: Defaults.makeDefaultASF,
             cognitoUserPoolAnalyticsHandlerFactory: Defaults.makeUserPoolAnalytics)
-        let input = SignUpInput(username: username,
+        let input = await SignUpInput(username: username,
                                 password: password,
                                 clientMetadata: [:],
                                 validationData: [:],
@@ -64,7 +64,7 @@ class SignUpInputTests: XCTestCase {
     }
 
 #if canImport(UIKit)
-    func testSignUpInputValidationData() throws {
+    func testSignUpInputValidationData() async throws {
         let username = "jeff"
         let password = "a2z"
         let clientSecret = UUID().uuidString
@@ -77,7 +77,7 @@ class SignUpInputTests: XCTestCase {
             cognitoUserPoolFactory: Defaults.makeDefaultUserPool,
             cognitoUserPoolASFFactory: Defaults.makeDefaultASF,
             cognitoUserPoolAnalyticsHandlerFactory: Defaults.makeUserPoolAnalytics)
-        let input = SignUpInput(username: username,
+        let input = await SignUpInput(username: username,
                                 password: password,
                                 clientMetadata: [:],
                                 validationData: [:],

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -22,5 +22,5 @@ public class AmplifyAWSServiceConfiguration {
 
     public static let userAgentLib: String = "lib/\(platformName)#\(amplifyVersion)"
 
-    public static let userAgentOS: String = "os/\(DeviceInfo.current.operatingSystem.name)#\(DeviceInfo.current.operatingSystem.version)"
+    nonisolated(unsafe) public static let userAgentOS: String = "os/\(DeviceInfo.current.operatingSystem.name)#\(DeviceInfo.current.operatingSystem.version)"
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift
@@ -22,5 +22,6 @@ public class AmplifyAWSServiceConfiguration {
 
     public static let userAgentLib: String = "lib/\(platformName)#\(amplifyVersion)"
 
-    nonisolated(unsafe) public static let userAgentOS: String = "os/\(DeviceInfo.current.operatingSystem.name)#\(DeviceInfo.current.operatingSystem.version)"
+    @MainActor
+    public static let userAgentOS: String = "os/\(DeviceInfo.current.operatingSystem.name)#\(DeviceInfo.current.operatingSystem.version)"
 }

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Context/PinpointContext.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Context/PinpointContext.swift
@@ -110,7 +110,7 @@ class PinpointContext {
     private let storage: PinpointContextStorage
 
     init(with configuration: PinpointContextConfiguration,
-         endpointInformation: EndpointInformation = .current,
+         endpointInformationProvider: EndpointInformationProvider = DefaultEndpointInformationProvider(),
          userDefaults: UserDefaultsBehaviour = UserDefaults.standard,
          keychainStore: KeychainStoreBehavior = KeychainStore(service: PinpointContext.Constants.Keychain.service),
          fileManager: FileManagerBehaviour = FileManager.default,
@@ -130,7 +130,7 @@ class PinpointContext {
                                                              uniqueDeviceId: uniqueId,
                                                              isDebug: configuration.isDebug),
                                         pinpointClient: pinpointClient,
-                                        endpointInformation: endpointInformation,
+                                        endpointInformationProvider: endpointInformationProvider,
                                         userDefaults: userDefaults,
                                         keychain: keychainStore,
                                         remoteNotificationsHelper: remoteNotificationsHelper)

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Endpoint/EndpointClient.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Endpoint/EndpointClient.swift
@@ -32,7 +32,7 @@ actor EndpointClient: EndpointClientBehaviour {
 
     private let configuration: EndpointClient.Configuration
     private let archiver: AmplifyArchiverBehaviour
-    private let endpointInformation: EndpointInformation
+    private let endpointInformationProvider: EndpointInformationProvider
     private let userDefaults: UserDefaultsBehaviour
     private let keychain: KeychainStoreBehavior
     private let remoteNotificationsHelper: RemoteNotificationsBehaviour
@@ -43,7 +43,7 @@ actor EndpointClient: EndpointClientBehaviour {
     init(configuration: EndpointClient.Configuration,
          pinpointClient: PinpointClientProtocol,
          archiver: AmplifyArchiverBehaviour = AmplifyArchiver(),
-         endpointInformation: EndpointInformation = .current,
+         endpointInformationProvider: EndpointInformationProvider,
          userDefaults: UserDefaultsBehaviour = UserDefaults.standard,
          keychain: KeychainStoreBehavior = KeychainStore(service: PinpointContext.Constants.Keychain.service),
          remoteNotificationsHelper: RemoteNotificationsBehaviour = .default
@@ -51,7 +51,7 @@ actor EndpointClient: EndpointClientBehaviour {
         self.configuration = configuration
         self.pinpointClient = pinpointClient
         self.archiver = archiver
-        self.endpointInformation = endpointInformation
+        self.endpointInformationProvider = endpointInformationProvider
         self.userDefaults = userDefaults
         self.keychain = keychain
         self.remoteNotificationsHelper = remoteNotificationsHelper
@@ -99,6 +99,8 @@ actor EndpointClient: EndpointClientBehaviour {
         if let tokenData = Self.getStoredData(from: keychain, forKey: Constants.deviceTokenKey, fallbackTo: userDefaults) {
             deviceToken = tokenData.asHexString()
         }
+
+        let endpointInformation = await endpointInformationProvider.endpointInfo()
 
         endpointProfile.endpointId = configuration.uniqueDeviceId
         endpointProfile.deviceToken = deviceToken

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Endpoint/EndpointInformation.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Endpoint/EndpointInformation.swift
@@ -8,26 +8,24 @@
 import Amplify
 import Foundation
 
-protocol EndpointInformation {
+struct EndpointInformation {
     typealias Platform = (name: String, version: String)
 
-    var model: String { get }
-    var appVersion: String { get }
-    var platform: Platform { get }
+    let model: String
+    let appVersion: String
+    let platform: Platform
 }
 
-extension DeviceInfo: EndpointInformation {
-    var appVersion: String {
-        Bundle.main.appVersion
-    }
-
-    var platform: Platform {
-        operatingSystem
-    }
+protocol EndpointInformationProvider {
+    func endpointInfo() async -> EndpointInformation
 }
 
-extension EndpointInformation where Self == DeviceInfo {
-    static var current: EndpointInformation {
-        DeviceInfo.current
+struct DefaultEndpointInformationProvider: EndpointInformationProvider {
+    func endpointInfo() async -> EndpointInformation {
+        let deviceInfo = await DeviceInfo.current
+        let model = await DeviceInfo.current.model
+        let platform = await DeviceInfo.current.operatingSystem
+        let appVersion = Bundle.main.appVersion
+        return EndpointInformation(model: model, appVersion: appVersion, platform: platform)
     }
 }

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Session/ActivityTracking/ActivityTracker.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Session/ActivityTracking/ActivityTracker.swift
@@ -116,7 +116,7 @@ class ActivityTracker: ActivityTrackerBehaviour {
     }()
 
     @MainActor
-    private let notifications = [
+    private static let notifications = [
         applicationDidMoveToBackgroundNotification,
         applicationWillMoveToForegoundNotification,
         applicationWillTerminateNotification
@@ -127,7 +127,8 @@ class ActivityTracker: ActivityTrackerBehaviour {
         self.backgroundTrackingTimeout = backgroundTrackingTimeout
         self.stateMachine = stateMachine ?? StateMachine(initialState: .initializing,
                                                          resolver: ApplicationState.Resolver.resolve(currentState:event:))
-        for notification in notifications {
+
+        for notification in ActivityTracker.notifications {
             NotificationCenter.default.addObserver(self,
                                                    selector: #selector(handleApplicationStateChange),
                                                    name: notification,
@@ -136,7 +137,7 @@ class ActivityTracker: ActivityTrackerBehaviour {
     }
 
     deinit {
-        for notification in notifications {
+        for notification in ActivityTracker.notifications {
             NotificationCenter.default.removeObserver(self,
                                                       name: notification,
                                                       object: nil)

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/ActivityTrackerTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/ActivityTrackerTests.swift
@@ -20,6 +20,7 @@ class ActivityTrackerTests: XCTestCase {
     private var stateMachine: MockStateMachine!
     private var timeout: TimeInterval = 1
 
+    @MainActor
     private static let applicationDidMoveToBackgroundNotification: Notification.Name = {
 #if canImport(WatchKit)
     WKExtension.applicationDidEnterBackgroundNotification
@@ -30,6 +31,7 @@ class ActivityTrackerTests: XCTestCase {
 #endif
     }()
 
+    @MainActor
     private static  let applicationWillMoveToForegoundNotification: Notification.Name = {
 #if canImport(WatchKit)
     WKExtension.applicationWillEnterForegroundNotification
@@ -40,6 +42,7 @@ class ActivityTrackerTests: XCTestCase {
 #endif
     }()
 
+    @MainActor
     private static  var applicationWillTerminateNotification: Notification.Name = {
 #if canImport(WatchKit)
     WKExtension.applicationWillResignActiveNotification
@@ -79,7 +82,7 @@ class ActivityTrackerTests: XCTestCase {
         
         NotificationCenter.default.post(Notification(name: Self.applicationDidMoveToBackgroundNotification))
         NotificationCenter.default.post(Notification(name: Self.applicationWillMoveToForegoundNotification))
-        NotificationCenter.default.post(Notification(name: Self.applicationWillTerminateNotification))
+        await NotificationCenter.default.post(Notification(name: Self.applicationWillTerminateNotification))
         
         await fulfillment(of: [stateMachine.processExpectation!], timeout: 1)
         XCTAssertTrue(stateMachine.processedEvents.contains(.applicationDidMoveToBackground))
@@ -94,7 +97,7 @@ class ActivityTrackerTests: XCTestCase {
         
         NotificationCenter.default.post(Notification(name: Self.applicationDidMoveToBackgroundNotification))
 
-        await fulfillment(of: [stateMachine.processExpectation!], timeout: 2)
+        await fulfillment(of: [stateMachine.processExpectation!], timeout: 5)
         XCTAssertTrue(stateMachine.processedEvents.contains(.applicationDidMoveToBackground))
         XCTAssertTrue(stateMachine.processedEvents.contains(.backgroundTrackingDidTimeout))
 

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AwsPinpointAnalyticsKeychainMigrationTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AwsPinpointAnalyticsKeychainMigrationTests.swift
@@ -16,7 +16,7 @@ class AWSPinpointAnalyticsKeyValueStoreTests: XCTestCase {
     private let archiver = AmplifyArchiver()
     private let userDefaults = UserDefaults.standard
     private let pinpointClient = MockPinpointClient()
-    private let endpointInformation = MockEndpointInformation()
+    private let endpointInformationProvider = MockEndpointInformationProvider()
     private let currentApplicationId = "applicationId"
     private let currentEndpointId = "endpointId"
 
@@ -45,7 +45,7 @@ class AWSPinpointAnalyticsKeyValueStoreTests: XCTestCase {
                                                              isDebug: false),
                                         pinpointClient: pinpointClient,
                                         archiver: archiver,
-                                        endpointInformation: endpointInformation,
+                                        endpointInformationProvider: endpointInformationProvider,
                                         userDefaults: userDefaults,
                                         keychain: keychain)
         
@@ -68,7 +68,7 @@ class AWSPinpointAnalyticsKeyValueStoreTests: XCTestCase {
                                                              isDebug: false),
                                         pinpointClient: pinpointClient,
                                         archiver: archiver,
-                                        endpointInformation: endpointInformation,
+                                        endpointInformationProvider: endpointInformationProvider,
                                         userDefaults: userDefaults,
                                         keychain: keychain)
         

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
@@ -85,11 +85,9 @@ final class AWSCloudWatchLoggingSessionController {
     }
 
     func enable() {
-        Task {
-            updateSession()
-            await updateConsumer()
-            connectProducerAndConsumer()
-        }
+        updateSession()
+        updateConsumer()
+        connectProducerAndConsumer()
     }
 
     func disable() {
@@ -99,13 +97,12 @@ final class AWSCloudWatchLoggingSessionController {
         self.consumer = nil
     }
 
-    private func updateConsumer() async {
-        self.consumer = try? await createConsumer()
+    private func updateConsumer() {
+        self.consumer = try? createConsumer()
     }
 
-    private func createConsumer() async throws -> LogBatchConsumer? {
+    private func createConsumer() throws -> LogBatchConsumer? {
         if self.client == nil {
-            // TODO: FrameworkMetadata Replacement
             let configuration = try CloudWatchLogsClient.CloudWatchLogsClientConfiguration(
                 region: region,
                 credentialsProvider: credentialsProvider
@@ -117,7 +114,7 @@ final class AWSCloudWatchLoggingSessionController {
         }
 
         guard let cloudWatchClient = client else { return nil }
-        return await CloudWatchLoggingConsumer(client: cloudWatchClient,
+        return CloudWatchLoggingConsumer(client: cloudWatchClient,
                                                logGroupName: self.logGroupName,
                                                userIdentifier: self.userIdentifier)
     }
@@ -147,12 +144,10 @@ final class AWSCloudWatchLoggingSessionController {
     }
 
     private func userIdentifierDidChange() {
-        Task {
-            resetCurrentLogs()
-            updateSession()
-            await updateConsumer()
-            connectProducerAndConsumer()
-        }
+        resetCurrentLogs()
+        updateSession()
+        updateConsumer()
+        connectProducerAndConsumer()
     }
 
     private func updateSession() {

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Consumer/CloudWatchLoggingStreamNameFormatter.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Consumer/CloudWatchLoggingStreamNameFormatter.swift
@@ -20,26 +20,28 @@ import AppKit
 #endif
 
 /// Responsible for creating pre-formatted CloudWatch stream names.
-@MainActor
 struct CloudWatchLoggingStreamNameFormatter {
 
     let userIdentifier: String?
-    let deviceIdentifier: String?
+    var deviceIdentifier: String? {
+        get async {
+            #if canImport(WatchKit)
+            await WKInterfaceDevice.current().identifierForVendor?.uuidString
+            #elseif canImport(UIKit)
+            await UIDevice.current.identifierForVendor?.uuidString
+            #elseif canImport(AppKit)
+            Host.current().name
+            #else
+            Self.deviceIdentifierFromBundle()
+            #endif
+        }
+    }
 
     init(userIdentifier: String? = nil) {
         self.userIdentifier = userIdentifier
-        #if canImport(WatchKit)
-        self.deviceIdentifier = WKInterfaceDevice.current().identifierForVendor?.uuidString
-        #elseif canImport(UIKit)
-        self.deviceIdentifier = UIDevice.current.identifierForVendor?.uuidString
-        #elseif canImport(AppKit)
-        self.deviceIdentifier = Host.current().name
-        #else
-        self.deviceIdentifier = Self.deviceIdentifierFromBundle()
-        #endif
     }
 
-    func formattedStreamName() -> String {
-        return "\(deviceIdentifier ?? "").\(userIdentifier ?? "guest")"
+    func formattedStreamName() async -> String {
+        return "\(await deviceIdentifier ?? "").\(userIdentifier ?? "guest")"
     }
 }

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginHostApp/AWSCloudWatchLoggingPluginIntegrationTests/AWSCloudWatchLoggingPluginIntegrationTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginHostApp/AWSCloudWatchLoggingPluginIntegrationTests/AWSCloudWatchLoggingPluginIntegrationTests.swift
@@ -61,7 +61,14 @@ class AWSCloudWatchLoggingPluginIntergrationTests: XCTestCase {
         await Amplify.reset()
         let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.path ?? NSTemporaryDirectory()
         let directory = documents.appendingPathComponent("amplify")
-                                 .appendingPathComponent("logging")
+            .appendingPathComponent("logging")
+        let fileURLs = try FileManager.default.contentsOfDirectory(
+            at: URL(string: directory)!,
+            includingPropertiesForKeys: nil,
+            options: .skipsHiddenFiles)
+        for fileURL in fileURLs {
+            try FileManager.default.removeItem(at: fileURL)
+        }
         try FileManager.default.removeItem(atPath: directory)
     }
     

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+DownloadBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+DownloadBehavior.swift
@@ -33,7 +33,7 @@ extension AWSS3StorageService {
                                                                                  metadata: nil,
                                                                                  accelerate: accelerate,
                                                                                  expires: nil)
-                startDownload(preSignedURL: preSignedURL, transferTask: transferTask)
+                await startDownload(preSignedURL: preSignedURL, transferTask: transferTask)
             } catch {
                 onEvent(.failed(StorageError.unknown("Failed to get pre-signed URL", nil)))
             }
@@ -42,14 +42,14 @@ extension AWSS3StorageService {
 
     private func startDownload(preSignedURL: URL,
                                transferTask: StorageTransferTask,
-                               startTransfer: Bool = true) {
+                               startTransfer: Bool = true) async {
         guard case .download = transferTask.transferType else {
             fatalError("Transfer type must be download")
         }
         var request = URLRequest(url: preSignedURL)
         request.cachePolicy = .reloadIgnoringLocalCacheData
         request.httpMethod = "GET"
-        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue(await userAgent, forHTTPHeaderField: "User-Agent")
         request.setHTTPRequestHeaders(transferTask: transferTask)
 
         urlRequestDelegate?.willSend(request: request)

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+UploadBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService+UploadBehavior.swift
@@ -39,7 +39,7 @@ extension AWSS3StorageService {
                                                                                  metadata: metadata,
                                                                                  accelerate: accelerate,
                                                                                  expires: nil)
-                startUpload(preSignedURL: preSignedURL,
+                await startUpload(preSignedURL: preSignedURL,
                             fileURL: uploadFileURL,
                             contentType: contentType,
                             transferTask: transferTask)
@@ -53,7 +53,7 @@ extension AWSS3StorageService {
                      fileURL: URL,
                      contentType: String,
                      transferTask: StorageTransferTask,
-                     startTransfer: Bool = true) {
+                     startTransfer: Bool = true) async {
         guard case .upload = transferTask.transferType else {
             fatalError("Transfer type must be upload")
         }
@@ -63,7 +63,7 @@ extension AWSS3StorageService {
         request.networkServiceType = .responsiveData
 
         request.setValue(contentType, forHTTPHeaderField: "Content-Type")
-        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue(await userAgent, forHTTPHeaderField: "User-Agent")
 
         request.setHTTPRequestHeaders(transferTask: transferTask)
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
@@ -31,7 +31,12 @@ class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy {
     /// - Tag: AWSS3StorageService.client
     var client: S3ClientProtocol
 
-    let userAgent: String
+    var userAgent: String {
+        get async {
+            await AmplifyAWSServiceConfiguration.userAgentOS
+        }
+    }
+    
     let storageConfiguration: StorageConfiguration
     let sessionConfiguration: URLSessionConfiguration
     var delegateQueue: OperationQueue?
@@ -133,7 +138,6 @@ class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy {
         self.preSignedURLBuilder = preSignedURLBuilder
         self.awsS3 = awsS3
         self.bucket = bucket
-        self.userAgent = "\(AmplifyAWSServiceConfiguration.userAgentLib) \(AmplifyAWSServiceConfiguration.userAgentOS)"
 
         StorageBackgroundEventsRegistry.register(identifier: identifier)
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
@@ -33,7 +33,7 @@ class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy {
 
     var userAgent: String {
         get async {
-            await AmplifyAWSServiceConfiguration.userAgentOS
+            "\(AmplifyAWSServiceConfiguration.userAgentLib) \(await AmplifyAWSServiceConfiguration.userAgentOS)"
         }
     }
     

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
@@ -111,7 +111,7 @@ class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
                   fatalError("Part number is required")
               }
 
-        let startUploadPart: (URL, URL) -> Void = { [weak self] partialFileURL, preSignedURL in
+        let startUploadPart: (URL, URL) async -> Void = { [weak self] partialFileURL, preSignedURL in
             guard let self = self else { return }
             var request = URLRequest(url: preSignedURL)
             request.cachePolicy = .reloadIgnoringLocalCacheData
@@ -122,7 +122,7 @@ class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
             // [UploadPart](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html)
             // operation, the "MultiPart/UploadPart" suffix is added to the
             // user agent.
-            let userAgent = serviceProxy.userAgent.appending(" MultiPart/UploadPart")
+            let userAgent = await serviceProxy.userAgent.appending(" MultiPart/UploadPart")
             request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
 
             self.serviceProxy?.urlRequestDelegate?.willSend(request: request)
@@ -157,7 +157,7 @@ class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
                         accelerate: nil,
                         expires: nil
                     )
-                    startUploadPart(partialFileURL, preSignedURL)
+                    await startUploadPart(partialFileURL, preSignedURL)
                 } catch {
                     self.session?.fail(error: error)
                 }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageServiceProxy.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageServiceProxy.swift
@@ -12,7 +12,7 @@ protocol StorageServiceProxy: AnyObject {
     var preSignedURLBuilder: AWSS3PreSignedURLBuilderBehavior! { get }
     var awsS3: AWSS3Behavior! { get }
     var urlSession: URLSession { get }
-    var userAgent: String { get }
+    var userAgent: String { get async }
     var urlRequestDelegate: URLRequestDelegate? { get }
 
     func register(task: StorageTransferTask)

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageTransferTaskTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageTransferTaskTests.swift
@@ -123,7 +123,7 @@ class StorageTransferTaskTests: XCTestCase {
     /// Given: A StorageTransferTask with status not being paused
     /// When: resume is invoked
     /// Then: No event is reported and the task is not set to .inProgress
-    func testResume_withTaskNotPaused_shouldNotCallResume_andNotReportEvent() {
+    func testResume_withTaskNotPaused_shouldNotCallResume_andNotReportEvent() async {
         let expectation = expectation(description: "no event is received on resume when the session is not paused")
         expectation.isInverted = true
         let task = createTask(
@@ -137,7 +137,7 @@ class StorageTransferTaskTests: XCTestCase {
         XCTAssertEqual(task.status, .unknown)
         
         task.resume()
-        waitForExpectations(timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 0.5)
         
         XCTAssertEqual(task.status, .unknown)
     }

--- a/AmplifyTestCommon/Mocks/MockDevMenuContextProvider.swift
+++ b/AmplifyTestCommon/Mocks/MockDevMenuContextProvider.swift
@@ -10,6 +10,7 @@ import Amplify
 import UIKit
 
 /// Mock class for presenting UI context to developer menu
+@MainActor
 class MockDevMenuContextProvider: DevMenuPresentationContextProvider {
 
     let uiWindow = UIWindow()

--- a/AmplifyTests/CategoryTests/Hub/HubCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubCategoryConfigurationTests.swift
@@ -129,7 +129,7 @@ class HubCategoryConfigurationTests: XCTestCase {
         XCTAssertNotNil(try Amplify.Hub.getPlugin(for: "MockSecondHubCategoryPlugin"))
     }
 
-    func testCanUseDefaultPluginIfOnlyOnePlugin() throws {
+    func testCanUseDefaultPluginIfOnlyOnePlugin() async throws {
         let plugin = MockHubCategoryPlugin()
         let methodInvokedOnDefaultPlugin = expectation(description: "test method invoked on default plugin")
         plugin.listeners.append { message in
@@ -146,8 +146,7 @@ class HubCategoryConfigurationTests: XCTestCase {
 
         let unsubscribeToken = UnsubscribeToken(channel: .storage, id: UUID())
         Amplify.Hub.removeListener(unsubscribeToken)
-
-        waitForExpectations(timeout: 1.0)
+        await fulfillment(of: [methodInvokedOnDefaultPlugin], timeout: 1)
     }
 
     func testPreconditionFailureInvokingWithMultiplePlugins() throws {

--- a/AmplifyTests/DevMenuTests/DevMenuExtensionTests.swift
+++ b/AmplifyTests/DevMenuTests/DevMenuExtensionTests.swift
@@ -10,11 +10,12 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
+@MainActor
 class DevMenuExtensionTests: XCTestCase {
     let provider = MockDevMenuContextProvider()
     override func setUp() async throws {
         do {
-            await Amplify.enableDevMenu(contextProvider: provider)
+            Amplify.enableDevMenu(contextProvider: provider)
 
             /// After await Amplify.reset() is called in teardown(), Amplify.configure() doesn't
             /// initialize the plugin for LoggingCategory . This doesn't call Amplify.getLoggingCategoryPlugin()

--- a/AmplifyTests/DevMenuTests/PersistentLogWrapperTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLogWrapperTests.swift
@@ -10,13 +10,14 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
+@MainActor
 class PersistentLogWrapperTests: XCTestCase {
 
     let provider = MockDevMenuContextProvider()
 
     override func setUp() async throws {
         do {
-            await Amplify.enableDevMenu(contextProvider: provider)
+            Amplify.enableDevMenu(contextProvider: provider)
 
             /// After await Amplify.reset() is called in teardown(), Amplify.configure() doesn't
             /// initialize the plugin for LoggingCategory . This doesn't call Amplify.getLoggingCategoryPlugin()

--- a/AmplifyTests/DevMenuTests/PersistentLoggingPluginTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLoggingPluginTests.swift
@@ -10,13 +10,14 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
+@MainActor
 class PersistentLoggingPluginTests: XCTestCase {
 
     let provider = MockDevMenuContextProvider()
 
     override func setUp() async throws {
         do {
-            await Amplify.enableDevMenu(contextProvider: provider)
+            Amplify.enableDevMenu(contextProvider: provider)
 
             /// After await Amplify.reset() is called in teardown(), Amplify.configure() doesn't
             /// initialize the plugin for LoggingCategory . This doesn't call Amplify.getLoggingCategoryPlugin()

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,27 @@ let dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/aws-amplify/amplify-swift-utils-notifications.git", from: "1.1.0")
 ]
 
+let swift6Settings: [SwiftSetting] = [
+    .enableExperimentalFeature("ConciseMagicFile"),
+    .enableExperimentalFeature("ForwardTrailingClosures"),
+    .enableExperimentalFeature("AccessLevelOnImport"),
+    .enableExperimentalFeature("InternalImportsByDefault"),
+    .enableExperimentalFeature("GlobalConcurrency"),
+    .enableExperimentalFeature("InferSendableFromCaptures"),
+    .enableExperimentalFeature("RegionBasedIsolation"),
+    .enableExperimentalFeature("InternalImportsByDefault"),
+    .enableExperimentalFeature("StrictConcurrency"),
+    .enableExperimentalFeature("ImplicitOpenExistentials"),
+    .enableExperimentalFeature("BareSlashRegexLiterals"),
+    .enableExperimentalFeature("DeprecateApplicationMain"),
+    .enableExperimentalFeature("ImportObjcForwardDeclarations"),
+    .enableExperimentalFeature("DisableOutwardActorInference"),
+    .enableExperimentalFeature("DeprecateApplicationMain"),
+    .enableExperimentalFeature("IsolatedDefaultValues")
+]
+let isSwift6Enabled = true
+let allTargets = false
+
 let amplifyTargets: [Target] = [
     .target(
         name: "Amplify",
@@ -25,7 +46,8 @@ let amplifyTargets: [Target] = [
         ],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .target(
         name: "AWSPluginsCore",
@@ -39,7 +61,8 @@ let amplifyTargets: [Target] = [
         ],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .target(
         name: "AmplifyTestCommon",
@@ -58,7 +81,8 @@ let amplifyTargets: [Target] = [
             "Models/Collection/connection-schema.graphql",
             "Models/TransformerV2/schema.graphql",
             "Models/CustomPrimaryKey/primarykey_schema.graphql"
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .testTarget(
         name: "AmplifyTests",
@@ -71,18 +95,22 @@ let amplifyTargets: [Target] = [
         exclude: [
             "Info.plist",
             "CoreTests/README.md"
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .target(
         name: "AmplifyAsyncTesting",
         dependencies: [],
         path: "AmplifyAsyncTesting/Sources/AsyncTesting",
+        swiftSettings: swift6Settings,
         linkerSettings: [.linkedFramework("XCTest")]
+
     ),
     .testTarget(
         name: "AmplifyAsyncTestingTests",
         dependencies: ["AmplifyAsyncTesting"],
-        path: "AmplifyAsyncTesting/Tests/AsyncTestingTests"
+        path: "AmplifyAsyncTesting/Tests/AsyncTestingTests",
+        swiftSettings: swift6Settings
     ),
     .target(
         name: "AWSPluginsTestCommon",
@@ -94,7 +122,8 @@ let amplifyTargets: [Target] = [
         path: "AmplifyPlugins/Core/AWSPluginsTestCommon",
         exclude: [
             "Info.plist"
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .testTarget(
         name: "AWSPluginsCoreTests",
@@ -106,7 +135,8 @@ let amplifyTargets: [Target] = [
         path: "AmplifyPlugins/Core/AWSPluginsCoreTests",
         exclude: [
             "Info.plist"
-        ]
+        ],
+        swiftSettings: swift6Settings
     )
 ]
 
@@ -124,7 +154,8 @@ let apiTargets: [Target] = [
         ],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .testTarget(
         name: "AWSAPIPluginTests",
@@ -137,7 +168,8 @@ let apiTargets: [Target] = [
         path: "AmplifyPlugins/API/Tests/AWSAPIPluginTests",
         exclude: [
             "Info.plist"
-        ]
+        ],
+        swiftSettings: swift6Settings
     )
 ]
 
@@ -146,14 +178,16 @@ let authTargets: [Target] = [
             dependencies: [
                 "libtommathAmplify"
             ],
-            path: "AmplifyPlugins/Auth/Sources/AmplifyBigInteger"
+            path: "AmplifyPlugins/Auth/Sources/AmplifyBigInteger",
+            swiftSettings: swift6Settings
            ),
     .target(
         name: "AmplifySRP",
         dependencies: [
             .target(name: "AmplifyBigInteger")
         ],
-        path: "AmplifyPlugins/Auth/Sources/AmplifySRP"
+        path: "AmplifyPlugins/Auth/Sources/AmplifySRP",
+        swiftSettings: swift6Settings
     ),
     .target(
         name: "AWSCognitoAuthPlugin",
@@ -168,7 +202,8 @@ let authTargets: [Target] = [
         path: "AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin",
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .target(
         name: "libtommathAmplify",
@@ -177,7 +212,8 @@ let authTargets: [Target] = [
             "changes.txt",
             "LICENSE",
             "README.md"
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .testTarget(
         name: "AWSCognitoAuthPluginUnitTests",
@@ -187,14 +223,16 @@ let authTargets: [Target] = [
             "AmplifyTestCommon"
         ],
         path: "AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests",
-        resources: [.copy("TestResources")]
+        resources: [.copy("TestResources")],
+        swiftSettings: swift6Settings
     ),
     .testTarget(
         name: "AmplifyBigIntegerTests",
         dependencies: [
             "AmplifyBigInteger"
         ],
-        path: "AmplifyPlugins/Auth/Tests/AmplifyBigIntegerUnitTests"
+        path: "AmplifyPlugins/Auth/Tests/AmplifyBigIntegerUnitTests",
+        swiftSettings: swift6Settings
     )
 ]
 
@@ -212,7 +250,8 @@ let dataStoreTargets: [Target] = [
         ],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .testTarget(
         name: "AWSDataStoreCategoryPluginTests",
@@ -224,7 +263,8 @@ let dataStoreTargets: [Target] = [
         path: "AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests",
         exclude: [
             "Info.plist"
-        ]
+        ],
+        swiftSettings: swift6Settings
     )
 ]
 
@@ -241,7 +281,8 @@ let storageTargets: [Target] = [
         ],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .testTarget(
         name: "AWSS3StoragePluginTests",
@@ -254,7 +295,8 @@ let storageTargets: [Target] = [
         path: "AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests",
         exclude: [
             "Resources/Info.plist"
-        ]
+        ],
+        swiftSettings: swift6Settings
     )
 ]
 
@@ -271,7 +313,8 @@ let geoTargets: [Target] = [
         ],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .testTarget(
         name: "AWSLocationGeoPluginTests",
@@ -284,7 +327,8 @@ let geoTargets: [Target] = [
         exclude: [
             "Resources/Info.plist"
         ],
-        resources: []
+        resources: [],
+        swiftSettings: swift6Settings
     )
 ]
 
@@ -302,7 +346,8 @@ let internalPinpointTargets: [Target] = [
         path: "AmplifyPlugins/Internal/Sources/InternalAWSPinpoint",
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .testTarget(
         name: "InternalAWSPinpointUnitTests",
@@ -311,7 +356,8 @@ let internalPinpointTargets: [Target] = [
             "AmplifyTestCommon",
             "AmplifyAsyncTesting"
         ],
-        path: "AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests"
+        path: "AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests",
+        swiftSettings: swift6Settings
     )
 ]
 
@@ -324,7 +370,8 @@ let analyticsTargets: [Target] = [
         path: "AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin",
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .testTarget(
         name: "AWSPinpointAnalyticsPluginUnitTests",
@@ -332,7 +379,8 @@ let analyticsTargets: [Target] = [
             "AWSPinpointAnalyticsPlugin",
             "AmplifyTestCommon"
         ],
-        path: "AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests"
+        path: "AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests",
+        swiftSettings: swift6Settings
     )
 ]
 
@@ -345,7 +393,8 @@ let pushNotificationsTargets: [Target] = [
         path: "AmplifyPlugins/Notifications/Push/Sources/AWSPinpointPushNotificationsPlugin",
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .testTarget(
         name: "AWSPinpointPushNotificationsPluginUnitTests",
@@ -353,7 +402,8 @@ let pushNotificationsTargets: [Target] = [
             "AWSPinpointPushNotificationsPlugin",
             "AmplifyTestCommon"
         ],
-        path: "AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests"
+        path: "AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests",
+        swiftSettings: swift6Settings
     )
 ]
 
@@ -375,13 +425,15 @@ let predictionsTargets: [Target] = [
         exclude: [],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .testTarget(
         name: "AWSPredictionsPluginUnitTests",
         dependencies: ["AWSPredictionsPlugin"],
         path: "AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests",
-        resources: [.copy("TestResources/TestImages") ]
+        resources: [.copy("TestResources/TestImages") ],
+        swiftSettings: swift6Settings
     ),
     .target(
         name: "CoreMLPredictionsPlugin",
@@ -394,7 +446,8 @@ let predictionsTargets: [Target] = [
         ],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .testTarget(
         name: "CoreMLPredictionsPluginUnitTests",
@@ -403,7 +456,8 @@ let predictionsTargets: [Target] = [
             "AmplifyTestCommon"
         ],
         path: "AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests",
-        resources: [.copy("TestResources/TestImages")]
+        resources: [.copy("TestResources/TestImages")],
+        swiftSettings: swift6Settings
     )
 ]
 
@@ -418,7 +472,8 @@ let loggingTargets: [Target] = [
         path: "AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin",
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ]
+        ],
+        swiftSettings: swift6Settings
     ),
     .testTarget(
         name: "AWSCloudWatchLoggingPluginTests",

--- a/Package.swift
+++ b/Package.swift
@@ -15,27 +15,6 @@ let dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/aws-amplify/amplify-swift-utils-notifications.git", from: "1.1.0")
 ]
 
-let swift6Settings: [SwiftSetting] = [
-    .enableExperimentalFeature("ConciseMagicFile"),
-    .enableExperimentalFeature("ForwardTrailingClosures"),
-    .enableExperimentalFeature("AccessLevelOnImport"),
-    .enableExperimentalFeature("InternalImportsByDefault"),
-    .enableExperimentalFeature("GlobalConcurrency"),
-    .enableExperimentalFeature("InferSendableFromCaptures"),
-    .enableExperimentalFeature("RegionBasedIsolation"),
-    .enableExperimentalFeature("InternalImportsByDefault"),
-    .enableExperimentalFeature("StrictConcurrency"),
-    .enableExperimentalFeature("ImplicitOpenExistentials"),
-    .enableExperimentalFeature("BareSlashRegexLiterals"),
-    .enableExperimentalFeature("DeprecateApplicationMain"),
-    .enableExperimentalFeature("ImportObjcForwardDeclarations"),
-    .enableExperimentalFeature("DisableOutwardActorInference"),
-    .enableExperimentalFeature("DeprecateApplicationMain"),
-    .enableExperimentalFeature("IsolatedDefaultValues")
-]
-let isSwift6Enabled = true
-let allTargets = false
-
 let amplifyTargets: [Target] = [
     .target(
         name: "Amplify",
@@ -46,8 +25,7 @@ let amplifyTargets: [Target] = [
         ],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .target(
         name: "AWSPluginsCore",
@@ -61,8 +39,7 @@ let amplifyTargets: [Target] = [
         ],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .target(
         name: "AmplifyTestCommon",
@@ -81,8 +58,7 @@ let amplifyTargets: [Target] = [
             "Models/Collection/connection-schema.graphql",
             "Models/TransformerV2/schema.graphql",
             "Models/CustomPrimaryKey/primarykey_schema.graphql"
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .testTarget(
         name: "AmplifyTests",
@@ -95,22 +71,19 @@ let amplifyTargets: [Target] = [
         exclude: [
             "Info.plist",
             "CoreTests/README.md"
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .target(
         name: "AmplifyAsyncTesting",
         dependencies: [],
         path: "AmplifyAsyncTesting/Sources/AsyncTesting",
-        swiftSettings: swift6Settings,
         linkerSettings: [.linkedFramework("XCTest")]
 
     ),
     .testTarget(
         name: "AmplifyAsyncTestingTests",
         dependencies: ["AmplifyAsyncTesting"],
-        path: "AmplifyAsyncTesting/Tests/AsyncTestingTests",
-        swiftSettings: swift6Settings
+        path: "AmplifyAsyncTesting/Tests/AsyncTestingTests"
     ),
     .target(
         name: "AWSPluginsTestCommon",
@@ -122,8 +95,7 @@ let amplifyTargets: [Target] = [
         path: "AmplifyPlugins/Core/AWSPluginsTestCommon",
         exclude: [
             "Info.plist"
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .testTarget(
         name: "AWSPluginsCoreTests",
@@ -135,8 +107,7 @@ let amplifyTargets: [Target] = [
         path: "AmplifyPlugins/Core/AWSPluginsCoreTests",
         exclude: [
             "Info.plist"
-        ],
-        swiftSettings: swift6Settings
+        ]
     )
 ]
 
@@ -154,8 +125,7 @@ let apiTargets: [Target] = [
         ],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .testTarget(
         name: "AWSAPIPluginTests",
@@ -168,8 +138,7 @@ let apiTargets: [Target] = [
         path: "AmplifyPlugins/API/Tests/AWSAPIPluginTests",
         exclude: [
             "Info.plist"
-        ],
-        swiftSettings: swift6Settings
+        ]
     )
 ]
 
@@ -178,16 +147,14 @@ let authTargets: [Target] = [
             dependencies: [
                 "libtommathAmplify"
             ],
-            path: "AmplifyPlugins/Auth/Sources/AmplifyBigInteger",
-            swiftSettings: swift6Settings
+            path: "AmplifyPlugins/Auth/Sources/AmplifyBigInteger"
            ),
     .target(
         name: "AmplifySRP",
         dependencies: [
             .target(name: "AmplifyBigInteger")
         ],
-        path: "AmplifyPlugins/Auth/Sources/AmplifySRP",
-        swiftSettings: swift6Settings
+        path: "AmplifyPlugins/Auth/Sources/AmplifySRP"
     ),
     .target(
         name: "AWSCognitoAuthPlugin",
@@ -202,8 +169,7 @@ let authTargets: [Target] = [
         path: "AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin",
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .target(
         name: "libtommathAmplify",
@@ -212,8 +178,7 @@ let authTargets: [Target] = [
             "changes.txt",
             "LICENSE",
             "README.md"
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .testTarget(
         name: "AWSCognitoAuthPluginUnitTests",
@@ -223,16 +188,14 @@ let authTargets: [Target] = [
             "AmplifyTestCommon"
         ],
         path: "AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests",
-        resources: [.copy("TestResources")],
-        swiftSettings: swift6Settings
+        resources: [.copy("TestResources")]
     ),
     .testTarget(
         name: "AmplifyBigIntegerTests",
         dependencies: [
             "AmplifyBigInteger"
         ],
-        path: "AmplifyPlugins/Auth/Tests/AmplifyBigIntegerUnitTests",
-        swiftSettings: swift6Settings
+        path: "AmplifyPlugins/Auth/Tests/AmplifyBigIntegerUnitTests"
     )
 ]
 
@@ -250,8 +213,7 @@ let dataStoreTargets: [Target] = [
         ],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .testTarget(
         name: "AWSDataStoreCategoryPluginTests",
@@ -263,8 +225,7 @@ let dataStoreTargets: [Target] = [
         path: "AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests",
         exclude: [
             "Info.plist"
-        ],
-        swiftSettings: swift6Settings
+        ]
     )
 ]
 
@@ -281,8 +242,7 @@ let storageTargets: [Target] = [
         ],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .testTarget(
         name: "AWSS3StoragePluginTests",
@@ -295,8 +255,7 @@ let storageTargets: [Target] = [
         path: "AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests",
         exclude: [
             "Resources/Info.plist"
-        ],
-        swiftSettings: swift6Settings
+        ]
     )
 ]
 
@@ -313,8 +272,7 @@ let geoTargets: [Target] = [
         ],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .testTarget(
         name: "AWSLocationGeoPluginTests",
@@ -327,8 +285,7 @@ let geoTargets: [Target] = [
         exclude: [
             "Resources/Info.plist"
         ],
-        resources: [],
-        swiftSettings: swift6Settings
+        resources: []
     )
 ]
 
@@ -346,8 +303,7 @@ let internalPinpointTargets: [Target] = [
         path: "AmplifyPlugins/Internal/Sources/InternalAWSPinpoint",
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .testTarget(
         name: "InternalAWSPinpointUnitTests",
@@ -356,8 +312,7 @@ let internalPinpointTargets: [Target] = [
             "AmplifyTestCommon",
             "AmplifyAsyncTesting"
         ],
-        path: "AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests",
-        swiftSettings: swift6Settings
+        path: "AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests"
     )
 ]
 
@@ -370,8 +325,7 @@ let analyticsTargets: [Target] = [
         path: "AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin",
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .testTarget(
         name: "AWSPinpointAnalyticsPluginUnitTests",
@@ -379,8 +333,7 @@ let analyticsTargets: [Target] = [
             "AWSPinpointAnalyticsPlugin",
             "AmplifyTestCommon"
         ],
-        path: "AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests",
-        swiftSettings: swift6Settings
+        path: "AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests"
     )
 ]
 
@@ -393,8 +346,7 @@ let pushNotificationsTargets: [Target] = [
         path: "AmplifyPlugins/Notifications/Push/Sources/AWSPinpointPushNotificationsPlugin",
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .testTarget(
         name: "AWSPinpointPushNotificationsPluginUnitTests",
@@ -402,8 +354,7 @@ let pushNotificationsTargets: [Target] = [
             "AWSPinpointPushNotificationsPlugin",
             "AmplifyTestCommon"
         ],
-        path: "AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests",
-        swiftSettings: swift6Settings
+        path: "AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests"
     )
 ]
 
@@ -425,15 +376,13 @@ let predictionsTargets: [Target] = [
         exclude: [],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .testTarget(
         name: "AWSPredictionsPluginUnitTests",
         dependencies: ["AWSPredictionsPlugin"],
         path: "AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests",
-        resources: [.copy("TestResources/TestImages") ],
-        swiftSettings: swift6Settings
+        resources: [.copy("TestResources/TestImages") ]
     ),
     .target(
         name: "CoreMLPredictionsPlugin",
@@ -446,8 +395,7 @@ let predictionsTargets: [Target] = [
         ],
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .testTarget(
         name: "CoreMLPredictionsPluginUnitTests",
@@ -456,8 +404,7 @@ let predictionsTargets: [Target] = [
             "AmplifyTestCommon"
         ],
         path: "AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests",
-        resources: [.copy("TestResources/TestImages")],
-        swiftSettings: swift6Settings
+        resources: [.copy("TestResources/TestImages")]
     )
 ]
 
@@ -472,8 +419,7 @@ let loggingTargets: [Target] = [
         path: "AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin",
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
-        ],
-        swiftSettings: swift6Settings
+        ]
     ),
     .testTarget(
         name: "AWSCloudWatchLoggingPluginTests",

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
UIDevice is marked with `@MainActor` attribute resulting in errors when calling it from synchronous non-isolated context.
Resolve strict concurrency error by updating `DeviceInfo` and calling `UIDevice` from main-actor isolated context.

This results in changes in AWSCognitoAuthPlugin and InternalAWSPinpoint so that calls to DeviceInfo is executed in an async context.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
