### PR TITLE
fix: Adding factory extensions for Optional StorageBucket

### DIFF
--- a/Amplify/Categories/Storage/StorageBucket.swift
+++ b/Amplify/Categories/Storage/StorageBucket.swift
@@ -50,7 +50,6 @@ public extension StorageBucket where Self == ResolvedStorageBucket {
     }
 }
 
-
 /// Conforms to `StorageBucket`. Represents a Storage Bucket defined by a name in the AmplifyOutputs file.
 ///
 /// - Tag: OutputsStorageBucket
@@ -63,4 +62,20 @@ public struct OutputsStorageBucket: StorageBucket {
 /// - Tag: ResolvedStorageBucket
 public struct ResolvedStorageBucket: StorageBucket {
     public let bucketInfo: BucketInfo
+}
+
+public extension Optional where Wrapped == any StorageBucket {
+    /// References a `StorageBucket` in the AmplifyOutputs file using the given name.
+    ///
+    /// - Parameter name: The name of the bucket
+    static func fromOutputs(name: String) -> (any StorageBucket)? {
+        return OutputsStorageBucket.fromOutputs(name: name)
+    }
+
+    /// References a `StorageBucket` using the data from the given `BucketInfo`.
+    ///
+    /// - Parameter bucketInfo: A `BucketInfo` instance
+    static func fromBucketInfo(_ bucketInfo: BucketInfo) -> (any StorageBucket)? {
+        return ResolvedStorageBucket.fromBucketInfo(bucketInfo)
+    }
 }


### PR DESCRIPTION
## Description
This PR adds the `.fromOutputs(name:)` and `fromBucketInfo(_:)` factory extension methods to `Optiona<any StorageBucket>` as well.

This is desired because all public APIs that take a `bucket` have it as an optional parameter defaulting to nil. This meant that for customers there was no autocomplete suggestion when attempting to create the bucket:

**Before**:
![Screenshot 2024-08-21 at 11 30 03](https://github.com/user-attachments/assets/f221c17d-52b4-4499-86f6-a8be27c4cd82)

**After**:
![image](https://github.com/user-attachments/assets/952fcc86-5b28-4d6b-8f74-fcff05cf79ef)



## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
