### PR TITLE
fix(API): Fixing issue with CN endpoints

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AppSyncRealTimeClientFactory.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AppSyncRealTimeClientFactory.swift
@@ -136,7 +136,7 @@ extension AppSyncRealTimeClientFactory {
             return url
         }
 
-        guard host.hasSuffix("amazonaws.com") else {
+        guard host.hasSuffix("amazonaws.com") || host.hasSuffix("amazonaws.com.cn") else {
             return url.appendingPathComponent("realtime")
         }
 
@@ -163,7 +163,7 @@ extension AppSyncRealTimeClientFactory {
             return url
         }
 
-        guard host.hasSuffix("amazonaws.com") else {
+        guard host.hasSuffix("amazonaws.com") || host.hasSuffix("amazonaws.com.cn") else {
             if url.lastPathComponent == "realtime" {
                 return url.deletingLastPathComponent()
             }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/SubscriptionFactory/AppSyncRealTimeClientFactoryTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/SubscriptionFactory/AppSyncRealTimeClientFactoryTests.swift
@@ -17,6 +17,12 @@ class AppSyncRealTimeClientFactoryTests: XCTestCase {
             AppSyncRealTimeClientFactory.appSyncRealTimeEndpoint(appSyncEndpoint),
             URL(string: "wss://abc.appsync-realtime-api.amazonaws.com/graphql")
         )
+
+        let appSyncEndpointCN = URL(string: "https://abc.appsync-api.amazonaws.com.cn/graphql")!
+        XCTAssertEqual(
+            AppSyncRealTimeClientFactory.appSyncRealTimeEndpoint(appSyncEndpointCN),
+            URL(string: "wss://abc.appsync-realtime-api.amazonaws.com.cn/graphql")
+        )
     }
 
     func testAppSyncRealTimeEndpoint_withAWSAppSyncRealTimeDomain_returnTheSameDomain() {
@@ -24,6 +30,12 @@ class AppSyncRealTimeClientFactoryTests: XCTestCase {
         XCTAssertEqual(
             AppSyncRealTimeClientFactory.appSyncRealTimeEndpoint(appSyncEndpoint),
             URL(string: "wss://abc.appsync-realtime-api.amazonaws.com/graphql")
+        )
+
+        let appSyncEndpointCN = URL(string: "wss://abc.appsync-realtime-api.amazonaws.com.cn/graphql")!
+        XCTAssertEqual(
+            AppSyncRealTimeClientFactory.appSyncRealTimeEndpoint(appSyncEndpointCN),
+            URL(string: "wss://abc.appsync-realtime-api.amazonaws.com.cn/graphql")
         )
     }
 
@@ -33,6 +45,12 @@ class AppSyncRealTimeClientFactoryTests: XCTestCase {
             AppSyncRealTimeClientFactory.appSyncRealTimeEndpoint(appSyncEndpoint),
             URL(string: "https://test.example.com/graphql/realtime")
         )
+
+        let appSyncEndpointCN = URL(string: "https://test.example.com.cn/graphql")!
+        XCTAssertEqual(
+            AppSyncRealTimeClientFactory.appSyncRealTimeEndpoint(appSyncEndpointCN),
+            URL(string: "https://test.example.com.cn/graphql/realtime")
+        )
     }
 
     func testAppSyncApiEndpoint_withAWSAppSyncRealTimeDomain_returnCorrectApiDomain() {
@@ -40,6 +58,12 @@ class AppSyncRealTimeClientFactoryTests: XCTestCase {
         XCTAssertEqual(
             AppSyncRealTimeClientFactory.appSyncApiEndpoint(appSyncEndpoint),
             URL(string: "https://abc.appsync-api.amazonaws.com/graphql")
+        )
+
+        let appSyncEndpointCN = URL(string: "wss://abc.appsync-realtime-api.amazonaws.com.cn/graphql")!
+        XCTAssertEqual(
+            AppSyncRealTimeClientFactory.appSyncApiEndpoint(appSyncEndpointCN),
+            URL(string: "https://abc.appsync-api.amazonaws.com.cn/graphql")
         )
     }
 
@@ -49,6 +73,12 @@ class AppSyncRealTimeClientFactoryTests: XCTestCase {
             AppSyncRealTimeClientFactory.appSyncApiEndpoint(appSyncEndpoint),
             URL(string: "https://abc.appsync-api.amazonaws.com/graphql")
         )
+
+        let appSyncEndpointCN = URL(string: "https://abc.appsync-api.amazonaws.com.cn/graphql")!
+        XCTAssertEqual(
+            AppSyncRealTimeClientFactory.appSyncApiEndpoint(appSyncEndpointCN),
+            URL(string: "https://abc.appsync-api.amazonaws.com.cn/graphql")
+        )
     }
 
     func testAppSyncApiEndpoint_withCustomDomain_returnCorrectRealtimePath() {
@@ -56,6 +86,12 @@ class AppSyncRealTimeClientFactoryTests: XCTestCase {
         XCTAssertEqual(
             AppSyncRealTimeClientFactory.appSyncApiEndpoint(appSyncEndpoint),
             URL(string: "https://test.example.com/graphql")
+        )
+
+        let appSyncEndpointCN = URL(string: "https://test.example.com.cn/graphql")!
+        XCTAssertEqual(
+            AppSyncRealTimeClientFactory.appSyncApiEndpoint(appSyncEndpointCN),
+            URL(string: "https://test.example.com.cn/graphql")
         )
     }
 }


### PR DESCRIPTION
## Issue \#
- https://github.com/aws-amplify/amplify-swift/issues/3915

## Description
This PR fixes an issue when handling CN endpoints in our `AppSyncRealTimeClientFactory`. 

## General Checklist
<!-- Check or cross out if not relevant -->

- [X] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] All integration tests pass
  [![Integration Tests | API - All](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_api.yml/badge.svg?branch=ruisebas%2Fappsync-china)](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_api.yml)
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
