### PR TITLE
chore: Marking Storage's key-based API as deprecated in the Category implementation.

### DIFF
--- a/Amplify/Categories/Storage/StorageCategory+ClientBehavior.swift
+++ b/Amplify/Categories/Storage/StorageCategory+ClientBehavior.swift
@@ -9,6 +9,7 @@ import Foundation
 
 extension StorageCategory: StorageCategoryBehavior {
 
+    @available(*, deprecated, message: "Use getURL(path:options:)")
     @discardableResult
     public func getURL(
         key: String,
@@ -25,6 +26,7 @@ extension StorageCategory: StorageCategoryBehavior {
         try await plugin.getURL(path: path, options: options)
     }
 
+    @available(*, deprecated, message: "Use downloadData(path:options:)")
     @discardableResult
     public func downloadData(
         key: String,
@@ -41,6 +43,7 @@ extension StorageCategory: StorageCategoryBehavior {
         plugin.downloadData(path: path, options: options)
     }
 
+    @available(*, deprecated, message: "Use downloadFile(path:options:)")
     @discardableResult
     public func downloadFile(
         key: String,
@@ -59,6 +62,7 @@ extension StorageCategory: StorageCategoryBehavior {
         plugin.downloadFile(path: path, local: local, options: options)
     }
 
+    @available(*, deprecated, message: "Use uploadData(path:options:)")
     @discardableResult
     public func uploadData(
         key: String,
@@ -77,6 +81,7 @@ extension StorageCategory: StorageCategoryBehavior {
         plugin.uploadData(path: path, data: data, options: options)
     }
 
+    @available(*, deprecated, message: "Use uploadFile(path:options:)")
     @discardableResult
     public func uploadFile(
         key: String,
@@ -95,6 +100,7 @@ extension StorageCategory: StorageCategoryBehavior {
         plugin.uploadFile(path: path, local: local, options: options)
     }
 
+    @available(*, deprecated, message: "Use remove(path:options:)")
     @discardableResult
     public func remove(
         key: String,
@@ -111,6 +117,7 @@ extension StorageCategory: StorageCategoryBehavior {
         try await plugin.remove(path: path, options: options)
     }
 
+    @available(*, deprecated, message: "Use list(path:options:)")
     @discardableResult
     public func list(
         options: StorageListOperation.Request.Options? = nil


### PR DESCRIPTION
## Issue \#
- https://github.com/aws-amplify/amplify-swift/issues/3860

## Description
When we introduced the new `path: StoragePath` parameters for the Storage APIs, we [deprecated the old ones using `key: String`](https://github.com/aws-amplify/amplify-swift/commit/0d13d9f3408f3e779899f7a0c3a15ffe6b57baff#diff-ffc8ecfb9d8e2abf8b86f9aeb48129d6b4404104be17a01c91b29bd00a528a2e). However, we only did so in the category protocol and not in the category implementation itself, which results in the warning not being propagated to the users because `Amplify.Storage` is not typed to the protocol, but rather to the actual implementation.

So in order to discourage the usage of these APIs and raise awareness of the new ones, I'm adding the deprecation annotations to the category as well. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
