### PR TITLE
chore: Avoid updating labels on closed issues [skip ci]

### DIFF
--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -21,6 +21,7 @@ jobs:
 
   adjust-labels:
     runs-on: ubuntu-latest
+    if: ${{ github.event.issue.state == 'open' }}
     permissions:
       issues: write
     env:


### PR DESCRIPTION
## Description
This PR avoids updating labels when comments are posted on closed issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
