### PR TITLE
feat(Storage): Adding subpath strategy to the List operation

### DIFF
--- a/Amplify/Categories/Storage/Operation/Request/StorageListRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageListRequest.swift
@@ -60,6 +60,11 @@ public extension StorageListRequest {
         @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let path: String?
 
+        /// The strategy to use when listing contents from subpaths. Defaults to [`.include`](x-source-tag://SubpathStrategy.include)
+        ///
+        /// - Tag: StorageListRequestOptions.subpathStrategy
+        public let subpathStrategy: SubpathStrategy
+
         /// Number between 1 and 1,000 that indicates the limit of how many entries to fetch when
         /// retreiving file lists from the server.
         ///
@@ -94,15 +99,47 @@ public extension StorageListRequest {
         public init(accessLevel: StorageAccessLevel = .guest,
                     targetIdentityId: String? = nil,
                     path: String? = nil,
+                    subpathStrategy: SubpathStrategy = .include,
                     pageSize: UInt = 1000,
                     nextToken: String? = nil,
                     pluginOptions: Any? = nil) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.path = path
+            self.subpathStrategy = subpathStrategy
             self.pageSize = pageSize
             self.nextToken = nextToken
             self.pluginOptions = pluginOptions
+        }
+    }
+}
+
+public extension StorageListRequest.Options {
+    /// Represents the strategy used when listing contents from subpaths relative to the given path.
+    ///
+    /// - Tag: StorageListRequestOptions.SubpathStrategy
+    enum SubpathStrategy {
+        /// Items from nested subpaths are included in the results
+        ///
+        /// - Tag: SubpathStrategy.include
+        case include
+
+        /// Items from nested subpaths are not included in the results. Their subpaths are instead grouped under [`StorageListResult.excludedSubpaths`](StorageListResult.excludedSubpaths).
+        ///
+        /// - Parameter delimitedBy: The delimiter used to determine subpaths. Defaults to `"/"`
+        ///
+        /// - SeeAlso: [`StorageListResult.excludedSubpaths`](x-source-tag://StorageListResult.excludedSubpaths)
+        ///
+        /// - Tag: SubpathStrategy.excludeWithDelimiter
+        case exclude(delimitedBy: String = "/")
+
+        /// Items from nested subpaths are not included in the results. Their subpaths are instead grouped under [`StorageListResult.excludedSubpaths`](StorageListResult.excludedSubpaths).
+        ///
+        /// - SeeAlso: [`StorageListResult.excludedSubpaths`](x-source-tag://StorageListResult.excludedSubpaths)
+        ///
+        /// - Tag: SubpathStrategy.exclude
+        public static var exclude: SubpathStrategy {
+            return .exclude()
         }
     }
 }

--- a/Amplify/Categories/Storage/Result/StorageListResult.swift
+++ b/Amplify/Categories/Storage/Result/StorageListResult.swift
@@ -17,8 +17,13 @@ public struct StorageListResult {
     /// [StorageCategoryBehavior.list](x-source-tag://StorageCategoryBehavior.list).
     ///
     /// - Tag: StorageListResult.init
-    public init(items: [Item], nextToken: String? = nil) {
+    public init(
+        items: [Item],
+        excludedSubpaths: [String] = [],
+        nextToken: String? = nil
+    ) {
         self.items = items
+        self.excludedSubpaths = excludedSubpaths
         self.nextToken = nextToken
     }
 
@@ -26,6 +31,13 @@ public struct StorageListResult {
     ///
     /// - Tag: StorageListResult.items
     public var items: [Item]
+
+
+    /// Array of excluded subpaths in the Result. 
+    /// This field is only populated when [`StorageListRequest.Options.subpathStrategy`](x-source-tag://StorageListRequestOptions.subpathStragegy) is set to [`.exclude()`](x-source-tag://SubpathStrategy.exclude).
+    ///
+    /// - Tag: StorageListResult.excludedSubpaths
+    public var excludedSubpaths: [String]
 
     /// Opaque string indicating the page offset at which to resume a listing. This value is usually copied to
     /// [StorageListRequestOptions.nextToken](x-source-tag://StorageListRequestOptions.nextToken).

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/SubpathStategy+Delimiter.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/SubpathStategy+Delimiter.swift
@@ -1,0 +1,20 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+
+extension StorageListRequest.Options.SubpathStrategy {
+    /// The delimiter for this strategy 
+    var delimiter: String? {
+        switch self {
+        case .exclude(let delimiter):
+            return delimiter
+        case .include:
+            return nil
+        }
+    }
+}

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginAsyncBehaviorTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginAsyncBehaviorTests.swift
@@ -114,4 +114,22 @@ class AWSS3StoragePluginAsyncBehaviorTests: XCTestCase {
         XCTAssertEqual(1, storageService.interactions.count)
     }
 
+    /// - Given: A plugin configured with a mocked service
+    /// - When: The list API is invoked with subpathStrategy set to .exclude
+    /// - Then: The list of excluded subpaths and the list of items should be populated
+    func testPluginListWithCommonPrefixesAsync() async throws  {
+        storageService.listHandler = { (_, _) in
+            return .init(
+                items: [.init(path: "path")],
+                excludedSubpaths: ["subpath1", "subpath2"]
+            )
+        }
+        let output = try await storagePlugin.list(options: .init(subpathStrategy: .exclude))
+        XCTAssertEqual(1, output.items.count, String(describing: output))
+        XCTAssertEqual("path", output.items.first?.path)
+        XCTAssertEqual(2, output.excludedSubpaths.count)
+        XCTAssertEqual("subpath1", output.excludedSubpaths[0])
+        XCTAssertEqual("subpath2", output.excludedSubpaths[1])
+        XCTAssertEqual(1, storageService.interactions.count)
+    }
 }


### PR DESCRIPTION
## Description
This PR introduces the `subpathStrategy` parameter to `StorageListRequest.Options` and its corresponding `SubpathStrategy` enum type.

Using this field will affect the results included in the response:
- `subpathStrategy: .include`: Objects that are included in nested subpaths will be included in the response. **This is the default behaviour**
- `subpathStrategy: .exclude`: Objects that are included in nested subpaths are not included in the response, instead their subpaths are included in the `excludedSubpaths` list.
- `subpathStrategy: .exclude(delimitedBy:)`: Same as above, but it allows to set a custom character as delimiter for subpaths. The delimiter parameter defaults to `"/"`, which is the same as `.exclude`.

## General Checklist
- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] [All integration tests pass](https://github.com/aws-amplify/amplify-swift/actions/runs/9976983528)
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [X] Documentation update for the change if required
  - https://github.com/aws-amplify/docs/pull/7831
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
