### PR TITLE
feat(Storage): Implementing support for multiple buckets

### DIFF
--- a/Amplify/Categories/Storage/Operation/Request/StorageDownloadDataRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageDownloadDataRequest.swift
@@ -64,6 +64,11 @@ public extension StorageDownloadDataRequest {
         @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let targetIdentityId: String?
 
+        /// A Storage Bucket that contains the object to download. Defaults to `nil`, in which case the default one will be used.
+        ///
+        /// - Tag: StorageDownloadDataRequest.bucket
+        public let bucket: (any StorageBucket)?
+
         /// Extra plugin specific options, only used in special circumstances when the existing options do not provide
         /// a way to utilize the underlying storage system's functionality. See plugin documentation for expected
         /// key/values
@@ -90,20 +95,28 @@ public extension StorageDownloadDataRequest {
 
         ///
         /// - Tag: StorageDownloadDataRequestOptions.init
-        @available(*, deprecated, message: "Use init(pluginOptions)")
-        public init(accessLevel: StorageAccessLevel = .guest,
-                    targetIdentityId: String? = nil,
-                    pluginOptions: Any? = nil) {
+        @available(*, deprecated, message: "Use init(bucket:pluginOptions)")
+        public init(
+            accessLevel: StorageAccessLevel = .guest,
+            targetIdentityId: String? = nil,
+            bucket: (any StorageBucket)? = nil,
+            pluginOptions: Any? = nil
+        ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
+            self.bucket = bucket
             self.pluginOptions = pluginOptions
         }
 
         ///
         /// - Tag: StorageDownloadDataRequestOptions.init
-        public init(pluginOptions: Any? = nil) {
+        public init(
+            bucket: (any StorageBucket)? = nil,
+            pluginOptions: Any? = nil
+        ) {
             self.accessLevel = .guest
             self.targetIdentityId = nil
+            self.bucket = bucket
             self.pluginOptions = pluginOptions
         }
     }

--- a/Amplify/Categories/Storage/Operation/Request/StorageDownloadDataRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageDownloadDataRequest.swift
@@ -95,23 +95,30 @@ public extension StorageDownloadDataRequest {
 
         ///
         /// - Tag: StorageDownloadDataRequestOptions.init
-        @available(*, deprecated, message: "Use init(bucket:pluginOptions)")
+        @available(*, deprecated, message: "Use init(pluginOptions)")
         public init(
             accessLevel: StorageAccessLevel = .guest,
             targetIdentityId: String? = nil,
-            bucket: (any StorageBucket)? = nil,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
-            self.bucket = bucket
+            self.bucket = nil
             self.pluginOptions = pluginOptions
         }
 
         ///
         /// - Tag: StorageDownloadDataRequestOptions.init
+        public init(pluginOptions: Any? = nil) {
+            self.accessLevel = .guest
+            self.targetIdentityId = nil
+            self.bucket = nil
+            self.pluginOptions = pluginOptions
+        }
+
+        /// - Tag: StorageDownloadDataRequestOptions.init
         public init(
-            bucket: (any StorageBucket)? = nil,
+            bucket: some StorageBucket,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = .guest

--- a/Amplify/Categories/Storage/Operation/Request/StorageDownloadFileRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageDownloadFileRequest.swift
@@ -84,22 +84,29 @@ public extension StorageDownloadFileRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageDownloadFileRequestOptions.init
-        @available(*, deprecated, message: "Use init(bucket:pluginOptions)")
+        @available(*, deprecated, message: "Use init(pluginOptions)")
         public init(
             accessLevel: StorageAccessLevel = .guest,
             targetIdentityId: String? = nil,
-            bucket: (any StorageBucket)? = nil,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
-            self.bucket = bucket
+            self.bucket = nil
+            self.pluginOptions = pluginOptions
+        }
+
+        /// - Tag: StorageDownloadFileRequestOptions.init
+        public init(pluginOptions: Any? = nil) {
+            self.accessLevel = .guest
+            self.targetIdentityId = nil
+            self.bucket = nil
             self.pluginOptions = pluginOptions
         }
 
         /// - Tag: StorageDownloadFileRequestOptions.init
         public init(
-            bucket: (any StorageBucket)? = nil,
+            bucket: some StorageBucket,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = .guest

--- a/Amplify/Categories/Storage/Operation/Request/StorageDownloadFileRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageDownloadFileRequest.swift
@@ -71,6 +71,11 @@ public extension StorageDownloadFileRequest {
         @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let targetIdentityId: String?
 
+        /// A Storage Bucket that contains the object to download. Defaults to `nil`, in which case the default one will be used.
+        ///
+        /// - Tag: StorageDownloadDataRequest.bucket
+        public let bucket: (any StorageBucket)?
+
         /// Extra plugin specific options, only used in special circumstances when the existing options do not provide
         /// a way to utilize the underlying storage system's functionality. See plugin documentation for expected
         /// key/values
@@ -79,20 +84,27 @@ public extension StorageDownloadFileRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageDownloadFileRequestOptions.init
-        @available(*, deprecated, message: "Use init(pluginOptions)")
-        public init(accessLevel: StorageAccessLevel = .guest,
-                    targetIdentityId: String? = nil,
-                    pluginOptions: Any? = nil) {
+        @available(*, deprecated, message: "Use init(bucket:pluginOptions)")
+        public init(
+            accessLevel: StorageAccessLevel = .guest,
+            targetIdentityId: String? = nil,
+            bucket: (any StorageBucket)? = nil,
+            pluginOptions: Any? = nil
+        ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
+            self.bucket = bucket
             self.pluginOptions = pluginOptions
         }
 
         /// - Tag: StorageDownloadFileRequestOptions.init
-        @available(*, deprecated, message: "Use init(pluginOptions)")
-        public init(pluginOptions: Any? = nil) {
+        public init(
+            bucket: (any StorageBucket)? = nil,
+            pluginOptions: Any? = nil
+        ) {
             self.accessLevel = .guest
             self.targetIdentityId = nil
+            self.bucket = bucket
             self.pluginOptions = pluginOptions
         }
     }

--- a/Amplify/Categories/Storage/Operation/Request/StorageGetURLRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageGetURLRequest.swift
@@ -88,25 +88,36 @@ public extension StorageGetURLRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageGetURLRequest.Options.init
-        @available(*, deprecated, message: "Use init(expires:bucket:pluginOptions)")
+        @available(*, deprecated, message: "Use init(expires:pluginOptions)")
         public init(
             accessLevel: StorageAccessLevel = .guest,
             targetIdentityId: String? = nil,
             expires: Int = Options.defaultExpireInSeconds,
-            bucket: (any StorageBucket)? = nil,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.expires = expires
-            self.bucket = bucket
+            self.bucket = nil
             self.pluginOptions = pluginOptions
         }
 
         /// - Tag: StorageGetURLRequest.Options.init
         public init(
             expires: Int = Options.defaultExpireInSeconds,
-            bucket: (any StorageBucket)? = nil,
+            pluginOptions: Any? = nil
+        ) {
+            self.expires = expires
+            self.bucket = nil
+            self.pluginOptions = pluginOptions
+            self.accessLevel = .guest
+            self.targetIdentityId = nil
+        }
+
+        /// - Tag: StorageGetURLRequest.Options.init
+        public init(
+            expires: Int = Options.defaultExpireInSeconds,
+            bucket: some StorageBucket,
             pluginOptions: Any? = nil
         ) {
             self.expires = expires

--- a/Amplify/Categories/Storage/Operation/Request/StorageGetURLRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageGetURLRequest.swift
@@ -73,6 +73,11 @@ public extension StorageGetURLRequest {
         /// - Tag: StorageGetURLRequest.Options.expires
         public let expires: Int
 
+        /// A Storage Bucket that contains the object. Defaults to `nil`, in which case the default one will be used.
+        ///
+        /// - Tag: StorageDownloadDataRequest.bucket
+        public let bucket: (any StorageBucket)?
+
         /// Extra plugin specific options, only used in special circumstances when the existing options do
         /// not provide a way to utilize the underlying storage system's functionality. See plugin
         /// documentation or
@@ -83,21 +88,29 @@ public extension StorageGetURLRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageGetURLRequest.Options.init
-        @available(*, deprecated, message: "Use init(expires:pluginOptions)")
-        public init(accessLevel: StorageAccessLevel = .guest,
-                    targetIdentityId: String? = nil,
-                    expires: Int = Options.defaultExpireInSeconds,
-                    pluginOptions: Any? = nil) {
+        @available(*, deprecated, message: "Use init(expires:bucket:pluginOptions)")
+        public init(
+            accessLevel: StorageAccessLevel = .guest,
+            targetIdentityId: String? = nil,
+            expires: Int = Options.defaultExpireInSeconds,
+            bucket: (any StorageBucket)? = nil,
+            pluginOptions: Any? = nil
+        ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.expires = expires
+            self.bucket = bucket
             self.pluginOptions = pluginOptions
         }
 
         /// - Tag: StorageGetURLRequest.Options.init
-        public init(expires: Int = Options.defaultExpireInSeconds,
-                    pluginOptions: Any? = nil) {
+        public init(
+            expires: Int = Options.defaultExpireInSeconds,
+            bucket: (any StorageBucket)? = nil,
+            pluginOptions: Any? = nil
+        ) {
             self.expires = expires
+            self.bucket = bucket
             self.pluginOptions = pluginOptions
             self.accessLevel = .guest
             self.targetIdentityId = nil

--- a/Amplify/Categories/Storage/Operation/Request/StorageListRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageListRequest.swift
@@ -78,6 +78,11 @@ public extension StorageListRequest {
         /// - Tag: StorageListRequestOptions.pageSize
         public let pageSize: UInt
 
+        /// A Storage Bucket that contains the objects to list. Defaults to `nil`, in which case the default one will be used.
+        ///
+        /// - Tag: StorageDownloadDataRequest.bucket
+        public let bucket: (any StorageBucket)?
+
         /// Opaque string indicating the page offset at which to resume a listing. This is usually a copy of
         /// the value from [StorageListResult.nextToken](x-source-tag://StorageListResult.nextToken).
         ///
@@ -96,18 +101,22 @@ public extension StorageListRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageListRequestOptions.init
-        public init(accessLevel: StorageAccessLevel = .guest,
-                    targetIdentityId: String? = nil,
-                    path: String? = nil,
-                    subpathStrategy: SubpathStrategy = .include,
-                    pageSize: UInt = 1000,
-                    nextToken: String? = nil,
-                    pluginOptions: Any? = nil) {
+        public init(
+            accessLevel: StorageAccessLevel = .guest,
+            targetIdentityId: String? = nil,
+            path: String? = nil,
+            subpathStrategy: SubpathStrategy = .include,
+            pageSize: UInt = 1000,
+            bucket: (any StorageBucket)? = nil,
+            nextToken: String? = nil,
+            pluginOptions: Any? = nil
+        ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.path = path
             self.subpathStrategy = subpathStrategy
             self.pageSize = pageSize
+            self.bucket = bucket
             self.nextToken = nextToken
             self.pluginOptions = pluginOptions
         }

--- a/Amplify/Categories/Storage/Operation/Request/StorageListRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageListRequest.swift
@@ -107,13 +107,30 @@ public extension StorageListRequest {
             path: String? = nil,
             subpathStrategy: SubpathStrategy = .include,
             pageSize: UInt = 1000,
-            bucket: (any StorageBucket)? = nil,
             nextToken: String? = nil,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.path = path
+            self.subpathStrategy = subpathStrategy
+            self.pageSize = pageSize
+            self.bucket = nil
+            self.nextToken = nextToken
+            self.pluginOptions = pluginOptions
+        }
+
+        /// - Tag: StorageListRequestOptions.init
+        public init(
+            subpathStrategy: SubpathStrategy = .include,
+            pageSize: UInt = 1000,
+            bucket: some StorageBucket,
+            nextToken: String? = nil,
+            pluginOptions: Any? = nil
+        ) {
+            self.accessLevel = .guest
+            self.targetIdentityId = nil
+            self.path = nil
             self.subpathStrategy = subpathStrategy
             self.pageSize = pageSize
             self.bucket = bucket

--- a/Amplify/Categories/Storage/Operation/Request/StorageRemoveRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageRemoveRequest.swift
@@ -71,10 +71,19 @@ public extension StorageRemoveRequest {
         /// - Tag: StorageRemoveRequestOptions.init
         public init(
             accessLevel: StorageAccessLevel = .guest,
-            bucket: (any StorageBucket)? = nil,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
+            self.bucket = nil
+            self.pluginOptions = pluginOptions
+        }
+
+        /// - Tag: StorageRemoveRequestOptions.init
+        public init(
+            bucket: some StorageBucket,
+            pluginOptions: Any? = nil
+        ) {
+            self.accessLevel = .guest
             self.bucket = bucket
             self.pluginOptions = pluginOptions
         }

--- a/Amplify/Categories/Storage/Operation/Request/StorageRemoveRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageRemoveRequest.swift
@@ -56,6 +56,11 @@ public extension StorageRemoveRequest {
         @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
         public let accessLevel: StorageAccessLevel
 
+        /// A Storage Bucket that contains the object to remove. Defaults to `nil`, in which case the default one will be used.
+        ///
+        /// - Tag: StorageDownloadDataRequest.bucket
+        public let bucket: (any StorageBucket)?
+
         /// Extra plugin specific options, only used in special circumstances when the existing options do not provide
         /// a way to utilize the underlying storage system's functionality. See plugin documentation for expected
         /// key/values
@@ -64,9 +69,13 @@ public extension StorageRemoveRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageRemoveRequestOptions.init
-        public init(accessLevel: StorageAccessLevel = .guest,
-                    pluginOptions: Any? = nil) {
+        public init(
+            accessLevel: StorageAccessLevel = .guest,
+            bucket: (any StorageBucket)? = nil,
+            pluginOptions: Any? = nil
+        ) {
             self.accessLevel = accessLevel
+            self.bucket = bucket
             self.pluginOptions = pluginOptions
         }
     }

--- a/Amplify/Categories/Storage/Operation/Request/StorageUploadDataRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageUploadDataRequest.swift
@@ -93,19 +93,18 @@ public extension StorageUploadDataRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageUploadDataRequestOptions.init
-        @available(*, deprecated, message: "Use init(metadata:bucket:contentType:options)")
+        @available(*, deprecated, message: "Use init(metadata:contentType:options)")
         public init(
             accessLevel: StorageAccessLevel = .guest,
             targetIdentityId: String? = nil,
             metadata: [String: String]? = nil,
-            bucket: (any StorageBucket)? = nil,
             contentType: String? = nil,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.metadata = metadata
-            self.bucket = bucket
+            self.bucket = nil
             self.contentType = contentType
             self.pluginOptions = pluginOptions
         }
@@ -113,7 +112,21 @@ public extension StorageUploadDataRequest {
         /// - Tag: StorageUploadDataRequestOptions.init
         public init(
             metadata: [String: String]? = nil,
-            bucket: (any StorageBucket)? = nil,
+            contentType: String? = nil,
+            pluginOptions: Any? = nil
+        ) {
+            self.accessLevel = .guest
+            self.targetIdentityId = nil
+            self.metadata = metadata
+            self.bucket = nil
+            self.contentType = contentType
+            self.pluginOptions = pluginOptions
+        }
+
+        /// - Tag: StorageUploadDataRequestOptions.init
+        public init(
+            metadata: [String: String]? = nil,
+            bucket: some StorageBucket,
             contentType: String? = nil,
             pluginOptions: Any? = nil
         ) {

--- a/Amplify/Categories/Storage/Operation/Request/StorageUploadDataRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageUploadDataRequest.swift
@@ -75,6 +75,11 @@ public extension StorageUploadDataRequest {
         /// - Tag: StorageUploadDataRequestOptions.metadata
         public let metadata: [String: String]?
 
+        /// A specific Storage Bucket to upload the data. Defaults to `nil`, in which case the default one will be used.
+        ///
+        /// - Tag: StorageDownloadDataRequest.bucket
+        public let bucket: (any StorageBucket)?
+
         /// The standard MIME type describing the format of the object to store
         ///
         /// - Tag: StorageUploadDataRequestOptions.contentType
@@ -88,28 +93,34 @@ public extension StorageUploadDataRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageUploadDataRequestOptions.init
-        @available(*, deprecated, message: "Use init(metadata:contentType:options)")
-        public init(accessLevel: StorageAccessLevel = .guest,
-                    targetIdentityId: String? = nil,
-                    metadata: [String: String]? = nil,
-                    contentType: String? = nil,
-                    pluginOptions: Any? = nil
+        @available(*, deprecated, message: "Use init(metadata:bucket:contentType:options)")
+        public init(
+            accessLevel: StorageAccessLevel = .guest,
+            targetIdentityId: String? = nil,
+            metadata: [String: String]? = nil,
+            bucket: (any StorageBucket)? = nil,
+            contentType: String? = nil,
+            pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.metadata = metadata
+            self.bucket = bucket
             self.contentType = contentType
             self.pluginOptions = pluginOptions
         }
 
         /// - Tag: StorageUploadDataRequestOptions.init
-        public init(metadata: [String: String]? = nil,
-                    contentType: String? = nil,
-                    pluginOptions: Any? = nil
+        public init(
+            metadata: [String: String]? = nil,
+            bucket: (any StorageBucket)? = nil,
+            contentType: String? = nil,
+            pluginOptions: Any? = nil
         ) {
             self.accessLevel = .guest
             self.targetIdentityId = nil
             self.metadata = metadata
+            self.bucket = bucket
             self.contentType = contentType
             self.pluginOptions = pluginOptions
         }

--- a/Amplify/Categories/Storage/Operation/Request/StorageUploadFileRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageUploadFileRequest.swift
@@ -72,6 +72,11 @@ public extension StorageUploadFileRequest {
         /// - Tag: StorageUploadFileRequestOptions.metadata
         public let metadata: [String: String]?
 
+        /// A specific Storage Bucket to upload the file. Defaults to `nil`, in which case the default one will be used.
+        ///
+        /// - Tag: StorageUploadFileRequestOptions.bucket
+        public let bucket: (any StorageBucket)?
+
         /// The standard MIME type describing the format of the object to store
         ///
         /// - Tag: StorageUploadFileRequestOptions.contentType
@@ -85,28 +90,34 @@ public extension StorageUploadFileRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageUploadFileRequestOptions.init
-        @available(*, deprecated, message: "Use init(metadata:contentType:pluginOptions)")
-        public init(accessLevel: StorageAccessLevel = .guest,
-                    targetIdentityId: String? = nil,
-                    metadata: [String: String]? = nil,
-                    contentType: String? = nil,
-                    pluginOptions: Any? = nil
+        @available(*, deprecated, message: "Use init(metadata:bucket:contentType:pluginOptions)")
+        public init(
+            accessLevel: StorageAccessLevel = .guest,
+            targetIdentityId: String? = nil,
+            metadata: [String: String]? = nil,
+            bucket: (any StorageBucket)? = nil,
+            contentType: String? = nil,
+            pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.metadata = metadata
+            self.bucket = bucket
             self.contentType = contentType
             self.pluginOptions = pluginOptions
         }
 
         /// - Tag: StorageUploadFileRequestOptions.init
-        public init(metadata: [String: String]? = nil,
-                    contentType: String? = nil,
-                    pluginOptions: Any? = nil
+        public init(
+            metadata: [String: String]? = nil,
+            bucket: (any StorageBucket)? = nil,
+            contentType: String? = nil,
+            pluginOptions: Any? = nil
         ) {
             self.accessLevel = .guest
             self.targetIdentityId = nil
             self.metadata = metadata
+            self.bucket = bucket
             self.contentType = contentType
             self.pluginOptions = pluginOptions
         }

--- a/Amplify/Categories/Storage/Operation/Request/StorageUploadFileRequest.swift
+++ b/Amplify/Categories/Storage/Operation/Request/StorageUploadFileRequest.swift
@@ -90,19 +90,18 @@ public extension StorageUploadFileRequest {
         public let pluginOptions: Any?
 
         /// - Tag: StorageUploadFileRequestOptions.init
-        @available(*, deprecated, message: "Use init(metadata:bucket:contentType:pluginOptions)")
+        @available(*, deprecated, message: "Use init(metadata:contentType:pluginOptions)")
         public init(
             accessLevel: StorageAccessLevel = .guest,
             targetIdentityId: String? = nil,
             metadata: [String: String]? = nil,
-            bucket: (any StorageBucket)? = nil,
             contentType: String? = nil,
             pluginOptions: Any? = nil
         ) {
             self.accessLevel = accessLevel
             self.targetIdentityId = targetIdentityId
             self.metadata = metadata
-            self.bucket = bucket
+            self.bucket = nil
             self.contentType = contentType
             self.pluginOptions = pluginOptions
         }
@@ -110,7 +109,21 @@ public extension StorageUploadFileRequest {
         /// - Tag: StorageUploadFileRequestOptions.init
         public init(
             metadata: [String: String]? = nil,
-            bucket: (any StorageBucket)? = nil,
+            contentType: String? = nil,
+            pluginOptions: Any? = nil
+        ) {
+            self.accessLevel = .guest
+            self.targetIdentityId = nil
+            self.metadata = metadata
+            self.bucket = nil
+            self.contentType = contentType
+            self.pluginOptions = pluginOptions
+        }
+
+        /// - Tag: StorageUploadFileRequestOptions.init
+        public init(
+            metadata: [String: String]? = nil,
+            bucket: some StorageBucket,
             contentType: String? = nil,
             pluginOptions: Any? = nil
         ) {

--- a/Amplify/Categories/Storage/StorageBucket.swift
+++ b/Amplify/Categories/Storage/StorageBucket.swift
@@ -1,0 +1,66 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// Protocol that represents a Storage bucket.
+///
+/// - Tag: StorageBucket
+public protocol StorageBucket { }
+
+/// Represents information about a Storage bucket
+///
+/// - Tag: BucketInfo
+public struct BucketInfo: Hashable {
+
+    /// The name of the bucket
+    /// - Tag: BucketInfo.bucketName
+    public let bucketName: String
+
+    /// The region of the bucket
+    /// - Tag: BucketInfo.region
+    public let region: String
+
+    public init(bucketName: String, region: String) {
+        self.bucketName = bucketName
+        self.region = region
+    }
+}
+
+public extension StorageBucket where Self == OutputsStorageBucket {
+
+    /// References a `StorageBucket` in the AmplifyOutputs file using the given name.
+    ///
+    /// - Parameter name: The name of the bucket
+    static func fromOutputs(name: String) -> Self {
+        return OutputsStorageBucket(name: name)
+    }
+}
+
+public extension StorageBucket where Self == ResolvedStorageBucket {
+    /// References a `StorageBucket` using the data from the given `BucketInfo`.
+    ///
+    /// - Parameter bucketInfo: A `BucketInfo` instance
+    static func fromBucketInfo(_ bucketInfo: BucketInfo) -> Self {
+        return ResolvedStorageBucket(bucketInfo: bucketInfo)
+    }
+}
+
+
+/// Conforms to `StorageBucket`. Represents a Storage Bucket defined by a name in the AmplifyOutputs file.
+///
+/// - Tag: OutputsStorageBucket
+public struct OutputsStorageBucket: StorageBucket {
+    public let name: String
+}
+
+/// Conforms to `StorageBucket`. Represents a Storage Bucket defined by a name and a region defined in `BucketInfo`.
+///
+/// - Tag: ResolvedStorageBucket
+public struct ResolvedStorageBucket: StorageBucket {
+    public let bucketInfo: BucketInfo
+}

--- a/Amplify/Categories/Storage/StorageBucket.swift
+++ b/Amplify/Categories/Storage/StorageBucket.swift
@@ -50,7 +50,6 @@ public extension StorageBucket where Self == ResolvedStorageBucket {
     }
 }
 
-
 /// Conforms to `StorageBucket`. Represents a Storage Bucket defined by a name in the AmplifyOutputs file.
 ///
 /// - Tag: OutputsStorageBucket
@@ -63,4 +62,20 @@ public struct OutputsStorageBucket: StorageBucket {
 /// - Tag: ResolvedStorageBucket
 public struct ResolvedStorageBucket: StorageBucket {
     public let bucketInfo: BucketInfo
+}
+
+public extension Optional where Wrapped == any StorageBucket {
+    /// References a `StorageBucket` in the AmplifyOutputs file using the given name.
+    ///
+    /// - Parameter name: The name of the bucket
+    static func fromOutputs(name: String) -> (any StorageBucket)? {
+        return OutputsStorageBucket.fromOutputs(name: name)
+    }
+
+    /// References a `StorageBucket` using the data from the given `BucketInfo`.
+    ///
+    /// - Parameter bucketInfo: A `BucketInfo` instance
+    static func fromBucketInfo(_ bucketInfo: BucketInfo) -> (any StorageBucket)? {
+        return ResolvedStorageBucket.fromBucketInfo(bucketInfo)
+    }
 }

--- a/Amplify/Categories/Storage/StorageBucket.swift
+++ b/Amplify/Categories/Storage/StorageBucket.swift
@@ -16,7 +16,6 @@ public protocol StorageBucket { }
 ///
 /// - Tag: BucketInfo
 public struct BucketInfo: Hashable {
-
     /// The name of the bucket
     /// - Tag: BucketInfo.bucketName
     public let bucketName: String
@@ -32,7 +31,6 @@ public struct BucketInfo: Hashable {
 }
 
 public extension StorageBucket where Self == OutputsStorageBucket {
-
     /// References a `StorageBucket` in the AmplifyOutputs file using the given name.
     ///
     /// - Parameter name: The name of the bucket
@@ -62,20 +60,4 @@ public struct OutputsStorageBucket: StorageBucket {
 /// - Tag: ResolvedStorageBucket
 public struct ResolvedStorageBucket: StorageBucket {
     public let bucketInfo: BucketInfo
-}
-
-public extension Optional where Wrapped == any StorageBucket {
-    /// References a `StorageBucket` in the AmplifyOutputs file using the given name.
-    ///
-    /// - Parameter name: The name of the bucket
-    static func fromOutputs(name: String) -> (any StorageBucket)? {
-        return OutputsStorageBucket.fromOutputs(name: name)
-    }
-
-    /// References a `StorageBucket` using the data from the given `BucketInfo`.
-    ///
-    /// - Parameter bucketInfo: A `BucketInfo` instance
-    static func fromBucketInfo(_ bucketInfo: BucketInfo) -> (any StorageBucket)? {
-        return ResolvedStorageBucket.fromBucketInfo(bucketInfo)
-    }
 }

--- a/Amplify/Core/Configuration/AmplifyOutputsData.swift
+++ b/Amplify/Core/Configuration/AmplifyOutputsData.swift
@@ -176,6 +176,25 @@ public struct AmplifyOutputsData: Codable {
     public struct Storage: Codable {
         public let awsRegion: AWSRegion
         public let bucketName: String
+        public let buckets: [Bucket]?
+
+        @_spi(InternalAmplifyConfiguration)
+        public struct Bucket: Codable {
+            public let name: String
+            public let bucketName: String
+            public let awsRegion: AWSRegion
+        }
+
+        // Internal init used for testing
+        init(
+            awsRegion: AWSRegion,
+            bucketName: String,
+            buckets: [Bucket]? = nil
+        ) {
+            self.awsRegion = awsRegion
+            self.bucketName = bucketName
+            self.buckets = buckets
+        }
     }
 
     @_spi(InternalAmplifyConfiguration)

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+ClientBehavior.swift
@@ -19,6 +19,6 @@ extension AWSS3StoragePlugin {
     ///
     /// - Tag: AWSS3StoragePlugin.getEscapeHatch
     public func getEscapeHatch() -> S3Client {
-        return storageService.getEscapeHatch()
+        return defaultStorageService.getEscapeHatch()
     }
 }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+Reset.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+Reset.swift
@@ -18,10 +18,19 @@ extension AWSS3StoragePlugin {
     ///
     /// - Tag: AWSS3StoragePlugin.reset
     public func reset() async {
-        if storageService != nil {
-            storageService.reset()
-            storageService = nil
+        if defaultBucket != nil {
+            defaultBucket = nil
         }
+
+        for storageService in storageServicesByBucket.values {
+            storageService.reset()
+        }
+        storageServicesByBucket.removeAll()
+
+        if additionalBucketsByName != nil {
+            additionalBucketsByName = nil
+        }
+
         if authService != nil {
             authService = nil
         }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+StorageBucket.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin+StorageBucket.swift
@@ -1,0 +1,74 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@_spi(InternalAmplifyConfiguration) import Amplify
+import Foundation
+
+extension AWSS3StoragePlugin {
+    /// Returns a AWSS3StorageServiceBehavior instance for the given StorageBucket
+    func storageService(for bucket: (any StorageBucket)?) throws -> AWSS3StorageServiceBehavior {
+        guard let bucket else {
+            // When no bucket is provided, use the default one
+            return defaultStorageService
+        }
+
+        let bucketInfo = try bucketInfo(from: bucket)
+        guard let storageService = storageServicesByBucket[bucketInfo.bucketName] else {
+            // If no service was found for the bucket, create one
+            let storageService = try createStorageService(
+                authService: authService,
+                bucketInfo: bucketInfo
+            )
+            storageServicesByBucket[bucketInfo.bucketName] = storageService
+            return storageService
+        }
+
+        return storageService
+    }
+
+    /// Returns a AWSS3StorageServiceProvider callback for the given StorageBucket
+    func storageServiceProvider(for bucket: (any StorageBucket)?) -> AWSS3StorageServiceProvider {
+        let storageServiceResolver: () throws -> AWSS3StorageServiceBehavior = { [weak self] in
+            guard let self = self else {
+                throw StorageError.unknown("AWSS3StoragePlugin was deallocated", nil)
+            }
+            return try self.storageService(for: bucket)
+        }
+        return storageServiceResolver
+    }
+
+    /// Returns a valid `BucketInfo` instance from the given StorageBucket
+    private func bucketInfo(from bucket: any StorageBucket) throws -> BucketInfo {
+        switch bucket {
+        case let outputsBucket as OutputsStorageBucket:
+            guard let additionalBucketsByName else {
+                let errorDescription = "Amplify was not configured using an Amplify Outputs file"
+                let recoverySuggestion = "Make sure that `Amplify.configure(with:)` is invoked"
+                throw StorageError.validation("bucket", errorDescription, recoverySuggestion, nil)
+            }
+
+            guard let awsBucket = additionalBucketsByName[outputsBucket.name] else {
+                let errorDescription = "Unable to lookup bucket from provided name in Amplify Outputs"
+                let recoverySuggestion = "Make sure the bucket name exists in the Amplify Outputs file"
+                throw StorageError.validation("bucket", errorDescription, recoverySuggestion, nil)
+            }
+
+            return .init(
+                bucketName: awsBucket.bucketName,
+                region: awsBucket.awsRegion
+            )
+
+        case let resolvedBucket as ResolvedStorageBucket:
+            return resolvedBucket.bucketInfo
+
+        default:
+            let errorDescription = "The specified StorageBucket is not supported"
+            let recoverySuggestion = "Please specify a StorageBucket from the Outputs file or from BucketInfo"
+            throw StorageError.validation("bucket", errorDescription, recoverySuggestion, nil)
+        }
+    }
+}

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
@@ -5,9 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Amplify
+@_spi(InternalAmplifyConfiguration) import Amplify
 import Foundation
 import AWSPluginsCore
+import InternalAmplifyCredentials
 
 /// The AWSS3StoragePlugin which conforms to the Amplify plugin protocols and implements the Storage
 /// Plugin APIs for AWS S3.
@@ -15,11 +16,25 @@ import AWSPluginsCore
 /// - Tag: AWSS3StoragePlugin
 final public class AWSS3StoragePlugin: StorageCategoryPlugin {
 
-    /// An instance of the S3 storage service.
-    var storageService: AWSS3StorageServiceBehavior!
+    /// The default S3 storage service.
+    var defaultStorageService: AWSS3StorageServiceBehavior! {
+        guard let defaultBucket else {
+            return nil
+        }
+        return storageServicesByBucket[defaultBucket.bucketInfo.bucketName]
+    }
+
+    /// The default bucket
+    var defaultBucket: ResolvedStorageBucket!
+
+    /// A dictionary of S3 storage service instances grouped by a specific bucket
+    var storageServicesByBucket: AtomicDictionary<String, AWSS3StorageServiceBehavior> = [:]
+
+    /// A dictionary of additional Outputs-based buckets, grouped by their names
+    var additionalBucketsByName: [String: AmplifyOutputsData.Storage.Bucket]?
 
     /// An instance of the authentication service.
-    var authService: AWSAuthServiceBehavior!
+    var authService: AWSAuthCredentialsProviderBehavior!
 
     /// A queue that regulates the execution of operations.
     var queue: OperationQueue!

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadDataOperation.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadDataOperation.swift
@@ -22,7 +22,7 @@ class AWSS3StorageUploadDataOperation: AmplifyInProcessReportingOperation<
 >, StorageUploadDataOperation {
 
     let storageConfiguration: AWSS3StoragePluginConfiguration
-    let storageService: AWSS3StorageServiceBehavior
+    let storageServiceProvider: AWSS3StorageServiceProvider
     let authService: AWSAuthServiceBehavior
 
     var storageTaskReference: StorageTaskReference?
@@ -30,15 +30,21 @@ class AWSS3StorageUploadDataOperation: AmplifyInProcessReportingOperation<
     /// Serial queue for synchronizing access to `storageTaskReference`.
     private let storageTaskActionQueue = DispatchQueue(label: "com.amazonaws.amplify.StorageTaskActionQueue")
 
+    private var storageService: AWSS3StorageServiceBehavior {
+        get throws {
+            return try storageServiceProvider()
+        }
+    }
+
     init(_ request: StorageUploadDataRequest,
          storageConfiguration: AWSS3StoragePluginConfiguration,
-         storageService: AWSS3StorageServiceBehavior,
+         storageServiceProvider: @escaping AWSS3StorageServiceProvider,
          authService: AWSAuthServiceBehavior,
          progressListener: InProcessListener? = nil,
          resultListener: ResultListener? = nil) {
 
         self.storageConfiguration = storageConfiguration
-        self.storageService = storageService
+        self.storageServiceProvider = storageServiceProvider
         self.authService = authService
         super.init(categoryType: .storage,
                    eventName: HubPayload.EventName.Storage.uploadData,
@@ -102,7 +108,7 @@ class AWSS3StorageUploadDataOperation: AmplifyInProcessReportingOperation<
 
                 let accelerate = try AWSS3PluginOptions.accelerateValue(pluginOptions: request.options.pluginOptions)
                 if request.data.count > StorageUploadDataRequest.Options.multiPartUploadSizeThreshold {
-                    storageService.multiPartUpload(
+                    try storageService.multiPartUpload(
                         serviceKey: serviceKey,
                         uploadSource: .data(request.data),
                         contentType: request.options.contentType,
@@ -112,7 +118,7 @@ class AWSS3StorageUploadDataOperation: AmplifyInProcessReportingOperation<
                         self?.onServiceEvent(event: event)
                     }
                 } else {
-                    storageService.upload(
+                    try storageService.upload(
                         serviceKey: serviceKey,
                         uploadSource: .data(request.data),
                         contentType: request.options.contentType,

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadFileOperation.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Operation/AWSS3StorageUploadFileOperation.swift
@@ -22,7 +22,7 @@ class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation<
 >, StorageUploadFileOperation {
 
     let storageConfiguration: AWSS3StoragePluginConfiguration
-    let storageService: AWSS3StorageServiceBehavior
+    let storageServiceProvider: AWSS3StorageServiceProvider
     let authService: AWSAuthServiceBehavior
 
     var storageTaskReference: StorageTaskReference?
@@ -30,15 +30,21 @@ class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation<
     /// Serial queue for synchronizing access to `storageTaskReference`.
     private let storageTaskActionQueue = DispatchQueue(label: "com.amazonaws.amplify.StorageTaskActionQueue")
 
+    private var storageService: AWSS3StorageServiceBehavior {
+        get throws {
+            return try storageServiceProvider()
+        }
+    }
+
     init(_ request: StorageUploadFileRequest,
          storageConfiguration: AWSS3StoragePluginConfiguration,
-         storageService: AWSS3StorageServiceBehavior,
+         storageServiceProvider: @escaping AWSS3StorageServiceProvider,
          authService: AWSAuthServiceBehavior,
          progressListener: InProcessListener? = nil,
          resultListener: ResultListener? = nil) {
 
         self.storageConfiguration = storageConfiguration
-        self.storageService = storageService
+        self.storageServiceProvider = storageServiceProvider
         self.authService = authService
         super.init(categoryType: .storage,
                    eventName: HubPayload.EventName.Storage.uploadFile,
@@ -124,7 +130,7 @@ class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation<
 
                 let accelerate = try AWSS3PluginOptions.accelerateValue(pluginOptions: request.options.pluginOptions)
                 if uploadSize > StorageUploadFileRequest.Options.multiPartUploadSizeThreshold {
-                    storageService.multiPartUpload(
+                    try storageService.multiPartUpload(
                         serviceKey: serviceKey,
                         uploadSource: .local(request.local),
                         contentType: request.options.contentType,
@@ -134,7 +140,7 @@ class AWSS3StorageUploadFileOperation: AmplifyInProcessReportingOperation<
                         self?.onServiceEvent(event: event)
                     }
                 } else {
-                    storageService.upload(
+                    try storageService.upload(
                         serviceKey: serviceKey,
                         uploadSource: .local(request.local),
                         contentType: request.options.contentType,

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
@@ -57,13 +57,14 @@ class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy {
                      region: String,
                      bucket: String,
                      httpClientEngineProxy: HttpClientEngineProxy? = nil,
-                     storageConfiguration: StorageConfiguration = .default,
+                     storageConfiguration: StorageConfiguration? = nil,
                      storageTransferDatabase: StorageTransferDatabase = .default,
                      fileSystem: FileSystem = .default,
                      sessionConfiguration: URLSessionConfiguration? = nil,
                      delegateQueue: OperationQueue? = nil,
                      logger: Logger = storageLogger) throws {
         let credentialsProvider = authService.getCredentialsProvider()
+        let storageConfiguration = storageConfiguration ?? .init(forBucket: bucket)
         let clientConfig = try S3Client.S3ClientConfiguration(
             region: region,
             credentialsProvider: credentialsProvider,
@@ -113,7 +114,7 @@ class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy {
     }
 
     init(authService: AWSAuthCredentialsProviderBehavior,
-         storageConfiguration: StorageConfiguration = .default,
+         storageConfiguration: StorageConfiguration? = nil,
          storageTransferDatabase: StorageTransferDatabase = .default,
          fileSystem: FileSystem = .default,
          sessionConfiguration: URLSessionConfiguration,
@@ -123,6 +124,7 @@ class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy {
          preSignedURLBuilder: AWSS3PreSignedURLBuilderBehavior,
          awsS3: AWSS3Behavior,
          bucket: String) {
+        let storageConfiguration = storageConfiguration ?? .init(forBucket: bucket)
         self.storageConfiguration = storageConfiguration
         self.storageTransferDatabase = storageTransferDatabase
         self.fileSystem = fileSystem

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageServiceBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageServiceBehavior.swift
@@ -9,6 +9,7 @@ import Foundation
 import Amplify
 import AWSS3
 
+typealias AWSS3StorageServiceProvider = () throws -> AWSS3StorageServiceBehavior
 protocol AWSS3StorageServiceBehavior {
     typealias StorageServiceDownloadEventHandler = (StorageServiceDownloadEvent) -> Void
     typealias StorageServiceDownloadEvent =

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageConfiguration.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageConfiguration.swift
@@ -20,10 +20,6 @@ struct StorageConfiguration {
     let allowsCellularAccess: Bool
     let timeoutIntervalForResource: TimeInterval
 
-    static let `default`: StorageConfiguration = {
-        StorageConfiguration()
-    }()
-
     init(sessionIdentifier: String = Defaults.sessionIdentifier,
          sharedContainerIdentifier: String = Defaults.sharedContainerIdentifier,
          allowsCellularAccess: Bool = Defaults.allowsCellularAccess,
@@ -32,5 +28,11 @@ struct StorageConfiguration {
         self.sharedContainerIdentifier = sharedContainerIdentifier
         self.allowsCellularAccess = allowsCellularAccess
         self.timeoutIntervalForResource = timeoutIntervalForResource
+    }
+
+    init(forBucket bucket: String) {
+        self.init(
+            sessionIdentifier: "\(Defaults.sessionIdentifier).\(bucket)"
+        )
     }
 }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Tasks/AWSS3StorageListObjectsTask.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Tasks/AWSS3StorageListObjectsTask.swift
@@ -56,6 +56,7 @@ class AWSS3StorageListObjectsTask: StorageListObjectsTask, DefaultLogger {
                 }
                 return StorageListResult.Item(
                     path: path,
+                    size: s3Object.size,
                     eTag: s3Object.eTag,
                     lastModified: s3Object.lastModified
                 )

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginResetTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginResetTests.swift
@@ -16,7 +16,7 @@ class AWSS3StoragePluginResetTests: AWSS3StoragePluginTests {
         await resettable.reset()
 
         XCTAssertNil(storagePlugin.authService)
-        XCTAssertNil(storagePlugin.storageService)
+        XCTAssertNil(storagePlugin.defaultStorageService)
         XCTAssertNil(storagePlugin.queue)
     }
 }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginStorageBucketTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginStorageBucketTests.swift
@@ -1,0 +1,174 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import AWSS3StoragePlugin
+@testable import AWSPluginsTestCommon
+
+class AWSS3StoragePluginStorageBucketTests: XCTestCase {
+    private var storagePlugin: AWSS3StoragePlugin!
+    private var defaultService: MockAWSS3StorageService!
+    private var authService: MockAWSAuthService!
+    private var queue: OperationQueue!
+    private let defaultBucketInfo = BucketInfo(
+        bucketName: "bucketName",
+        region: "us-east-1"
+    )
+    private let additionalBucketInfo = BucketInfo(
+        bucketName: "anotherBucketName",
+        region: "us-east-2"
+    )
+
+    private var additionalS3Bucket: AmplifyOutputsData.Storage.Bucket {
+        return .init(
+            name: "anotherBucket",
+            bucketName: additionalBucketInfo.bucketName,
+            awsRegion: additionalBucketInfo.region
+        )
+    }
+
+    override func setUp() {
+        storagePlugin = AWSS3StoragePlugin()
+        defaultService = MockAWSS3StorageService()
+        authService = MockAWSAuthService()
+        queue = OperationQueue()
+        storagePlugin.configure(
+            defaultBucket: .fromBucketInfo(defaultBucketInfo),
+            storageService: defaultService,
+            authService: authService,
+            defaultAccessLevel: .guest,
+            queue: queue
+        )
+    }
+
+    override func tearDown() async throws {
+        try await Task.sleep(seconds: 0.1) // This is unfortunate but necessary to give the DB time to recover the URLSession tasks
+        await storagePlugin.reset()
+        queue.cancelAllOperations()
+        storagePlugin = nil
+        defaultService = nil
+        authService = nil
+        queue = nil
+    }
+
+    /// Given: A configured AWSS3StoragePlugin
+    /// When: storageService(for:) is invoked with nil
+    /// Then: The default storage service should be returned
+    func testStorageService_withNil_shouldReturnDefaultService() throws {
+        let storageService = try storagePlugin.storageService(for: nil)
+        guard let mockService = storageService as? MockAWSS3StorageService else {
+            XCTFail("Expected a MockAWSS3StorageService, got \(type(of: storageService))")
+            return
+        }
+        XCTAssertTrue(mockService === defaultService)
+    }
+
+    /// Given: A AWSS3StoragePlugin configured with additional bucket names
+    /// When: storageService(for:) is invoked with .fromOutputs with an existing value
+    /// Then: A valid AWSS3StorageService should be returned pointing to that bucket
+    func testStorageService_withBucketFromOutputs_shouldReturnStorageService() throws {
+        storagePlugin.additionalBucketsByName = [
+            additionalS3Bucket.name: additionalS3Bucket
+        ]
+        let storageService = try storagePlugin.storageService(for: .fromOutputs(name: additionalS3Bucket.name))
+        guard let newService = storageService as? AWSS3StorageService else {
+            XCTFail("Expected a AWSS3StorageService, got \(type(of: storageService))")
+            return
+        }
+        XCTAssertFalse(newService === defaultService)
+        XCTAssertEqual(newService.bucket, additionalS3Bucket.bucketName)
+    }
+
+    /// Given: A AWSS3StoragePlugin configured without additional buckets (i.e. no AmplifyOutputs)
+    /// When: storageService(for:) is invoked with .fromOutputs
+    /// Then: A StorageError.validation error is thrown
+    func testStorageService_withBucketFromOutputs_withoutConfiguringOutputs_shouldThrowValidationException() {
+        storagePlugin.additionalBucketsByName = nil
+        do {
+            _ = try storagePlugin.storageService(for: .fromOutputs(name: "anotherBucket"))
+            XCTFail("Expected StorageError.validation to be thrown")
+        } catch {
+            guard let storageError = error as? StorageError,
+                  case .validation(let field, _, _, _) = storageError else {
+                XCTFail("Expected StorageError.validation, got \(error)")
+                return
+            }
+            XCTAssertEqual(field, "bucket")
+        }
+    }
+
+    /// Given: A AWSS3StoragePlugin configured with additional bucket names
+    /// When: storageService(for:) is invoked with .fromOutputs with a non-existing value
+    /// Then: A StorageError.validation error is thrown
+    func testStorageService_withInvalidBucketFromOutputs_shouldThrowValidationException() {
+        storagePlugin.additionalBucketsByName = [
+            additionalS3Bucket.name: additionalS3Bucket
+        ]
+        do {
+            _ = try storagePlugin.storageService(for: .fromOutputs(name: "invalidBucket"))
+            XCTFail("Expected StorageError.validation to be thrown")
+        } catch {
+            guard let storageError = error as? StorageError,
+                  case .validation(let field, _, _, _) = storageError else {
+                XCTFail("Expected StorageError.validation, got \(error)")
+                return
+            }
+            XCTAssertEqual(field, "bucket")
+        }
+    }
+
+    /// Given: A configured AWSS3StoragePlugin
+    /// When: storageService(for:) is invoked with .fromBucketInfo
+    /// Then: A valid AWSS3StorageService should be returned pointing to that bucket
+    func testStorageService_withBucketFromBucketInfo_shouldReturnStorageService() throws {
+        let storageService = try storagePlugin.storageService(for: .fromBucketInfo(additionalBucketInfo))
+        guard let newService = storageService as? AWSS3StorageService else {
+            XCTFail("Expected a AWSS3StorageService, got \(type(of: storageService))")
+            return
+        }
+        XCTAssertFalse(newService === defaultService)
+        XCTAssertEqual(newService.bucket, additionalBucketInfo.bucketName)
+    }
+
+    /// Given: A configured AWSS3StoragePlugin
+    /// When: storageService(for:) is invoked with an invalid instance that conforms to StorageBucket
+    /// Then: A StorageError.validation error is thrown
+    func testStorageService_withInvalidStorageBucket_shouldThrowValidationException() {
+        do {
+            _ = try storagePlugin.storageService(for: InvalidBucket())
+            XCTFail("Expected StorageError.validation to be thrown")
+        } catch {
+            guard let storageError = error as? StorageError,
+                  case .validation(let field, _, _, _) = storageError else {
+                XCTFail("Expected StorageError.validation, got \(error)")
+                return
+            }
+            XCTAssertEqual(field, "bucket")
+        }
+    }
+
+    /// Given: A configured AWSS3StoragePlugin
+    /// When: storageService(for:) is invoked for a bucket that was not accessed before (i.e. a new one)
+    /// Then: A new Storage Service should be created
+    func testStorageService_withNewBucket_shouldReturnNewService() throws {
+        XCTAssertEqual(storagePlugin.storageServicesByBucket.count, 1)
+        _ = try storagePlugin.storageService(for: .fromBucketInfo(additionalBucketInfo))
+        XCTAssertEqual(storagePlugin.storageServicesByBucket.count, 2)
+    }
+
+    /// Given: A configured AWSS3StoragePlugin
+    /// When: storageService(for:) is invoked for a bucket that was accessed before (e.g. the default one)
+    /// Then: A new Storage Service should not be created
+    func testStorageService_withPreviouslyAccessedBucket_shouldReturnExistingService() throws {
+        XCTAssertEqual(storagePlugin.storageServicesByBucket.count, 1)
+        _ = try storagePlugin.storageService(for: .fromBucketInfo(defaultBucketInfo))
+        XCTAssertEqual(storagePlugin.storageServicesByBucket.count, 1)
+    }
+
+    private struct InvalidBucket: StorageBucket {}
+}

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginTestBase.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginTestBase.swift
@@ -10,6 +10,7 @@ import Amplify
 @testable import AWSS3StoragePlugin
 @testable import AmplifyTestCommon
 @testable import AWSPluginsTestCommon
+import InternalAmplifyCredentials
 
 class AWSS3StoragePluginTests: XCTestCase {
     var storagePlugin: AWSS3StoragePlugin!
@@ -33,9 +34,29 @@ class AWSS3StoragePluginTests: XCTestCase {
         authService = MockAWSAuthService()
         queue = MockOperationQueue()
 
-        storagePlugin.configure(storageService: storageService,
+        storagePlugin.configure(defaultBucket: .fromBucketInfo(.init(bucketName: testBucket, region: testRegion)),
+                                storageService: storageService,
                                 authService: authService,
                                 defaultAccessLevel: defaultAccessLevel,
                                 queue: queue)
+    }
+}
+
+
+extension AWSS3StoragePlugin {
+    /// Convenience configuration method for testing purposes, with a default bucket with name "test-bucket" and region "us-east-1"
+    func configure(
+        storageService: AWSS3StorageServiceBehavior,
+        authService: AWSAuthCredentialsProviderBehavior,
+        defaultAccessLevel: StorageAccessLevel,
+        queue: OperationQueue = OperationQueue()
+    ) {
+        configure(
+            defaultBucket: .fromBucketInfo(.init(bucketName: "test-bucket", region: "us-east-1")),
+            storageService: storageService,
+            authService: authService,
+            defaultAccessLevel: defaultAccessLevel,
+            queue: queue
+        )
     }
 }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/AWSS3StorageOperations+StorageServiceProvider.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/AWSS3StorageOperations+StorageServiceProvider.swift
@@ -1,0 +1,99 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import Amplify
+@testable import AWSPluginsCore
+@testable import AWSS3StoragePlugin
+import Foundation
+
+extension AWSS3StorageDownloadFileOperation {
+    convenience init(
+        _ request: StorageDownloadFileRequest,
+        storageConfiguration: AWSS3StoragePluginConfiguration,
+        storageService: AWSS3StorageServiceBehavior,
+        authService: AWSAuthServiceBehavior,
+        progressListener: InProcessListener? = nil,
+        resultListener: ResultListener? = nil
+    ) {
+        self.init(
+            request,
+            storageConfiguration: storageConfiguration,
+            storageServiceProvider: {
+                return storageService
+            },
+            authService: authService,
+            progressListener: progressListener,
+            resultListener: resultListener
+        )
+    }
+}
+
+extension AWSS3StorageDownloadDataOperation {
+    convenience init(
+        _ request: StorageDownloadDataRequest,
+        storageConfiguration: AWSS3StoragePluginConfiguration,
+        storageService: AWSS3StorageServiceBehavior,
+        authService: AWSAuthServiceBehavior,
+        progressListener: InProcessListener? = nil,
+        resultListener: ResultListener? = nil
+    ) {
+        self.init(
+            request,
+            storageConfiguration: storageConfiguration,
+            storageServiceProvider: {
+                return storageService
+            },
+            authService: authService,
+            progressListener: progressListener,
+            resultListener: resultListener
+        )
+    }
+}
+
+extension AWSS3StorageUploadDataOperation {
+    convenience init(
+        _ request: StorageUploadDataRequest,
+        storageConfiguration: AWSS3StoragePluginConfiguration,
+        storageService: AWSS3StorageServiceBehavior,
+        authService: AWSAuthServiceBehavior,
+        progressListener: InProcessListener? = nil,
+        resultListener: ResultListener? = nil
+    ) {
+        self.init(
+            request,
+            storageConfiguration: storageConfiguration,
+            storageServiceProvider: {
+                return storageService
+            },
+            authService: authService,
+            progressListener: progressListener,
+            resultListener: resultListener
+        )
+    }
+}
+
+extension AWSS3StorageUploadFileOperation {
+    convenience init(
+        _ request: StorageUploadFileRequest,
+        storageConfiguration: AWSS3StoragePluginConfiguration,
+        storageService: AWSS3StorageServiceBehavior,
+        authService: AWSAuthServiceBehavior,
+        progressListener: InProcessListener? = nil,
+        resultListener: ResultListener? = nil
+    ) {
+        self.init(
+            request,
+            storageConfiguration: storageConfiguration,
+            storageServiceProvider: {
+                return storageService
+            },
+            authService: authService,
+            progressListener: progressListener,
+            resultListener: resultListener
+        )
+    }
+}

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginMultipleBucketTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginMultipleBucketTests.swift
@@ -1,0 +1,531 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import AWSS3StoragePlugin
+import XCTest
+
+class AWSS3StoragePluginMultipleBucketTests: AWSS3StoragePluginTestBase {
+    var customBucket: (any StorageBucket)!
+
+    override func setUp() async throws {
+        guard let outputs = try? AmplifyOutputs.amplifyOutputs.resolveConfiguration(),
+              let additionalBucket = outputs.storage?.buckets?.first else {
+            throw XCTSkip("Multibucket has not been configured. Skipping test")
+        }
+        customBucket = .fromBucketInfo(.init(
+            bucketName: additionalBucket.bucketName,
+            region: additionalBucket.awsRegion
+        ))
+        try await super.setUp()
+    }
+
+    override func tearDown() async throws {
+        try await Task.sleep(seconds: 0.1)
+        try await super.tearDown()
+    }
+
+    /// Given: An data object
+    /// When: Upload the data to a custom buckets using keys
+    /// Then: The operation completes successfully
+    func testUploadData_toCustomBucket_usingKey_shouldSucceed() async throws {
+        let key = UUID().uuidString
+        let data = Data(key.utf8)
+
+        let uploaded = try await Amplify.Storage.uploadData(
+            key: key,
+            data: data,
+            options: .init(bucket: customBucket)
+        ).value
+        XCTAssertEqual(uploaded, key)
+
+        let deleted = try await Amplify.Storage.remove(
+            key: key,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, key)
+    }
+
+    /// Given: An data object
+    /// When: Upload the data to a custom bucket using StoragePath
+    /// Then: The operation completes successfully
+    func testUploadData_toCustomBucket_usingStoragePath_shouldSucceed() async throws {
+        let id = UUID().uuidString
+        let data = Data(id.utf8)
+        let path: StringStoragePath = .fromString("public/\(id)")
+
+        let uploaded = try await Amplify.Storage.uploadData(
+            path: path,
+            data: data,
+            options: .init(bucket: customBucket)
+        ).value
+        XCTAssertEqual(uploaded, path.string)
+
+        let deleted = try await Amplify.Storage.remove(
+            path: path,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, path.string)
+    }
+
+    /// Given: A file with contents
+    /// When: Upload the file to a custom bucket using key
+    /// Then: The operation completes successfully and all URLSession and SDK requests include a user agent
+    func testUploadFile_toCustomBucket_usingKey_shouldSucceed() async throws {
+        let key = UUID().uuidString
+        let filePath = NSTemporaryDirectory() + key + ".tmp"
+
+        let fileURL = URL(fileURLWithPath: filePath)
+        FileManager.default.createFile(atPath: filePath, contents: Data(key.utf8), attributes: nil)
+
+        let uploaded = try await Amplify.Storage.uploadFile(
+            key: key,
+            local: fileURL,
+            options: .init(bucket: customBucket)
+        ).value
+        XCTAssertEqual(uploaded, key)
+
+        let deleted = try await Amplify.Storage.remove(
+            key: key,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, key)
+    }
+
+    /// Given: A file with contents
+    /// When: Upload the file to a custom bucket using StoragePath
+    /// Then: The operation completes successfully and all URLSession and SDK requests include a user agent
+    func testUploadFile_toCustomBucket_usingStoragePath_shouldSucceed() async throws {
+        let id = UUID().uuidString
+        let filePath = NSTemporaryDirectory() + id + ".tmp"
+        let path: StringStoragePath = .fromString("public/\(id)")
+
+        let fileURL = URL(fileURLWithPath: filePath)
+        FileManager.default.createFile(atPath: filePath, contents: Data(id.utf8), attributes: nil)
+
+        let uploaded = try await Amplify.Storage.uploadFile(
+            path: path,
+            local: fileURL,
+            options: .init(bucket: customBucket)
+        ).value
+        XCTAssertEqual(uploaded, path.string)
+
+        let deleted = try await Amplify.Storage.remove(
+            path: path,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, path.string)
+    }
+
+    /// Given: A large  data object
+    /// When: Upload the data to a custom bucket using key
+    /// Then: The operation completes successfully
+    func testUploadLargeData_toCustomBucket_usingKey_shouldSucceed() async throws {
+        let key = UUID().uuidString
+
+        let uploaded = try await Amplify.Storage.uploadData(
+            key: key,
+            data: AWSS3StoragePluginTestBase.largeDataObject,
+            options: .init(bucket: customBucket)
+        ).value
+        XCTAssertEqual(uploaded, key)
+
+        let deleted = try await Amplify.Storage.remove(
+            key: key,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, key)
+    }
+
+    /// Given: A large  data object
+    /// When: Upload the data to a custom bucket using StoragePath
+    /// Then: The operation completes successfully
+    func testUploadLargeData_toCustomBucket_usingStoragePath_shouldSucceed() async throws {
+        let id = UUID().uuidString
+        let path: StringStoragePath = .fromString("public/\(id)")
+
+        let uploaded = try await Amplify.Storage.uploadData(
+            path: path,
+            data: AWSS3StoragePluginTestBase.largeDataObject,
+            options: .init(bucket: customBucket)
+        ).value
+        XCTAssertEqual(uploaded, path.string)
+
+        let deleted = try await Amplify.Storage.remove(
+            path: path,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, path.string)
+    }
+
+    /// Given: A large file
+    /// When: Upload the file to a custom bucket using key
+    /// Then: The operation completes successfully
+    func testUploadLargeFile_toCustomBucket_usingKey_shouldSucceed() async throws {
+        let key = UUID().uuidString
+        let filePath = NSTemporaryDirectory() + key + ".tmp"
+        let fileURL = URL(fileURLWithPath: filePath)
+
+        FileManager.default.createFile(
+            atPath: filePath,
+            contents: AWSS3StoragePluginTestBase.largeDataObject,
+            attributes: nil
+        )
+
+        let uploaded = try await Amplify.Storage.uploadFile(
+            key: key,
+            local: fileURL,
+            options: .init(bucket: customBucket)
+        ).value
+        XCTAssertEqual(uploaded, key)
+
+
+        let deleted = try await Amplify.Storage.remove(
+            key: key,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, key)
+    }
+
+    /// Given: A large file
+    /// When: Upload the file to a custom bucket using key
+    /// Then: The operation completes successfully
+    func testUploadLargeFile_toCustomBucket_usingStoragePath_shouldSucceed() async throws {
+        let id = UUID().uuidString
+        let filePath = NSTemporaryDirectory() + id + ".tmp"
+        let fileURL = URL(fileURLWithPath: filePath)
+        let path: StringStoragePath = .fromString("public/\(id)")
+
+        FileManager.default.createFile(
+            atPath: filePath,
+            contents: AWSS3StoragePluginTestBase.largeDataObject,
+            attributes: nil
+        )
+
+        let uploaded = try await Amplify.Storage.uploadFile(
+            path: path,
+            local: fileURL,
+            options: .init(bucket: customBucket)
+        ).value
+        XCTAssertEqual(uploaded, path.string)
+
+
+        let deleted = try await Amplify.Storage.remove(
+            path: path,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, path.string)
+    }
+
+    /// Given: An object in storage in a custom bucket
+    /// When: Call the downloadData API using key
+    /// Then: The operation completes successfully with the data retrieved
+    func testDownloadData_fromCustomBucket_usingKey_shouldSucceed() async throws {
+        let key = UUID().uuidString
+        let data = Data(key.utf8)
+        try await uploadData(
+            key: key, 
+            data: data,
+            options: .init(bucket: customBucket)
+        )
+
+        let downloaded = try await Amplify.Storage.downloadData(
+            key: key,
+            options: .init(bucket: customBucket)
+        ).value
+        XCTAssertEqual(data.count, downloaded.count)
+
+        let deleted = try await Amplify.Storage.remove(
+            key: key,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, key)
+    }
+
+    /// Given: An object in storage in a custom bucket
+    /// When: Call the downloadData API using StoragePath
+    /// Then: The operation completes successfully with the data retrieved
+    func testDownloadData_fromCustomBucket_usingStoragePath_shouldSucceed() async throws {
+        let id = UUID().uuidString
+        let data = Data(id.utf8)
+        let path: StringStoragePath = .fromString("public/\(id)")
+        try await uploadData(
+            path: path,
+            data: data,
+            options: .init(bucket: customBucket)
+        )
+
+        let downloaded = try await Amplify.Storage.downloadData(
+            path: path,
+            options: .init(bucket: customBucket)
+        ).value
+        XCTAssertEqual(data.count, downloaded.count)
+
+        let deleted = try await Amplify.Storage.remove(
+            path: path,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, path.string)
+    }
+
+    /// Given: An object in storage in a custom bucket
+    /// When: Call the downloadFile API using key
+    /// Then: The operation completes successfully the local file containing the data from the object
+    func testDownloadFile_fromCustomBucket_usingKey_shouldSucceed() async throws {
+        let key = UUID().uuidString
+        let timestamp = String(Date().timeIntervalSince1970)
+        let timestampData = Data(timestamp.utf8)
+        try await uploadData(
+            key: key,
+            data: timestampData,
+            options: .init(bucket: customBucket)
+        )
+        let filePath = NSTemporaryDirectory() + key + ".tmp"
+        let fileURL = URL(fileURLWithPath: filePath)
+        removeFileIfExisting(fileURL)
+
+        try await Amplify.Storage.downloadFile(
+            key: key,
+            local: fileURL,
+            options: .init(bucket: customBucket)
+        ).value
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
+        do {
+            let result = try String(contentsOf: fileURL, encoding: .utf8)
+            XCTAssertEqual(result, timestamp)
+        } catch {
+            XCTFail("Failed to read downloaded file")
+        }
+        
+        removeFileIfExisting(fileURL)
+        let deleted = try await Amplify.Storage.remove(
+            key: key,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, key)
+    }
+
+    /// Given: An object in storage in a custom bucket
+    /// When: Call the downloadFile API using StoragePath
+    /// Then: The operation completes successfully the local file containing the data from the object
+    func testDownloadFile_fromCustomBucket_usingStoragePath_shouldSucceed() async throws {
+        let id = UUID().uuidString
+        let timestamp = String(Date().timeIntervalSince1970)
+        let timestampData = Data(timestamp.utf8)
+        let path: StringStoragePath = .fromString("public/\(id)")
+        try await uploadData(
+            path: path,
+            data: timestampData,
+            options: .init(bucket: customBucket)
+        )
+        let filePath = NSTemporaryDirectory() + id + ".tmp"
+        let fileURL = URL(fileURLWithPath: filePath)
+        removeFileIfExisting(fileURL)
+
+        try await Amplify.Storage.downloadFile(
+            path: path,
+            local: fileURL,
+            options: .init(bucket: customBucket)
+        ).value
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
+        do {
+            let result = try String(contentsOf: fileURL, encoding: .utf8)
+            XCTAssertEqual(result, timestamp)
+        } catch {
+            XCTFail("Failed to read downloaded file")
+        }
+
+        removeFileIfExisting(fileURL)
+        let deleted = try await Amplify.Storage.remove(
+            path: path,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, path.string)
+    }
+
+    /// Given: An object in storage in a custom bucket
+    /// When: Call the getURL API using key
+    /// Then: The operation completes successfully with the URL retrieved
+    func testGetRemoteURL_fromCustomBucket_usingKey_sholdSucceed() async throws {
+        let key = UUID().uuidString
+        try await uploadData(
+            key: key,
+            data: Data(key.utf8),
+            options: .init(bucket: customBucket)
+        )
+
+        let remoteURL = try await Amplify.Storage.getURL(
+            key: key,
+            options: .init(bucket: customBucket)
+        )
+
+        let (data, response) = try await URLSession.shared.data(from: remoteURL)
+        let httpResponse = try XCTUnwrap(response as? HTTPURLResponse)
+        XCTAssertEqual(httpResponse.statusCode, 200)
+
+        let dataString = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertEqual(dataString, key)
+
+        let deleted = try await Amplify.Storage.remove(
+            key: key,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, key)
+    }
+
+    /// Given: An object in storage in a custom bucket
+    /// When: Call the getURL API using StoragePath
+    /// Then: The operation completes successfully with the URL retrieved
+    func testGetRemoteURL_fromCustomBucket_usingStoragePath_sholdSucceed() async throws {
+        let id = UUID().uuidString
+        let path: StringStoragePath = .fromString("public/\(id)")
+        try await uploadData(
+            path: path,
+            data: Data(id.utf8),
+            options: .init(bucket: customBucket)
+        )
+
+        let remoteURL = try await Amplify.Storage.getURL(
+            path: path,
+            options: .init(bucket: customBucket)
+        )
+
+        let (data, response) = try await URLSession.shared.data(from: remoteURL)
+        let httpResponse = try XCTUnwrap(response as? HTTPURLResponse)
+        XCTAssertEqual(httpResponse.statusCode, 200)
+
+        let dataString = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertEqual(dataString, id)
+
+        let deleted = try await Amplify.Storage.remove(
+            path: path,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, path.string)
+    }
+
+    /// Given: An object in storage in a custom bucket
+    /// When: Call the list API using key
+    /// Then: The operation completes successfully with the key retrieved
+    func testList_fromOtherBucket_usingKey_shouldSucceed() async throws {
+        let key = UUID().uuidString
+        try await uploadData(
+            key: key,
+            data: Data(key.utf8),
+            options: .init(bucket: customBucket)
+        )
+
+        let result = try await Amplify.Storage.list(
+            options: .init(
+                path: key,
+                bucket: customBucket
+            )
+        )
+        let items = try XCTUnwrap(result.items)
+
+        XCTAssertEqual(items.count, 1)
+        let item = try XCTUnwrap(items.first)
+        XCTAssertEqual(item.key, key)
+        XCTAssertNotNil(item.eTag)
+        XCTAssertNotNil(item.lastModified)
+        XCTAssertNotNil(item.size)
+
+        let deleted = try await Amplify.Storage.remove(
+            key: key,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, key)
+    }
+
+    /// Given: An object in storage in a custom bucket
+    /// When: Call the list API using StoragePath
+    /// Then: The operation completes successfully with the key retrieved
+    func testList_fromOtherBucket_usingStoragePath_shouldSucceed() async throws {
+        let id = UUID().uuidString
+        let path: StringStoragePath = .fromString("public/\(id)")
+        try await uploadData(
+            path: path,
+            data: Data(id.utf8),
+            options: .init(bucket: customBucket)
+        )
+
+        let result = try await Amplify.Storage.list(
+            path: path,
+            options: .init(bucket: customBucket)
+        )
+        let items = try XCTUnwrap(result.items)
+
+        XCTAssertEqual(items.count, 1)
+        let item = try XCTUnwrap(items.first)
+        XCTAssertEqual(item.path, path.string)
+        XCTAssertNotNil(item.eTag)
+        XCTAssertNotNil(item.lastModified)
+        XCTAssertNotNil(item.size)
+
+        let deleted = try await Amplify.Storage.remove(
+            path: path,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, path.string)
+    }
+
+    /// Given: An object in storage  in a custom bucket
+    /// When: Call the remove API using key
+    /// Then: The operation completes successfully with the key removed from storage
+    func testRemoveKey_fromCustomBucket_usingKey_shouldSucceed() async throws {
+        let key = UUID().uuidString
+        try await uploadData(
+            key: key,
+            data: Data(key.utf8),
+            options: .init(bucket: customBucket)
+        )
+
+        let deleted = try await Amplify.Storage.remove(
+            key: key,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, key)
+    }
+
+    /// Given: An object in storage  in a custom bucket
+    /// When: Call the remove API using StoragePath
+    /// Then: The operation completes successfully with the key removed from storage
+    func testRemoveKey_fromCustomBucket_usingStoragePath_shouldSucceed() async throws {
+        let id = UUID().uuidString
+        let path: StringStoragePath = .fromString("public/\(id)")
+        try await uploadData(
+            path: path,
+            data: Data(id.utf8),
+            options: .init(bucket: customBucket)
+        )
+
+        let deleted = try await Amplify.Storage.remove(
+            path: path,
+            options: .init(bucket: customBucket)
+        )
+        XCTAssertEqual(deleted, path.string)
+    }
+
+    private func removeFileIfExisting(_ fileURL: URL) {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return
+        }
+        do {
+            try FileManager.default.removeItem(at: fileURL)
+        } catch {
+            XCTFail("Failed to remove file at \(fileURL)")
+        }
+    }
+}
+
+private extension StringStoragePath {
+    var string: String {
+        return resolve("")
+    }
+}

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginMultipleBucketTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginMultipleBucketTests.swift
@@ -10,7 +10,7 @@
 import XCTest
 
 class AWSS3StoragePluginMultipleBucketTests: AWSS3StoragePluginTestBase {
-    var customBucket: (any StorageBucket)!
+    private var customBucket: ResolvedStorageBucket!
 
     override func setUp() async throws {
         guard let outputs = try? AmplifyOutputs.amplifyOutputs.resolveConfiguration(),
@@ -352,7 +352,7 @@ class AWSS3StoragePluginMultipleBucketTests: AWSS3StoragePluginTestBase {
     /// Given: An object in storage in a custom bucket
     /// When: Call the getURL API using key
     /// Then: The operation completes successfully with the URL retrieved
-    func testGetRemoteURL_fromCustomBucket_usingKey_sholdSucceed() async throws {
+    func testGetRemoteURL_fromCustomBucket_usingKey_shouldSucceed() async throws {
         let key = UUID().uuidString
         try await uploadData(
             key: key,
@@ -382,7 +382,7 @@ class AWSS3StoragePluginMultipleBucketTests: AWSS3StoragePluginTestBase {
     /// Given: An object in storage in a custom bucket
     /// When: Call the getURL API using StoragePath
     /// Then: The operation completes successfully with the URL retrieved
-    func testGetRemoteURL_fromCustomBucket_usingStoragePath_sholdSucceed() async throws {
+    func testGetRemoteURL_fromCustomBucket_usingStoragePath_shouldSucceed() async throws {
         let id = UUID().uuidString
         let path: StringStoragePath = .fromString("public/\(id)")
         try await uploadData(
@@ -408,39 +408,6 @@ class AWSS3StoragePluginMultipleBucketTests: AWSS3StoragePluginTestBase {
             options: .init(bucket: customBucket)
         )
         XCTAssertEqual(deleted, path.string)
-    }
-
-    /// Given: An object in storage in a custom bucket
-    /// When: Call the list API using key
-    /// Then: The operation completes successfully with the key retrieved
-    func testList_fromOtherBucket_usingKey_shouldSucceed() async throws {
-        let key = UUID().uuidString
-        try await uploadData(
-            key: key,
-            data: Data(key.utf8),
-            options: .init(bucket: customBucket)
-        )
-
-        let result = try await Amplify.Storage.list(
-            options: .init(
-                path: key,
-                bucket: customBucket
-            )
-        )
-        let items = try XCTUnwrap(result.items)
-
-        XCTAssertEqual(items.count, 1)
-        let item = try XCTUnwrap(items.first)
-        XCTAssertEqual(item.key, key)
-        XCTAssertNotNil(item.eTag)
-        XCTAssertNotNil(item.lastModified)
-        XCTAssertNotNil(item.size)
-
-        let deleted = try await Amplify.Storage.remove(
-            key: key,
-            options: .init(bucket: customBucket)
-        )
-        XCTAssertEqual(deleted, key)
     }
 
     /// Given: An object in storage in a custom bucket

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageHostApp.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		68828E4628C2736C006E7C0A /* AWSS3StoragePluginProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB08C28BEAF8E00C8A6EB /* AWSS3StoragePluginProgressTests.swift */; };
 		68828E4728C27745006E7C0A /* AWSS3StoragePluginPutDataResumabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB08828BEAF8E00C8A6EB /* AWSS3StoragePluginPutDataResumabilityTests.swift */; };
 		68828E4828C2AAA6006E7C0A /* AWSS3StoragePluginGetDataResumabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684FB08B28BEAF8E00C8A6EB /* AWSS3StoragePluginGetDataResumabilityTests.swift */; };
+		68DAFA7A2C7796CD00346A43 /* AWSS3StoragePluginMultipleBucketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68DAFA792C7796CD00346A43 /* AWSS3StoragePluginMultipleBucketTests.swift */; };
 		734605222BACB5CC0039F0EB /* AWSS3StoragePluginUploadIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734605212BACB5CC0039F0EB /* AWSS3StoragePluginUploadIntegrationTests.swift */; };
 		734605242BACB60E0039F0EB /* AWSS3StoragePluginDownloadIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 734605232BACB60E0039F0EB /* AWSS3StoragePluginDownloadIntegrationTests.swift */; };
 		901AB3E92AE2C2DC000F825B /* AWSS3StoragePluginUploadMetadataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901AB3E82AE2C2DC000F825B /* AWSS3StoragePluginUploadMetadataTestCase.swift */; };
@@ -166,6 +167,7 @@
 		684FB0A928BEB07200C8A6EB /* AWSS3StoragePluginIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSS3StoragePluginIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		684FB0C228BEB45600C8A6EB /* AuthSignInHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSignInHelper.swift; sourceTree = "<group>"; };
 		684FB0C528BEB84800C8A6EB /* StorageHostApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StorageHostApp.entitlements; sourceTree = "<group>"; };
+		68DAFA792C7796CD00346A43 /* AWSS3StoragePluginMultipleBucketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3StoragePluginMultipleBucketTests.swift; sourceTree = "<group>"; };
 		734605212BACB5CC0039F0EB /* AWSS3StoragePluginUploadIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3StoragePluginUploadIntegrationTests.swift; sourceTree = "<group>"; };
 		734605232BACB60E0039F0EB /* AWSS3StoragePluginDownloadIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3StoragePluginDownloadIntegrationTests.swift; sourceTree = "<group>"; };
 		901AB3E82AE2C2DC000F825B /* AWSS3StoragePluginUploadMetadataTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3StoragePluginUploadMetadataTestCase.swift; sourceTree = "<group>"; };
@@ -321,6 +323,7 @@
 				488C2A722BAE04DC009AD2BA /* AWSS3StoragePluginRemoveIntegrationTests.swift */,
 				488C2A742BAFCA7C009AD2BA /* AWSS3StoragePluginListObjectsIntegrationTests.swift */,
 				488C2A762BAFD4B3009AD2BA /* AWSS3StoragePluginGetURLIntegrationTests.swift */,
+				68DAFA792C7796CD00346A43 /* AWSS3StoragePluginMultipleBucketTests.swift */,
 			);
 			path = AWSS3StoragePluginIntegrationTests;
 			sourceTree = "<group>";
@@ -647,6 +650,7 @@
 				21F7630F2BD6B8640048845A /* AsyncTesting.swift in Sources */,
 				21F763102BD6B8640048845A /* AWSS3StoragePluginGetDataResumabilityTests.swift in Sources */,
 				21F763112BD6B8640048845A /* AWSS3StoragePluginUploadMetadataTestCase.swift in Sources */,
+				68DAFA7A2C7796CD00346A43 /* AWSS3StoragePluginMultipleBucketTests.swift in Sources */,
 				21F763122BD6B8640048845A /* AsyncExpectation.swift in Sources */,
 				21F763132BD6B8640048845A /* AWSS3StoragePluginProgressTests.swift in Sources */,
 				21F763142BD6B8640048845A /* AWSS3StoragePluginAccessLevelTests.swift in Sources */,

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageStressTests/StorageStressTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageStressTests/StorageStressTests.swift
@@ -230,15 +230,19 @@ final class StorageStressTests: XCTestCase {
 
     private func invalidateCurrentSession() {
         Self.logger.debug("Invalidating URLSession")
-        guard let plugin = try? Amplify.Storage.getPlugin(for: "awsS3StoragePlugin") as? AWSS3StoragePlugin,
-              let service = plugin.storageService as? AWSS3StorageService else {
-            print("Unable to to cast to AWSS3StorageService")
+        guard let plugin = try? Amplify.Storage.getPlugin(for: "awsS3StoragePlugin") as? AWSS3StoragePlugin else {
+            print("Unable to to cast to AWSS3StoragePlugin")
             return
         }
 
-        if let delegate = service.urlSession.delegate as? StorageServiceSessionDelegate {
-            delegate.storageService = nil
+        for serviceBehaviour in plugin.storageServicesByBucket.values {
+            guard let service = serviceBehaviour as? AWSS3StorageService else {
+                continue
+            }
+            if let delegate = service.urlSession.delegate as? StorageServiceSessionDelegate {
+                delegate.storageService = nil
+            }
+            service.urlSession.invalidateAndCancel()
         }
-        service.urlSession.invalidateAndCancel()
     }
 }

--- a/api-dump/AWSDataStorePlugin.json
+++ b/api-dump/AWSDataStorePlugin.json
@@ -8205,7 +8205,7 @@
       "-module",
       "AWSDataStorePlugin",
       "-o",
-      "\/var\/folders\/4d\/0gnh84wj53j7wyk695q0tc_80000gn\/T\/tmp.BZQxGLOyZz\/AWSDataStorePlugin.json",
+      "\/var\/folders\/m_\/cksx93ys47x4621g0zbw_m4m0000gn\/T\/tmp.xrcnJX8DBh\/AWSDataStorePlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/AWSDataStorePlugin.json
+++ b/api-dump/AWSDataStorePlugin.json
@@ -8205,7 +8205,7 @@
       "-module",
       "AWSDataStorePlugin",
       "-o",
-      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.7LdqMpKABA\/AWSDataStorePlugin.json",
+      "\/var\/folders\/4d\/0gnh84wj53j7wyk695q0tc_80000gn\/T\/tmp.nR3YWolup0\/AWSDataStorePlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/AWSDataStorePlugin.json
+++ b/api-dump/AWSDataStorePlugin.json
@@ -8205,7 +8205,7 @@
       "-module",
       "AWSDataStorePlugin",
       "-o",
-      "\/var\/folders\/4d\/0gnh84wj53j7wyk695q0tc_80000gn\/T\/tmp.nR3YWolup0\/AWSDataStorePlugin.json",
+      "\/var\/folders\/k7\/4hy4p20s2rv4clw77d3qcl380000gr\/T\/tmp.nF2YaRsn2M\/AWSDataStorePlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/AWSDataStorePlugin.json
+++ b/api-dump/AWSDataStorePlugin.json
@@ -8205,7 +8205,7 @@
       "-module",
       "AWSDataStorePlugin",
       "-o",
-      "\/var\/folders\/m_\/cksx93ys47x4621g0zbw_m4m0000gn\/T\/tmp.xrcnJX8DBh\/AWSDataStorePlugin.json",
+      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.7LdqMpKABA\/AWSDataStorePlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/AWSPluginsCore.json
+++ b/api-dump/AWSPluginsCore.json
@@ -24463,7 +24463,7 @@
       "-module",
       "AWSPluginsCore",
       "-o",
-      "\/var\/folders\/4d\/0gnh84wj53j7wyk695q0tc_80000gn\/T\/tmp.nR3YWolup0\/AWSPluginsCore.json",
+      "\/var\/folders\/k7\/4hy4p20s2rv4clw77d3qcl380000gr\/T\/tmp.nF2YaRsn2M\/AWSPluginsCore.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/AWSPluginsCore.json
+++ b/api-dump/AWSPluginsCore.json
@@ -24463,7 +24463,7 @@
       "-module",
       "AWSPluginsCore",
       "-o",
-      "\/var\/folders\/4d\/0gnh84wj53j7wyk695q0tc_80000gn\/T\/tmp.BZQxGLOyZz\/AWSPluginsCore.json",
+      "\/var\/folders\/m_\/cksx93ys47x4621g0zbw_m4m0000gn\/T\/tmp.xrcnJX8DBh\/AWSPluginsCore.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/AWSPluginsCore.json
+++ b/api-dump/AWSPluginsCore.json
@@ -24463,7 +24463,7 @@
       "-module",
       "AWSPluginsCore",
       "-o",
-      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.7LdqMpKABA\/AWSPluginsCore.json",
+      "\/var\/folders\/4d\/0gnh84wj53j7wyk695q0tc_80000gn\/T\/tmp.nR3YWolup0\/AWSPluginsCore.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/AWSPluginsCore.json
+++ b/api-dump/AWSPluginsCore.json
@@ -24463,7 +24463,7 @@
       "-module",
       "AWSPluginsCore",
       "-o",
-      "\/var\/folders\/m_\/cksx93ys47x4621g0zbw_m4m0000gn\/T\/tmp.xrcnJX8DBh\/AWSPluginsCore.json",
+      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.7LdqMpKABA\/AWSPluginsCore.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/CoreMLPredictionsPlugin.json
+++ b/api-dump/CoreMLPredictionsPlugin.json
@@ -430,7 +430,7 @@
       "-module",
       "CoreMLPredictionsPlugin",
       "-o",
-      "\/var\/folders\/4d\/0gnh84wj53j7wyk695q0tc_80000gn\/T\/tmp.nR3YWolup0\/CoreMLPredictionsPlugin.json",
+      "\/var\/folders\/k7\/4hy4p20s2rv4clw77d3qcl380000gr\/T\/tmp.nF2YaRsn2M\/CoreMLPredictionsPlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/CoreMLPredictionsPlugin.json
+++ b/api-dump/CoreMLPredictionsPlugin.json
@@ -430,7 +430,7 @@
       "-module",
       "CoreMLPredictionsPlugin",
       "-o",
-      "\/var\/folders\/4d\/0gnh84wj53j7wyk695q0tc_80000gn\/T\/tmp.BZQxGLOyZz\/CoreMLPredictionsPlugin.json",
+      "\/var\/folders\/m_\/cksx93ys47x4621g0zbw_m4m0000gn\/T\/tmp.xrcnJX8DBh\/CoreMLPredictionsPlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/CoreMLPredictionsPlugin.json
+++ b/api-dump/CoreMLPredictionsPlugin.json
@@ -430,7 +430,7 @@
       "-module",
       "CoreMLPredictionsPlugin",
       "-o",
-      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.7LdqMpKABA\/CoreMLPredictionsPlugin.json",
+      "\/var\/folders\/4d\/0gnh84wj53j7wyk695q0tc_80000gn\/T\/tmp.nR3YWolup0\/CoreMLPredictionsPlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/CoreMLPredictionsPlugin.json
+++ b/api-dump/CoreMLPredictionsPlugin.json
@@ -430,7 +430,7 @@
       "-module",
       "CoreMLPredictionsPlugin",
       "-o",
-      "\/var\/folders\/m_\/cksx93ys47x4621g0zbw_m4m0000gn\/T\/tmp.xrcnJX8DBh\/CoreMLPredictionsPlugin.json",
+      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.7LdqMpKABA\/CoreMLPredictionsPlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",


### PR DESCRIPTION
## Issues:
- https://github.com/aws-amplify/amplify-swift/issues/2947

## Description
This PR adds multiple bucket support to all Amplify Storage APIs.

All changes have been reviewed in the previous PRs:
- https://github.com/aws-amplify/amplify-swift/pull/3817
- https://github.com/aws-amplify/amplify-swift/pull/3829
- https://github.com/aws-amplify/amplify-swift/pull/3833

## General Checklist
<!-- Check or cross out if not relevant -->

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [X] All integration tests pass
  - [![Integration Tests | Storage](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_storage.yml/badge.svg?branch=feature%2Fmultibucket-storage&event=workflow_dispatch)](https://github.com/aws-amplify/amplify-swift/actions/runs/10908438859)
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [X] Documentation update for the change if required
  - https://github.com/aws-amplify/docs/pull/7918
- [X] PR title conforms to conventional commit style
- [X] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
