### PR TITLE
fix(predictions): use UTC timezone in date formatter

### DIFF
--- a/.github/workflows/build_scheme.yml
+++ b/.github/workflows/build_scheme.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Save the dependencies cache in main
         if: inputs.save_build_cache && steps.dependencies-cache.outputs.cache-hit != 'true' && github.ref_name == 'main'
-        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: ${{ steps.dependencies-cache.outputs.cache-primary-key }}
@@ -93,7 +93,7 @@ jobs:
 
       - name: Save the build cache
         if: inputs.save_build_cache && github.ref_name == 'main'
-        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
           key: ${{ steps.build-cache.outputs.cache-primary-key }}

--- a/.github/workflows/build_scheme.yml
+++ b/.github/workflows/build_scheme.yml
@@ -47,7 +47,7 @@ jobs:
         id: dependencies-cache
         timeout-minutes: 4
         continue-on-error: true
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: amplify-packages-${{ hashFiles('Package.resolved') }}
@@ -59,7 +59,7 @@ jobs:
         if: steps.dependencies-cache.outputs.cache-hit
         timeout-minutes: 4
         continue-on-error: true
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
           key: Amplify-${{ inputs.platform }}-build-cache

--- a/.github/workflows/integ_test_auth_webauthn.yml
+++ b/.github/workflows/integ_test_auth_webauthn.yml
@@ -47,7 +47,7 @@ jobs:
         id: dependencies-cache
         timeout-minutes: 4
         continue-on-error: true
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: amplify-packages-${{ hashFiles('Package.resolved') }}
@@ -59,7 +59,7 @@ jobs:
         if: steps.dependencies-cache.outputs.cache-hit
         timeout-minutes: 4
         continue-on-error: true
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
           key: Amplify-iOS-build-cache

--- a/.github/workflows/integ_test_push_notifications.yml
+++ b/.github/workflows/integ_test_push_notifications.yml
@@ -70,7 +70,7 @@ jobs:
         id: dependencies-cache
         timeout-minutes: 4
         continue-on-error: true
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: amplify-packages-${{ hashFiles('Package.resolved') }}
@@ -82,7 +82,7 @@ jobs:
         if: steps.dependencies-cache.outputs.cache-hit
         timeout-minutes: 4
         continue-on-error: true
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
           key: Amplify-${{ matrix.platform }}-build-cache

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -73,7 +73,7 @@ jobs:
         id: dependencies-cache
         timeout-minutes: 4
         continue-on-error: true
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: amplify-packages-${{ hashFiles('Package.resolved') }}
@@ -85,7 +85,7 @@ jobs:
         if: steps.dependencies-cache.outputs.cache-hit
         timeout-minutes: 4
         continue-on-error: true
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
           key: Amplify-${{ inputs.platform }}-build-cache

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -61,7 +61,7 @@ jobs:
         id: dependencies-cache
         timeout-minutes: 4
         continue-on-error: true
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData/Amplify
           key: amplify-packages-${{ hashFiles('Package.resolved') }}
@@ -73,7 +73,7 @@ jobs:
         if: steps.dependencies-cache.outputs.cache-hit
         timeout-minutes: 4
         continue-on-error: true
-        uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ github.workspace }}/Build
           key: Amplify-${{ inputs.platform }}-build-cache

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/WebSocketSession.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/WebSocketSession.swift
@@ -128,7 +128,9 @@ final class WebSocketSession {
             }
             
             let dateFormatter = DateFormatter()
+            dateFormatter.locale = Locale(identifier: "en_US_POSIX")
             dateFormatter.dateFormat = "EEE, d MMM yyyy HH:mm:ss z"
+            dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
             guard let serverDate = dateFormatter.date(from: dateString) else {
                 Amplify.log.verbose("\(#function): Error parsing Date header in expected format")
                 onServerDateReceived(nil)


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
https://github.com/aws-amplify/amplify-ui-swift-liveness/issues/189

## Description
<!-- Why is this change required? What problem does it solve? -->
AWS Amplify UI Liveness users with `en_TH` locale were observing crashes due to AWS server date being incorrectly formatted. This was occurring due to difference in parsing year in Buddhist Calendar vs. Gregorian calendar. Fix involves setting `en_US_POSIX` locale and GMT timezone in the date formatter.
https://developer.apple.com/library/archive/qa/qa1480/_index.html

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
