### PR TITLE
feat(amplify): make GraphQLOperationType extends from String

### DIFF
--- a/Amplify/Categories/API/Request/GraphQLOperationType.swift
+++ b/Amplify/Categories/API/Request/GraphQLOperationType.swift
@@ -6,7 +6,7 @@
 //
 
 /// The type of a GraphQL operation
-public enum GraphQLOperationType {
+public enum GraphQLOperationType: String {
     /// A GraphQL Query operation
     case query
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/SingleDirectiveGraphQLDocument.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/SingleDirectiveGraphQLDocument.swift
@@ -8,12 +8,6 @@
 import Amplify
 import Foundation
 
-public enum GraphQLOperationType: String {
-    case mutation
-    case query
-    case subscription
-}
-
 public typealias GraphQLParameterName = String
 
 /// Represents a single directive GraphQL document. Concrete types that conform to this protocol must


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

During the `amplify-flutter` migration to datastore v2, and with SPM not yet supported by the Google Flutter framework, the Amplify Flutter team needs to copy datastore v2 and its dependency packages into the Flutter repository and build for the `amplify-flutter` project. The `GraphQLOperationType` data structure appears in both the `Amplify` package and the `AmplifyPluginsCore` package, causing a name collision. This issue did not arise in the Swift package due to different package namespaces, but it is problematic in amplify-flutter as all the code shares the same namespace.

In this PR, we propose a solution to retain the `GraphQLOperationType` declaration in the `Amplify` package and extend it with a String value. The declaration in the `AmplifyPluginsCore` package is removed, as it is an internal package. 

### Is this a breaking change?
**Removing the public declaration of GraphQLOperationType in the AmplifyPluginsCore package**

This should not be considered a breaking change, as AmplifyPluginsCore is an internal package.

**Adding a String value to the existing public declaration of GraphQLOperationType in the Amplify package**

It is unclear if this qualifies as a breaking change. While adding a String value is generally considered an additive change, it does alter the definition of the public data structure.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
