### PR TITLE
fix: Updating init parameters to some StorageBucket for autocompletion

### DIFF
--- a/Amplify/Categories/Storage/Operation/Request/StorageDownloadDataRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageDownloadDataRequest.swift
@@ -95,23 +95,30 @@ public extension StorageDownloadDataRequest {
 
         ///
         /// - Tag: StorageDownloadDataRequestOptions.init
-        @available(*, deprecated, message: "Use init(bucket:pluginOptions)")
+        @available(*, deprecated, message: "Use init(pluginOptions)")
         public init(
             accessLevel: StorageAccessLevel = .guest,
             targetIdentityId: String? = nil,
-            bucket: (any StorageBucket)? = nil,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
-            self.bucket = bucket
+            self.bucket = nil
             self.pluginOptions = pluginOptions
         }
 
         ///
         /// - Tag: StorageDownloadDataRequestOptions.init
+        public init(pluginOptions: Any? = nil) {
+            self.accessLevel = .guest
+            self.targetIdentityId = nil
+            self.bucket = nil
+            self.pluginOptions = pluginOptions
+        }
+
+        /// - Tag: StorageDownloadDataRequestOptions.init
         public init(
-            bucket: (any StorageBucket)? = nil,
+            bucket: some StorageBucket,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = .guest

--- a/Amplify/Categories/Storage/Operation/Request/StorageDownloadFileRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageDownloadFileRequest.swift
@@ -84,22 +84,29 @@ public extension StorageDownloadFileRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageDownloadFileRequestOptions.init
-        @available(*, deprecated, message: "Use init(bucket:pluginOptions)")
+        @available(*, deprecated, message: "Use init(pluginOptions)")
         public init(
             accessLevel: StorageAccessLevel = .guest,
             targetIdentityId: String? = nil,
-            bucket: (any StorageBucket)? = nil,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
-            self.bucket = bucket
+            self.bucket = nil
+            self.pluginOptions = pluginOptions
+        }
+
+        /// - Tag: StorageDownloadFileRequestOptions.init
+        public init(pluginOptions: Any? = nil) {
+            self.accessLevel = .guest
+            self.targetIdentityId = nil
+            self.bucket = nil
             self.pluginOptions = pluginOptions
         }
 
         /// - Tag: StorageDownloadFileRequestOptions.init
         public init(
-            bucket: (any StorageBucket)? = nil,
+            bucket: some StorageBucket,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = .guest

--- a/Amplify/Categories/Storage/Operation/Request/StorageGetURLRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageGetURLRequest.swift
@@ -88,25 +88,36 @@ public extension StorageGetURLRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageGetURLRequest.Options.init
-        @available(*, deprecated, message: "Use init(expires:bucket:pluginOptions)")
+        @available(*, deprecated, message: "Use init(expires:pluginOptions)")
         public init(
             accessLevel: StorageAccessLevel = .guest,
             targetIdentityId: String? = nil,
             expires: Int = Options.defaultExpireInSeconds,
-            bucket: (any StorageBucket)? = nil,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.expires = expires
-            self.bucket = bucket
+            self.bucket = nil
             self.pluginOptions = pluginOptions
         }
 
         /// - Tag: StorageGetURLRequest.Options.init
         public init(
             expires: Int = Options.defaultExpireInSeconds,
-            bucket: (any StorageBucket)? = nil,
+            pluginOptions: Any? = nil
+        ) {
+            self.expires = expires
+            self.bucket = nil
+            self.pluginOptions = pluginOptions
+            self.accessLevel = .guest
+            self.targetIdentityId = nil
+        }
+
+        /// - Tag: StorageGetURLRequest.Options.init
+        public init(
+            expires: Int = Options.defaultExpireInSeconds,
+            bucket: some StorageBucket,
             pluginOptions: Any? = nil
         ) {
             self.expires = expires

--- a/Amplify/Categories/Storage/Operation/Request/StorageListRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageListRequest.swift
@@ -107,13 +107,30 @@ public extension StorageListRequest {
             path: String? = nil,
             subpathStrategy: SubpathStrategy = .include,
             pageSize: UInt = 1000,
-            bucket: (any StorageBucket)? = nil,
             nextToken: String? = nil,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.path = path
+            self.subpathStrategy = subpathStrategy
+            self.pageSize = pageSize
+            self.bucket = nil
+            self.nextToken = nextToken
+            self.pluginOptions = pluginOptions
+        }
+
+        /// - Tag: StorageListRequestOptions.init
+        public init(
+            subpathStrategy: SubpathStrategy = .include,
+            pageSize: UInt = 1000,
+            bucket: some StorageBucket,
+            nextToken: String? = nil,
+            pluginOptions: Any? = nil
+        ) {
+            self.accessLevel = .guest
+            self.targetIdentityId = nil
+            self.path = nil
             self.subpathStrategy = subpathStrategy
             self.pageSize = pageSize
             self.bucket = bucket

--- a/Amplify/Categories/Storage/Operation/Request/StorageRemoveRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageRemoveRequest.swift
@@ -71,10 +71,19 @@ public extension StorageRemoveRequest {
         /// - Tag: StorageRemoveRequestOptions.init
         public init(
             accessLevel: StorageAccessLevel = .guest,
-            bucket: (any StorageBucket)? = nil,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
+            self.bucket = nil
+            self.pluginOptions = pluginOptions
+        }
+
+        /// - Tag: StorageRemoveRequestOptions.init
+        public init(
+            bucket: some StorageBucket,
+            pluginOptions: Any? = nil
+        ) {
+            self.accessLevel = .guest
             self.bucket = bucket
             self.pluginOptions = pluginOptions
         }

--- a/Amplify/Categories/Storage/Operation/Request/StorageUploadDataRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageUploadDataRequest.swift
@@ -93,19 +93,18 @@ public extension StorageUploadDataRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageUploadDataRequestOptions.init
-        @available(*, deprecated, message: "Use init(metadata:bucket:contentType:options)")
+        @available(*, deprecated, message: "Use init(metadata:contentType:options)")
         public init(
             accessLevel: StorageAccessLevel = .guest,
             targetIdentityId: String? = nil,
             metadata: [String: String]? = nil,
-            bucket: (any StorageBucket)? = nil,
             contentType: String? = nil,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.metadata = metadata
-            self.bucket = bucket
+            self.bucket = nil
             self.contentType = contentType
             self.pluginOptions = pluginOptions
         }
@@ -113,7 +112,21 @@ public extension StorageUploadDataRequest {
         /// - Tag: StorageUploadDataRequestOptions.init
         public init(
             metadata: [String: String]? = nil,
-            bucket: (any StorageBucket)? = nil,
+            contentType: String? = nil,
+            pluginOptions: Any? = nil
+        ) {
+            self.accessLevel = .guest
+            self.targetIdentityId = nil
+            self.metadata = metadata
+            self.bucket = nil
+            self.contentType = contentType
+            self.pluginOptions = pluginOptions
+        }
+
+        /// - Tag: StorageUploadDataRequestOptions.init
+        public init(
+            metadata: [String: String]? = nil,
+            bucket: some StorageBucket,
             contentType: String? = nil,
             pluginOptions: Any? = nil
         ) {

--- a/Amplify/Categories/Storage/Operation/Request/StorageUploadFileRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageUploadFileRequest.swift
@@ -90,19 +90,18 @@ public extension StorageUploadFileRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageUploadFileRequestOptions.init
-        @available(*, deprecated, message: "Use init(metadata:bucket:contentType:pluginOptions)")
+        @available(*, deprecated, message: "Use init(metadata:contentType:pluginOptions)")
         public init(
             accessLevel: StorageAccessLevel = .guest,
             targetIdentityId: String? = nil,
             metadata: [String: String]? = nil,
-            bucket: (any StorageBucket)? = nil,
             contentType: String? = nil,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.metadata = metadata
-            self.bucket = bucket
+            self.bucket = nil
             self.contentType = contentType
             self.pluginOptions = pluginOptions
         }
@@ -110,7 +109,21 @@ public extension StorageUploadFileRequest {
         /// - Tag: StorageUploadFileRequestOptions.init
         public init(
             metadata: [String: String]? = nil,
-            bucket: (any StorageBucket)? = nil,
+            contentType: String? = nil,
+            pluginOptions: Any? = nil
+        ) {
+            self.accessLevel = .guest
+            self.targetIdentityId = nil
+            self.metadata = metadata
+            self.bucket = nil
+            self.contentType = contentType
+            self.pluginOptions = pluginOptions
+        }
+
+        /// - Tag: StorageUploadFileRequestOptions.init
+        public init(
+            metadata: [String: String]? = nil,
+            bucket: some StorageBucket,
             contentType: String? = nil,
             pluginOptions: Any? = nil
         ) {

--- a/Amplify/Categories/Storage/StorageBucket.swift
+++ b/Amplify/Categories/Storage/StorageBucket.swift
@@ -16,7 +16,6 @@ public protocol StorageBucket { }
 ///
 /// - Tag: BucketInfo
 public struct BucketInfo: Hashable {
-
     /// The name of the bucket
     /// - Tag: BucketInfo.bucketName
     public let bucketName: String
@@ -32,7 +31,6 @@ public struct BucketInfo: Hashable {
 }
 
 public extension StorageBucket where Self == OutputsStorageBucket {
-
     /// References a `StorageBucket` in the AmplifyOutputs file using the given name.
     ///
     /// - Parameter name: The name of the bucket
@@ -62,20 +60,4 @@ public struct OutputsStorageBucket: StorageBucket {
 /// - Tag: ResolvedStorageBucket
 public struct ResolvedStorageBucket: StorageBucket {
     public let bucketInfo: BucketInfo
-}
-
-public extension Optional where Wrapped == any StorageBucket {
-    /// References a `StorageBucket` in the AmplifyOutputs file using the given name.
-    ///
-    /// - Parameter name: The name of the bucket
-    static func fromOutputs(name: String) -> (any StorageBucket)? {
-        return OutputsStorageBucket.fromOutputs(name: name)
-    }
-
-    /// References a `StorageBucket` using the data from the given `BucketInfo`.
-    ///
-    /// - Parameter bucketInfo: A `BucketInfo` instance
-    static func fromBucketInfo(_ bucketInfo: BucketInfo) -> (any StorageBucket)? {
-        return ResolvedStorageBucket.fromBucketInfo(bucketInfo)
-    }
 }


### PR DESCRIPTION
## Description
Adding a public extension on `Optional` is probably not a great idea, as we do not own that type.
So in order to provide better support for Xcode's suggestion, I've created initializers that take `some StorageBucket` and removed the `(any StorageBucket)? = nil` parameter.

Now all `Options` types will have an initializer that can take a `bucket: some StorageBucket` and one that doesn't take it, which internally defaults the property to `nil`.

I've also decided to ultimately exclude the `bucket` parameter from the old **deprecated** inits to discourage their usage: customers wanting to set `bucket` will need to use the new initializers (which support both Gen1 and Gen2 anyway).

--- 
As a side note, the reason why Xcode doesn't provide autocompletion when the parameter is defined as `any StorageBucket` is probably because of the **`some`** vs **`any`** differences. 

Both `.fromOutputs(name:)` and `.fromBucketInfo(_:)` are methods defined in extensions of actual conformances of `StorageProtocol`. Yet using the **`any`** keyboard tells the compiler that the parameter's actual type will **not** be known at compile time; so it doesn't bother looking into actual types. Using **`some`** instead means that the type must be known at compile time, so the IDE looks for implementations that can match.

But that's just a theory. A Swift theory.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
