### PR TITLE
chore: Update aws-sdk-swift to 1.0.69

### DIFF
--- a/.github/composite_actions/get_platform_parameters/action.yml
+++ b/.github/composite_actions/get_platform_parameters/action.yml
@@ -41,7 +41,7 @@ runs:
 
     - id: get-xcode-version
       run: |
-        LATEST_XCODE_VERSION=16.0.0
+        LATEST_XCODE_VERSION=16.2.0
         MINIMUM_XCODE_VERSION=15.0.1
 
         INPUT_XCODE_VERSION=${{ inputs.xcode_version }}
@@ -67,15 +67,15 @@ runs:
         case $INPUT_PLATFORM/$INPUT_XCODE_VERSION in
           iOS/latest) 
             DEVICE="iPhone 16"
-            OS_VERSION="18.0"
+            OS_VERSION="18.2"
             ;;
           iOS/*)
-            DEVICE="iPhone 14"
-            OS_VERSION="17.0.1"
+            DEVICE="iPhone 15"
+            OS_VERSION="17.0"
             ;;
           tvOS/latest)
             DEVICE="Apple TV 4K (3rd generation)"
-            OS_VERSION="18.0"
+            OS_VERSION="18.2"
             ;;
           tvOS/*)
             DEVICE="Apple TV 4K (3rd generation)"
@@ -83,15 +83,15 @@ runs:
             ;;
           watchOS/latest)
             DEVICE="Apple Watch Series 10 (46mm)"
-            OS_VERSION="11.0"
+            OS_VERSION="11.2"
             ;;
           watchOS/*)
-            DEVICE="Apple Watch Series 8 (45mm)"
+            DEVICE="Apple Watch Series 7 (45mm)"
             OS_VERSION="10.0"
             ;;
           visionOS/latest)
             DEVICE="Apple Vision Pro"
-            OS_VERSION="2.0"
+            OS_VERSION="2.2"
             ;;
           visionOS/*)
             DEVICE="Apple Vision Pro"

--- a/.github/workflows/build_scheme.yml
+++ b/.github/workflows/build_scheme.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Attempt to restore the build cache from main
         id: build-cache
+        if: steps.dependencies-cache.outputs.cache-hit
         timeout-minutes: 4
         continue-on-error: true
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1

--- a/.github/workflows/integ_test_auth_webauthn.yml
+++ b/.github/workflows/integ_test_auth_webauthn.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Attempt to restore the build cache
         id: build-cache
+        if: steps.dependencies-cache.outputs.cache-hit
         timeout-minutes: 4
         continue-on-error: true
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1

--- a/.github/workflows/integ_test_push_notifications.yml
+++ b/.github/workflows/integ_test_push_notifications.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   push-notification-integration-tests:
     name: ${{ matrix.platform }} Tests | PushNotificationHostApp
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 30
     environment: IntegrationTest
     strategy:
@@ -79,6 +79,7 @@ jobs:
 
       - name: Attempt to restore the build cache
         id: build-cache
+        if: steps.dependencies-cache.outputs.cache-hit
         timeout-minutes: 4
         continue-on-error: true
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -82,6 +82,7 @@ jobs:
 
       - name: Attempt to restore the build cache
         id: build-cache
+        if: steps.dependencies-cache.outputs.cache-hit
         timeout-minutes: 4
         continue-on-error: true
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Attempt to restore the build cache
         id: build-cache
+        if: steps.dependencies-cache.outputs.cache-hit
         timeout-minutes: 4
         continue-on-error: true
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift",
       "state" : {
-        "revision" : "3f844bef042cc0a4c3381f7090414ce3f9a7e935",
-        "version" : "0.37.0"
+        "revision" : "dd17a98750b6182edacd6e8f0c30aa289c472b22",
+        "version" : "0.40.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift",
       "state" : {
-        "revision" : "c6c1064da9bfccb119a7a8ab9ba636fb3bbfa6f5",
-        "version" : "1.0.47"
+        "revision" : "9ad12684f6cb9c9b60e840c051a2bba604024650",
+        "version" : "1.0.69"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "3cd9f181b3ba8ff71da43bf53c09f8de6790a4ad",
-        "version" : "0.96.0"
+        "revision" : "402f091374dcf72c1e7ed43af10e3ee7e634fad8",
+        "version" : "0.106.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let platforms: [SupportedPlatform] = [
     .watchOS(.v9)
 ]
 let dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/awslabs/aws-sdk-swift", exact: "1.0.47"),
+    .package(url: "https://github.com/awslabs/aws-sdk-swift", exact: "1.0.69"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", exact: "0.15.3"),
     .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.1.0"),
     .package(url: "https://github.com/aws-amplify/amplify-swift-utils-notifications.git", from: "1.1.0")


### PR DESCRIPTION
## Description
This PR includes the changes from https://github.com/aws-amplify/amplify-swift/pull/3942 to upgrade the [aws-sdk-swift](https://github.com/awslabs/aws-sdk-swift) dependency to 1.0.69, which makes it possible to enable C++ interoperability mode ([ref](https://github.com/awslabs/aws-crt-swift/releases/tag/v0.38.0)).

I'm also updating the Xcode and OS versions in our workflows, and skipping the usage of the build cache when the dependency cache is not found (this caused issues when updating dependencies)

## General Checklist
- [ ] Added new tests to cover change, if needed
- [X] Build succeeds with all target using Swift Package Manager
- [X] All unit tests pass
- [ ] All integration tests pass
  - [![Integration Tests (Except DataStore & API)](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test.yml/badge.svg?branch=test%2Fsdk-upgrade)](https://github.com/aws-amplify/amplify-swift/actions/runs/12717946528)
  - [![Integration Tests | API - All](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_api.yml/badge.svg?branch=test%2Fsdk-upgrade)](https://github.com/aws-amplify/amplify-swift/actions/runs/12717947542)
  - [![Integration Tests | DataStore - All](https://github.com/aws-amplify/amplify-swift/actions/workflows/integ_test_datastore.yml/badge.svg?branch=test%2Fsdk-upgrade)](https://github.com/aws-amplify/amplify-swift/actions/runs/12717948733)
- [X] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
