### PR TITLE
fix(datastore): use error description to produce clearer error info

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventToAnyModelMapper.swift
@@ -83,7 +83,7 @@ final class IncomingAsyncSubscriptionEventToAnyModelMapper: Subscriber, AmplifyC
         case .success(let mutationSync):
             modelsFromSubscription.send(.payload(mutationSync))
         case .failure(let failure):
-            log.error(error: failure)
+            log.error(failure.errorDescription)
         }
     }
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
When logging an error with the error itself, the log generates messages like `The operation couldn’t be completed`, which is no help for developers.

<img width="848" alt="image" src="https://github.com/aws-amplify/amplify-swift/assets/459711/aff802dc-2bd2-45d1-b782-19ff359289cb">

## Description
<!-- Why is this change required? What problem does it solve? -->

Updated to use the error description, to give more error info in error log.

<img width="857" alt="image" src="https://github.com/aws-amplify/amplify-swift/assets/459711/44c3c20f-00cf-44f1-b803-f694b8c9f693">


## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
