### PR TITLE
chore(ci): upgrade dependency rexml version to 3.3.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.3.2)
+    rexml (3.3.4)
       strscan
     rouge (2.0.7)
     ruby-macho (2.5.1)

--- a/canaries/example/Gemfile.lock
+++ b/canaries/example/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.3.2)
+    rexml (3.3.4)
       strscan
     rouge (2.0.7)
     ruby2_keywords (0.0.5)
@@ -221,4 +221,4 @@ DEPENDENCIES
   fastlane
 
 BUNDLED WITH
-   2.3.11
+   2.3.7


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

https://github.com/aws-amplify/amplify-swift/security/dependabot/13
https://github.com/aws-amplify/amplify-swift/security/dependabot/14

## Description
<!-- Why is this change required? What problem does it solve? -->

Upgrade CI dependency gem `rexml` to `>= 3.3.3`

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
