### PR TITLE
fix(logging): no log should be logged when loglevel is none

### DIFF
--- a/Amplify/Categories/Logging/LogLevel.swift
+++ b/Amplify/Categories/Logging/LogLevel.swift
@@ -9,12 +9,12 @@
 ///
 public extension Amplify {
     enum LogLevel: Int, Codable {
+        case none
         case error
         case warn
         case info
         case debug
         case verbose
-        case none
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.singleValueContainer()

--- a/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/Internal/OSLogWrapper.swift
+++ b/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/Internal/OSLogWrapper.swift
@@ -29,7 +29,7 @@ final class OSLogWrapper: Logger {
     }
 
     public func error(_ message: @autoclosure () -> String) {
-        guard enabled else { return }
+        guard enabled, logLevel.rawValue >= LogLevel.error.rawValue else { return }
         os_log("%@",
                log: osLog,
                type: OSLogType.error,
@@ -37,7 +37,7 @@ final class OSLogWrapper: Logger {
     }
 
     public func error(error: Error) {
-        guard enabled else { return }
+        guard enabled, logLevel.rawValue >= LogLevel.error.rawValue else { return }
         os_log("%@",
                log: osLog,
                type: OSLogType.error,

--- a/AmplifyTests/CategoryTests/Logging/DefaultLoggingPluginTests.swift
+++ b/AmplifyTests/CategoryTests/Logging/DefaultLoggingPluginTests.swift
@@ -155,4 +155,43 @@ class DefaultLoggingPluginTests: XCTestCase {
                                globalMessageCorrectlyEvaluated],
                           timeout: 0.1)
     }
+
+    /// - Given: default configuration
+    /// - When:
+    ///   - set logLevel to .none
+    /// - Then:
+    ///   - no log is recorded
+    func testLoggerWithNoneLogLevel_noLogsAreRecorded() async {
+        Amplify.Logging.logLevel = .none
+
+        let errorMessageIncorrectlyEvaluated = expectation(description: "error message was incorrectly evaluated")
+        errorMessageIncorrectlyEvaluated.isInverted = true
+        Amplify.Logging.error("error \(errorMessageIncorrectlyEvaluated.fulfill())")
+
+        let warnMessageIncorrectlyEvaluated = expectation(description: "warn message was incorrectly evaluated")
+        warnMessageIncorrectlyEvaluated.isInverted = true
+        Amplify.Logging.warn("warn \(warnMessageIncorrectlyEvaluated.fulfill())")
+
+        let infoMessageIncorrectlyEvaluated = expectation(description: "info message was incorrectly evaluated")
+        infoMessageIncorrectlyEvaluated.isInverted = true
+        Amplify.Logging.info("info \(infoMessageIncorrectlyEvaluated.fulfill())")
+
+        let debugMessageIncorrectlyEvaluated = expectation(description: "debug message was incorrectly evaluated")
+        debugMessageIncorrectlyEvaluated.isInverted = true
+        Amplify.Logging.debug("debug \(debugMessageIncorrectlyEvaluated.fulfill())")
+
+        let verboseMessageIncorrectlyEvaluated = expectation(description: "verbose message was incorrectly evaluated")
+        verboseMessageIncorrectlyEvaluated.isInverted = true
+        Amplify.Logging.verbose("verbose \(verboseMessageIncorrectlyEvaluated.fulfill())")
+        await fulfillment(
+            of: [
+                errorMessageIncorrectlyEvaluated,
+                warnMessageIncorrectlyEvaluated,
+                infoMessageIncorrectlyEvaluated,
+                debugMessageIncorrectlyEvaluated,
+                verboseMessageIncorrectlyEvaluated
+            ],
+            timeout: 0.3
+        )
+    }
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

https://github.com/aws-amplify/amplify-swift/issues/3727

## Description
<!-- Why is this change required? What problem does it solve? -->

The log level `.none` should not produce any logs, but it is currently misplaced in the `LogLevel` enum and has the same effect as `.verbose`. 
In this PR, we have updated `.none` to be lower than the `.error` log level. Additionally, we have added a log level check guard condition in the `log.error` API.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
