### PR TITLE
fix: Fixing the WebAuthn integration tests

### DIFF
--- a/.github/workflows/integ_test_auth.yml
+++ b/.github/workflows/integ_test_auth.yml
@@ -22,6 +22,11 @@ on:
         required: true
         default: true
         type: boolean
+      webauthn-ios:
+        description: '🔐 WebAuthn iOS'
+        required: true
+        default: true
+        type: boolean
   workflow_call:
 
 permissions:
@@ -59,8 +64,8 @@ jobs:
       timeout-minutes: 30
     secrets: inherit
 
-  # Disabling the integration test because the job is not able to connect to the local server
-  # auth-webauthn-integration-test-iOS:
-  #   name: Auth WebAuthn Integration Tests (iOS)
-  #   uses: ./.github/workflows/integ_test_auth_webauthn.yml
-  #   secrets: inherit
+  auth-webauthn-integration-test-iOS:
+    if: ${{ inputs.webauthn-ios != 'false' }}
+    name: Auth WebAuthn Integration Tests (iOS)
+    uses: ./.github/workflows/integ_test_auth_webauthn.yml
+    secrets: inherit

--- a/AmplifyPlugins/Auth/Tests/AuthWebAuthnApp/AuthWebAuthnAppUITests/AuthWebAuthnAppUITests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthWebAuthnApp/AuthWebAuthnAppUITests/AuthWebAuthnAppUITests.swift
@@ -19,7 +19,9 @@ final class AuthWebAuthnAppUITests: XCTestCase {
     private var deleteButton: XCUIElement!
     private var deleteUserButton: XCUIElement!
     private var springboard: XCUIApplication!
-    private var continueButton: XCUIElement!
+    private var continueButton: XCUIElement! {
+        springboard.otherElements["ASAuthorizationControllerContinueButton"]
+    }
 
     private lazy var deviceIdentifier: String = {
         let paths = Bundle.main.bundleURL.pathComponents
@@ -57,7 +59,6 @@ final class AuthWebAuthnAppUITests: XCTestCase {
         signInButton = nil
         deleteButton = nil
         deleteUserButton = nil
-        continueButton = nil
         springboard = nil
         try await uninstallApp()
     }
@@ -233,9 +234,6 @@ final class AuthWebAuthnAppUITests: XCTestCase {
         signOutButton = app.buttons["SignOut"]
 
         springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        // The Continue button only appears when a FaceID operation is triggered,
-        // so we're also not checking for its existance
-        continueButton = springboard.otherElements["ASAuthorizationControllerContinueButton"]
     }
 
     @MainActor

--- a/AmplifyPlugins/Auth/Tests/AuthWebAuthnApp/AuthWebAuthnAppUITests/LocalServer.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthWebAuthnApp/AuthWebAuthnAppUITests/LocalServer.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum LocalServer {
-    static let endpoint = "http://127.0.0.1:9293"
+    static let endpoint = "http://127.0.0.1:9294"
     
     case boot(String)
     case enroll(String)

--- a/AmplifyPlugins/Auth/Tests/AuthWebAuthnApp/LocalServer/index.mjs
+++ b/AmplifyPlugins/Auth/Tests/AuthWebAuthnApp/LocalServer/index.mjs
@@ -72,6 +72,6 @@ app.post('/match', async (req, res) => {
     }
 })
 
-app.listen(9293, () => {
+app.listen(9294, () => {
     console.log("Simulator server started!")
 })


### PR DESCRIPTION
## Description
Fixing the WebAuthn integration tests

## General Checklist

- [ ] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] All integration tests pass
   [![Integration Tests | Auth - WebAuthn](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_auth_webauthn.yml/badge.svg)](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_auth_webauthn.yml)
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
