### PR TITLE
feat(Storage): Adding StorageBucket

### DIFF
--- a/Amplify/Categories/Storage/Operation/Request/StorageDownloadDataRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageDownloadDataRequest.swift
@@ -64,6 +64,11 @@ public extension StorageDownloadDataRequest {
         @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let targetIdentityId: String?
 
+        /// A Storage Bucket that contains the object to download. Defaults to `nil`, in which case the default one will be used.
+        ///
+        /// - Tag: StorageDownloadDataRequest.bucket
+        public let bucket: (any StorageBucket)?
+
         /// Extra plugin specific options, only used in special circumstances when the existing options do not provide
         /// a way to utilize the underlying storage system's functionality. See plugin documentation for expected
         /// key/values
@@ -90,20 +95,28 @@ public extension StorageDownloadDataRequest {
 
         ///
         /// - Tag: StorageDownloadDataRequestOptions.init
-        @available(*, deprecated, message: "Use init(pluginOptions)")
-        public init(accessLevel: StorageAccessLevel = .guest,
-                    targetIdentityId: String? = nil,
-                    pluginOptions: Any? = nil) {
+        @available(*, deprecated, message: "Use init(bucket:pluginOptions)")
+        public init(
+            accessLevel: StorageAccessLevel = .guest,
+            targetIdentityId: String? = nil,
+            bucket: (any StorageBucket)? = nil,
+            pluginOptions: Any? = nil
+        ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
+            self.bucket = bucket
             self.pluginOptions = pluginOptions
         }
 
         ///
         /// - Tag: StorageDownloadDataRequestOptions.init
-        public init(pluginOptions: Any? = nil) {
+        public init(
+            bucket: (any StorageBucket)? = nil,
+            pluginOptions: Any? = nil
+        ) {
             self.accessLevel = .guest
             self.targetIdentityId = nil
+            self.bucket = bucket
             self.pluginOptions = pluginOptions
         }
     }

--- a/Amplify/Categories/Storage/Operation/Request/StorageDownloadFileRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageDownloadFileRequest.swift
@@ -71,6 +71,11 @@ public extension StorageDownloadFileRequest {
         @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let targetIdentityId: String?
 
+        /// A Storage Bucket that contains the object to download. Defaults to `nil`, in which case the default one will be used.
+        ///
+        /// - Tag: StorageDownloadDataRequest.bucket
+        public let bucket: (any StorageBucket)?
+
         /// Extra plugin specific options, only used in special circumstances when the existing options do not provide
         /// a way to utilize the underlying storage system's functionality. See plugin documentation for expected
         /// key/values
@@ -79,20 +84,27 @@ public extension StorageDownloadFileRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageDownloadFileRequestOptions.init
-        @available(*, deprecated, message: "Use init(pluginOptions)")
-        public init(accessLevel: StorageAccessLevel = .guest,
-                    targetIdentityId: String? = nil,
-                    pluginOptions: Any? = nil) {
+        @available(*, deprecated, message: "Use init(bucket:pluginOptions)")
+        public init(
+            accessLevel: StorageAccessLevel = .guest,
+            targetIdentityId: String? = nil,
+            bucket: (any StorageBucket)? = nil,
+            pluginOptions: Any? = nil
+        ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
+            self.bucket = bucket
             self.pluginOptions = pluginOptions
         }
 
         /// - Tag: StorageDownloadFileRequestOptions.init
-        @available(*, deprecated, message: "Use init(pluginOptions)")
-        public init(pluginOptions: Any? = nil) {
+        public init(
+            bucket: (any StorageBucket)? = nil,
+            pluginOptions: Any? = nil
+        ) {
             self.accessLevel = .guest
             self.targetIdentityId = nil
+            self.bucket = bucket
             self.pluginOptions = pluginOptions
         }
     }

--- a/Amplify/Categories/Storage/Operation/Request/StorageGetURLRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageGetURLRequest.swift
@@ -73,6 +73,11 @@ public extension StorageGetURLRequest {
         /// - Tag: StorageGetURLRequest.Options.expires
         public let expires: Int
 
+        /// A Storage Bucket that contains the object. Defaults to `nil`, in which case the default one will be used.
+        ///
+        /// - Tag: StorageDownloadDataRequest.bucket
+        public let bucket: (any StorageBucket)?
+
         /// Extra plugin specific options, only used in special circumstances when the existing options do
         /// not provide a way to utilize the underlying storage system's functionality. See plugin
         /// documentation or
@@ -83,21 +88,29 @@ public extension StorageGetURLRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageGetURLRequest.Options.init
-        @available(*, deprecated, message: "Use init(expires:pluginOptions)")
-        public init(accessLevel: StorageAccessLevel = .guest,
-                    targetIdentityId: String? = nil,
-                    expires: Int = Options.defaultExpireInSeconds,
-                    pluginOptions: Any? = nil) {
+        @available(*, deprecated, message: "Use init(expires:bucket:pluginOptions)")
+        public init(
+            accessLevel: StorageAccessLevel = .guest,
+            targetIdentityId: String? = nil,
+            expires: Int = Options.defaultExpireInSeconds,
+            bucket: (any StorageBucket)? = nil,
+            pluginOptions: Any? = nil
+        ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.expires = expires
+            self.bucket = bucket
             self.pluginOptions = pluginOptions
         }
 
         /// - Tag: StorageGetURLRequest.Options.init
-        public init(expires: Int = Options.defaultExpireInSeconds,
-                    pluginOptions: Any? = nil) {
+        public init(
+            expires: Int = Options.defaultExpireInSeconds,
+            bucket: (any StorageBucket)? = nil,
+            pluginOptions: Any? = nil
+        ) {
             self.expires = expires
+            self.bucket = bucket
             self.pluginOptions = pluginOptions
             self.accessLevel = .guest
             self.targetIdentityId = nil

--- a/Amplify/Categories/Storage/Operation/Request/StorageListRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageListRequest.swift
@@ -78,6 +78,11 @@ public extension StorageListRequest {
         /// - Tag: StorageListRequestOptions.pageSize
         public let pageSize: UInt
 
+        /// A Storage Bucket that contains the objects to list. Defaults to `nil`, in which case the default one will be used.
+        ///
+        /// - Tag: StorageDownloadDataRequest.bucket
+        public let bucket: (any StorageBucket)?
+
         /// Opaque string indicating the page offset at which to resume a listing. This is usually a copy of
         /// the value from [StorageListResult.nextToken](x-source-tag://StorageListResult.nextToken).
         ///
@@ -96,18 +101,22 @@ public extension StorageListRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageListRequestOptions.init
-        public init(accessLevel: StorageAccessLevel = .guest,
-                    targetIdentityId: String? = nil,
-                    path: String? = nil,
-                    subpathStrategy: SubpathStrategy = .include,
-                    pageSize: UInt = 1000,
-                    nextToken: String? = nil,
-                    pluginOptions: Any? = nil) {
+        public init(
+            accessLevel: StorageAccessLevel = .guest,
+            targetIdentityId: String? = nil,
+            path: String? = nil,
+            subpathStrategy: SubpathStrategy = .include,
+            pageSize: UInt = 1000,
+            bucket: (any StorageBucket)? = nil,
+            nextToken: String? = nil,
+            pluginOptions: Any? = nil
+        ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.path = path
             self.subpathStrategy = subpathStrategy
             self.pageSize = pageSize
+            self.bucket = bucket
             self.nextToken = nextToken
             self.pluginOptions = pluginOptions
         }

--- a/Amplify/Categories/Storage/Operation/Request/StorageRemoveRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageRemoveRequest.swift
@@ -56,6 +56,11 @@ public extension StorageRemoveRequest {
         @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let accessLevel: StorageAccessLevel
 
+        /// A Storage Bucket that contains the object to remove. Defaults to `nil`, in which case the default one will be used.
+        ///
+        /// - Tag: StorageDownloadDataRequest.bucket
+        public let bucket: (any StorageBucket)?
+
         /// Extra plugin specific options, only used in special circumstances when the existing options do not provide
         /// a way to utilize the underlying storage system's functionality. See plugin documentation for expected
         /// key/values
@@ -64,9 +69,13 @@ public extension StorageRemoveRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageRemoveRequestOptions.init
-        public init(accessLevel: StorageAccessLevel = .guest,
-                    pluginOptions: Any? = nil) {
+        public init(
+            accessLevel: StorageAccessLevel = .guest,
+            bucket: (any StorageBucket)? = nil,
+            pluginOptions: Any? = nil
+        ) {
             self.accessLevel = accessLevel
+            self.bucket = bucket
             self.pluginOptions = pluginOptions
         }
     }

--- a/Amplify/Categories/Storage/Operation/Request/StorageUploadDataRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageUploadDataRequest.swift
@@ -75,6 +75,11 @@ public extension StorageUploadDataRequest {
         /// - Tag: StorageUploadDataRequestOptions.metadata
         public let metadata: [String: String]?
 
+        /// A specific Storage Bucket to upload the data. Defaults to `nil`, in which case the default one will be used.
+        ///
+        /// - Tag: StorageDownloadDataRequest.bucket
+        public let bucket: (any StorageBucket)?
+
         /// The standard MIME type describing the format of the object to store
         ///
         /// - Tag: StorageUploadDataRequestOptions.contentType
@@ -88,28 +93,34 @@ public extension StorageUploadDataRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageUploadDataRequestOptions.init
-        @available(*, deprecated, message: "Use init(metadata:contentType:options)")
-        public init(accessLevel: StorageAccessLevel = .guest,
-                    targetIdentityId: String? = nil,
-                    metadata: [String: String]? = nil,
-                    contentType: String? = nil,
-                    pluginOptions: Any? = nil
+        @available(*, deprecated, message: "Use init(metadata:bucket:contentType:options)")
+        public init(
+            accessLevel: StorageAccessLevel = .guest,
+            targetIdentityId: String? = nil,
+            metadata: [String: String]? = nil,
+            bucket: (any StorageBucket)? = nil,
+            contentType: String? = nil,
+            pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.metadata = metadata
+            self.bucket = bucket
             self.contentType = contentType
             self.pluginOptions = pluginOptions
         }
 
         /// - Tag: StorageUploadDataRequestOptions.init
-        public init(metadata: [String: String]? = nil,
-                    contentType: String? = nil,
-                    pluginOptions: Any? = nil
+        public init(
+            metadata: [String: String]? = nil,
+            bucket: (any StorageBucket)? = nil,
+            contentType: String? = nil,
+            pluginOptions: Any? = nil
         ) {
             self.accessLevel = .guest
             self.targetIdentityId = nil
             self.metadata = metadata
+            self.bucket = bucket
             self.contentType = contentType
             self.pluginOptions = pluginOptions
         }

--- a/Amplify/Categories/Storage/Operation/Request/StorageUploadFileRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageUploadFileRequest.swift
@@ -72,6 +72,11 @@ public extension StorageUploadFileRequest {
         /// - Tag: StorageUploadFileRequestOptions.metadata
         public let metadata: [String: String]?
 
+        /// A specific Storage Bucket to upload the file. Defaults to `nil`, in which case the default one will be used.
+        ///
+        /// - Tag: StorageUploadFileRequestOptions.bucket
+        public let bucket: (any StorageBucket)?
+
         /// The standard MIME type describing the format of the object to store
         ///
         /// - Tag: StorageUploadFileRequestOptions.contentType
@@ -85,28 +90,34 @@ public extension StorageUploadFileRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageUploadFileRequestOptions.init
-        @available(*, deprecated, message: "Use init(metadata:contentType:pluginOptions)")
-        public init(accessLevel: StorageAccessLevel = .guest,
-                    targetIdentityId: String? = nil,
-                    metadata: [String: String]? = nil,
-                    contentType: String? = nil,
-                    pluginOptions: Any? = nil
+        @available(*, deprecated, message: "Use init(metadata:bucket:contentType:pluginOptions)")
+        public init(
+            accessLevel: StorageAccessLevel = .guest,
+            targetIdentityId: String? = nil,
+            metadata: [String: String]? = nil,
+            bucket: (any StorageBucket)? = nil,
+            contentType: String? = nil,
+            pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.metadata = metadata
+            self.bucket = bucket
             self.contentType = contentType
             self.pluginOptions = pluginOptions
         }
 
         /// - Tag: StorageUploadFileRequestOptions.init
-        public init(metadata: [String: String]? = nil,
-                    contentType: String? = nil,
-                    pluginOptions: Any? = nil
+        public init(
+            metadata: [String: String]? = nil,
+            bucket: (any StorageBucket)? = nil,
+            contentType: String? = nil,
+            pluginOptions: Any? = nil
         ) {
             self.accessLevel = .guest
             self.targetIdentityId = nil
             self.metadata = metadata
+            self.bucket = bucket
             self.contentType = contentType
             self.pluginOptions = pluginOptions
         }

--- a/Amplify/Categories/Storage/StorageBucket.swift
+++ b/Amplify/Categories/Storage/StorageBucket.swift
@@ -1,0 +1,66 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// Protocol that represents a Storage bucket.
+///
+/// - Tag: StorageBucket
+public protocol StorageBucket { }
+
+/// Represents information about a Storage bucket
+///
+/// - Tag: BucketInfo
+public struct BucketInfo: Hashable {
+
+    /// The name of the bucket
+    /// - Tag: BucketInfo.bucketName
+    public let bucketName: String
+
+    /// The region of the bucket
+    /// - Tag: BucketInfo.region
+    public let region: String
+
+    public init(bucketName: String, region: String) {
+        self.bucketName = bucketName
+        self.region = region
+    }
+}
+
+public extension StorageBucket where Self == OutputsStorageBucket {
+
+    /// References a `StorageBucket` in the AmplifyOutputs file using the given name.
+    ///
+    /// - Parameter name: The name of the bucket
+    static func fromOutputs(name: String) -> Self {
+        return OutputsStorageBucket(name: name)
+    }
+}
+
+public extension StorageBucket where Self == ResolvedStorageBucket {
+    /// References a `StorageBucket` using the data from the given `BucketInfo`.
+    ///
+    /// - Parameter bucketInfo: A `BucketInfo` instance
+    static func fromBucketInfo(_ bucketInfo: BucketInfo) -> Self {
+        return ResolvedStorageBucket(bucketInfo: bucketInfo)
+    }
+}
+
+
+/// Conforms to `StorageBucket`. Represents a Storage Bucket defined by a name in the AmplifyOutputs file.
+///
+/// - Tag: OutputsStorageBucket
+public struct OutputsStorageBucket: StorageBucket {
+    public let name: String
+}
+
+/// Conforms to `StorageBucket`. Represents a Storage Bucket defined by a name and a region defined in `BucketInfo`.
+///
+/// - Tag: ResolvedStorageBucket
+public struct ResolvedStorageBucket: StorageBucket {
+    public let bucketInfo: BucketInfo
+}

--- a/api-dump/AWSDataStorePlugin.json
+++ b/api-dump/AWSDataStorePlugin.json
@@ -8205,7 +8205,7 @@
       "-module",
       "AWSDataStorePlugin",
       "-o",
-      "\/var\/folders\/hn\/5bx1f4_d4ds5vhwhkxc7vdcr0000gn\/T\/tmp.nAGRifhwH6\/AWSDataStorePlugin.json",
+      "\/var\/folders\/m_\/cksx93ys47x4621g0zbw_m4m0000gn\/T\/tmp.xrcnJX8DBh\/AWSDataStorePlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/AWSPluginsCore.json
+++ b/api-dump/AWSPluginsCore.json
@@ -24273,7 +24273,7 @@
       "-module",
       "AWSPluginsCore",
       "-o",
-      "\/var\/folders\/hn\/5bx1f4_d4ds5vhwhkxc7vdcr0000gn\/T\/tmp.nAGRifhwH6\/AWSPluginsCore.json",
+      "\/var\/folders\/m_\/cksx93ys47x4621g0zbw_m4m0000gn\/T\/tmp.xrcnJX8DBh\/AWSPluginsCore.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/CoreMLPredictionsPlugin.json
+++ b/api-dump/CoreMLPredictionsPlugin.json
@@ -430,7 +430,7 @@
       "-module",
       "CoreMLPredictionsPlugin",
       "-o",
-      "\/var\/folders\/hn\/5bx1f4_d4ds5vhwhkxc7vdcr0000gn\/T\/tmp.nAGRifhwH6\/CoreMLPredictionsPlugin.json",
+      "\/var\/folders\/m_\/cksx93ys47x4621g0zbw_m4m0000gn\/T\/tmp.xrcnJX8DBh\/CoreMLPredictionsPlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",


### PR DESCRIPTION
## Description
This PR adds the new `StorageBucket` protocol and its default implementations.
It also adds an optional `bucket: StorageBucket` parameter to the existing Request.Options enums.

## General Checklist

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
