### PR TITLE
fix(predictions): use serial queue for WebSocketSession delegate queue

### DIFF
--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/WebSocketSession.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/WebSocketSession.swift
@@ -15,13 +15,19 @@ final class WebSocketSession {
     private var receiveMessage: ((Result<URLSessionWebSocketTask.Message, Error>) -> WebSocketMessageResult)?
     private var onSocketClosed: ((URLSessionWebSocketTask.CloseCode) -> Void)?
     private var onServerDateReceived: ((Date?) -> Void)?
+    private let delegateQueue: OperationQueue
 
     init() {
+        self.delegateQueue = OperationQueue()
+        self.delegateQueue.maxConcurrentOperationCount = 1
+        self.delegateQueue.qualityOfService = .userInteractive
+        
         self.urlSessionWebSocketDelegate = Delegate()
+
         self.session = URLSession(
             configuration: .default,
             delegate: urlSessionWebSocketDelegate,
-            delegateQueue: .init()
+            delegateQueue: delegateQueue
         )
     }
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
Customers have reported receiving intermittent `InvalidSignatureException` during liveness checks.

## Description
<!-- Why is this change required? What problem does it solve? -->
According to Apple docs, `URLSession` delegate queue should use a serial queue for delegate and completion handler callbacks. This PR updates the `URLSession` initializer with a serial queue.
Also, calls to `WebSocketSession` object APIs are put under a serial queue as well.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
