### PR TITLE
feat(Storage): Implementing support for multiple buckets

### DIFF
--- a/Amplify/Core/Configuration/AmplifyOutputsData.swift
+++ b/Amplify/Core/Configuration/AmplifyOutputsData.swift
@@ -176,6 +176,25 @@ public struct AmplifyOutputsData: Codable {
     public struct Storage: Codable {
         public let awsRegion: AWSRegion
         public let bucketName: String
+        public let buckets: [Bucket]?
+
+        @_spi(InternalAmplifyConfiguration)
+        public struct Bucket: Codable {
+            public let name: String
+            public let bucketName: String
+            public let awsRegion: AWSRegion
+        }
+
+        // Internal init used for testing
+        init(
+            awsRegion: AWSRegion,
+            bucketName: String,
+            buckets: [Bucket]? = nil
+        ) {
+            self.awsRegion = awsRegion
+            self.bucketName = bucketName
+            self.buckets = buckets
+        }
     }
 
     @_spi(InternalAmplifyConfiguration)

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+ClientBehavior.swift
@@ -19,6 +19,6 @@ extension AWSS3StoragePlugin {
     ///
     /// - Tag: AWSS3StoragePlugin.getEscapeHatch
     public func getEscapeHatch() -> S3Client {
-        return storageService.getEscapeHatch()
+        return defaultStorageService.getEscapeHatch()
     }
 }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+Reset.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+Reset.swift
@@ -18,10 +18,19 @@ extension AWSS3StoragePlugin {
     ///
     /// - Tag: AWSS3StoragePlugin.reset
     public func reset() async {
-        if storageService != nil {
-            storageService.reset()
-            storageService = nil
+        if defaultBucket != nil {
+            defaultBucket = nil
         }
+
+        for storageService in storageServicesByBucket.values {
+            storageService.reset()
+        }
+        storageServicesByBucket.removeAll()
+
+        if additionalBucketsByName != nil {
+            additionalBucketsByName = nil
+        }
+
         if authService != nil {
             authService = nil
         }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+StorageBucket.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+StorageBucket.swift
@@ -1,0 +1,74 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@_spi(InternalAmplifyConfiguration) import Amplify
+import Foundation
+
+extension AWSS3StoragePlugin {
+    /// Returns a AWSS3StorageServiceBehavior instance for the given StorageBucket
+    func storageService(for bucket: (any StorageBucket)?) throws -> AWSS3StorageServiceBehavior {
+        guard let bucket else {
+            // When no bucket is provided, use the default one
+            return defaultStorageService
+        }
+
+        let bucketInfo = try bucketInfo(from: bucket)
+        guard let storageService = storageServicesByBucket[bucketInfo.bucketName] else {
+            // If no service was found for the bucket, create one
+            let storageService = try createStorageService(
+                authService: authService,
+                bucketInfo: bucketInfo
+            )
+            storageServicesByBucket[bucketInfo.bucketName] = storageService
+            return storageService
+        }
+
+        return storageService
+    }
+
+    /// Returns a AWSS3StorageServiceProvider callback for the given StorageBucket
+    func storageServiceProvider(for bucket: (any StorageBucket)?) -> AWSS3StorageServiceProvider {
+        let storageServiceResolver: () throws -> AWSS3StorageServiceBehavior = { [weak self] in
+            guard let self = self else {
+                throw StorageError.unknown("AWSS3StoragePlugin was deallocated", nil)
+            }
+            return try self.storageService(for: bucket)
+        }
+        return storageServiceResolver
+    }
+
+    /// Returns a valid `BucketInfo` instance from the given StorageBucket
+    private func bucketInfo(from bucket: any StorageBucket) throws -> BucketInfo {
+        switch bucket {
+        case let outputsBucket as OutputsStorageBucket:
+            guard let additionalBucketsByName else {
+                let errorDescription = "Amplify was not configured using an Amplify Outputs file"
+                let recoverySuggestion = "Make sure that `Amplify.configure(with:)` is invoked"
+                throw StorageError.validation("bucket", errorDescription, recoverySuggestion, nil)
+            }
+
+            guard let awsBucket = additionalBucketsByName[outputsBucket.name] else {
+                let errorDescription = "Unable to lookup bucket from provided name in Amplify Outputs"
+                let recoverySuggestion = "Make sure the bucket name exists in the Amplify Outputs file"
+                throw StorageError.validation("bucket", errorDescription, recoverySuggestion, nil)
+            }
+
+            return .init(
+                bucketName: awsBucket.bucketName,
+                region: awsBucket.awsRegion
+            )
+
+        case let resolvedBucket as ResolvedStorageBucket:
+            return resolvedBucket.bucketInfo
+
+        default:
+            let errorDescription = "The specified StorageBucket is not supported"
+            let recoverySuggestion = "Please specify a StorageBucket from the Outputs file or from BucketInfo"
+            throw StorageError.validation("bucket", errorDescription, recoverySuggestion, nil)
+        }
+    }
+}

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
@@ -5,9 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Amplify
+@_spi(InternalAmplifyConfiguration) import Amplify
 import Foundation
 import AWSPluginsCore
+import InternalAmplifyCredentials
 
 /// The AWSS3StoragePlugin which conforms to the Amplify plugin protocols and implements the Storage
 /// Plugin APIs for AWS S3.
@@ -15,11 +16,25 @@ import AWSPluginsCore
 /// - Tag: AWSS3StoragePlugin
 final public class AWSS3StoragePlugin: StorageCategoryPlugin {
 
-    /// An instance of the S3 storage service.
-    var storageService: AWSS3StorageServiceBehavior!
+    /// The default S3 storage service.
+    var defaultStorageService: AWSS3StorageServiceBehavior! {
+        guard let defaultBucket else {
+            return nil
+        }
+        return storageServicesByBucket[defaultBucket.bucketInfo.bucketName]
+    }
+
+    /// The default bucket
+    var defaultBucket: ResolvedStorageBucket!
+
+    /// A dictionary of S3 storage service instances grouped by a specific bucket
+    var storageServicesByBucket: AtomicDictionary<String, AWSS3StorageServiceBehavior> = [:]
+
+    /// A dictionary of additional Outputs-based buckets, grouped by their names
+    var additionalBucketsByName: [String: AmplifyOutputsData.Storage.Bucket]?
 
     /// An instance of the authentication service.
-    var authService: AWSAuthServiceBehavior!
+    var authService: AWSAuthCredentialsProviderBehavior!
 
     /// A queue that regulates the execution of operations.
     var queue: OperationQueue!

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadDataOperation.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadDataOperation.swift
@@ -22,7 +22,7 @@ class AWSS3StorageUploadDataOperation: AmplifyInProcessReportingOperation<
 >, StorageUploadDataOperation {
 
     let storageConfiguration: AWSS3StoragePluginConfiguration
-    let storageService: AWSS3StorageServiceBehavior
+    let storageServiceProvider: AWSS3StorageServiceProvider
     let authService: AWSAuthServiceBehavior
 
     var storageTaskReference: StorageTaskReference?
@@ -30,15 +30,21 @@ class AWSS3StorageUploadDataOperation: AmplifyInProcessReportingOperation<
     /// Serial queue for synchronizing access to `storageTaskReference`.
     private let storageTaskActionQueue = DispatchQueue(label: "com.amazonaws.amplify.StorageTaskActionQueue")
 
+    private var storageService: AWSS3StorageServiceBehavior {
+        get throws {
+            return try storageServiceProvider()
+        }
+    }
+
     init(_ request: StorageUploadDataRequest,
          storageConfiguration: AWSS3StoragePluginConfiguration,
-         storageService: AWSS3StorageServiceBehavior,
+         storageServiceProvider: @escaping AWSS3StorageServiceProvider,
          authService: AWSAuthServiceBehavior,
          progressListener: InProcessListener? = nil,
          resultListener: ResultListener? = nil) {
 
         self.storageConfiguration = storageConfiguration
-        self.storageService = storageService
+        self.storageServiceProvider = storageServiceProvider
         self.authService = authService
         super.init(categoryType: .storage,
                    eventName: HubPayload.EventName.Storage.uploadData,
@@ -102,7 +108,7 @@ class AWSS3StorageUploadDataOperation: AmplifyInProcessReportingOperation<
 
                 let accelerate = try AWSS3PluginOptions.accelerateValue(pluginOptions: request.options.pluginOptions)
                 if request.data.count > StorageUploadDataRequest.Options.multiPartUploadSizeThreshold {
-                    storageService.multiPartUpload(
+                    try storageService.multiPartUpload(
                         serviceKey: serviceKey,
                         uploadSource: .data(request.data),
                         contentType: request.options.contentType,
@@ -112,7 +118,7 @@ class AWSS3StorageUploadDataOperation: AmplifyInProcessReportingOperation<
                         self?.onServiceEvent(event: event)
                     }
                 } else {
-                    storageService.upload(
+                    try storageService.upload(
                         serviceKey: serviceKey,
                         uploadSource: .data(request.data),
                         contentType: request.options.contentType,

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadFileOperation.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadFileOperation.swift
@@ -22,7 +22,7 @@ class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation<
 >, StorageUploadFileOperation {
 
     let storageConfiguration: AWSS3StoragePluginConfiguration
-    let storageService: AWSS3StorageServiceBehavior
+    let storageServiceProvider: AWSS3StorageServiceProvider
     let authService: AWSAuthServiceBehavior
 
     var storageTaskReference: StorageTaskReference?
@@ -30,15 +30,21 @@ class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation<
     /// Serial queue for synchronizing access to `storageTaskReference`.
     private let storageTaskActionQueue = DispatchQueue(label: "com.amazonaws.amplify.StorageTaskActionQueue")
 
+    private var storageService: AWSS3StorageServiceBehavior {
+        get throws {
+            return try storageServiceProvider()
+        }
+    }
+
     init(_ request: StorageUploadFileRequest,
          storageConfiguration: AWSS3StoragePluginConfiguration,
-         storageService: AWSS3StorageServiceBehavior,
+         storageServiceProvider: @escaping AWSS3StorageServiceProvider,
          authService: AWSAuthServiceBehavior,
          progressListener: InProcessListener? = nil,
          resultListener: ResultListener? = nil) {
 
         self.storageConfiguration = storageConfiguration
-        self.storageService = storageService
+        self.storageServiceProvider = storageServiceProvider
         self.authService = authService
         super.init(categoryType: .storage,
                    eventName: HubPayload.EventName.Storage.uploadFile,
@@ -124,7 +130,7 @@ class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation<
 
                 let accelerate = try AWSS3PluginOptions.accelerateValue(pluginOptions: request.options.pluginOptions)
                 if uploadSize > StorageUploadFileRequest.Options.multiPartUploadSizeThreshold {
-                    storageService.multiPartUpload(
+                    try storageService.multiPartUpload(
                         serviceKey: serviceKey,
                         uploadSource: .local(request.local),
                         contentType: request.options.contentType,
@@ -134,7 +140,7 @@ class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation<
                         self?.onServiceEvent(event: event)
                     }
                 } else {
-                    storageService.upload(
+                    try storageService.upload(
                         serviceKey: serviceKey,
                         uploadSource: .local(request.local),
                         contentType: request.options.contentType,

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
@@ -57,13 +57,14 @@ class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy {
                      region: String,
                      bucket: String,
                      httpClientEngineProxy: HttpClientEngineProxy? = nil,
-                     storageConfiguration: StorageConfiguration = .default,
+                     storageConfiguration: StorageConfiguration? = nil,
                      storageTransferDatabase: StorageTransferDatabase = .default,
                      fileSystem: FileSystem = .default,
                      sessionConfiguration: URLSessionConfiguration? = nil,
                      delegateQueue: OperationQueue? = nil,
                      logger: Logger = storageLogger) throws {
         let credentialsProvider = authService.getCredentialsProvider()
+        let storageConfiguration = storageConfiguration ?? .init(forBucket: bucket)
         let clientConfig = try S3Client.S3ClientConfiguration(
             region: region,
             credentialsProvider: credentialsProvider,
@@ -113,7 +114,7 @@ class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy {
     }
 
     init(authService: AWSAuthCredentialsProviderBehavior,
-         storageConfiguration: StorageConfiguration = .default,
+         storageConfiguration: StorageConfiguration? = nil,
          storageTransferDatabase: StorageTransferDatabase = .default,
          fileSystem: FileSystem = .default,
          sessionConfiguration: URLSessionConfiguration,
@@ -123,6 +124,7 @@ class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy {
          preSignedURLBuilder: AWSS3PreSignedURLBuilderBehavior,
          awsS3: AWSS3Behavior,
          bucket: String) {
+        let storageConfiguration = storageConfiguration ?? .init(forBucket: bucket)
         self.storageConfiguration = storageConfiguration
         self.storageTransferDatabase = storageTransferDatabase
         self.fileSystem = fileSystem

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageServiceBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageServiceBehavior.swift
@@ -9,6 +9,7 @@ import Foundation
 import Amplify
 import AWSS3
 
+typealias AWSS3StorageServiceProvider = () throws -> AWSS3StorageServiceBehavior
 protocol AWSS3StorageServiceBehavior {
     typealias StorageServiceDownloadEventHandler = (StorageServiceDownloadEvent) -> Void
     typealias StorageServiceDownloadEvent =

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageConfiguration.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageConfiguration.swift
@@ -20,10 +20,6 @@ struct StorageConfiguration {
     let allowsCellularAccess: Bool
     let timeoutIntervalForResource: TimeInterval
 
-    static let `default`: StorageConfiguration = {
-        StorageConfiguration()
-    }()
-
     init(sessionIdentifier: String = Defaults.sessionIdentifier,
          sharedContainerIdentifier: String = Defaults.sharedContainerIdentifier,
          allowsCellularAccess: Bool = Defaults.allowsCellularAccess,
@@ -32,5 +28,11 @@ struct StorageConfiguration {
         self.sharedContainerIdentifier = sharedContainerIdentifier
         self.allowsCellularAccess = allowsCellularAccess
         self.timeoutIntervalForResource = timeoutIntervalForResource
+    }
+
+    init(forBucket bucket: String) {
+        self.init(
+            sessionIdentifier: "\(Defaults.sessionIdentifier).\(bucket)"
+        )
     }
 }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginResetTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginResetTests.swift
@@ -16,7 +16,7 @@ class AWSS3StoragePluginResetTests: AWSS3StoragePluginTests {
         await resettable.reset()
 
         XCTAssertNil(storagePlugin.authService)
-        XCTAssertNil(storagePlugin.storageService)
+        XCTAssertNil(storagePlugin.defaultStorageService)
         XCTAssertNil(storagePlugin.queue)
     }
 }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginTestBase.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginTestBase.swift
@@ -10,6 +10,7 @@ import Amplify
 @testable import AWSS3StoragePlugin
 @testable import AmplifyTestCommon
 @testable import AWSPluginsTestCommon
+import InternalAmplifyCredentials
 
 class AWSS3StoragePluginTests: XCTestCase {
     var storagePlugin: AWSS3StoragePlugin!
@@ -33,9 +34,29 @@ class AWSS3StoragePluginTests: XCTestCase {
         authService = MockAWSAuthService()
         queue = MockOperationQueue()
 
-        storagePlugin.configure(storageService: storageService,
+        storagePlugin.configure(defaultBucket: .fromBucketInfo(.init(bucketName: testBucket, region: testRegion)),
+                                storageService: storageService,
                                 authService: authService,
                                 defaultAccessLevel: defaultAccessLevel,
                                 queue: queue)
+    }
+}
+
+
+extension AWSS3StoragePlugin {
+    /// Convenience configuration method for testing purposes, with a default bucket with name "test-bucket" and region "us-east-1"
+    func configure(
+        storageService: AWSS3StorageServiceBehavior,
+        authService: AWSAuthCredentialsProviderBehavior,
+        defaultAccessLevel: StorageAccessLevel,
+        queue: OperationQueue = OperationQueue()
+    ) {
+        configure(
+            defaultBucket: .fromBucketInfo(.init(bucketName: "test-bucket", region: "us-east-1")),
+            storageService: storageService,
+            authService: authService,
+            defaultAccessLevel: defaultAccessLevel,
+            queue: queue
+        )
     }
 }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/AWSS3StorageOperations+StorageServiceProvider.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/AWSS3StorageOperations+StorageServiceProvider.swift
@@ -1,0 +1,99 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import Amplify
+@testable import AWSPluginsCore
+@testable import AWSS3StoragePlugin
+import Foundation
+
+extension AWSS3StorageDownloadFileOperation {
+    convenience init(
+        _ request: StorageDownloadFileRequest,
+        storageConfiguration: AWSS3StoragePluginConfiguration,
+        storageService: AWSS3StorageServiceBehavior,
+        authService: AWSAuthServiceBehavior,
+        progressListener: InProcessListener? = nil,
+        resultListener: ResultListener? = nil
+    ) {
+        self.init(
+            request,
+            storageConfiguration: storageConfiguration,
+            storageServiceProvider: {
+                return storageService
+            },
+            authService: authService,
+            progressListener: progressListener,
+            resultListener: resultListener
+        )
+    }
+}
+
+extension AWSS3StorageDownloadDataOperation {
+    convenience init(
+        _ request: StorageDownloadDataRequest,
+        storageConfiguration: AWSS3StoragePluginConfiguration,
+        storageService: AWSS3StorageServiceBehavior,
+        authService: AWSAuthServiceBehavior,
+        progressListener: InProcessListener? = nil,
+        resultListener: ResultListener? = nil
+    ) {
+        self.init(
+            request,
+            storageConfiguration: storageConfiguration,
+            storageServiceProvider: {
+                return storageService
+            },
+            authService: authService,
+            progressListener: progressListener,
+            resultListener: resultListener
+        )
+    }
+}
+
+extension AWSS3StorageUploadDataOperation {
+    convenience init(
+        _ request: StorageUploadDataRequest,
+        storageConfiguration: AWSS3StoragePluginConfiguration,
+        storageService: AWSS3StorageServiceBehavior,
+        authService: AWSAuthServiceBehavior,
+        progressListener: InProcessListener? = nil,
+        resultListener: ResultListener? = nil
+    ) {
+        self.init(
+            request,
+            storageConfiguration: storageConfiguration,
+            storageServiceProvider: {
+                return storageService
+            },
+            authService: authService,
+            progressListener: progressListener,
+            resultListener: resultListener
+        )
+    }
+}
+
+extension AWSS3StorageUploadFileOperation {
+    convenience init(
+        _ request: StorageUploadFileRequest,
+        storageConfiguration: AWSS3StoragePluginConfiguration,
+        storageService: AWSS3StorageServiceBehavior,
+        authService: AWSAuthServiceBehavior,
+        progressListener: InProcessListener? = nil,
+        resultListener: ResultListener? = nil
+    ) {
+        self.init(
+            request,
+            storageConfiguration: storageConfiguration,
+            storageServiceProvider: {
+                return storageService
+            },
+            authService: authService,
+            progressListener: progressListener,
+            resultListener: resultListener
+        )
+    }
+}

--- a/api-dump/AWSDataStorePlugin.json
+++ b/api-dump/AWSDataStorePlugin.json
@@ -8205,7 +8205,7 @@
       "-module",
       "AWSDataStorePlugin",
       "-o",
-      "\/var\/folders\/m_\/cksx93ys47x4621g0zbw_m4m0000gn\/T\/tmp.xrcnJX8DBh\/AWSDataStorePlugin.json",
+      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.7LdqMpKABA\/AWSDataStorePlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/AWSPluginsCore.json
+++ b/api-dump/AWSPluginsCore.json
@@ -24273,7 +24273,7 @@
       "-module",
       "AWSPluginsCore",
       "-o",
-      "\/var\/folders\/m_\/cksx93ys47x4621g0zbw_m4m0000gn\/T\/tmp.xrcnJX8DBh\/AWSPluginsCore.json",
+      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.7LdqMpKABA\/AWSPluginsCore.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/CoreMLPredictionsPlugin.json
+++ b/api-dump/CoreMLPredictionsPlugin.json
@@ -430,7 +430,7 @@
       "-module",
       "CoreMLPredictionsPlugin",
       "-o",
-      "\/var\/folders\/m_\/cksx93ys47x4621g0zbw_m4m0000gn\/T\/tmp.xrcnJX8DBh\/CoreMLPredictionsPlugin.json",
+      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.7LdqMpKABA\/CoreMLPredictionsPlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",


### PR DESCRIPTION
## Description
This PR makes the main changes in order to add support for multiple buckets to our existing **Storage** implementation.

The main changes are the following:

### AmplifyOutputsData
Added the new optional `buckets` array to the Storage configuration, plus a convenience initializer for testing purposes.

### AWSS3StoragePlugin
We have pretty much all of the service-related logic encapsulated inside the `AWSS3StorageServiceBehavior` protocol, which is implemented by `AWSS3StorageService`. This implementation, along its many related objects, heavily relies on the assumption of only one bucket and region.

To avoid a complete refactor, we will now have one storage service per bucket. S3 bucket names are globally unique, so we can store them in a dictionary using the bucket name as key for easy retrieval.

On plugin configuration we will only instantiate the "default" storage service,  keeping the existing behaviour. We will only instantiate new services (and store them in the dictionary) when required, to prevent unnecessary memory usage if a customer has many buckets in their configuration but never attempts any Storage operation on most of them. 

I've also added an optional `additionalBucketsByName` dictionary that is set when Amplify is configured with `AmplifyOutputs`. This is needed because we need to be able to perform the bucket lookup when the customer provides a `StorageBucket.fromOutputs(:)` bucket.

Finally, i've changed the type of `authService` to be `AWSAuthCredentialsProviderBehavior`. This was an oversight during the `AmplifyCredentials` refactor, but it's not a breaking change because `AWSAuthService` conforms to both.

### AWSS3Storage<*>Operation
The APIs for uploading and downloading do not directly throw errors, instead they return an `AmplifyTask` that can be used to monitor progress and completion. 

Since retrieving the storage service can throw (e.g. if a wrong bucket name is passed), and the operations need a service in order to execute, I've created the `AWSS3StorageServiceProvider` callback that can throw. We can invoke this provider when the operation is actually running, since we can report errors by then.

### StorageConfiguration
I've removed the `.default` static property and instead crated a new `.init(forBucket:)` that just appends it to the default `sessionIdentifier` in order for it to be unique. This was needed because otherwise the URLSession delegate methods were not being reported to the proper storage service, which made it impossible to properly propagate the results.

## General Checklist
- [ ] Added new tests to cover change, if needed. **TBA in a follow up PR**
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required **TBA in a follow up PR**
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
