### PR TITLE
fix(datastore): change OutgoingMutationQueue use TaskQueue for state transitions

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -137,7 +137,7 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
         queryMutationEventsFromStorage { [weak self] in
             guard let self = self else { return }
             guard case .starting = self.stateMachine.state else {
-                self.log.debug("Failed to continue doStart operation, current state(\(self.stateMachine.state)) is not starting")
+                self.log.debug("Unexpected state transition while performing `doStart()` during `.starting` state. Current state: \(self.stateMachine.state).")
                 return
             }
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -27,10 +27,7 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
     private let operationQueue: OperationQueue
 
     /// A DispatchQueue for synchronizing state on the mutation queue
-    private let mutationDispatchQueue = DispatchQueue(
-        label: "com.amazonaws.OutgoingMutationQueue",
-        target: DispatchQueue.global()
-    )
+    private let mutationDispatchQueue = TaskQueue<Void>()
 
     private weak var api: APICategoryGraphQLBehaviorExtended?
     private weak var reconciliationQueue: IncomingEventReconciliationQueue?
@@ -55,7 +52,7 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
 
         let operationQueue = OperationQueue()
         operationQueue.name = "com.amazonaws.OutgoingMutationOperationQueue"
-        operationQueue.underlyingQueue = mutationDispatchQueue
+        operationQueue.qualityOfService = .default
         operationQueue.maxConcurrentOperationCount = 1
         operationQueue.isSuspended = true
 
@@ -139,6 +136,10 @@ final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
 
         queryMutationEventsFromStorage { [weak self] in
             guard let self = self else { return }
+            guard case .starting = self.stateMachine.state else {
+                self.log.debug("Failed to continue doStart operation, current state(\(self.stateMachine.state)) is not starting")
+                return
+            }
 
             self.operationQueue.isSuspended = false
             // State machine notification to ".receivedSubscription" will be handled in `receive(subscription:)`


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
- https://github.com/aws-amplify/amplify-swift/issues/3325
- https://github.com/aws-amplify/amplify-swift/issues/3467
- https://github.com/aws-amplify/amplify-swift/issues/3649

The crash reports indicate that a `SEGV_ACCERR` occurred due to an attempted dereference of a garbage pointer. In the implementation of the `OutgoingMutationQueue`, the `mutationDispatchQueue` was targeted to the concurrent global queue, with state transition actions being dispatched to this queue. This setup means that `starting` and `stopping` could trigger two state transite operations running concurrently. Specifically, the starting action needs to complete some I/O work, while the stopping action is cleaning up the operation queue, potentially causing a data race.

## Description
<!-- Why is this change required? What problem does it solve? -->

In this PR, we modified `mutationDispatchQueue` to use the `TaskQueue` implementation, ensuring that all state transition actions run serially. Also, we set the mutation event `operationQueue` to have the same QOS as the global queue and removed the underlying queue.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
