### PR TITLE
fix(ci): update unstable release file path in CI scripts

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -46,7 +46,8 @@ platform :ios do
   desc "Increment versions"
   private_lane :increment_versions do |options|
     version = options[:version].to_s
-    set_key_value(file: "AmplifyPlugins/Core/AWSPluginsCore/ServiceConfiguration/AmplifyAWSServiceConfiguration.swift", key: "amplifyVersion", value: version)
+    configuration_file_path = "AmplifyPlugins/Core/AmplifyCredentials/AmplifyAWSServiceConfiguration.swift"
+    set_key_value(file: configuration_file_path, key: "amplifyVersion", value: version)
   end
 
   desc "Commit and push"
@@ -77,7 +78,7 @@ platform :ios do
     version = options[:version].to_s
     changelog = options[:changelog]
     tag = "#{version}"
-  
+
     sh('bundle', 'exec', 'swift', 'package', 'update')
 
     write_changelog(changelog: changelog, path: 'CHANGELOG.md')


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

During refactoring #3666 , we've moved file `AmplifyAWSServiceConfiguration.swift` from `AmplifyPluginsCore` to new package `InternalAmplifyCredential`. The new path for this file should be `AmplifyPlugins/Core/AmplifyCredentials/AmplifyAWSServiceConfiguration.swift`.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
