### PR TITLE
test(datastore): fix broken datastore observeQuery integ tests

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
@@ -83,6 +83,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         try await clearDataStore()
         var snapshots = [DataStoreQuerySnapshot<Post>]()
         let snapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
+        snapshotWithIsSynced.assertForOverFulfill = false
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self)).sink { completed in
             switch completed {
             case .finished:
@@ -130,6 +131,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         var isObserveQueryReadyForTest = false
         let observeQueryReadyForTest = expectation(description: "received query snapshot with .isSynced true")
         let snapshotWithPost = expectation(description: "received first snapshot")
+        snapshotWithPost.assertForOverFulfill = false
         let post = Post(title: "title", content: "content", createdAt: .now())
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self)).sink { completed in
             switch completed {
@@ -339,6 +341,7 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         try await clearDataStore()
 
         let snapshotWithIsSynced = expectation(description: "query snapshot with isSynced true")
+        snapshotWithIsSynced.assertForOverFulfill = false
         var snapshots = [DataStoreQuerySnapshot<Post>]()
 
         Amplify.Publisher.create(Amplify.DataStore.observeQuery(for: Post.self)).sink { completed in
@@ -363,7 +366,6 @@ class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
         await fulfillment(of: [snapshotWithIsSynced], timeout: 30)
         XCTAssertTrue(snapshots.count >= 2)
         XCTAssertFalse(snapshots[0].isSynced)
-        XCTAssertEqual(1, snapshots.filter({ $0.isSynced }).count)
 
         let theSyncedSnapshot = snapshots.first(where: { $0.isSynced })
         XCTAssertNotNil(theSyncedSnapshot)


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

There are several flaky datastore integration tests related to the `observeQuery` API. The query snapshots are being observed multiple times within the test cases, whereas the assertion should only occur once.

## Description
<!-- Why is this change required? What problem does it solve? -->

This is expected behavior. During the test case setup, if a new record is created. The subsequent incoming mutation event from the AppSync server (with version 1) will be received, and a snapshot may be triggered by [the after-sync listener](https://github.com/aws-amplify/amplify-swift/blob/main/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStoreObserveQueryOperation.swift#L248-L253).

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
