### PR TITLE
chore: update xcodeproj gem to 1.25.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,5 @@ source 'https://rubygems.org'
 gem 'xcpretty', '0.3.0'
 gem 'fastlane', '2.205.1'
 gem 'jazzy', '0.14.2'
-gem "xcodeproj", git: "https://github.com/CocoaPods/Xcodeproj.git", :branch => "master", ref: "fe55cf5"
 eval_gemfile('fastlane/Pluginfile')
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,4 @@
 GIT
-  remote: https://github.com/CocoaPods/Xcodeproj.git
-  revision: fe55cf57badef2ca27fb9d4f801d9b834de1f871
-  ref: fe55cf5
-  branch: master
-  specs:
-    xcodeproj (1.24.0)
-      CFPropertyList (>= 2.3.3, < 4.0)
-      atomos (~> 0.1.3)
-      claide (>= 1.0.2, < 2.0)
-      colored2 (~> 3.1)
-      nanaimo (~> 0.3.0)
-      rexml (>= 3.3.2, < 4.0)
-
-GIT
   remote: https://github.com/aws-amplify/amplify-ci-support
   revision: 74ed2db1f09d93b48129590bcd17cc9b53251756
   branch: main
@@ -308,6 +294,13 @@ GEM
     word_wrap (1.0.0)
     xcinvoke (0.3.0)
       liferaft (~> 0.0.6)
+    xcodeproj (1.25.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.3.0)
+      rexml (>= 3.3.2, < 4.0)
     xcpretty (0.3.0)
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)
@@ -320,8 +313,7 @@ DEPENDENCIES
   fastlane (= 2.205.1)
   fastlane-plugin-release_actions!
   jazzy (= 0.14.2)
-  xcodeproj!
   xcpretty (= 0.3.0)
 
 BUNDLED WITH
-   2.3.7
+   2.5.14


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
Dependabot alerts related to old rexml version

## Description
<!-- Why is this change required? What problem does it solve? -->
Reverting changes from https://github.com/aws-amplify/amplify-swift/pull/3796 and updating bundle dependencies

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
