### PR TITLE
chore: Update aws-sdk-swift to 1.0.69

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift",
       "state" : {
-        "revision" : "3f844bef042cc0a4c3381f7090414ce3f9a7e935",
-        "version" : "0.37.0"
+        "revision" : "dd17a98750b6182edacd6e8f0c30aa289c472b22",
+        "version" : "0.40.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift",
       "state" : {
-        "revision" : "c6c1064da9bfccb119a7a8ab9ba636fb3bbfa6f5",
-        "version" : "1.0.47"
+        "revision" : "9ad12684f6cb9c9b60e840c051a2bba604024650",
+        "version" : "1.0.69"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "3cd9f181b3ba8ff71da43bf53c09f8de6790a4ad",
-        "version" : "0.96.0"
+        "revision" : "402f091374dcf72c1e7ed43af10e3ee7e634fad8",
+        "version" : "0.106.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let platforms: [SupportedPlatform] = [
     .watchOS(.v9)
 ]
 let dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/awslabs/aws-sdk-swift", exact: "1.0.47"),
+    .package(url: "https://github.com/awslabs/aws-sdk-swift", exact: "1.0.69"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", exact: "0.15.3"),
     .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.1.0"),
     .package(url: "https://github.com/aws-amplify/amplify-swift-utils-notifications.git", from: "1.1.0")


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

This PR updates [aws-sdk-swift](https://github.com/awslabs/aws-sdk-swift) to 1.0.69, which makes it possible to enable C++ interoperability mode ([ref](https://github.com/awslabs/aws-crt-swift/releases/tag/v0.38.0)).

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
