### PR TITLE
feat(auth): adding support for keychain sharing using app groups

### DIFF
--- a/Amplify/Categories/Auth/Models/AccessGroup.swift
+++ b/Amplify/Categories/Auth/Models/AccessGroup.swift
@@ -7,22 +7,43 @@
 
 import Foundation
 
+/// A structure representing an access group for managing keychain items.
 public struct AccessGroup {
+    /// The name of the access group.
     public let name: String?
+    
+    /// A flag indicating whether to migrate keychain items.
     public let migrateKeychainItems: Bool
 
+    /**
+     Initializes an `AccessGroup` with the specified name and migration option.
+     
+     - Parameter name: The name of the access group.
+     - Parameter migrateKeychainItemsOfUserSession: A flag indicating whether to migrate keychain items. Defaults to `false`.
+     */
     public init(name: String, migrateKeychainItemsOfUserSession: Bool = false) {
         self.init(name: name, migrateKeychainItems: migrateKeychainItemsOfUserSession)
     }
 
+    /**
+     Creates an `AccessGroup` instance with no specified name.
+     
+     - Parameter migrateKeychainItemsOfUserSession: A flag indicating whether to migrate keychain items.
+     - Returns: An `AccessGroup` instance with the migration option set.
+     */
     public static func none(migrateKeychainItemsOfUserSession: Bool) -> AccessGroup {
         return .init(migrateKeychainItems: migrateKeychainItemsOfUserSession)
     }
 
+    /**
+     A static property representing an `AccessGroup` with no name and no migration.
+     
+     - Returns: An `AccessGroup` instance with no name and the migration option set to `false`.
+     */
     public static var none: AccessGroup {
         return .none(migrateKeychainItemsOfUserSession: false)
     }
-
+    
     private init(name: String? = nil, migrateKeychainItems: Bool) {
         self.name = name
         self.migrateKeychainItems = migrateKeychainItems

--- a/Amplify/Categories/Auth/Models/AccessGroup.swift
+++ b/Amplify/Categories/Auth/Models/AccessGroup.swift
@@ -1,0 +1,30 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+public struct AccessGroup {
+    public let name: String?
+    public let migrateKeychainItems: Bool
+
+    public init(name: String, migrateKeychainItemsOfUserSession: Bool = false) {
+        self.init(name: name, migrateKeychainItems: migrateKeychainItemsOfUserSession)
+    }
+
+    public static func none(migrateKeychainItemsOfUserSession: Bool) -> AccessGroup {
+        return .init(name: nil, migrateKeychainItems: migrateKeychainItemsOfUserSession)
+    }
+
+    public static var none: AccessGroup {
+        return .none(migrateKeychainItemsOfUserSession: false)
+    }
+
+    private init(name: String?, migrateKeychainItems: Bool) {
+        self.name = name
+        self.migrateKeychainItems = migrateKeychainItems
+    }
+}

--- a/Amplify/Categories/Auth/Models/AccessGroup.swift
+++ b/Amplify/Categories/Auth/Models/AccessGroup.swift
@@ -16,14 +16,14 @@ public struct AccessGroup {
     }
 
     public static func none(migrateKeychainItemsOfUserSession: Bool) -> AccessGroup {
-        return .init(name: nil, migrateKeychainItems: migrateKeychainItemsOfUserSession)
+        return .init(migrateKeychainItems: migrateKeychainItemsOfUserSession)
     }
 
     public static var none: AccessGroup {
         return .none(migrateKeychainItemsOfUserSession: false)
     }
 
-    private init(name: String?, migrateKeychainItems: Bool) {
+    private init(name: String? = nil, migrateKeychainItems: Bool) {
         self.name = name
         self.migrateKeychainItems = migrateKeychainItems
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -186,8 +186,11 @@ extension AWSCognitoAuthPlugin {
     }
 
     private func makeCredentialStore() -> AmplifyAuthCredentialStoreBehavior {
-        return AWSCognitoAuthCredentialStore(authConfiguration: authConfiguration, accessGroup: secureStoragePreferences?.accessGroup?.name,
-                                             migrateKeychainItemsOfUserSession: secureStoragePreferences?.accessGroup?.migrateKeychainItems ?? false)
+        return AWSCognitoAuthCredentialStore(
+            authConfiguration: authConfiguration,
+            accessGroup: secureStoragePreferences?.accessGroup?.name,
+            migrateKeychainItemsOfUserSession: secureStoragePreferences?.accessGroup?.migrateKeychainItems ?? false
+        )
     }
 
     private func makeLegacyKeychainStore(service: String) -> KeychainStoreBehavior {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+Configure.swift
@@ -186,7 +186,8 @@ extension AWSCognitoAuthPlugin {
     }
 
     private func makeCredentialStore() -> AmplifyAuthCredentialStoreBehavior {
-        AWSCognitoAuthCredentialStore(authConfiguration: authConfiguration)
+        return AWSCognitoAuthCredentialStore(authConfiguration: authConfiguration, accessGroup: secureStoragePreferences?.accessGroup?.name,
+                                             migrateKeychainItemsOfUserSession: secureStoragePreferences?.accessGroup?.migrateKeychainItems ?? false)
     }
 
     private func makeLegacyKeychainStore(service: String) -> KeychainStoreBehavior {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
@@ -35,6 +35,9 @@ public final class AWSCognitoAuthPlugin: AWSCognitoAuthPluginBehavior {
     /// The user network preferences for timeout and retry
     let networkPreferences: AWSCognitoNetworkPreferences?
 
+    /// The user secure storage preferences for access group
+    let secureStoragePreferences: AWSCognitoSecureStoragePreferences?
+
     @_spi(InternalAmplifyConfiguration)
     internal(set) public var jsonConfiguration: JSONValue?
 
@@ -43,15 +46,14 @@ public final class AWSCognitoAuthPlugin: AWSCognitoAuthPluginBehavior {
         return "awsCognitoAuthPlugin"
     }
 
-    /// Instantiates an instance of the AWSCognitoAuthPlugin.
-    public init() {
-        self.networkPreferences = nil
-    }
-
-    /// Instantiates an instance of the AWSCognitoAuthPlugin with custom network preferences
+    /// Instantiates an instance of the AWSCognitoAuthPlugin with optionally custom network
+    /// preferences and custom secure storage preferences
     /// - Parameters:
     ///   - networkPreferences: network preferences
-    public init(networkPreferences: AWSCognitoNetworkPreferences) {
+    ///   - secureStoragePreferences: secure storage preferences
+    public init(networkPreferences: AWSCognitoNetworkPreferences? = nil,
+                secureStoragePreferences: AWSCognitoSecureStoragePreferences = AWSCognitoSecureStoragePreferences()) {
         self.networkPreferences = networkPreferences
+        self.secureStoragePreferences = secureStoragePreferences
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
@@ -46,8 +46,8 @@ public final class AWSCognitoAuthPlugin: AWSCognitoAuthPluginBehavior {
         return "awsCognitoAuthPlugin"
     }
 
-    /// Instantiates an instance of the AWSCognitoAuthPlugin with optionally custom network
-    /// preferences and custom secure storage preferences
+    /// Instantiates an instance of the AWSCognitoAuthPlugin with optional custom network
+    /// preferences and optional custom secure storage preferences
     /// - Parameters:
     ///   - networkPreferences: network preferences
     ///   - secureStoragePreferences: secure storage preferences

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ClientBehavior/AWSCognitoAuthPlugin+ClientBehavior.swift
@@ -114,7 +114,11 @@ extension AWSCognitoAuthPlugin: AuthCategoryBehavior {
     public func fetchAuthSession(options: AuthFetchSessionRequest.Options?) async throws -> AuthSession {
         let options = options ?? AuthFetchSessionRequest.Options()
         let request = AuthFetchSessionRequest(options: options)
-        let task = AWSAuthFetchSessionTask(request, authStateMachine: authStateMachine)
+        let forceReconfigure = secureStoragePreferences?.accessGroup?.name != nil
+        let task = AWSAuthFetchSessionTask(request,
+                                           authStateMachine: authStateMachine,
+                                           configuration: authConfiguration,
+                                           forceReconfigure: forceReconfigure)
         return try await taskQueue.sync {
             return try await task.value
         } as! AuthSession

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AWSCognitoAuthCredentialStore.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AWSCognitoAuthCredentialStore.swift
@@ -55,7 +55,7 @@ struct AWSCognitoAuthCredentialStore {
         let oldAccessGroup = retrieveStoredAccessGroup()
         if migrateKeychainItemsOfUserSession {
             try? migrateKeychainItemsToAccessGroup()
-        } else if oldAccessGroup == nil && oldAccessGroup != accessGroup{
+        } else if oldAccessGroup == nil && oldAccessGroup != accessGroup {
             try? KeychainStore(service: service)._removeAll()
         }
             

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AWSCognitoAuthCredentialStore.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/AWSCognitoAuthCredentialStore.swift
@@ -26,6 +26,10 @@ struct AWSCognitoAuthCredentialStore {
     private var isKeychainConfiguredKey: String {
         "\(userDefaultsNameSpace).isKeychainConfigured"
     }
+    /// This UserDefaults Key is use to retrieve the stored access group to determine
+    /// which access group the migration should happen from
+    /// If none is found, the unshared service is used for migration and all items
+    /// under that service are queried
     private var accessGroupKey: String {
         "\(userDefaultsNameSpace).accessGroup"
     }
@@ -48,11 +52,14 @@ struct AWSCognitoAuthCredentialStore {
             self.keychain = KeychainStore(service: service)
         }
         
+        let oldAccessGroup = retrieveStoredAccessGroup()
         if migrateKeychainItemsOfUserSession {
             try? migrateKeychainItemsToAccessGroup()
+        } else if oldAccessGroup == nil && oldAccessGroup != accessGroup{
+            try? KeychainStore(service: service)._removeAll()
         }
             
-        try? saveStoredAccessGroup()
+        saveStoredAccessGroup()
 
         if !userDefaults.bool(forKey: isKeychainConfiguredKey) {
             try? clearAllCredentials()
@@ -202,11 +209,11 @@ extension AWSCognitoAuthCredentialStore: AmplifyAuthCredentialStoreBehavior {
         try keychain._removeAll()
     }
     
-    private func retrieveStoredAccessGroup() throws -> String? {
+    private func retrieveStoredAccessGroup() -> String? {
         return userDefaults.string(forKey: accessGroupKey)
     }
     
-    private func saveStoredAccessGroup() throws {
+    private func saveStoredAccessGroup() {
         if let accessGroup {
             userDefaults.set(accessGroup, forKey: accessGroupKey)
         } else {
@@ -215,33 +222,10 @@ extension AWSCognitoAuthCredentialStore: AmplifyAuthCredentialStoreBehavior {
     }
     
     private func migrateKeychainItemsToAccessGroup() throws {
-        let oldAccessGroup = try? retrieveStoredAccessGroup()
-        let oldKeychain: KeychainStoreBehavior
+        let oldAccessGroup = retrieveStoredAccessGroup()
         
         if oldAccessGroup == accessGroup {
-            log.verbose("[AWSCognitoAuthCredentialStore] Stored access group is the same as current access group, aborting migration")
-            return
-        }
-        
-        if let oldAccessGroup {
-            oldKeychain = KeychainStore(service: sharedService, accessGroup: oldAccessGroup)
-        } else {
-            oldKeychain = KeychainStore(service: service)
-        }
-        
-        let authCredentialStoreKey = generateSessionKey(for: authConfiguration)
-        let authCredentialData: Data
-        let awsCredential: AmplifyCredentials
-        do {
-            authCredentialData = try oldKeychain._getData(authCredentialStoreKey)
-            awsCredential = try decode(data: authCredentialData)
-        } catch {
-            log.verbose("[AWSCognitoAuthCredentialStore] Could not retrieve previous credentials in keychain under old access group, nothing to migrate")
-            return
-        }
-        
-        guard awsCredential.areValid() else {
-            log.verbose("[AWSCognitoAuthCredentialStore] Credentials found are not valid (expired) in old access group keychain, aborting migration")
+            log.info("[AWSCognitoAuthCredentialStore] Stored access group is the same as current access group, aborting migration")
             return
         }
         
@@ -281,10 +265,4 @@ private extension AWSCognitoAuthCredentialStore {
 
 }
 
-extension AWSCognitoAuthCredentialStore: DefaultLogger {
-    public static var log: Logger {
-        Amplify.Logging.logger(forNamespace: String(describing: self))
-    }
-
-    public nonisolated var log: Logger { Self.log }
-}
+extension AWSCognitoAuthCredentialStore: DefaultLogger { }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSCognitoSecureStoragePreferences.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSCognitoSecureStoragePreferences.swift
@@ -8,11 +8,15 @@
 import Foundation
 import Amplify
 
+/// A struct to store preferences for how the plugin uses storage
 public struct AWSCognitoSecureStoragePreferences {
 
     /// The access group that the keychain will use for auth items
     public let accessGroup: AccessGroup?
 
+    /// Creates an intstance of AWSCognitoSecureStoragePreferences
+    /// - Parameters:
+    ///   - accessGroup: access group to be used
     public init(accessGroup: AccessGroup? = nil) {
         self.accessGroup = accessGroup
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSCognitoSecureStoragePreferences.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSCognitoSecureStoragePreferences.swift
@@ -1,0 +1,19 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Amplify
+
+public struct AWSCognitoSecureStoragePreferences {
+
+    /// The access group that the keychain will use for auth items
+    public let accessGroup: AccessGroup?
+
+    public init(accessGroup: AccessGroup? = nil) {
+        self.accessGroup = accessGroup
+    }
+}

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFetchSessionTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFetchSessionTask.swift
@@ -13,19 +13,29 @@ class AWSAuthFetchSessionTask: AuthFetchSessionTask, DefaultLogger {
     private let authStateMachine: AuthStateMachine
     private let fetchAuthSessionHelper: FetchAuthSessionOperationHelper
     private let taskHelper: AWSAuthTaskHelper
+    private let configuration: AuthConfiguration
+    private let forceReconfigure: Bool
 
     var eventName: HubPayloadEventName {
         HubPayload.EventName.Auth.fetchSessionAPI
     }
 
-    init(_ request: AuthFetchSessionRequest, authStateMachine: AuthStateMachine) {
+    init(_ request: AuthFetchSessionRequest, authStateMachine: AuthStateMachine, configuration: AuthConfiguration, forceReconfigure: Bool = false) {
         self.request = request
         self.authStateMachine = authStateMachine
         self.fetchAuthSessionHelper = FetchAuthSessionOperationHelper()
         self.taskHelper = AWSAuthTaskHelper(authStateMachine: authStateMachine)
+        self.configuration = configuration
+        self.forceReconfigure = forceReconfigure
     }
 
     func execute() async throws -> AuthSession {
+        log.verbose("Starting execution")
+        if forceReconfigure {
+            log.verbose("Reconfiguring auth state machine for keychain sharing")
+            let event = AuthEvent(eventType: .reconfigure(configuration))
+            await authStateMachine.send(event)
+        }
         await taskHelper.didStateMachineConfigured()
         let doesNeedForceRefresh = request.options.forceRefresh
         return try await fetchAuthSessionHelper.fetch(authStateMachine,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFetchSessionTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFetchSessionTask.swift
@@ -20,7 +20,12 @@ class AWSAuthFetchSessionTask: AuthFetchSessionTask, DefaultLogger {
         HubPayload.EventName.Auth.fetchSessionAPI
     }
 
-    init(_ request: AuthFetchSessionRequest, authStateMachine: AuthStateMachine, configuration: AuthConfiguration, forceReconfigure: Bool = false) {
+    init(
+        _ request: AuthFetchSessionRequest,
+        authStateMachine: AuthStateMachine,
+        configuration: AuthConfiguration,
+        forceReconfigure: Bool = false
+    ) {
         self.request = request
         self.authStateMachine = authStateMachine
         self.fetchAuthSessionHelper = FetchAuthSessionOperationHelper()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MockCredentialStoreBehavior.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MockCredentialStoreBehavior.swift
@@ -15,12 +15,15 @@ class MockKeychainStoreBehavior: KeychainStoreBehavior {
     typealias VoidHandler = () -> Void
 
     let data: String
+    let allData: [(key: String, value: Data)]
     let removeAllHandler: VoidHandler?
+    let mockKey: String = "mockKey"
 
     init(data: String,
          removeAllHandler: VoidHandler? = nil) {
         self.data = data
         self.removeAllHandler = removeAllHandler
+        self.allData = [(key: mockKey, value: Data(data.utf8))]
     }
 
     func _getString(_ key: String) throws -> String {
@@ -40,5 +43,9 @@ class MockKeychainStoreBehavior: KeychainStoreBehavior {
 
     func _removeAll() throws {
         removeAllHandler?()
+    }
+    
+    func _getAll() throws -> [(key: String, value: Data)] {
+        return allData
     }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MockCredentialStoreBehavior.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MockCredentialStoreBehavior.swift
@@ -15,7 +15,6 @@ class MockKeychainStoreBehavior: KeychainStoreBehavior {
     typealias VoidHandler = () -> Void
 
     let data: String
-    let allData: [(key: String, value: Data)]
     let removeAllHandler: VoidHandler?
     let mockKey: String = "mockKey"
 
@@ -23,7 +22,6 @@ class MockKeychainStoreBehavior: KeychainStoreBehavior {
          removeAllHandler: VoidHandler? = nil) {
         self.data = data
         self.removeAllHandler = removeAllHandler
-        self.allData = [(key: mockKey, value: Data(data.utf8))]
     }
 
     func _getString(_ key: String) throws -> String {
@@ -45,7 +43,4 @@ class MockKeychainStoreBehavior: KeychainStoreBehavior {
         removeAllHandler?()
     }
     
-    func _getAll() throws -> [(key: String, value: Data)] {
-        return allData
-    }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MockCredentialStoreBehavior.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MockCredentialStoreBehavior.swift
@@ -16,7 +16,6 @@ class MockKeychainStoreBehavior: KeychainStoreBehavior {
 
     let data: String
     let removeAllHandler: VoidHandler?
-    let mockKey: String = "mockKey"
 
     init(data: String,
          removeAllHandler: VoidHandler? = nil) {
@@ -42,5 +41,4 @@ class MockKeychainStoreBehavior: KeychainStoreBehavior {
     func _removeAll() throws {
         removeAllHandler?()
     }
-    
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/AWSCognitoAuthPluginAmplifyOutputsConfigTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/AWSCognitoAuthPluginAmplifyOutputsConfigTests.swift
@@ -123,4 +123,84 @@ class AWSCognitoAuthPluginAmplifyOutputsConfigTests: XCTestCase {
             XCTFail("Should not throw error. \(error)")
         }
     }
+    
+    /// Test Auth configuration with valid config for user pool and identity pool, with secure storage preferences
+    ///
+    /// - Given: Given valid config for user pool and identity pool with secure storage preferences
+    /// - When:
+    ///    - I configure auth with the given configuration and secure storage preferences
+    /// - Then:
+    ///    - I should not get any error while configuring auth
+    ///
+    func testConfigWithUserPoolAndIdentityPoolWithSecureStoragePreferences() throws {
+        let plugin = AWSCognitoAuthPlugin(
+            secureStoragePreferences: .init(
+                accessGroup: AccessGroup(name: "xx")
+            )
+        )
+        try Amplify.add(plugin: plugin)
+
+        let amplifyConfig = AmplifyOutputsData(auth: .init(
+                awsRegion: "us-east-1",
+                userPoolId: "xx",
+                userPoolClientId: "xx",
+                identityPoolId: "xx"))
+
+        do {
+            try Amplify.configure(amplifyConfig)
+
+            let escapeHatch = plugin.getEscapeHatch()
+            guard case .userPoolAndIdentityPool(let userPoolClient, let identityPoolClient) = escapeHatch else {
+                XCTFail("Expected .userPool, got \(escapeHatch)")
+                return
+            }
+            XCTAssertNotNil(userPoolClient)
+            XCTAssertNotNil(identityPoolClient)
+
+        } catch {
+            XCTFail("Should not throw error. \(error)")
+        }
+    }
+    
+    /// Test Auth configuration with valid config for user pool and identity pool, with network preferences and secure storage preferences
+    ///
+    /// - Given: Given valid config for user pool and identity pool, network preferences, and secure storage preferences
+    /// - When:
+    ///    - I configure auth with the given configuration, network preferences, and secure storage preferences
+    /// - Then:
+    ///    - I should not get any error while configuring auth
+    ///
+    func testConfigWithUserPoolAndIdentityPoolWithNetworkPreferencesAndSecureStoragePreferences() throws {
+        let plugin = AWSCognitoAuthPlugin(
+            networkPreferences: .init(
+                maxRetryCount: 2,
+                timeoutIntervalForRequest: 60,
+                timeoutIntervalForResource: 60),
+            secureStoragePreferences: .init(
+                accessGroup: AccessGroup(name: "xx")
+            )
+        )
+        try Amplify.add(plugin: plugin)
+
+        let amplifyConfig = AmplifyOutputsData(auth: .init(
+                awsRegion: "us-east-1",
+                userPoolId: "xx",
+                userPoolClientId: "xx",
+                identityPoolId: "xx"))
+
+        do {
+            try Amplify.configure(amplifyConfig)
+
+            let escapeHatch = plugin.getEscapeHatch()
+            guard case .userPoolAndIdentityPool(let userPoolClient, let identityPoolClient) = escapeHatch else {
+                XCTFail("Expected .userPool, got \(escapeHatch)")
+                return
+            }
+            XCTAssertNotNil(userPoolClient)
+            XCTAssertNotNil(identityPoolClient)
+
+        } catch {
+            XCTFail("Should not throw error. \(error)")
+        }
+    }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
@@ -235,6 +235,102 @@ class AWSCognitoAuthPluginConfigTests: XCTestCase {
             XCTFail("Should not throw error. \(error)")
         }
     }
+    
+    /// Test Auth configuration with valid config for user pool and identity pool, with secure storage preferences
+    ///
+    /// - Given: Given valid config for user pool and identity pool, and secure storage preferences
+    /// - When:
+    ///    - I configure auth with the given configuration and secure storage preferences
+    /// - Then:
+    ///    - I should not get any error while configuring auth
+    ///
+    func testConfigWithUserPoolAndIdentityPoolWithSecureStoragePreferences() throws {
+        let plugin = AWSCognitoAuthPlugin(
+            secureStoragePreferences: .init(
+                accessGroup: AccessGroup(name: "xx")
+            )
+        )
+        try Amplify.add(plugin: plugin)
+
+        let categoryConfig = AuthCategoryConfiguration(plugins: [
+            "awsCognitoAuthPlugin": [
+                "CredentialsProvider": ["CognitoIdentity": ["Default":
+                                                                ["PoolId": "xx",
+                                                                 "Region": "us-east-1"]
+                                                           ]],
+                "CognitoUserPool": ["Default": [
+                    "PoolId": "xx",
+                    "Region": "us-east-1",
+                    "AppClientId": "xx",
+                    "AppClientSecret": "xx"]]
+            ]
+        ])
+        let amplifyConfig = AmplifyConfiguration(auth: categoryConfig)
+        do {
+            try Amplify.configure(amplifyConfig)
+            
+            let escapeHatch = plugin.getEscapeHatch()
+            guard case .userPoolAndIdentityPool(let userPoolClient, let identityPoolClient) = escapeHatch else {
+                XCTFail("Expected .userPool, got \(escapeHatch)")
+                return
+            }
+            XCTAssertNotNil(userPoolClient)
+            XCTAssertNotNil(identityPoolClient)
+
+        } catch {
+            XCTFail("Should not throw error. \(error)")
+        }
+    }
+    
+    /// Test Auth configuration with valid config for user pool and identity pool, with network preferences and secure storage preferences
+    ///
+    /// - Given: Given valid config for user pool and identity pool, network preferences, and secure storage preferences
+    /// - When:
+    ///    - I configure auth with the given configuration, network preferences, and secure storage preferences
+    /// - Then:
+    ///    - I should not get any error while configuring auth
+    ///
+    func testConfigWithUserPoolAndIdentityPoolWithNetworkPreferencesAndSecureStoragePreferences() throws {
+        let plugin = AWSCognitoAuthPlugin(
+            networkPreferences: .init(
+                maxRetryCount: 2,
+                timeoutIntervalForRequest: 60,
+                timeoutIntervalForResource: 60),
+            secureStoragePreferences: .init(
+                accessGroup: AccessGroup(name: "xx")
+            )
+        )
+        try Amplify.add(plugin: plugin)
+
+        let categoryConfig = AuthCategoryConfiguration(plugins: [
+            "awsCognitoAuthPlugin": [
+                "CredentialsProvider": ["CognitoIdentity": ["Default":
+                                                                ["PoolId": "xx",
+                                                                 "Region": "us-east-1"]
+                                                           ]],
+                "CognitoUserPool": ["Default": [
+                    "PoolId": "xx",
+                    "Region": "us-east-1",
+                    "AppClientId": "xx",
+                    "AppClientSecret": "xx"]]
+            ]
+        ])
+        let amplifyConfig = AmplifyConfiguration(auth: categoryConfig)
+        do {
+            try Amplify.configure(amplifyConfig)
+            
+            let escapeHatch = plugin.getEscapeHatch()
+            guard case .userPoolAndIdentityPool(let userPoolClient, let identityPoolClient) = escapeHatch else {
+                XCTFail("Expected .userPool, got \(escapeHatch)")
+                return
+            }
+            XCTAssertNotNil(userPoolClient)
+            XCTAssertNotNil(identityPoolClient)
+
+        } catch {
+            XCTFail("Should not throw error. \(error)")
+        }
+    }
 
     /// Test that the Auth plugin emits `InternalConfigureAuth` that is used by the Logging Category
     ///

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/DefaultConfig.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/DefaultConfig.swift
@@ -366,6 +366,10 @@ struct MockLegacyStore: KeychainStoreBehavior {
     func _removeAll() throws {
 
     }
+    
+    func _getAll() throws -> [(key: String, value: Data)] {
+        return []
+    }
 
 }
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/DefaultConfig.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/DefaultConfig.swift
@@ -366,10 +366,6 @@ struct MockLegacyStore: KeychainStoreBehavior {
     func _removeAll() throws {
 
     }
-    
-    func _getAll() throws -> [(key: String, value: Data)] {
-        return []
-    }
 
 }
 

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthHostApp.xcodeproj/project.pbxproj
@@ -245,6 +245,8 @@
 		B43C26C827BC9D54003F3BF7 /* AuthConfirmSignUpTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthConfirmSignUpTests.swift; sourceTree = "<group>"; };
 		B43C26C927BC9D54003F3BF7 /* AuthResendSignUpCodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthResendSignUpCodeTests.swift; sourceTree = "<group>"; };
 		B4B9F45628F47B7B004F346F /* amplify-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "amplify-ios"; path = ../../../..; sourceTree = "<group>"; };
+		E2A7D1732C5D76CB00B06999 /* AuthHostApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AuthHostApp.entitlements; sourceTree = "<group>"; };
+		E2A7D1742C5D774200B06999 /* AuthWatchApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AuthWatchApp.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -342,6 +344,7 @@
 		485CB53127B614CE006CCEC7 = {
 			isa = PBXGroup;
 			children = (
+				E2A7D1742C5D774200B06999 /* AuthWatchApp.entitlements */,
 				485CB5C627B62C5C006CCEC7 /* Packages */,
 				485CB53C27B614CE006CCEC7 /* AuthHostApp */,
 				485CB5A027B61E04006CCEC7 /* AuthIntegrationTests */,
@@ -367,7 +370,7 @@
 		485CB53C27B614CE006CCEC7 /* AuthHostApp */ = {
 			isa = PBXGroup;
 			children = (
-				907EA7602A4B6F56005E3AA8 /* AuthHostApp.entitlements */,
+				E2A7D1732C5D76CB00B06999 /* AuthHostApp.entitlements */,
 				681DFEA728E747B80000C36A /* AsyncTesting */,
 				485CB53D27B614CE006CCEC7 /* AuthHostAppApp.swift */,
 				485CB53F27B614CE006CCEC7 /* ContentView.swift */,
@@ -1335,6 +1338,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = AuthWatchApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -1365,6 +1369,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = AuthWatchApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AWSAuthBaseTest.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AWSAuthBaseTest.swift
@@ -32,6 +32,10 @@ class AWSAuthBaseTest: XCTestCase {
     var amplifyOutputsFile =
         "testconfiguration/AWSCognitoAuthPluginIntegrationTests-amplify_outputs"
     let credentialsFile = "testconfiguration/AWSCognitoAuthPluginIntegrationTests-credentials"
+    let keychainAccessGroup = "94KV3E626L.com.aws.amplify.auth.AuthHostAppShared"
+    let keychainAccessGroup2 = "94KV3E626L.com.aws.amplify.auth.AuthHostAppShared2"
+    let keychainAccessGroupWatch = "W3DRXD72QU.com.amazon.aws.amplify.swift.AuthWatchAppShared"
+    let keychainAccessGroupWatch2 = "W3DRXD72QU.com.amazon.aws.amplify.swift.AuthWatchAppShared2"
 
     var amplifyConfiguration: AmplifyConfiguration!
     var amplifyOutputs: AmplifyOutputsData!

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/CredentialStore/CredentialStoreConfigurationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/CredentialStore/CredentialStoreConfigurationTests.swift
@@ -218,4 +218,315 @@ class CredentialStoreConfigurationTests: AWSAuthBaseTest {
         let credentials = try? newCredentialStore.retrieveCredential()
         XCTAssertNil(credentials)
     }
+    
+    /// Test migrating to a shared access group keeps credentials
+    ///
+    /// - Given: A user registered is configured
+    /// - When:
+    ///    - The credential store is re-initialized with shared access group and migration set to true
+    /// - Then:
+    ///    - The old credentials should still persist
+    ///
+    func testCredentialsRemainOnMigrationToSharedAccessGroup() {
+        // Given
+        let identityId = "identityId"
+        // Migration only happens if credentials are not expired, hence
+        // the need for nonimmediate expiration test data
+        let awsCredentials = AuthAWSCognitoCredentials.nonimmediateExpiryTestData
+        let initialCognitoCredentials = AmplifyCredentials.userPoolAndIdentityPool(
+            signedInData: .testData,
+            identityID: identityId,
+            credentials: awsCredentials)
+        let initialAuthConfig = AuthConfiguration.userPoolsAndIdentityPools(
+            Defaults.makeDefaultUserPoolConfigData(),
+            Defaults.makeIdentityConfigData())
+        let credentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig)
+        do {
+            try credentialStore.saveCredential(initialCognitoCredentials)
+        } catch {
+            XCTFail("Unable to save credentials")
+        }
+
+        // When migrating to shared access group with same configuration
+        #if os(watchOS)
+        let newCredentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, accessGroup: keychainAccessGroupWatch, migrateKeychainItemsOfUserSession: true)
+        #else
+        let newCredentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, accessGroup: keychainAccessGroup, migrateKeychainItemsOfUserSession: true)
+        #endif
+
+        // Then
+        guard let credentials = try? newCredentialStore.retrieveCredential(),
+              case .userPoolAndIdentityPool(let retrievedTokens,
+                                            let retrievedIdentityID,
+                                            let retrievedCredentials) = credentials else {
+            XCTFail("Unable to retrieve Credentials")
+            return
+        }
+        XCTAssertNotNil(credentials)
+        XCTAssertNotNil(retrievedTokens)
+        XCTAssertNotNil(retrievedIdentityID)
+        XCTAssertNotNil(retrievedCredentials)
+        XCTAssertEqual(retrievedIdentityID, identityId)
+        XCTAssertEqual(retrievedCredentials, awsCredentials)
+    }
+    
+    /// Test migrating from a shared access group to an unshared access group keeps credentials
+    ///
+    /// - Given: A user registered is configured
+    /// - When:
+    ///    - The credential store is re-initialized with unshared access group and migration set to true
+    /// - Then:
+    ///    - The old credentials should still persist
+    ///
+    func testCredentialsRemainOnMigrationFromSharedAccessGroup() {
+        // Given
+        let identityId = "identityId"
+        let awsCredentials = AuthAWSCognitoCredentials.nonimmediateExpiryTestData
+        // Migration only happens if credentials are not expired, hence
+        // the need for nonimmediate expiration test data
+        let initialCognitoCredentials = AmplifyCredentials.userPoolAndIdentityPool(
+            signedInData: .testData,
+            identityID: identityId,
+            credentials: awsCredentials)
+        let initialAuthConfig = AuthConfiguration.userPoolsAndIdentityPools(
+            Defaults.makeDefaultUserPoolConfigData(),
+            Defaults.makeIdentityConfigData())
+        #if os(watchOS)
+        let credentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, accessGroup: keychainAccessGroupWatch)
+        #else
+        let credentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, accessGroup: keychainAccessGroup)
+        #endif
+        do {
+            try credentialStore.saveCredential(initialCognitoCredentials)
+        } catch {
+            XCTFail("Unable to save credentials")
+        }
+
+        // When migrating to unshared access group with same configuration
+        let newCredentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, migrateKeychainItemsOfUserSession: true)
+
+        // Then
+        guard let credentials = try? newCredentialStore.retrieveCredential(),
+              case .userPoolAndIdentityPool(let retrievedTokens,
+                                            let retrievedIdentityID,
+                                            let retrievedCredentials) = credentials else {
+            XCTFail("Unable to retrieve Credentials")
+            return
+        }
+        XCTAssertNotNil(credentials)
+        XCTAssertNotNil(retrievedTokens)
+        XCTAssertNotNil(retrievedIdentityID)
+        XCTAssertNotNil(retrievedCredentials)
+        XCTAssertEqual(retrievedIdentityID, identityId)
+        XCTAssertEqual(retrievedCredentials, awsCredentials)
+    }
+    
+    /// Test migrating from a shared access group to another shared access group keeps credentials
+    ///
+    /// - Given: A user registered is configured
+    /// - When:
+    ///    - The credential store is re-initialized with another shared access group and migration set to true
+    /// - Then:
+    ///    - The old credentials should still persist
+    ///
+    func testCredentialsRemainOnMigrationFromSharedAccessGroupToAnotherSharedAccessGroup() {
+        // Given
+        let identityId = "identityId"
+        let awsCredentials = AuthAWSCognitoCredentials.nonimmediateExpiryTestData
+        // Migration only happens if credentials are not expired, hence
+        // the need for nonimmediate expiration test data
+        let initialCognitoCredentials = AmplifyCredentials.userPoolAndIdentityPool(
+            signedInData: .testData,
+            identityID: identityId,
+            credentials: awsCredentials)
+        let initialAuthConfig = AuthConfiguration.userPoolsAndIdentityPools(
+            Defaults.makeDefaultUserPoolConfigData(),
+            Defaults.makeIdentityConfigData())
+        #if os(watchOS)
+        let credentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, accessGroup: keychainAccessGroupWatch)
+        #else
+        let credentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, accessGroup: keychainAccessGroup)
+        #endif
+        do {
+            try credentialStore.saveCredential(initialCognitoCredentials)
+        } catch {
+            XCTFail("Unable to save credentials")
+        }
+
+        // When migrating to another shared access group with same configuration
+        #if os(watchOS)
+        let newCredentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, accessGroup: keychainAccessGroupWatch2, migrateKeychainItemsOfUserSession: true)
+        #else
+        let newCredentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, accessGroup: keychainAccessGroup2, migrateKeychainItemsOfUserSession: true)
+        #endif
+
+        // Then
+        guard let credentials = try? newCredentialStore.retrieveCredential(),
+              case .userPoolAndIdentityPool(let retrievedTokens,
+                                            let retrievedIdentityID,
+                                            let retrievedCredentials) = credentials else {
+            XCTFail("Unable to retrieve Credentials")
+            return
+        }
+        XCTAssertNotNil(credentials)
+        XCTAssertNotNil(retrievedTokens)
+        XCTAssertNotNil(retrievedIdentityID)
+        XCTAssertNotNil(retrievedCredentials)
+        XCTAssertEqual(retrievedIdentityID, identityId)
+        XCTAssertEqual(retrievedCredentials, awsCredentials)
+    }
+    
+    /// Test moving to a shared access group without migration should not keep credentials
+    ///
+    /// - Given: A user registered is configured
+    /// - When:
+    ///    - The credential store is re-initialized with shared access group and migration set to false
+    /// - Then:
+    ///    - The old credentials should not persist
+    ///
+    func testCredentialsDoNotRemainOnNonMigrationToSharedAccessGroup() {
+        // Given
+        let identityId = "identityId"
+        let awsCredentials = AuthAWSCognitoCredentials.nonimmediateExpiryTestData
+        let initialCognitoCredentials = AmplifyCredentials.userPoolAndIdentityPool(
+            signedInData: .testData,
+            identityID: identityId,
+            credentials: awsCredentials)
+        let initialAuthConfig = AuthConfiguration.userPoolsAndIdentityPools(
+            Defaults.makeDefaultUserPoolConfigData(),
+            Defaults.makeIdentityConfigData())
+        let credentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig)
+        do {
+            try credentialStore.saveCredential(initialCognitoCredentials)
+        } catch {
+            XCTFail("Unable to save credentials")
+        }
+
+        // When moving to shared access group with same configuration but without migration
+        #if os(watchOS)
+        let newCredentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, accessGroup: keychainAccessGroupWatch, migrateKeychainItemsOfUserSession: false)
+        #else
+        let newCredentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, accessGroup: keychainAccessGroup, migrateKeychainItemsOfUserSession: false)
+        #endif
+
+        // Then
+        guard let credentials = try? newCredentialStore.retrieveCredential(),
+              case .userPoolAndIdentityPool(let retrievedTokens,
+                                            let retrievedIdentityID,
+                                            let retrievedCredentials) = credentials else {
+            // Expected
+            return
+        }
+        
+        // If credentials are present, they should not be the same as those that were not migrated
+        XCTAssertNotNil(credentials)
+        XCTAssertNotNil(retrievedTokens)
+        XCTAssertNotNil(retrievedIdentityID)
+        XCTAssertNotNil(retrievedCredentials)
+        XCTAssertNotEqual(retrievedCredentials, awsCredentials)
+    }
+
+    /// Test moving from a shared access group to an unshared access group without migration should not keep credentials
+    ///
+    /// - Given: A user registered is configured
+    /// - When:
+    ///    - The credential store is re-initialized with unshared access group and migration set to false
+    /// - Then:
+    ///    - The old credentials should not persist
+    ///
+    func testCredentialsDoNotRemainOnNonMigrationFromSharedAccessGroup() {
+        // Given
+        let identityId = "identityId"
+        let awsCredentials = AuthAWSCognitoCredentials.nonimmediateExpiryTestData
+        let initialCognitoCredentials = AmplifyCredentials.userPoolAndIdentityPool(
+            signedInData: .testData,
+            identityID: identityId,
+            credentials: awsCredentials)
+        let initialAuthConfig = AuthConfiguration.userPoolsAndIdentityPools(
+            Defaults.makeDefaultUserPoolConfigData(),
+            Defaults.makeIdentityConfigData())
+        #if os(watchOS)
+        let credentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, accessGroup: keychainAccessGroupWatch)
+        #else
+        let credentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, accessGroup: keychainAccessGroup)
+        #endif
+        do {
+            try credentialStore.saveCredential(initialCognitoCredentials)
+        } catch {
+            XCTFail("Unable to save credentials")
+        }
+
+        // When moving to unshared access group with same configuration but without migration
+        let newCredentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, migrateKeychainItemsOfUserSession: false)
+
+        // Then
+        guard let credentials = try? newCredentialStore.retrieveCredential(),
+              case .userPoolAndIdentityPool(let retrievedTokens,
+                                            let retrievedIdentityID,
+                                            let retrievedCredentials) = credentials else {
+            // Expected
+            return
+        }
+        
+        // If credentials are present, they should not be the same as those that were not migrated
+        XCTAssertNotNil(credentials)
+        XCTAssertNotNil(retrievedTokens)
+        XCTAssertNotNil(retrievedIdentityID)
+        XCTAssertNotNil(retrievedCredentials)
+        XCTAssertNotEqual(retrievedCredentials, awsCredentials)
+    }
+
+    /// Test moving from a shared access group to another shared access group without migration should not keep credentials
+    ///
+    /// - Given: A user registered is configured
+    /// - When:
+    ///    - The credential store is re-initialized with another shared access group and migration set to false
+    /// - Then:
+    ///    - The old credentials should not persist
+    ///
+    func testCredentialsDoNotRemainOnNonMigrationFromSharedAccessGroupToAnotherSharedAccessGroup() {
+        // Given
+        let identityId = "identityId"
+        let awsCredentials = AuthAWSCognitoCredentials.nonimmediateExpiryTestData
+        let initialCognitoCredentials = AmplifyCredentials.userPoolAndIdentityPool(
+            signedInData: .testData,
+            identityID: identityId,
+            credentials: awsCredentials)
+        let initialAuthConfig = AuthConfiguration.userPoolsAndIdentityPools(
+            Defaults.makeDefaultUserPoolConfigData(),
+            Defaults.makeIdentityConfigData())
+        #if os(watchOS)
+        let credentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, accessGroup: keychainAccessGroupWatch)
+        #else
+        let credentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, accessGroup: keychainAccessGroup)
+        #endif
+        do {
+            try credentialStore.saveCredential(initialCognitoCredentials)
+        } catch {
+            XCTFail("Unable to save credentials")
+        }
+
+        // When moving to another shared access group with same configuration but without migration
+        #if os(watchOS)
+        let newCredentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, accessGroup: keychainAccessGroupWatch2, migrateKeychainItemsOfUserSession: false)
+        #else
+        let newCredentialStore = AWSCognitoAuthCredentialStore(authConfiguration: initialAuthConfig, accessGroup: keychainAccessGroup2, migrateKeychainItemsOfUserSession: false)
+        #endif
+
+        // Then
+        guard let credentials = try? newCredentialStore.retrieveCredential(),
+              case .userPoolAndIdentityPool(let retrievedTokens,
+                                            let retrievedIdentityID,
+                                            let retrievedCredentials) = credentials else {
+            // Expected
+            return
+        }
+        
+        // If credentials are present, they should not be the same as those that were not migrated
+        XCTAssertNotNil(credentials)
+        XCTAssertNotNil(retrievedTokens)
+        XCTAssertNotNil(retrievedIdentityID)
+        XCTAssertNotNil(retrievedCredentials)
+        XCTAssertNotEqual(retrievedCredentials, awsCredentials)
+    }
 }

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/Helpers/AuthEnvironmentHelper.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/Helpers/AuthEnvironmentHelper.swift
@@ -40,6 +40,14 @@ extension AuthAWSCognitoCredentials {
             sessionToken: "xx",
             expiration: Date())
     }
+    
+    static var nonimmediateExpiryTestData: AuthAWSCognitoCredentials {
+        return AuthAWSCognitoCredentials(
+            accessKeyId: "xx",
+            secretAccessKey: "xx",
+            sessionToken: "xx",
+            expiration: Date() + TimeInterval(200))
+    }
 }
 
 extension AWSCognitoUserPoolTokens {

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthWatchApp.entitlements
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthWatchApp.entitlements
@@ -4,9 +4,8 @@
 <dict>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.aws.amplify.auth.AuthHostApp</string>
-		<string>$(AppIdentifierPrefix)com.aws.amplify.auth.AuthHostAppShared</string>
-		<string>$(AppIdentifierPrefix)com.aws.amplify.auth.AuthHostAppShared2</string>
+		<string>$(AppIdentifierPrefix)com.amazon.aws.amplify.swift.AuthWatchAppShared</string>
+		<string>$(AppIdentifierPrefix)com.amazon.aws.amplify.swift.AuthWatchAppShared2</string>
 	</array>
 </dict>
 </plist>

--- a/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStore.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStore.swift
@@ -75,13 +75,16 @@ public struct KeychainStore: KeychainStoreBehavior {
     }
 
     public init(service: String) {
-        attributes = KeychainStoreAttributes(service: service)
-        log.verbose("[KeychainStore] Initialized keychain with service=\(service), attributes=\(attributes), accessGroup=")
+        self.init(service: service, accessGroup: nil)
     }
 
     public init(service: String, accessGroup: String? = nil) {
         attributes = KeychainStoreAttributes(service: service, accessGroup: accessGroup)
-        log.verbose("[KeychainStore] Initialized keychain with service=\(service), attributes=\(attributes), accessGroup=\(attributes.accessGroup ?? "")")
+        log.verbose(
+            "[KeychainStore] Initialized keychain with service=\(service), " +
+            "attributes=\(attributes), " +
+            "accessGroup=\(attributes.accessGroup ?? "No access group specified")"
+        )
     }
 
     @_spi(KeychainStore)

--- a/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStore.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStore.swift
@@ -52,6 +52,11 @@ public protocol KeychainStoreBehavior {
     /// Removes all key-value pair in the Keychain.
     /// This System Programming Interface (SPI) may have breaking changes in future updates.
     func _removeAll() throws
+    
+    @_spi(KeychainStore)
+    /// Retrieves all key-value pairs in the keychain
+    /// This System Programming Interface (SPI) may have breaking changes in future updates.
+    func _getAll() throws -> [(key: String, value: Data)]
 }
 
 public struct KeychainStore: KeychainStoreBehavior {
@@ -70,14 +75,13 @@ public struct KeychainStore: KeychainStoreBehavior {
     }
 
     public init(service: String) {
-        self.init(service: service, accessGroup: nil)
+        attributes = KeychainStoreAttributes(service: service)
+        log.verbose("[KeychainStore] Initialized keychain with service=\(service), attributes=\(attributes), accessGroup=")
     }
 
     public init(service: String, accessGroup: String? = nil) {
-        var attributes = KeychainStoreAttributes(service: service)
-        attributes.accessGroup = accessGroup
-        self.init(attributes: attributes)
-        log.verbose("[KeychainStore] Initialized keychain with service=\(service), attributes=\(attributes), accessGroup=\(accessGroup ?? "")")
+        attributes = KeychainStoreAttributes(service: service, accessGroup: accessGroup)
+        log.verbose("[KeychainStore] Initialized keychain with service=\(service), attributes=\(attributes), accessGroup=\(attributes.accessGroup ?? "")")
     }
 
     @_spi(KeychainStore)
@@ -229,6 +233,48 @@ public struct KeychainStore: KeychainStoreBehavior {
         }
         log.verbose("[KeychainStore] Successfully removed all items from keychain")
     }
+    
+    @_spi(KeychainStore)
+    /// Retrieves all key-value pairs in the keychain
+    /// This System Programming Interface (SPI) may have breaking changes in future updates.
+    public func _getAll() throws -> [(key: String, value: Data)] {
+        log.verbose("[KeychainStore] Starting to retrieve all items from keychain")
+        var query = attributes.defaultGetQuery()
+        query[Constants.MatchLimit] = Constants.MatchLimitAll
+        query[Constants.ReturnData] = kCFBooleanTrue
+        query[Constants.ReturnAttributes] = kCFBooleanTrue
+        query[Constants.ReturnRef] = kCFBooleanTrue
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        switch status {
+        case errSecSuccess:
+            guard let items = result as? [[String: Any]] else {
+                log.error("[KeychainStore] The keychain items retrieved are not the correct type")
+                throw KeychainStoreError.unknown("The keychain items retrieved are not the correct type")
+            }
+
+            var keyValuePairs = [(key: String, value: Data)]()
+            for item in items {
+                guard let key = item[Constants.AttributeAccount] as? String,
+                      let value = item[Constants.ValueData] as? Data else {
+                    log.error("[KeychainStore] Unable to retrieve key or value from keychain item")
+                    continue
+                }
+                keyValuePairs.append((key: key, value: value))
+            }
+
+            log.verbose("[KeychainStore] Successfully retrieved \(keyValuePairs.count) items from keychain")
+            return keyValuePairs
+        case errSecItemNotFound:
+            log.verbose("[KeychainStore] No items found in keychain")
+            return []
+        default:
+            log.error("[KeychainStore] Error of status=\(status) occurred when attempting to retrieve all items from keychain")
+            throw KeychainStoreError.securityError(status)
+        }
+    }
 
 }
 
@@ -258,6 +304,7 @@ extension KeychainStore {
         /** Return Type Key Constants */
         static let ReturnData = String(kSecReturnData)
         static let ReturnAttributes = String(kSecReturnAttributes)
+        static let ReturnRef = String(kSecReturnRef)
 
         /** Value Type Key Constants */
         static let ValueData = String(kSecValueData)

--- a/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStoreAttributes.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStoreAttributes.swift
@@ -24,7 +24,7 @@ extension KeychainStoreAttributes {
             KeychainStore.Constants.UseDataProtectionKeyChain: kCFBooleanTrue
         ]
 
-        if let accessGroup = accessGroup {
+        if let accessGroup {
             query[KeychainStore.Constants.AttributeAccessGroup] = accessGroup
         }
         return query

--- a/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStoreMigrator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStoreMigrator.swift
@@ -1,0 +1,56 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Amplify
+
+public struct KeychainStoreMigrator {
+    let oldAttributes: KeychainStoreAttributes
+    let newAttributes: KeychainStoreAttributes
+    
+    public init(oldService: String, newService: String, oldAccessGroup: String?, newAccessGroup: String?) {
+        self.oldAttributes = KeychainStoreAttributes(service: oldService, accessGroup: oldAccessGroup)
+        self.newAttributes = KeychainStoreAttributes(service: newService, accessGroup: newAccessGroup)
+    }
+    
+    public func migrate() throws {
+        log.verbose("[KeychainStoreMigrator] Starting to migrate items")
+
+        var updateQuery = oldAttributes.defaultGetQuery()
+
+        var updateAttributes = [String: Any]()
+        updateAttributes[KeychainStore.Constants.AttributeService] = newAttributes.service
+        updateAttributes[KeychainStore.Constants.AttributeAccessGroup] = newAttributes.accessGroup
+
+        // Remove any current items to avoid duplicate item error
+        try? KeychainStore(service: newAttributes.service, accessGroup: newAttributes.accessGroup)._removeAll()
+        
+        let updateStatus = SecItemUpdate(updateQuery as CFDictionary, updateAttributes as CFDictionary)
+        switch updateStatus {
+        case errSecSuccess:
+            break
+        case errSecItemNotFound:
+            log.verbose("[KeychainStoreMigrator] No items to migrate, keychain under new access group is cleared")
+        case errSecDuplicateItem:
+            log.verbose("[KeychainStoreMigrator] Duplicate items found, could not migrate")
+            return
+        default:
+            log.error("[KeychainStoreMigrator] Error of status=\(updateStatus) occurred when attempting to migrate items in keychain")
+            throw KeychainStoreError.securityError(updateStatus)
+        }
+
+        log.verbose("[KeychainStoreMigrator] Successfully migrated items to new service and access group")
+    }
+}
+
+extension KeychainStoreMigrator: DefaultLogger {
+    public static var log: Logger {
+        Amplify.Logging.logger(forNamespace: String(describing: self))
+    }
+
+    public nonisolated var log: Logger { Self.log }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Keychain/KeychainStoreAttributesTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Keychain/KeychainStoreAttributesTests.swift
@@ -45,10 +45,28 @@ class KeychainStoreAttributesTests: XCTestCase {
         XCTAssertNil(defaultGetAttributes[KeychainStore.Constants.AttributeAccessible] as? String)
         XCTAssertNil(defaultGetAttributes[KeychainStore.Constants.UseDataProtectionKeyChain] as? String)
     }
+    
+    /// Given: an instance of `KeychainStoreAttributes`
+    /// When: `keychainStoreAttribute.defaultSetQuery()` is invoked with a required service param
+    /// Then: Validate if the attributes contain the correct set query params
+    ///     - AttributeService
+    ///     - Class
+    ///     - AttributeAccessible
+    ///     - UseDataProtectionKeyChain
+    func testDefaultSetQuery() {
+        keychainStoreAttribute = KeychainStoreAttributes(service: "someService")
+
+        let defaultSetAttributes = keychainStoreAttribute.defaultSetQuery()
+        XCTAssertEqual(defaultSetAttributes[KeychainStore.Constants.AttributeService] as? String, "someService")
+        XCTAssertEqual(defaultSetAttributes[KeychainStore.Constants.Class] as? String, KeychainStore.Constants.ClassGenericPassword)
+        XCTAssertNil(defaultSetAttributes[KeychainStore.Constants.AttributeAccessGroup] as? String)
+        XCTAssertEqual(defaultSetAttributes[KeychainStore.Constants.AttributeAccessible] as? String, KeychainStore.Constants.AttributeAccessibleAfterFirstUnlockThisDeviceOnly)
+        XCTAssertEqual(defaultSetAttributes[KeychainStore.Constants.UseDataProtectionKeyChain] as? Bool, true)
+    }
 
     /// Given: an instance of `KeychainStoreAttributes`
     /// When: `keychainStoreAttribute.defaultSetQuery()` is invoked with a required service param and access group
-    /// Then: Validate if the attributes contain the correct get query params
+    /// Then: Validate if the attributes contain the correct set query params
     ///     - AttributeService
     ///     - Class
     ///     - AttributeAccessGroup
@@ -57,12 +75,12 @@ class KeychainStoreAttributesTests: XCTestCase {
     func testDefaultSetQueryWithAccessGroup() {
         keychainStoreAttribute = KeychainStoreAttributes(service: "someService", accessGroup: "someAccessGroup")
 
-        let defaultGetAttributes = keychainStoreAttribute.defaultSetQuery()
-        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.AttributeService] as? String, "someService")
-        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.Class] as? String, KeychainStore.Constants.ClassGenericPassword)
-        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.AttributeAccessGroup] as? String, "someAccessGroup")
-        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.AttributeAccessible] as? String, KeychainStore.Constants.AttributeAccessibleAfterFirstUnlockThisDeviceOnly)
-        XCTAssertEqual(defaultGetAttributes[KeychainStore.Constants.UseDataProtectionKeyChain] as? Bool, true)
+        let defaultSetAttributes = keychainStoreAttribute.defaultSetQuery()
+        XCTAssertEqual(defaultSetAttributes[KeychainStore.Constants.AttributeService] as? String, "someService")
+        XCTAssertEqual(defaultSetAttributes[KeychainStore.Constants.Class] as? String, KeychainStore.Constants.ClassGenericPassword)
+        XCTAssertEqual(defaultSetAttributes[KeychainStore.Constants.AttributeAccessGroup] as? String, "someAccessGroup")
+        XCTAssertEqual(defaultSetAttributes[KeychainStore.Constants.AttributeAccessible] as? String, KeychainStore.Constants.AttributeAccessibleAfterFirstUnlockThisDeviceOnly)
+        XCTAssertEqual(defaultSetAttributes[KeychainStore.Constants.UseDataProtectionKeyChain] as? Bool, true)
     }
 
     override func tearDown() {

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockKeychainStore.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockKeychainStore.swift
@@ -61,6 +61,20 @@ class MockKeychainStore: KeychainStoreBehavior {
         stringValues.removeAll()
         dataValues.removeAll()
     }
+    
+    func _getAll() throws -> [(key: String, value: Data)] {
+        var allValues: [(key: String, value: Data)] = []
+        
+        for (key, value) in dataValues {
+            allValues.append((key: key, value: value))
+        }
+        
+        for (key, value) in stringValues {
+            allValues.append((key: key, value: value.data(using: .utf8)!))
+        }
+        
+        return allValues
+    }
 
     func resetCounters() {
         dataForKeyCount = 0

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockKeychainStore.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockKeychainStore.swift
@@ -61,20 +61,6 @@ class MockKeychainStore: KeychainStoreBehavior {
         stringValues.removeAll()
         dataValues.removeAll()
     }
-    
-    func _getAll() throws -> [(key: String, value: Data)] {
-        var allValues: [(key: String, value: Data)] = []
-        
-        for (key, value) in dataValues {
-            allValues.append((key: key, value: value))
-        }
-        
-        for (key, value) in stringValues {
-            allValues.append((key: key, value: value.data(using: .utf8)!))
-        }
-        
-        return allValues
-    }
 
     func resetCounters() {
         dataForKeyCount = 0

--- a/api-dump/AWSDataStorePlugin.json
+++ b/api-dump/AWSDataStorePlugin.json
@@ -8205,7 +8205,7 @@
       "-module",
       "AWSDataStorePlugin",
       "-o",
-      "\/var\/folders\/k7\/4hy4p20s2rv4clw77d3qcl380000gr\/T\/tmp.nF2YaRsn2M\/AWSDataStorePlugin.json",
+      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.Op48snuvLw\/AWSDataStorePlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/AWSDataStorePlugin.json
+++ b/api-dump/AWSDataStorePlugin.json
@@ -8205,7 +8205,7 @@
       "-module",
       "AWSDataStorePlugin",
       "-o",
-      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.Op48snuvLw\/AWSDataStorePlugin.json",
+      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.7FvtSuhXB9\/AWSDataStorePlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/AWSPluginsCore.json
+++ b/api-dump/AWSPluginsCore.json
@@ -138,196 +138,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "AWSAppSyncConfiguration",
-        "printedName": "AWSAppSyncConfiguration",
-        "children": [
-          {
-            "kind": "Var",
-            "name": "region",
-            "printedName": "region",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV6regionSSvp",
-            "mangledName": "$s14AWSPluginsCore23AWSAppSyncConfigurationV6regionSSvp",
-            "moduleName": "AWSPluginsCore",
-            "declAttributes": [
-              "HasStorage"
-            ],
-            "isLet": true,
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV6regionSSvg",
-                "mangledName": "$s14AWSPluginsCore23AWSAppSyncConfigurationV6regionSSvg",
-                "moduleName": "AWSPluginsCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "endpoint",
-            "printedName": "endpoint",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "URL",
-                "printedName": "Foundation.URL",
-                "usr": "s:10Foundation3URLV"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV8endpoint10Foundation3URLVvp",
-            "mangledName": "$s14AWSPluginsCore23AWSAppSyncConfigurationV8endpoint10Foundation3URLVvp",
-            "moduleName": "AWSPluginsCore",
-            "declAttributes": [
-              "HasStorage"
-            ],
-            "isLet": true,
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "URL",
-                    "printedName": "Foundation.URL",
-                    "usr": "s:10Foundation3URLV"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV8endpoint10Foundation3URLVvg",
-                "mangledName": "$s14AWSPluginsCore23AWSAppSyncConfigurationV8endpoint10Foundation3URLVvg",
-                "moduleName": "AWSPluginsCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "apiKey",
-            "printedName": "apiKey",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Swift.String?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "usr": "s:Sq"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV6apiKeySSSgvp",
-            "mangledName": "$s14AWSPluginsCore23AWSAppSyncConfigurationV6apiKeySSSgvp",
-            "moduleName": "AWSPluginsCore",
-            "declAttributes": [
-              "HasStorage"
-            ],
-            "isLet": true,
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "Swift.String?",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
-                      }
-                    ],
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV6apiKeySSSgvg",
-                "mangledName": "$s14AWSPluginsCore23AWSAppSyncConfigurationV6apiKeySSSgvg",
-                "moduleName": "AWSPluginsCore",
-                "implicit": true,
-                "declAttributes": [
-                  "Transparent"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init(with:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "AWSAppSyncConfiguration",
-                "printedName": "AWSPluginsCore.AWSAppSyncConfiguration",
-                "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "AmplifyOutputs",
-                "printedName": "Amplify.AmplifyOutputs",
-                "usr": "s:7Amplify0A7OutputsV"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV4withAC7Amplify0G7OutputsV_tKcfc",
-            "mangledName": "$s14AWSPluginsCore23AWSAppSyncConfigurationV4withAC7Amplify0G7OutputsV_tKcfc",
-            "moduleName": "AWSPluginsCore",
-            "throwing": true,
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Struct",
-        "usr": "s:14AWSPluginsCore23AWSAppSyncConfigurationV",
-        "mangledName": "$s14AWSPluginsCore23AWSAppSyncConfigurationV",
-        "moduleName": "AWSPluginsCore"
-      },
-      {
-        "kind": "TypeDecl",
         "name": "AppSyncErrorType",
         "printedName": "AppSyncErrorType",
         "children": [
@@ -3834,99 +3644,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "AWSCredentials",
-        "printedName": "AWSCredentials",
-        "children": [
-          {
-            "kind": "Var",
-            "name": "accessKeyId",
-            "printedName": "accessKeyId",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:14AWSPluginsCore14AWSCredentialsP11accessKeyIdSSvp",
-            "mangledName": "$s14AWSPluginsCore14AWSCredentialsP11accessKeyIdSSvp",
-            "moduleName": "AWSPluginsCore",
-            "protocolReq": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:14AWSPluginsCore14AWSCredentialsP11accessKeyIdSSvg",
-                "mangledName": "$s14AWSPluginsCore14AWSCredentialsP11accessKeyIdSSvg",
-                "moduleName": "AWSPluginsCore",
-                "genericSig": "<Self where Self : AWSPluginsCore.AWSCredentials>",
-                "protocolReq": true,
-                "reqNewWitnessTableEntry": true,
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "secretAccessKey",
-            "printedName": "secretAccessKey",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:14AWSPluginsCore14AWSCredentialsP15secretAccessKeySSvp",
-            "mangledName": "$s14AWSPluginsCore14AWSCredentialsP15secretAccessKeySSvp",
-            "moduleName": "AWSPluginsCore",
-            "protocolReq": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:14AWSPluginsCore14AWSCredentialsP15secretAccessKeySSvg",
-                "mangledName": "$s14AWSPluginsCore14AWSCredentialsP15secretAccessKeySSvg",
-                "moduleName": "AWSPluginsCore",
-                "genericSig": "<Self where Self : AWSPluginsCore.AWSCredentials>",
-                "protocolReq": true,
-                "reqNewWitnessTableEntry": true,
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Protocol",
-        "usr": "s:14AWSPluginsCore14AWSCredentialsP",
-        "mangledName": "$s14AWSPluginsCore14AWSCredentialsP",
-        "moduleName": "AWSPluginsCore"
-      },
-      {
-        "kind": "TypeDecl",
         "name": "AWSTemporaryCredentials",
         "printedName": "AWSTemporaryCredentials",
         "children": [
@@ -4027,6 +3744,99 @@
             "mangledName": "$s14AWSPluginsCore14AWSCredentialsP"
           }
         ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "AWSCredentials",
+        "printedName": "AWSCredentials",
+        "children": [
+          {
+            "kind": "Var",
+            "name": "accessKeyId",
+            "printedName": "accessKeyId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:14AWSPluginsCore14AWSCredentialsP11accessKeyIdSSvp",
+            "mangledName": "$s14AWSPluginsCore14AWSCredentialsP11accessKeyIdSSvp",
+            "moduleName": "AWSPluginsCore",
+            "protocolReq": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:14AWSPluginsCore14AWSCredentialsP11accessKeyIdSSvg",
+                "mangledName": "$s14AWSPluginsCore14AWSCredentialsP11accessKeyIdSSvg",
+                "moduleName": "AWSPluginsCore",
+                "genericSig": "<Self where Self : AWSPluginsCore.AWSCredentials>",
+                "protocolReq": true,
+                "reqNewWitnessTableEntry": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "secretAccessKey",
+            "printedName": "secretAccessKey",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:14AWSPluginsCore14AWSCredentialsP15secretAccessKeySSvp",
+            "mangledName": "$s14AWSPluginsCore14AWSCredentialsP15secretAccessKeySSvp",
+            "moduleName": "AWSPluginsCore",
+            "protocolReq": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:14AWSPluginsCore14AWSCredentialsP15secretAccessKeySSvg",
+                "mangledName": "$s14AWSPluginsCore14AWSCredentialsP15secretAccessKeySSvg",
+                "moduleName": "AWSPluginsCore",
+                "genericSig": "<Self where Self : AWSPluginsCore.AWSCredentials>",
+                "protocolReq": true,
+                "reqNewWitnessTableEntry": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Protocol",
+        "usr": "s:14AWSPluginsCore14AWSCredentialsP",
+        "mangledName": "$s14AWSPluginsCore14AWSCredentialsP",
+        "moduleName": "AWSPluginsCore"
       },
       {
         "kind": "TypeDecl",
@@ -5377,6 +5187,55 @@
             "throwing": true,
             "reqNewWitnessTableEntry": true,
             "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "_getAll",
+            "printedName": "_getAll()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[(key: Swift.String, value: Foundation.Data)]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Tuple",
+                    "printedName": "(key: Swift.String, value: Foundation.Data)",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Data",
+                        "printedName": "Foundation.Data",
+                        "usr": "s:10Foundation4DataV"
+                      }
+                    ]
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:14AWSPluginsCore21KeychainStoreBehaviorP7_getAllSaySS3key_10Foundation4DataV5valuetGyKF",
+            "mangledName": "$s14AWSPluginsCore21KeychainStoreBehaviorP7_getAllSaySS3key_10Foundation4DataV5valuetGyKF",
+            "moduleName": "AWSPluginsCore",
+            "genericSig": "<Self where Self : AWSPluginsCore.KeychainStoreBehavior>",
+            "protocolReq": true,
+            "declAttributes": [
+              "SPIAccessControl"
+            ],
+            "spi_group_names": [
+              "KeychainStore"
+            ],
+            "throwing": true,
+            "reqNewWitnessTableEntry": true,
+            "funcSelfKind": "NonMutating"
           }
         ],
         "declKind": "Protocol",
@@ -5648,6 +5507,52 @@
             "declKind": "Func",
             "usr": "s:14AWSPluginsCore13KeychainStoreV10_removeAllyyKF",
             "mangledName": "$s14AWSPluginsCore13KeychainStoreV10_removeAllyyKF",
+            "moduleName": "AWSPluginsCore",
+            "declAttributes": [
+              "SPIAccessControl"
+            ],
+            "spi_group_names": [
+              "KeychainStore"
+            ],
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "_getAll",
+            "printedName": "_getAll()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Array",
+                "printedName": "[(key: Swift.String, value: Foundation.Data)]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Tuple",
+                    "printedName": "(key: Swift.String, value: Foundation.Data)",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Data",
+                        "printedName": "Foundation.Data",
+                        "usr": "s:10Foundation4DataV"
+                      }
+                    ]
+                  }
+                ],
+                "usr": "s:Sa"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:14AWSPluginsCore13KeychainStoreV7_getAllSaySS3key_10Foundation4DataV5valuetGyKF",
+            "mangledName": "$s14AWSPluginsCore13KeychainStoreV7_getAllSaySS3key_10Foundation4DataV5valuetGyKF",
             "moduleName": "AWSPluginsCore",
             "declAttributes": [
               "SPIAccessControl"
@@ -24463,7 +24368,7 @@
       "-module",
       "AWSPluginsCore",
       "-o",
-      "\/var\/folders\/k7\/4hy4p20s2rv4clw77d3qcl380000gr\/T\/tmp.nF2YaRsn2M\/AWSPluginsCore.json",
+      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.Op48snuvLw\/AWSPluginsCore.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/AWSPluginsCore.json
+++ b/api-dump/AWSPluginsCore.json
@@ -6400,6 +6400,185 @@
       },
       {
         "kind": "TypeDecl",
+        "name": "KeychainStoreMigrator",
+        "printedName": "KeychainStoreMigrator",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(oldService:newService:oldAccessGroup:newAccessGroup:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "KeychainStoreMigrator",
+                "printedName": "AWSPluginsCore.KeychainStoreMigrator",
+                "usr": "s:14AWSPluginsCore21KeychainStoreMigratorV"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Swift.String?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:14AWSPluginsCore21KeychainStoreMigratorV10oldService03newG00F11AccessGroup0hiJ0ACSS_S2SSgAHtcfc",
+            "mangledName": "$s14AWSPluginsCore21KeychainStoreMigratorV10oldService03newG00F11AccessGroup0hiJ0ACSS_S2SSgAHtcfc",
+            "moduleName": "AWSPluginsCore",
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Function",
+            "name": "migrate",
+            "printedName": "migrate()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "s:14AWSPluginsCore21KeychainStoreMigratorV7migrateyyKF",
+            "mangledName": "$s14AWSPluginsCore21KeychainStoreMigratorV7migrateyyKF",
+            "moduleName": "AWSPluginsCore",
+            "throwing": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Var",
+            "name": "log",
+            "printedName": "log",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Logger",
+                "printedName": "any Amplify.Logger",
+                "usr": "s:7Amplify6LoggerP"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:14AWSPluginsCore21KeychainStoreMigratorV3log7Amplify6Logger_pvpZ",
+            "mangledName": "$s14AWSPluginsCore21KeychainStoreMigratorV3log7Amplify6Logger_pvpZ",
+            "moduleName": "AWSPluginsCore",
+            "static": true,
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Logger",
+                    "printedName": "any Amplify.Logger",
+                    "usr": "s:7Amplify6LoggerP"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:14AWSPluginsCore21KeychainStoreMigratorV3log7Amplify6Logger_pvgZ",
+                "mangledName": "$s14AWSPluginsCore21KeychainStoreMigratorV3log7Amplify6Logger_pvgZ",
+                "moduleName": "AWSPluginsCore",
+                "static": true,
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "log",
+            "printedName": "log",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Logger",
+                "printedName": "any Amplify.Logger",
+                "usr": "s:7Amplify6LoggerP"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:14AWSPluginsCore21KeychainStoreMigratorV3log7Amplify6Logger_pvp",
+            "mangledName": "$s14AWSPluginsCore21KeychainStoreMigratorV3log7Amplify6Logger_pvp",
+            "moduleName": "AWSPluginsCore",
+            "declAttributes": [
+              "Nonisolated"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Logger",
+                    "printedName": "any Amplify.Logger",
+                    "usr": "s:7Amplify6LoggerP"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:14AWSPluginsCore21KeychainStoreMigratorV3log7Amplify6Logger_pvg",
+                "mangledName": "$s14AWSPluginsCore21KeychainStoreMigratorV3log7Amplify6Logger_pvg",
+                "moduleName": "AWSPluginsCore",
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
+          }
+        ],
+        "declKind": "Struct",
+        "usr": "s:14AWSPluginsCore21KeychainStoreMigratorV",
+        "mangledName": "$s14AWSPluginsCore21KeychainStoreMigratorV",
+        "moduleName": "AWSPluginsCore",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "DefaultLogger",
+            "printedName": "DefaultLogger",
+            "usr": "s:7Amplify13DefaultLoggerP",
+            "mangledName": "$s7Amplify13DefaultLoggerP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
         "name": "AnyModel",
         "printedName": "AnyModel",
         "children": [
@@ -24368,7 +24547,7 @@
       "-module",
       "AWSPluginsCore",
       "-o",
-      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.Op48snuvLw\/AWSPluginsCore.json",
+      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.7FvtSuhXB9\/AWSPluginsCore.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/CoreMLPredictionsPlugin.json
+++ b/api-dump/CoreMLPredictionsPlugin.json
@@ -430,7 +430,7 @@
       "-module",
       "CoreMLPredictionsPlugin",
       "-o",
-      "\/var\/folders\/k7\/4hy4p20s2rv4clw77d3qcl380000gr\/T\/tmp.nF2YaRsn2M\/CoreMLPredictionsPlugin.json",
+      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.Op48snuvLw\/CoreMLPredictionsPlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",

--- a/api-dump/CoreMLPredictionsPlugin.json
+++ b/api-dump/CoreMLPredictionsPlugin.json
@@ -430,7 +430,7 @@
       "-module",
       "CoreMLPredictionsPlugin",
       "-o",
-      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.Op48snuvLw\/CoreMLPredictionsPlugin.json",
+      "\/var\/folders\/hw\/1f0gcr8d6kn9ms0_wn0_57qc0000gn\/T\/tmp.7FvtSuhXB9\/CoreMLPredictionsPlugin.json",
       "-I",
       ".build\/debug",
       "-sdk-version",


### PR DESCRIPTION
## Issue \#
https://github.com/aws-amplify/amplify-swift/issues/2508
https://github.com/aws-amplify/amplify-swift/issues/3277

## Integration Tests: 

[![Integration Tests (Except DataStore & API)](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test.yml/badge.svg?branch=harsh62%2Fkeychain-sharing-auth-plugin)](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test.yml)

[![Integration Tests | DataStore - All](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_datastore.yml/badge.svg?branch=harsh62%2Fkeychain-sharing-auth-plugin)](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_datastore.yml)

[![Integration Tests | API - All](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_api.yml/badge.svg?branch=harsh62%2Fkeychain-sharing-auth-plugin)](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_api.yml)

## Description
This allows Amplify Swift developers to set the access group they would like the auth session to be shared on. This PR, as opposed to [this PR](https://github.com/aws-amplify/amplify-swift/pull/3805), does not require the other app with which the auth session is being shared with to be reloaded. This helps immensely when writing a product with app extensions.

## Changes made
`AWSCognitoCredentialAuthCredentialStore` now uses access group to create keychain instance with said access group.
If an access group is specified: 
- a different keychain service is used, specifically for shared items.
- `fetchAuthSession` reconfigures the plugin when called, so that app reload is not required

Migration:
- Amplify developers can specify if they want migration to happen by setting the `migrateKeychainItemsOfUserSession` to `true` within the `accessGroup` struct
- migration involves moving any auth keychain items from the old access group (old access group name is stored in `UserDefaults`) to the new access group
- migration is a batched operation, and the items will no longer be accessible from the old access group

## Usage
### Migrating to a Shared Keychain

To use a shared keychain:

1. In Xcode, go to Project Settings → Signing & Capabilities
2. Click +Capability
3. Add Keychain Sharing capability
4. Add a keychain group
5. Repeat for all apps for which you want to share auth state, adding the same keychain group for all of them

To move to the shared keychain using this new keychain access group, specify the `accessGroup` parameter when instantiating the `AWSCognitoAuthPlugin`. If a user is currently signed-in, they will be logged out when first using the access group:

```swift
let accessGroup = AccessGroup(name: "\(teamID).com.example.sharedItems")
let secureStoragePreferences = AWSCognitoSecureStoragePreferences(
  accessGroup: accessGroup)
try Amplify.add(
  plugin: AWSCognitoAuthPlugin(
    secureStoragePreferences: secureStoragePreferences))
try Amplify.configure()
```

If you would prefer the user session to be migrated (which will allow the user to continue to be signed-in), then specify the `migrateKeychainItemsOfUserSession` boolean in the `AccessGroup` struct to be true like so:

```swift
let accessGroup = AccessGroup.none(migrateKeychainItemsOfUserSession: true)
let secureStoragePreferences = AWSCognitoSecureStoragePreferences(
  accessGroup: accessGroup)
try Amplify.add(
  plugin: AWSCognitoAuthPlugin(
    secureStoragePreferences: secureStoragePreferences))
try Amplify.configure()
```

Sign in a user with any sign-in method within one app that uses this access group. After reloading another app that uses this access group, the user will be signed in. Likewise, signing out of one app will sign out the other app after reloading it.

### Migrating to another Shared Keychain

To move to a different access group, update the name parameter of the `AccessGroup` to be the new access group. Set `migrateKeychainItemsOfUserSession` to `true` to migrate an existing user session under the previously used access group.

### Migrating from a Shared Keychain

If you’d like to stop sharing state between this app and other apps, you can set the access group to be `AccessGroup.none`  or `AccessGroup.none(migrateKeychainItemsOfUserSession: true)` if you’d like the session to be migrated.



## General Checklist
- [x] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [x] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [x] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
