### PR TITLE
feat(predictions): add web socket retry for clock skew

### DIFF
--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSTranscribeStreamingAdapter.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Dependency/AWSTranscribeStreamingAdapter.swift
@@ -131,17 +131,17 @@ class AWSTranscribeStreamingAdapter: AWSTranscribeStreamingBehavior {
                             continuation.yield(transcribedPayload)
                             let isPartial = transcribedPayload.transcript?.results?.map(\.isPartial) ?? []
                             let shouldContinue = isPartial.allSatisfy { $0 }
-                            return shouldContinue
+                            return shouldContinue ? .continueToReceive : .stopAndInvalidateSession
                         } catch {
-                            return true
+                            return .continueToReceive
                         }
                     case .success(.string):
-                        return true
+                        return .continueToReceive
                     case .failure(let error):
                         continuation.finish(throwing: error)
-                        return false
+                        return .stopAndInvalidateSession
                     @unknown default:
-                        return true
+                        return .continueToReceive
                     }
                 }
             }

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/WebSocketSession.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/WebSocketSession.swift
@@ -6,13 +6,15 @@
 //
 
 import Foundation
+import Amplify
 
 final class WebSocketSession {
     private let urlSessionWebSocketDelegate: Delegate
     private let session: URLSession
     private var task: URLSessionWebSocketTask?
-    private var receiveMessage: ((Result<URLSessionWebSocketTask.Message, Error>) -> Bool)?
+    private var receiveMessage: ((Result<URLSessionWebSocketTask.Message, Error>) -> WebSocketMessageResult)?
     private var onSocketClosed: ((URLSessionWebSocketTask.CloseCode) -> Void)?
+    private var onServerDateReceived: ((Date) -> Void)?
 
     init() {
         self.urlSessionWebSocketDelegate = Delegate()
@@ -23,7 +25,7 @@ final class WebSocketSession {
         )
     }
 
-    func onMessageReceived(_ receive: @escaping (Result<URLSessionWebSocketTask.Message, Error>) -> Bool) {
+    func onMessageReceived(_ receive: @escaping (Result<URLSessionWebSocketTask.Message, Error>) -> WebSocketMessageResult) {
         self.receiveMessage = receive
     }
 
@@ -34,25 +36,32 @@ final class WebSocketSession {
     func onSocketOpened(_ onOpen: @escaping () -> Void) {
         urlSessionWebSocketDelegate.onOpen = onOpen
     }
+    
+    func onServerDateReceived(_ onServerDateReceived: @escaping (Date) -> Void) {
+        urlSessionWebSocketDelegate.onServerDateReceived = onServerDateReceived
+    }
 
-    func receive(shouldContinue: Bool) {
-        guard shouldContinue else {
+    func receive(result: WebSocketMessageResult) {
+        switch result {
+        case .continueToReceive:
+            task?.receive(completionHandler: { [weak self] result in
+                if let webSocketResult = self?.receiveMessage?(result) {
+                    self?.receive(result: webSocketResult)
+                }
+            })
+        case .stopAndInvalidateSession:
             session.finishTasksAndInvalidate()
-            return
+        case .invalidateSessionAndRetry(let url):
+            session.finishTasksAndInvalidate()
+            open(url: url)
         }
-
-        task?.receive(completionHandler: { [weak self] result in
-            if let shouldContinue = self?.receiveMessage?(result) {
-                self?.receive(shouldContinue: shouldContinue)
-            }
-        })
     }
 
     func open(url: URL) {
         var request = URLRequest(url: url)
         request.setValue("no-store", forHTTPHeaderField: "Cache-Control")
         task = session.webSocketTask(with: request)
-        receive(shouldContinue: true)
+        receive(result: .continueToReceive)
         task?.resume()
     }
 
@@ -77,10 +86,12 @@ final class WebSocketSession {
         )
     }
 
-    final class Delegate: NSObject, URLSessionWebSocketDelegate {
+    final class Delegate: NSObject, URLSessionWebSocketDelegate, URLSessionTaskDelegate {
         var onClose: (URLSessionWebSocketTask.CloseCode) -> Void = { _ in }
         var onOpen: () -> Void = {}
+        var onServerDateReceived: (Date) -> Void = { _ in }
 
+        // MARK: - URLSessionWebSocketDelegate methods
         func urlSession(
             _ session: URLSession,
             webSocketTask: URLSessionWebSocketTask,
@@ -97,5 +108,32 @@ final class WebSocketSession {
         ) {
             onClose(closeCode)
         }
+        
+        // MARK: - URLSessionTaskDelegate methods
+        func urlSession(_ session: URLSession,
+                        task: URLSessionTask,
+                        didFinishCollecting metrics: URLSessionTaskMetrics
+        ) {
+            guard let httpResponse = metrics.transactionMetrics.first?.response as? HTTPURLResponse,
+                  let dateString = httpResponse.value(forHTTPHeaderField: "Date") else {
+                Amplify.log.verbose("\(#function): Couldn't find Date header in URLSession metrics")
+                return
+            }
+            
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "EEE, d MMM yyyy HH:mm:ss z"
+            guard let serverDate = dateFormatter.date(from: dateString) else {
+                Amplify.log.verbose("\(#function): Error parsing Date header in expected format")
+                return
+            }
+            
+            onServerDateReceived(serverDate)
+        }
+    }
+    
+    enum WebSocketMessageResult {
+        case continueToReceive
+        case stopAndInvalidateSession
+        case invalidateSessionAndRetry(url: URL)
     }
 }


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
Some liveness customers are setting up date on the device manually. This causes a clock skew when AWS Rekognition server time is different than device time and the signature calculated is incorrect. AWS Rekognition supports a maximum skew of 5 minutes. This leads to customer receiving `IncorrectSignatureException`.

## Description
<!-- Why is this change required? What problem does it solve? -->
This change adds a one-time retry for web socket connection when an `InvalidSignatureException` is received. 
This is in line with Android implementation here : https://github.com/aws-amplify/amplify-android/pull/2634

## Testing

Happy path - I performed manual testing by setting the device date manually for +1hr and -1hr of actual time. I tested for both cases when preview screen is enabled or not enabled in the `FaceLivenessDetectorView` component.

Error path - I uncommented the line 
```
websocket.onServerDateReceived { [weak self] serverDate in
    self?.serverDate = serverDate
}
```
to mimic the case when we don't receive `Date` header in 
```
urlSession(
    _ session: URLSession,
    task: URLSessionTask,
    didFinishCollecting metrics: URLSessionTaskMetrics
)
```
delegate callback. I tested for both cases when preview screen is enabled or not enabled in the `FaceLivenessDetectorView` component.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
