### PR TITLE
feat: Add AppSync components 

### DIFF
--- a/Amplify/Core/Configuration/AmplifyOutputsData.swift
+++ b/Amplify/Core/Configuration/AmplifyOutputsData.swift
@@ -251,7 +251,8 @@ public struct AmplifyOutputsData: Codable {
 public struct AmplifyOutputs {
 
     /// A closure that resolves the `AmplifyOutputsData` configuration
-    let resolveConfiguration: () throws -> AmplifyOutputsData
+    @_spi(InternalAmplifyConfiguration)
+    public let resolveConfiguration: () throws -> AmplifyOutputsData
 
     /// Resolves configuration with `amplify_outputs.json` in the main bundle.
     public static let amplifyOutputs: AmplifyOutputs = {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+AppSyncSigner.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+AppSyncSigner.swift
@@ -1,0 +1,102 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import AWSClientRuntime // AWSClientRuntime.CredentialsProviding
+import ClientRuntime // SdkHttpRequestBuilder
+import InternalAmplifyCredentials // AmplifyAWSCredentialsProvider()
+import AwsCommonRuntimeKit // CommonRuntimeKit.initialize()
+
+extension AWSCognitoAuthPlugin {
+
+    public static func createAppSyncSigner(region: String) -> ((URLRequest) async throws -> URLRequest) {
+        return { request in
+            try await signAppSyncRequest(request, region: region)
+        }
+    }
+    public static func signAppSyncRequest(_ urlRequest: URLRequest,
+                                          region: Swift.String,
+                                          credentialsProvider: AWSClientRuntime.CredentialsProviding = AmplifyAWSCredentialsProvider(),
+                                          signingName: Swift.String = "appsync",
+                                          date: ClientRuntime.Date = Date()) async throws -> URLRequest {
+        CommonRuntimeKit.initialize()
+
+        // Convert URLRequest to SDK's HTTPRequest
+        guard let requestBuilder = try createAppSyncSdkHttpRequestBuilder(
+            urlRequest: urlRequest) else {
+            return urlRequest
+        }
+
+        // Retrieve the credentials from credentials provider
+        let credentials = try await credentialsProvider.getCredentials()
+
+        // Prepare signing
+        let flags = SigningFlags(useDoubleURIEncode: true,
+                                 shouldNormalizeURIPath: true,
+                                 omitSessionToken: false)
+        let signedBodyHeader: AWSSignedBodyHeader = .none
+        let signedBodyValue: AWSSignedBodyValue = .empty
+        let signingConfig = AWSSigningConfig(credentials: credentials,
+                                             signedBodyHeader: signedBodyHeader,
+                                             signedBodyValue: signedBodyValue,
+                                             flags: flags,
+                                             date: date,
+                                             service: signingName,
+                                             region: region,
+                                             signatureType: .requestHeaders,
+                                             signingAlgorithm: .sigv4)
+
+        // Sign request
+        guard let httpRequest = await AWSSigV4Signer.sigV4SignedRequest(
+            requestBuilder: requestBuilder,
+
+            signingConfig: signingConfig
+        ) else {
+            return urlRequest
+        }
+
+        // Update original request with new headers
+        return setHeaders(from: httpRequest, to: urlRequest)
+    }
+
+    static func setHeaders(from sdkRequest: SdkHttpRequest, to urlRequest: URLRequest) -> URLRequest {
+        var urlRequest = urlRequest
+        for header in sdkRequest.headers.headers {
+            urlRequest.setValue(header.value.joined(separator: ","), forHTTPHeaderField: header.name)
+        }
+        return urlRequest
+    }
+
+    static func createAppSyncSdkHttpRequestBuilder(urlRequest: URLRequest) throws -> SdkHttpRequestBuilder? {
+
+        guard let url = urlRequest.url,
+              let host = url.host else {
+            return nil
+        }
+
+        var headers = urlRequest.allHTTPHeaderFields ?? [:]
+        headers.updateValue(host, forKey: "host")
+
+        let httpMethod = (urlRequest.httpMethod?.uppercased())
+            .flatMap(HttpMethodType.init(rawValue:)) ?? .get
+
+        let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems?
+            .map { ClientRuntime.SDKURLQueryItem(name: $0.name, value: $0.value)} ?? []
+
+        let requestBuilder = SdkHttpRequestBuilder()
+            .withHost(host)
+            .withPath(url.path)
+            .withQueryItems(queryItems)
+            .withMethod(httpMethod)
+            .withPort(443)
+            .withProtocol(.https)
+            .withHeaders(.init(headers))
+            .withBody(.data(urlRequest.httpBody))
+
+        return requestBuilder
+    }
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+AppSyncSigner.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+AppSyncSigner.swift
@@ -14,6 +14,15 @@ import AwsCommonRuntimeKit // CommonRuntimeKit.initialize()
 
 extension AWSCognitoAuthPlugin {
 
+
+    /// Creates a AWS IAM SigV4 signer capable of signing AWS AppSync requests.
+    ///
+    /// **Note**. Although this method is static, **Amplify.Auth** is required to be configured with **AWSCognitoAuthPlugin** as
+    /// it depends on the credentials provider from Cognito through `Amplify.Auth.fetchAuthSession()`. The static type allows
+    /// developers to simplify their callsite without having to access the method on the plugin instance.
+    ///
+    /// - Parameter region: The region of the AWS AppSync API
+    /// - Returns: A closure that takes in a requestand returns a signed request.
     public static func createAppSyncSigner(region: String) -> ((URLRequest) async throws -> URLRequest) {
         return { request in
             try await signAppSyncRequest(request, 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/AWSCognitoAuthPluginAppSyncSignerTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/AWSCognitoAuthPluginAppSyncSignerTests.swift
@@ -1,0 +1,40 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+@testable import AWSCognitoAuthPlugin
+
+class AWSCognitoAuthPluginAppSyncSignerTests: XCTestCase {
+
+    /// Tests translating the URLRequest to the SDKRequest
+    /// The translation should account for expected fields, as asserted in the test.
+    func testCreateAppSyncSdkHttpRequestBuilder() throws {
+        var urlRequest = URLRequest(url: URL(string: "http://graphql.com")!)
+        urlRequest.httpMethod = "post"
+        let dataObject = Data()
+        urlRequest.httpBody = dataObject
+        guard let sdkRequestBuilder = try AWSCognitoAuthPlugin.createAppSyncSdkHttpRequestBuilder(urlRequest: urlRequest) else {
+            XCTFail("Could not create SDK request")
+            return
+        }
+
+        let request = sdkRequestBuilder.build()
+        XCTAssertEqual(request.host, "graphql.com")
+        XCTAssertEqual(request.path, "")
+        XCTAssertEqual(request.queryItems, [])
+        XCTAssertEqual(request.method, .post)
+        XCTAssertEqual(request.endpoint.port, 443)
+        XCTAssertEqual(request.endpoint.protocolType, .https)
+        XCTAssertEqual(request.endpoint.headers?.headers, [.init(name: "host", value: "graphql.com")])
+        guard case let .data(data) = request.body else {
+            XCTFail("Unexpected body")
+            return
+        }
+        XCTAssertEqual(data, dataObject)
+    }
+}

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		21CFD7C62C7524570071C70F /* AppSyncSignerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CFD7C52C7524570071C70F /* AppSyncSignerTests.swift */; };
 		21F762A52BD6B1AA0048845A /* AuthSessionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB5B727B61F0F006CCEC7 /* AuthSessionHelper.swift */; };
 		21F762A62BD6B1AA0048845A /* AsyncTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681DFEA828E747B80000C36A /* AsyncTesting.swift */; };
 		21F762A72BD6B1AA0048845A /* AuthSRPSignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485CB5BE27B61F1D006CCEC7 /* AuthSRPSignInTests.swift */; };
@@ -169,6 +170,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		21CFD7C52C7524570071C70F /* AppSyncSignerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncSignerTests.swift; sourceTree = "<group>"; };
 		21F762CB2BD6B1AA0048845A /* AuthGen2IntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AuthGen2IntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		21F762CC2BD6B1CD0048845A /* AuthGen2IntegrationTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = AuthGen2IntegrationTests.xctestplan; sourceTree = "<group>"; };
 		4821B2F1286B5F74000EC1D7 /* AuthDeleteUserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthDeleteUserTests.swift; sourceTree = "<group>"; };
@@ -268,6 +270,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		21CFD7C42C75243B0071C70F /* AppSyncSignerTests */ = {
+			isa = PBXGroup;
+			children = (
+				21CFD7C52C7524570071C70F /* AppSyncSignerTests.swift */,
+			);
+			path = AppSyncSignerTests;
+			sourceTree = "<group>";
+		};
 		4821B2F0286B5F74000EC1D7 /* AuthDeleteUserTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -355,6 +365,7 @@
 		485CB5A027B61E04006CCEC7 /* AuthIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
+				21CFD7C42C75243B0071C70F /* AppSyncSignerTests */,
 				21F762CC2BD6B1CD0048845A /* AuthGen2IntegrationTests.xctestplan */,
 				48916F362A412AF800E3E1B1 /* MFATests */,
 				97B370C32878DA3500F1C088 /* DeviceTests */,
@@ -851,6 +862,7 @@
 				681DFEAC28E747B80000C36A /* AsyncExpectation.swift in Sources */,
 				48E3AB3128E52590004EE395 /* GetCurrentUserTests.swift in Sources */,
 				48916F3A2A412CEE00E3E1B1 /* TOTPHelper.swift in Sources */,
+				21CFD7C62C7524570071C70F /* AppSyncSignerTests.swift in Sources */,
 				485CB5B127B61EAC006CCEC7 /* AWSAuthBaseTest.swift in Sources */,
 				485CB5C027B61F1E006CCEC7 /* SignedOutAuthSessionTests.swift in Sources */,
 				485CB5BA27B61F10006CCEC7 /* AuthSignInHelper.swift in Sources */,

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AppSyncSignerTests/AppSyncSignerTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AppSyncSignerTests/AppSyncSignerTests.swift
@@ -15,14 +15,14 @@ class AppSyncSignerTests: AWSAuthBaseTest {
     ///
     /// - Given: Base test configures Amplify and adds AWSCognitoAuthPlugin
     /// - When:
-    ///    - I invoke AWSCognitoAuthPlugin.signAppSyncRequest(request, region)
+    ///    - I invoke AWSCognitoAuthPlugin's AppSync signer
     /// - Then:
     ///    - I should get a signed request.
     ///
     func testSignAppSyncRequest() async throws {
         let request = URLRequest(url: URL(string: "http://graphql.com")!)
-        let signedRequest = try await AWSCognitoAuthPlugin.signAppSyncRequest(request, region: "us-east-1")
-
+        let signer = AWSCognitoAuthPlugin.createAppSyncSigner(region: "us-east-1")
+        let signedRequest = try await signer(request)
         guard let headers = signedRequest.allHTTPHeaderFields else {
             XCTFail("Missing headers")
             return

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AppSyncSignerTests/AppSyncSignerTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AppSyncSignerTests/AppSyncSignerTests.swift
@@ -1,0 +1,36 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Amplify
+import AWSCognitoAuthPlugin
+
+class AppSyncSignerTests: AWSAuthBaseTest {
+
+    /// Test signing an AppSync request with a live credentials provider
+    ///
+    /// - Given: Base test configures Amplify and adds AWSCognitoAuthPlugin
+    /// - When:
+    ///    - I invoke AWSCognitoAuthPlugin.signAppSyncRequest(request, region)
+    /// - Then:
+    ///    - I should get a signed request.
+    ///
+    func testSignAppSyncRequest() async throws {
+        let request = URLRequest(url: URL(string: "http://graphql.com")!)
+        let signedRequest = try await AWSCognitoAuthPlugin.signAppSyncRequest(request, region: "us-east-1")
+
+        guard let headers = signedRequest.allHTTPHeaderFields else {
+            XCTFail("Missing headers")
+            return
+        }
+        XCTAssertEqual(headers.count, 4)
+        let containsExpectedHeaders = headers.keys.contains(where: { key in
+            key == "Authorization" || key == "Host" || key == "X-Amz-Security-Token" || key == "X-Amz-Date"
+        })
+        XCTAssertTrue(containsExpectedHeaders)
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCore/API/AWSAppSyncConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/API/AWSAppSyncConfiguration.swift
@@ -8,11 +8,25 @@
 import Foundation
 @_spi(InternalAmplifyConfiguration) import Amplify
 
+
+/// Hold necessary AWS AppSync configuration values to interact with the AppSync API
 public struct AWSAppSyncConfiguration {
+    
+    /// The region of the AWS AppSync API
     public let region: String
+
+    /// The endpoint of the AWS AppSync API
     public let endpoint: URL
+
+    /// API key for API Key authentication.
     public let apiKey: String?
 
+
+    /// Initializes an `AWSAppSyncConfiguration` instance using the provided AmplifyOutputs file.
+    /// AmplifyOutputs support multiple ways to read the `amplify_outputs.json` configuration file
+    ///
+    /// For example, `try AWSAppSyncConfiguraton(with: .amplifyOutputs)` will read the
+    /// `amplify_outputs.json` file from the main bundle.
     public init(with amplifyOutputs: AmplifyOutputs) throws {
         let resolvedConfiguration = try amplifyOutputs.resolveConfiguration()
 
@@ -28,6 +42,5 @@ public struct AWSAppSyncConfiguration {
         }
         self.endpoint = endpoint
         self.apiKey = dataCategory.apiKey
-
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/API/AWSAppSyncConfiguration.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/API/AWSAppSyncConfiguration.swift
@@ -1,0 +1,33 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+@_spi(InternalAmplifyConfiguration) import Amplify
+
+public struct AWSAppSyncConfiguration {
+    public let region: String
+    public let endpoint: URL
+    public let apiKey: String?
+
+    public init(with amplifyOutputs: AmplifyOutputs) throws {
+        let resolvedConfiguration = try amplifyOutputs.resolveConfiguration()
+
+        guard let dataCategory = resolvedConfiguration.data else {
+            throw ConfigurationError.invalidAmplifyOutputsFile(
+                "Missing data category", "", nil)
+        }
+
+        self.region = dataCategory.awsRegion
+        guard let endpoint = URL(string: dataCategory.url) else {
+            throw ConfigurationError.invalidAmplifyOutputsFile(
+                "Missing region from data category", "", nil)
+        }
+        self.endpoint = endpoint
+        self.apiKey = dataCategory.apiKey
+
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/API/AWSAppSyncConfigurationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/API/AWSAppSyncConfigurationTests.swift
@@ -1,0 +1,31 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AWSPluginsCore
+@_spi(InternalAmplifyConfiguration) @testable import Amplify
+
+final class AWSAppSyncConfigurationTests: XCTestCase {
+
+    func testSuccess() throws {
+        let config = AmplifyOutputsData(data: .init(
+            awsRegion: "us-east-1",
+            url: "http://www.example.com",
+            modelIntrospection: nil,
+            apiKey: "apiKey123",
+            defaultAuthorizationType: .amazonCognitoUserPools,
+            authorizationTypes: [.apiKey, .awsIAM]))
+        let encoder = JSONEncoder()
+        let data = try! encoder.encode(config)
+
+        let configuration = try AWSAppSyncConfiguration(with: .data(data))
+
+        XCTAssertEqual(configuration.region, "us-east-1")
+        XCTAssertEqual(configuration.endpoint, URL(string: "http://www.example.com")!)
+        XCTAssertEqual(configuration.apiKey, "apiKey123")
+    }
+}

--- a/AmplifyPlugins/Core/AmplifyCredentials/AmplifyAWSCredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentials/AmplifyAWSCredentialsProvider.swift
@@ -12,10 +12,7 @@ import AWSPluginsCore
 import Foundation
 
 public class AmplifyAWSCredentialsProvider: AWSClientRuntime.CredentialsProviding {
-
-    public init() {
-    }
-
+    
     public func getCredentials() async throws -> AWSClientRuntime.AWSCredentials {
         let authSession = try await Amplify.Auth.fetchAuthSession()
         if let awsCredentialsProvider = authSession as? AuthAWSCredentialsProvider {

--- a/AmplifyPlugins/Core/AmplifyCredentials/AmplifyAWSCredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentials/AmplifyAWSCredentialsProvider.swift
@@ -13,6 +13,9 @@ import Foundation
 
 public class AmplifyAWSCredentialsProvider: AWSClientRuntime.CredentialsProviding {
 
+    public init() {
+    }
+
     public func getCredentials() async throws -> AWSClientRuntime.AWSCredentials {
         let authSession = try await Amplify.Auth.fetchAuthSession()
         if let awsCredentialsProvider = authSession as? AuthAWSCredentialsProvider {

--- a/api-dump/AWSDataStorePlugin.json
+++ b/api-dump/AWSDataStorePlugin.json
@@ -8205,7 +8205,7 @@
       "-module",
       "AWSDataStorePlugin",
       "-o",
-      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.rjSPtedPzR\/AWSDataStorePlugin.json",
+      "\/var\/folders\/4d\/0gnh84wj53j7wyk695q0tc_80000gn\/T\/tmp.BZQxGLOyZz\/AWSDataStorePlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/AWSPluginsCore.json
+++ b/api-dump/AWSPluginsCore.json
@@ -138,6 +138,196 @@
       },
       {
         "kind": "TypeDecl",
+        "name": "AWSAppSyncConfiguration",
+        "printedName": "AWSAppSyncConfiguration",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "region",
+            "printedName": "region",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV6regionSSvp",
+            "mangledName": "$s14AWSPluginsCore23AWSAppSyncConfigurationV6regionSSvp",
+            "moduleName": "AWSPluginsCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV6regionSSvg",
+                "mangledName": "$s14AWSPluginsCore23AWSAppSyncConfigurationV6regionSSvg",
+                "moduleName": "AWSPluginsCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "endpoint",
+            "printedName": "endpoint",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "URL",
+                "printedName": "Foundation.URL",
+                "usr": "s:10Foundation3URLV"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV8endpoint10Foundation3URLVvp",
+            "mangledName": "$s14AWSPluginsCore23AWSAppSyncConfigurationV8endpoint10Foundation3URLVvp",
+            "moduleName": "AWSPluginsCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "URL",
+                    "printedName": "Foundation.URL",
+                    "usr": "s:10Foundation3URLV"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV8endpoint10Foundation3URLVvg",
+                "mangledName": "$s14AWSPluginsCore23AWSAppSyncConfigurationV8endpoint10Foundation3URLVvg",
+                "moduleName": "AWSPluginsCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "apiKey",
+            "printedName": "apiKey",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV6apiKeySSSgvp",
+            "mangledName": "$s14AWSPluginsCore23AWSAppSyncConfigurationV6apiKeySSSgvp",
+            "moduleName": "AWSPluginsCore",
+            "declAttributes": [
+              "HasStorage"
+            ],
+            "isLet": true,
+            "hasStorage": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Swift.String?",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV6apiKeySSSgvg",
+                "mangledName": "$s14AWSPluginsCore23AWSAppSyncConfigurationV6apiKeySSSgvg",
+                "moduleName": "AWSPluginsCore",
+                "implicit": true,
+                "declAttributes": [
+                  "Transparent"
+                ],
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(with:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "AWSAppSyncConfiguration",
+                "printedName": "AWSPluginsCore.AWSAppSyncConfiguration",
+                "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "AmplifyOutputs",
+                "printedName": "Amplify.AmplifyOutputs",
+                "usr": "s:7Amplify0A7OutputsV"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV4withAC7Amplify0G7OutputsV_tKcfc",
+            "mangledName": "$s14AWSPluginsCore23AWSAppSyncConfigurationV4withAC7Amplify0G7OutputsV_tKcfc",
+            "moduleName": "AWSPluginsCore",
+            "throwing": true,
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV",
+        "mangledName": "$s14AWSPluginsCore23AWSAppSyncConfigurationV",
+        "moduleName": "AWSPluginsCore"
+      },
+      {
+        "kind": "TypeDecl",
         "name": "AppSyncErrorType",
         "printedName": "AppSyncErrorType",
         "children": [
@@ -24273,7 +24463,7 @@
       "-module",
       "AWSPluginsCore",
       "-o",
-      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.rjSPtedPzR\/AWSPluginsCore.json",
+      "\/var\/folders\/4d\/0gnh84wj53j7wyk695q0tc_80000gn\/T\/tmp.BZQxGLOyZz\/AWSPluginsCore.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/CoreMLPredictionsPlugin.json
+++ b/api-dump/CoreMLPredictionsPlugin.json
@@ -430,7 +430,7 @@
       "-module",
       "CoreMLPredictionsPlugin",
       "-o",
-      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.rjSPtedPzR\/CoreMLPredictionsPlugin.json",
+      "\/var\/folders\/4d\/0gnh84wj53j7wyk695q0tc_80000gn\/T\/tmp.BZQxGLOyZz\/CoreMLPredictionsPlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
This PR adds the following public APIs to facilitate connectivity with AppSync. 

**AppSync signer**

Extension on AWSCognitoAuthPlugin to provide a static method to sign AppSync requests. This API receives an URLRequest and returns a signed URLRequest. 

**AWSAppSync configuration**

A new type vended from AWSPluginsCore as AWSAppSyncConfiguration. This configuration has the functionality to read `amplify_outputs.json` similar to `Amplify.configure(with: amplifyOutputs)` and provide properties related to AppSync endpoint configuration such as region, endpoint, apiKey.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
