### PR TITLE
fix(predictions): region handling for creating correct streaming endpoint from region

### DIFF
--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/SPI/LivenessStreamingURL.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/SPI/LivenessStreamingURL.swift
@@ -7,8 +7,20 @@
 
 import Foundation
 
+private let ISO_PARTITION_BASE_DOMAIN: String = "csp.hci.ic.gov"
+private let DEFAULT_BASE_DOMAIN: String = "amazonaws.com"
+
 func streamingSessionURL(for region: String) throws -> URL {
-    let urlString = "wss://streaming-rekognition.\(region).amazonaws.com/start-face-liveness-session-websocket"
+
+    // Determine the base domain based on the region
+    let baseDomain: String
+    if region.lowercased().starts(with: "us-isof") {
+        baseDomain = ISO_PARTITION_BASE_DOMAIN
+    } else {
+        baseDomain = DEFAULT_BASE_DOMAIN
+    }
+
+    let urlString = "wss://streaming-rekognition.\(region).\(baseDomain)/start-face-liveness-session-websocket"
     guard let url = URL(string: urlString) else {
         throw FaceLivenessSessionError.invalidRegion
     }

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/SPI/LivenessStreamingURL.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/SPI/LivenessStreamingURL.swift
@@ -7,17 +7,17 @@
 
 import Foundation
 
-private let ISO_PARTITION_BASE_DOMAIN: String = "csp.hci.ic.gov"
-private let DEFAULT_BASE_DOMAIN: String = "amazonaws.com"
+private let isoPartitionBaseDomain: String = "csp.hci.ic.gov"
+private let defaultBaseDomain: String = "amazonaws.com"
 
 func streamingSessionURL(for region: String) throws -> URL {
 
     // Determine the base domain based on the region
     let baseDomain: String
     if region.lowercased().starts(with: "us-isof") {
-        baseDomain = ISO_PARTITION_BASE_DOMAIN
+        baseDomain = isoPartitionBaseDomain
     } else {
-        baseDomain = DEFAULT_BASE_DOMAIN
+        baseDomain = defaultBaseDomain
     }
 
     let urlString = "wss://streaming-rekognition.\(region).\(baseDomain)/start-face-liveness-session-websocket"


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
None

## Description
We need to construct the correct streaming endpoint with correct base domain depending on the regions. Not all region belong to commercial partition so the base domain becomes different. We can keep adding new regions in this check to get the desired base domain in future.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
