### PR TITLE
chore: remove unused internal modules after renaming

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplify-Package.xcscheme
@@ -490,34 +490,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AWSPluginsSDKCore"
-               BuildableName = "AWSPluginsSDKCore"
-               BlueprintName = "AWSPluginsSDKCore"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AmplifyCredentials"
-               BuildableName = "AmplifyCredentials"
-               BlueprintName = "AmplifyCredentials"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "InternalAmplifyCredentials"
                BuildableName = "InternalAmplifyCredentials"
                BlueprintName = "InternalAmplifyCredentials"
@@ -780,46 +752,6 @@
                BlueprintIdentifier = "AWSCloudWatchLoggingPluginTests"
                BuildableName = "AWSCloudWatchLoggingPluginTests"
                BlueprintName = "AWSCloudWatchLoggingPluginTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AmplifyNetworkUnitTests"
-               BuildableName = "AmplifyNetworkUnitTests"
-               BlueprintName = "AmplifyNetworkUnitTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "InternalAmplifyNetworkUnitTests"
-               BuildableName = "InternalAmplifyNetworkUnitTests"
-               BlueprintName = "InternalAmplifyNetworkUnitTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AWSPluginsSDKCoreTests"
-               BuildableName = "AWSPluginsSDKCoreTests"
-               BlueprintName = "AWSPluginsSDKCoreTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AmplifyCredentialsTests"
-               BuildableName = "AmplifyCredentialsTests"
-               BlueprintName = "AmplifyCredentialsTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
![image](https://github.com/aws-amplify/amplify-swift/assets/459711/8732f3d3-126a-4bdd-ba4c-c6111c2185fb)

## Description
<!-- Why is this change required? What problem does it solve? -->

There are some unused, dangling modules appearing in the `Amplify-Package` target. These modules were renamed and should be removed from the `Amplify-Package` scheme.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
