### PR TITLE
fix(core): remove InternalAmplifyCredentials from products

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -485,10 +485,6 @@ let package = Package(
             targets: ["AWSPluginsCore"]
         ),
         .library(
-            name: "InternalAmplifyCredentials",
-            targets: ["InternalAmplifyCredentials"]
-        ),
-        .library(
             name: "AWSAPIPlugin",
             targets: ["AWSAPIPlugin"]
         ),


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

- removing the `InternalAmplifyCredential` package, intended for internal use, from the products.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
