### PR TITLE
Fix accessing Availability.h macros in Swift (Xcode 26 support)

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ASF/ASFAppInfo.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ASF/ASFAppInfo.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AmplifyAvailability
 import Foundation
 
 struct ASFAppInfo: ASFAppInfoBehavior {
@@ -16,9 +17,9 @@ struct ASFAppInfo: ASFAppInfoBehavior {
     var targetSDK: String {
         var targetSDK: String = ""
 #if os(iOS) || os(watchOS) || os(tvOS)
-        targetSDK = "\(__IPHONE_OS_VERSION_MIN_REQUIRED)"
+        targetSDK = "\(getIOSVersionMinRequired())"
 #elseif os(macOS)
-        targetSDK = "\(__MAC_OS_X_VERSION_MIN_REQUIRED)"
+        targetSDK = "\(getMACOSXVersionMinRequired())"
 #else
         targetSDK = "Unknown"
 #endif

--- a/AmplifyPlugins/Auth/Sources/AmplifyAvailability/include/AmplifyAvailability.h
+++ b/AmplifyPlugins/Auth/Sources/AmplifyAvailability/include/AmplifyAvailability.h
@@ -1,0 +1,13 @@
+#include <Availability.h>
+
+#if TARGET_OS_IOS || TARGET_OS_WATCH || TARGET_OS_TV
+static inline int getIOSVersionMinRequired(void) {
+    return __IPHONE_OS_VERSION_MIN_REQUIRED;
+}
+#endif
+
+#if TARGET_OS_OSX
+static inline int getMACOSXVersionMinRequired(void) {
+    return __MAC_OS_X_VERSION_MIN_REQUIRED;
+}
+#endif

--- a/AmplifyPlugins/Auth/Sources/AmplifyAvailability/module.modulemap
+++ b/AmplifyPlugins/Auth/Sources/AmplifyAvailability/module.modulemap
@@ -1,0 +1,4 @@
+module AmplifyAvailability [system] {
+    header "include/AmplifyAvailability.h"
+    export *
+}

--- a/Package.swift
+++ b/Package.swift
@@ -179,6 +179,7 @@ let authTargets: [Target] = [
         name: "AWSCognitoAuthPlugin",
         dependencies: [
             .target(name: "Amplify"),
+            .target(name: "AmplifyAvailability"),
             .target(name: "AmplifySRP"),
             .target(name: "AWSPluginsCore"),
             .target(name: "InternalAmplifyCredentials"),
@@ -190,6 +191,10 @@ let authTargets: [Target] = [
         resources: [
             .copy("Resources/PrivacyInfo.xcprivacy")
         ]
+    ),
+    .systemLibrary(
+        name: "AmplifyAvailability",
+        path: "AmplifyPlugins/Auth/Sources/AmplifyAvailability"
     ),
     .target(
         name: "libtommathAmplify",


### PR DESCRIPTION
## Issue \#

#4003

## Description

Starting in Xcode 26, the Availability.h/AvailabilityInternal.h headers that contained the `__IPHONE_OS_VERSION_MIN_REQUIRED` and `__MAC_OS_X_VERSION_MIN_REQUIRED` preprocessor macros are no longer implicitly exposed to Swift code via the `os_availability`/`os_availability_internal` modules which has prevented the Amplify SDK from compiling.

I saw that the `xcode-26` branch just commented out the problematic code as a workaround, but I wanted to propose a more suitable fix that involved explicitly exposing the macro values to the AWSCognitoAuthPlugin target via a new AmplifyAvailability system library target.

The new target defines a module map that exposes the AmplifyAvailability.h header and within this header, we just redefine the Availability.h preprocessor macros via `getIOSVersionMinRequired()` and `getMACOSXVersionMinRequired()`. These new static symbols are now exposed to the Swift code and can be used instead to provide support both in Xcode 26 and older versions.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
