### PR TITLE
chore(build): resolve build warnings in amplify package

### DIFF
--- a/Amplify/DevMenu/AmplifyDevMenu.swift
+++ b/Amplify/DevMenu/AmplifyDevMenu.swift
@@ -13,7 +13,7 @@ import UIKit
 /// Presents a developer menu using the provided `DevMenuPresentationContextProvider`
 /// upon notification from a `TriggerRecognizer`. Default recognizer is a `LongPressGestureRecognizer`
 @MainActor
-public final class AmplifyDevMenu: DevMenuBehavior, TriggerDelegate {
+public final class AmplifyDevMenu: @preconcurrency DevMenuBehavior, @preconcurrency TriggerDelegate {
 
     weak var devMenuPresentationContextProvider: DevMenuPresentationContextProvider?
     var triggerRecognizer: TriggerRecognizer?

--- a/Amplify/DevMenu/View/IssueReporter.swift
+++ b/Amplify/DevMenu/View/IssueReporter.swift
@@ -97,11 +97,11 @@ struct IssueReporter: View {
     /// Open Amplify iOS issue logging screen on Github
     private func reportToGithub() {
         Task {
-            let issue = await IssueInfo(issueDescription: issueDescription,
+            let issue = IssueInfo(issueDescription: issueDescription,
                                         includeEnvInfo: includeEnvInfo,
                                         includeDeviceInfo: includeDeviceInfo)
             let issueDescriptionMarkdown =
-                await IssueInfoHelper.generateMarkdownForIssue(
+                IssueInfoHelper.generateMarkdownForIssue(
                     issue: issue)
 
             let urlString = amplifyIosNewIssueUrl + issueDescriptionMarkdown
@@ -122,10 +122,10 @@ struct IssueReporter: View {
     /// Copy issue as a markdown string to clipboard
     private func copyToClipboard() {
         Task {
-            let issue = await IssueInfo(issueDescription: issueDescription,
+            let issue = IssueInfo(issueDescription: issueDescription,
                                   includeEnvInfo: includeEnvInfo,
                                   includeDeviceInfo: includeDeviceInfo)
-            let value = await IssueInfoHelper.generateMarkdownForIssue(issue: issue)
+            let value = IssueInfoHelper.generateMarkdownForIssue(issue: issue)
             #if os(iOS)
             UIPasteboard.general.string = value
             #elseif canImport(AppKit)

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
@@ -407,7 +407,7 @@ fileprivate func toAPIError<R: Decodable>(_ errors: [Error], type: R.Type) -> AP
             GraphQLResponseError<R>.error(errors)
         )
 
-    case let errors as [WebSocketClient.Error]:
+    case _ as [WebSocketClient.Error]:
         return APIError.networkError("WebSocketClient connection aborted", nil, URLError(.networkConnectionLost))
     default:
         return APIError.operationError(

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/APISwiftCompatibility/APISwiftTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/APISwiftCompatibility/APISwiftTests.swift
@@ -13,7 +13,6 @@ final class APISwiftTests: XCTestCase {
     func testCreateBlogMutation() {
         let file = S3ObjectInput(bucket: "bucket", key: "let", region: "region")
         let input = CreateBlogInput(name: "name", file: file)
-        let condition = ModelBlogConditionInput(name: .init(eq: "name"))
         let mutation = CreateBlogMutation(input: input)
         
         let request = GraphQLRequest<CreateBlogMutation.Data>(
@@ -21,7 +20,7 @@ final class APISwiftTests: XCTestCase {
             variables: mutation.variables?.jsonObject,
             responseType: CreateBlogMutation.Data.self)
         
-        var expectedDocument = """
+        let expectedDocument = """
         mutation CreateBlog($input: CreateBlogInput!, $condition: ModelBlogConditionInput) {
           createBlog(input: $input, condition: $condition) {
             __typename

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AppSyncRealTimeClient/AppSyncRealTimeClientTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AppSyncRealTimeClient/AppSyncRealTimeClientTests.swift
@@ -554,7 +554,6 @@ class AppSyncRealTimeClientTests: XCTestCase {
 
     func testReconnect_whenHeartBeatSignalIsNotReceived() async throws {
         var cancellables = Set<AnyCancellable>()
-        let timeout = 1.0
         let mockWebSocketClient = MockWebSocketClient()
         let mockAppSyncRequestInterceptor = MockAppSyncRequestInterceptor()
         let appSyncClient = AppSyncRealTimeClient(

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -46,7 +46,7 @@ class AuthTokenURLRequestInterceptorTests: XCTestCase {
         do {
             _ = try await interceptor.intercept(request).allHTTPHeaderFields
         } catch {
-            guard case .operationError(let description, _, let underlyingError) = error as? APIError,
+            guard case .operationError(_, _, let underlyingError) = error as? APIError,
                let authError = underlyingError as? AuthError,
                case .sessionExpired = authError else {
                 XCTFail("Should be API.operationError with underlying AuthError.sessionExpired")

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLResponseDecoderPostComment4V2Tests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLResponseDecoderPostComment4V2Tests.swift
@@ -320,7 +320,7 @@ class GraphQLResponseDecoderPostComment4V2Tests: XCTestCase, SharedTestCasesPost
         XCTAssertEqual(input["postID"] as? String, post.id)
         
         let decoder = GraphQLResponseDecoder(request: request.toOperationRequest(operationType: .query))
-        var graphQLData: [String: JSONValue] = [
+        let graphQLData: [String: JSONValue] = [
             "\(request.decodePath!)": [
                 "id": "id",
                 "content": "content",

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ASF/CognitoUserPoolASF+KeyChain.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/ASF/CognitoUserPoolASF+KeyChain.swift
@@ -33,7 +33,7 @@ extension CognitoUserPoolASF {
                                asfDeviceId: String,
                                asfClient: AdvancedSecurityBehavior,
                                userPoolConfiguration: UserPoolConfigurationData) async -> String? {
-        let deviceInfo: ASFDeviceBehavior = await ASFDeviceInfo(id: asfDeviceId)
+        let deviceInfo: ASFDeviceBehavior = ASFDeviceInfo(id: asfDeviceId)
         let appInfo: ASFAppInfoBehavior = ASFAppInfo()
 
         do {

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSAuthCognitoSession.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/AWSAuthCognitoSession.swift
@@ -64,12 +64,7 @@ public struct AWSAuthCognitoSession: AuthSession,
             return .failure(AuthError.signedOut(
                             AuthPluginErrorConstants.userSubSignOutError.errorDescription,
                             AuthPluginErrorConstants.userSubSignOutError.recoverySuggestion))
-        } catch let error as AuthError {
-            return .failure(error)
         } catch {
-            let error = AuthError.unknown("""
-                            Could not retreive user sub from the fetched Cognito tokens.
-                            """)
             return .failure(error)
         }
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Errors/AuthenticationError.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Errors/AuthenticationError.swift
@@ -42,7 +42,7 @@ extension AuthenticationError: Codable {
         switch self {
         case .configuration(let message):
             try container.encode(message, forKey: .configuration)
-        case .service(let message, let error):
+        case .service(let message, _):
             try container.encode(message, forKey: .service)
         case .unknown(let message):
             try container.encode(message, forKey: .unknown)

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/CognitoASFTests/ASFDeviceInfoTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/CognitoASFTests/ASFDeviceInfoTests.swift
@@ -11,7 +11,7 @@ import XCTest
 class ASFDeviceInfoTests: XCTestCase {
 
     func testdeviceInfo() async {
-        let asf = await ASFDeviceInfo(id: "mockID")
+        let asf = ASFDeviceInfo(id: "mockID")
         let deviceFingerPrint = await asf.deviceInfo()
         XCTAssertNotNil(deviceFingerPrint)
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/CognitoASFTests/CognitoUserPoolASFTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/CognitoASFTests/CognitoUserPoolASFTests.swift
@@ -23,7 +23,7 @@ class CognitoUserPoolASFTests: XCTestCase {
     /// When: userContextData is invoked
     /// Then: A non-empty string is returned
     func testUserContextData_shouldReturnData() async throws {
-        let deviceInfo = await ASFDeviceInfo(id: "mockedDevice")
+        let deviceInfo = ASFDeviceInfo(id: "mockedDevice")
         let result = try await userPool.userContextData(
             for: "TestUser",
             deviceInfo: deviceInfo,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFederationToIdentityPoolTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFederationToIdentityPoolTests.swift
@@ -505,7 +505,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
             do {
                 _ = try (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
             }
-            catch let error as AuthError {
+            catch {
                 guard case .invalidState = error else {
                     XCTFail("Should throw Auth Error with invalid state \(error)")
                     return
@@ -585,7 +585,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
             do {
                 _ = try (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
             }
-            catch let error as AuthError {
+            catch {
                 guard case .invalidState = error else {
                     XCTFail("Should throw Auth Error with invalid state \(error)")
                     return
@@ -678,7 +678,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
             do {
                 _ = try (session as? AuthCognitoTokensProvider)?.getCognitoTokens().get()
             }
-            catch let error as AuthError {
+            catch {
                 guard case .invalidState = error else {
                     XCTFail("Should throw Auth Error with invalid state \(error)")
                     return

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorFetchDevicesTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorFetchDevicesTests.swift
@@ -20,7 +20,7 @@ class DeviceBehaviorFetchDevicesTests: BasePluginTest {
         super.setUp()
         mockIdentityProvider = MockIdentityProvider(
             mockListDevicesOutput: { _ in
-                try ListDevicesOutput()
+                ListDevicesOutput()
             }
         )
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorRememberDeviceTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/DeviceBehaviorTests/DeviceBehaviorRememberDeviceTests.swift
@@ -20,7 +20,7 @@ class DeviceBehaviorRememberDeviceTests: BasePluginTest {
         super.setUp()
         mockIdentityProvider = MockIdentityProvider(
             mockRememberDeviceResponse: { _ in
-                try UpdateDeviceStatusOutput()
+                UpdateDeviceStatusOutput()
             }
         )
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/ChangePasswordOutputResponse+Codable.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Cognito/Response/ChangePasswordOutputResponse+Codable.swift
@@ -16,7 +16,7 @@ extension ChangePasswordOutput: Codable {
 
     public init(from decoder: Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
-        guard let httpResponse = try containerValues.decodeIfPresent(HTTPResponse.self, forKey: .httpResponse) else {
+        guard (try containerValues.decodeIfPresent(HTTPResponse.self, forKey: .httpResponse)) != nil else {
             fatalError("Unable to decode http response")
         }
         self.init()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Results/AuthSignInResult+Codable.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthCodableImplementations/Results/AuthSignInResult+Codable.swift
@@ -30,7 +30,7 @@ extension AuthSignInResult: Codable {
     }
 }
 
-extension AuthSignInStep: Equatable {
+extension AuthSignInStep {
     public static func == (lhs: AuthSignInStep, rhs: AuthSignInStep) -> Bool {
         switch (lhs, rhs) {
         case (.confirmSignInWithSMSMFACode, .confirmSignInWithSMSMFACode),

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/CodableStates/AuthState+Codable.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/CodableStates/AuthState+Codable.swift
@@ -25,7 +25,6 @@ extension AuthState: Codable {
         if type == "AuthState.Configured" {
             let authenticationState = try values.decode(AuthenticationState.self, forKey: .authenticationState)
             let authorizationState = try values.decode(AuthorizationState.self, forKey: .authorizationState)
-            let signUpState = try values.decode(SignUpState.self, forKey: .signUpState)
             self = .configured(
                 authenticationState,
                 authorizationState,

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/CognitoAPIDecoding/CognitoAPIDecodingHelper.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/CognitoAPIDecoding/CognitoAPIDecodingHelper.swift
@@ -192,7 +192,7 @@ struct CognitoAPIDecodingHelper {
         switch responseType {
         case "failure":
             guard case .string(let errorType) = response["errorType"],
-                  case .string(let errorMessage) = response["errorType"] else {
+                  case .string(_) = response["errorType"] else {
                 fatalError()
             }
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStoreMigrator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStoreMigrator.swift
@@ -29,7 +29,7 @@ public struct KeychainStoreMigrator {
             try? KeychainStore(service: newAttributes.service, accessGroup: newAttributes.accessGroup)._removeAll()
         }
         
-        var updateQuery = oldAttributes.defaultGetQuery()
+        let updateQuery = oldAttributes.defaultGetQuery()
 
         var updateAttributes = [String: Any]()
         updateAttributes[KeychainStore.Constants.AttributeService] = newAttributes.service

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
@@ -334,7 +334,6 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
                                       includes: IncludedAssociations<M> = { _ in [] },
                                       limit: Int? = nil,
                                       authMode: AWSAuthorizationType? = nil) -> GraphQLRequest<List<M>> {
-        let primaryKeysOnly = (M.rootPath != nil) ? true : false
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(modelSchema: modelType.schema,
                                                                operationType: .query)
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .list))

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/WebSocket/LocalWebSocketServer.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/WebSocket/LocalWebSocketServer.swift
@@ -93,7 +93,7 @@ class LocalWebSocketServer {
 
     func sendTransientFailureToConnections() {
         self.connections.forEach {
-            var metadata = NWProtocolWebSocket.Metadata(opcode: .close)
+            let metadata = NWProtocolWebSocket.Metadata(opcode: .close)
             metadata.closeCode = .protocolCode(NWProtocolWebSocket.CloseCode.Defined.internalServerError)
             $0.send(
                 content: nil,

--- a/AmplifyPlugins/Core/AmplifyCredentials/AmplifyAWSCredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentials/AmplifyAWSCredentialsProvider.swift
@@ -12,7 +12,7 @@ import Foundation
 import Smithy
 import SmithyIdentity
 
-public class AmplifyAWSCredentialsProvider: AwsCommonRuntimeKit.CredentialsProviding {
+public class AmplifyAWSCredentialsProvider: AwsCommonRuntimeKit.CredentialsProviding, @unchecked Sendable {
 
     public func getCredentials() async throws -> AwsCommonRuntimeKit.Credentials {
         let authSession = try await Amplify.Auth.fetchAuthSession()

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/CascadeDeleteOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/CascadeDeleteOperation.swift
@@ -242,11 +242,11 @@ public class CascadeDeleteOperation<M: Model>: AsynchronousOperation, @unchecked
         return queriedModels
     }
 
-    private func collapseResults<M: Model>(
-        queryResult: DataStoreResult<[M]>?,
-        deleteResult: DataStoreResult<[M]>?,
+    private func collapseResults<Q: Model>(
+        queryResult: DataStoreResult<[Q]>?,
+        deleteResult: DataStoreResult<[Q]>?,
         associatedModels: [(ModelName, Model)]
-    ) -> DataStoreResult<QueryAndDeleteResult<M>> {
+    ) -> DataStoreResult<QueryAndDeleteResult<Q>> {
 
         guard let queryResult = queryResult else {
             return .failure(.unknown("queryResult not set during transaction", "coding error", nil))
@@ -519,8 +519,8 @@ public class CascadeDeleteOperation<M: Model>: AsynchronousOperation, @unchecked
 // MARK: - Supporting types
 extension CascadeDeleteOperation {
 
-    struct QueryAndDeleteResult<M: Model> {
-        let deletedModels: [M]
+    struct QueryAndDeleteResult<Q: Model> {
+        let deletedModels: [Q]
         let associatedModels: [(ModelName, Model)]
     }
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine+SyncRequirement.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine+SyncRequirement.swift
@@ -25,21 +25,12 @@ extension StorageEngine {
                ))
             }
 
-            guard let apiGraphQL = api as? APICategoryGraphQLBehavior else {
-                log.info("Unable to find GraphQL API plugin for syncEngine. syncEngine will not be started")
-                return .failure(.configuration(
-                    "Unable to find suitable GraphQL API plugin for syncEngine. syncEngine will not be started",
-                    "Ensure the API category has been setup and configured for your project",
-                    nil
-                ))
-            }
-
             let authPluginRequired = StorageEngine.requiresAuthPlugin(
                 api,
                 authModeStrategy: dataStoreConfiguration.authModeStrategyType
             )
             guard authPluginRequired else {
-                syncEngine.start(api: apiGraphQL, auth: nil)
+                syncEngine.start(api: api, auth: nil)
                 return .success(.successfullyInitialized)
             }
 
@@ -52,7 +43,7 @@ extension StorageEngine {
                 ))
             }
 
-            syncEngine.start(api: apiGraphQL, auth: auth)
+            syncEngine.start(api: api, auth: auth)
         }
 
         return .success(result)

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -163,7 +163,7 @@ final class InitialSyncOperation: AsynchronousOperation, @unchecked Sendable {
             return
         }
 
-        guard let api = api else {
+        guard api != nil else {
             finish(result: .failure(DataStoreError.nilAPIHandle()))
             return
         }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLStatementTests.swift
@@ -967,14 +967,6 @@ class SQLStatementTests: XCTestCase {
         where 1 = 1
           and "root"."@@postForeignKey" = ?
         """
-        let noJoin = """
-        select
-          "root"."@@primaryKey" as "@@primaryKey", "root"."id" as "id", "root"."content" as "content",
-          "root"."createdAt" as "createdAt", "root"."updatedAt" as "updatedAt", "root"."@@postForeignKey" as "@@postForeignKey"
-        from "CommentWithCompositeKey" as "root"
-        where 1 = 1
-          and "root"."@@postForeignKey" = ?
-        """
         XCTAssertEqual(statement.stringValue, expectedStatement)
     }
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/StateMachineTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/StateMachineTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import Combine
 
 // Testable import b/c StateMachine is an internal type
-@testable import AWSDataStorePlugin
+@testable @preconcurrency import AWSDataStorePlugin
 
 class StateMachineTests: XCTestCase {
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsLazyPostComment4V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsLazyPostComment4V2Tests.swift
@@ -387,7 +387,7 @@ final class StorageEngineTestsLazyPostComment4V2Tests: StorageEngineTestsBase, S
         let comment2 = LazyChildComment4V2(id: "id2", content: "content", post: post2)
         try await saveAsync(comment2)
         
-        var posts = try await queryAsync(LazyParentPost4V2.self)
+        let posts = try await queryAsync(LazyParentPost4V2.self)
         XCTAssertEqual(posts.count, 2)
         guard let postId1 = posts.first(where: { $0.id == "postId1" }) else {
             XCTFail("Couldn't find post with `postId1`")

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -791,7 +791,8 @@ class InitialSyncOperationTests: XCTestCase {
                 syncMetadataSaved.fulfill()
             }
         }
-        wait(for: [syncMetadataSaved], timeout: 1.0)
+        
+        await fulfillment(of: [syncMetadataSaved], timeout: 1.0)
 
         let apiWasQueried = expectation(description: "API was queried for a PaginatedList of AnyModel")
         let responder = QueryRequestResponder<PaginatedList<AnyModel>> { request in

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/ModelSyncedEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/ModelSyncedEventEmitterTests.swift
@@ -11,8 +11,8 @@ import Combine
 
 @testable import Amplify
 @testable import AmplifyTestCommon
-@testable import AWSPluginsCore
-@testable import AWSDataStorePlugin
+@testable @preconcurrency import AWSPluginsCore
+@testable @preconcurrency import AWSDataStorePlugin
 
 class ModelSyncedEventEmitterTests: XCTestCase {
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisherTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisherTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
-@testable import AWSDataStorePlugin
+@testable @preconcurrency import AWSDataStorePlugin
 
 final class IncomingAsyncSubscriptionEventPublisherTests: XCTestCase {
     var apiPlugin: MockAPICategoryPlugin!

--- a/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Mocks/MockAWSClientConfiguration.swift
+++ b/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Mocks/MockAWSClientConfiguration.swift
@@ -34,7 +34,7 @@ class MockEndPointResolver: EndpointResolver {
     }
 }
 
-class MockLogAgent: LogAgent {
+class MockLogAgent: LogAgent, @unchecked Sendable {
     func log(
         level: Smithy.LogAgentLevel,
         message: @autoclosure () -> String,

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/ActivityTrackerTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/ActivityTrackerTests.swift
@@ -80,8 +80,8 @@ class ActivityTrackerTests: XCTestCase {
         stateMachine.processExpectation = expectation(description: "Application state changed")
         stateMachine.processExpectation?.expectedFulfillmentCount = 3
         
-        NotificationCenter.default.post(Notification(name: Self.applicationDidMoveToBackgroundNotification))
-        NotificationCenter.default.post(Notification(name: Self.applicationWillMoveToForegoundNotification))
+        await NotificationCenter.default.post(Notification(name: Self.applicationDidMoveToBackgroundNotification))
+        await NotificationCenter.default.post(Notification(name: Self.applicationWillMoveToForegoundNotification))
         await NotificationCenter.default.post(Notification(name: Self.applicationWillTerminateNotification))
         
         await fulfillment(of: [stateMachine.processExpectation!], timeout: 1)

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AnalyticsClientTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AnalyticsClientTests.swift
@@ -152,7 +152,7 @@ class AnalyticsClientTests: XCTestCase {
     }
 }
 
-private class MockTransaction: SKPaymentTransaction {
+private class MockTransaction: SKPaymentTransaction, @unchecked Sendable {
     private let _transactionId: String
     private let _payment: SKPayment
     private class MockPayment: SKPayment {
@@ -183,7 +183,7 @@ private class MockTransaction: SKPaymentTransaction {
     }
 }
 
-private class MockProduct: SKProduct {
+private class MockProduct: SKProduct, @unchecked Sendable {
     private let _productId: String
     private let _price: Double
 

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EndpointClientTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EndpointClientTests.swift
@@ -182,7 +182,6 @@ class EndpointClientTests: XCTestCase {
     func testConvertToPublicEndpoint_shouldReturnPublicEndpoint() async {
         let endpointProfile = await endpointClient.currentEndpointProfile()
         let publicEndpoint = endpointClient.convertToPublicEndpoint(endpointProfile)
-        let mockModel = MockEndpointInformationProvider()
         XCTAssertNotNil(publicEndpoint)
         XCTAssertNil(publicEndpoint.address)
         XCTAssertEqual(publicEndpoint.attributes?.count, 0)

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EventRecorderTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EventRecorderTests.swift
@@ -136,7 +136,7 @@ class EventRecorderTests: XCTestCase {
         storage.events = [ event1, event2 ]
         pinpointClient.putEventsResult = .failure(NonRetryableError())
         do {
-            let events = try await recorder.submitAllEvents()
+            _ = try await recorder.submitAllEvents()
             XCTFail("Expected error")
         } catch {
             XCTAssertEqual(pinpointClient.putEventsCount, 1)
@@ -160,7 +160,7 @@ class EventRecorderTests: XCTestCase {
         storage.events = [ event1, event2 ]
         pinpointClient.putEventsResult = .failure(RetryableError())
         do {
-            let events = try await recorder.submitAllEvents()
+            _ = try await recorder.submitAllEvents()
             XCTFail("Expected error")
         } catch {
             XCTAssertEqual(pinpointClient.putEventsCount, 1)
@@ -184,7 +184,7 @@ class EventRecorderTests: XCTestCase {
         storage.events = [ event1, event2 ]
         pinpointClient.putEventsResult = .failure(ConnectivityError())
         do {
-            let events = try await recorder.submitAllEvents()
+            _ = try await recorder.submitAllEvents()
             XCTFail("Expected error")
         } catch {
             XCTAssertEqual(pinpointClient.putEventsCount, 1)
@@ -210,7 +210,7 @@ private struct NonRetryableError: Error, ModeledError {
     static var isThrottling = false
 }
 
-private class ConnectivityError: NSError {
+private class ConnectivityError: NSError, @unchecked Sendable {
     init() {
         super.init(
             domain: "ConnectivityError",

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/PinpointRequestsRegistryTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/PinpointRequestsRegistryTests.swift
@@ -103,7 +103,7 @@ private class MockHttpClientEngine: HTTPClient {
     func close() async {}
 }
 
-private class MockLogAgent: LogAgent {
+private class MockLogAgent: LogAgent, @unchecked Sendable {
     let name = "MockLogAgent"
     var level: LogAgentLevel = .info
 

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingSessionControllerTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingSessionControllerTests.swift
@@ -39,7 +39,6 @@ final class AWSCloudWatchLoggingSessionControllerTests: XCTestCase {
     /// When: a flush log is called and fails to flush logs
     /// Then: a flushLogFailure Hub Event is sent to the Logging channel
     func testConsumeFailureSendsHubEvent() async throws {
-        throw XCTSkip("Temporarily disabling test which only fails on GitHub CI/CD")
         let hubEventExpectation = expectation(description: "Should receive the hub event")
         unsubscribeToken = Amplify.Hub.listen(to: .logging) { payload in
             switch payload.eventName {

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/CloudWatchLogConsumerTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/CloudWatchLogConsumerTests.swift
@@ -27,7 +27,7 @@ final class CloudWatchLogConsumerTests: XCTestCase {
         client = MockCloudWatchLogsClient()
         logGroupName = UUID().uuidString
         logStreamName = UUID().uuidString
-        systemUnderTest = await CloudWatchLoggingConsumer(client: client, logGroupName: logGroupName, userIdentifier: "guest")
+        systemUnderTest = CloudWatchLoggingConsumer(client: client, logGroupName: logGroupName, userIdentifier: "guest")
     }
     
     override func tearDown() async throws {

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogRotationTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogRotationTests.swift
@@ -178,7 +178,7 @@ final class LogRotationTests: XCTestCase {
         XCTAssertEqual(systemUnderTest.currentLogFile.fileURL.lastPathComponent, "amplify.1.log")
         try systemUnderTest.rotate()
         
-        var rotatedContents = try FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+        let rotatedContents = try FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
         XCTAssertEqual(rotatedContents.map { $0.lastPathComponent }, [
             "amplify.2.log",
             "amplify.1.log",

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/LivenessTests/LivenessDecodingTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/LivenessTests/LivenessDecodingTests.swift
@@ -207,7 +207,7 @@ class LivenessDecodingTests: XCTestCase {
                 XCTFail("Input JSON is invalid")
                 return
             }
-            let serverSessionInformationEvent = try JSONDecoder().decode(
+            _ = try JSONDecoder().decode(
                 ServerSessionInformationEvent.self, from: data
             )
             

--- a/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/Mocks/MockOperationQueue.swift
+++ b/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/Mocks/MockOperationQueue.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-public class MockOperationQueue: OperationQueue {
+public class MockOperationQueue: OperationQueue, @unchecked Sendable {
 
     public var size = 0
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockOperationQueue.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Mocks/MockOperationQueue.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-public class MockOperationQueue: OperationQueue {
+public class MockOperationQueue: OperationQueue, @unchecked Sendable {
 
     public var size = 0
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests.swift
@@ -270,7 +270,6 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
         let filePath = NSTemporaryDirectory() + UUID().uuidString + ".tmp"
         let fileURL = URL(fileURLWithPath: filePath)
         FileManager.default.createFile(atPath: filePath, contents: testData, attributes: nil)
-        let expectedUploadSource = UploadSource.local(fileURL)
         let metadata = ["mykey": "Value"]
 
         let options = StorageUploadFileRequest.Options(accessLevel: .protected,
@@ -316,7 +315,6 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
         let filePath = NSTemporaryDirectory() + UUID().uuidString + ".tmp"
         let fileURL = URL(fileURLWithPath: filePath)
         FileManager.default.createFile(atPath: filePath, contents: testData, attributes: nil)
-        let expectedUploadSource = UploadSource.local(fileURL)
         let metadata = ["mykey": "Value"]
 
         let options = StorageUploadFileRequest.Options(accessLevel: .protected,
@@ -408,7 +406,6 @@ class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
         let filePath = NSTemporaryDirectory() + UUID().uuidString + ".tmp"
         let fileURL = URL(fileURLWithPath: filePath)
         FileManager.default.createFile(atPath: filePath, contents: testData, attributes: nil)
-        let expectedUploadSource = UploadSource.local(fileURL)
         let metadata = ["mykey": "Value"]
 
         let options = StorageUploadFileRequest.Options(accessLevel: .protected,

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileHandleTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileHandleTests.swift
@@ -19,7 +19,6 @@ class FileHandleTests: XCTestCase {
         let sourceFile = try createFile(from: sourceData)
         XCTAssertEqual(try StorageRequestUtils.getSize(sourceFile), UInt64(sourceString.count))
         
-        let fileSystem = FileSystem()
         let bytesReadLimit = 2
         
         let fileHandle = try FileHandle(forReadingFrom: sourceFile)

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -31,7 +31,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
 
         if let responder = responders[.saveModelListener] as? SaveModelResponder<M> {
             Task {
-                if let callback = await responder.callback((model: model,
+                if let callback = responder.callback((model: model,
                                                       where: condition)) {
                     completion(callback)
                 }
@@ -52,7 +52,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
 
         if let responder = responders[.queryByIdListener] as? QueryByIdResponder<M> {
             Task {
-                if let callback = await responder.callback((modelType: modelType, id: id)) {
+                if let callback = responder.callback((modelType: modelType, id: id)) {
                     completion(callback)
                 }
             }
@@ -73,7 +73,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
 
         if let responder = responders[.queryByIdListener] as? QueryByIdResponder<M> {
             Task {
-                if let callback = await responder.callback((modelType: modelType, id: id)) {
+                if let callback = responder.callback((modelType: modelType, id: id)) {
                     completion(callback)
                 }
             }
@@ -96,7 +96,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
 
         if let responder = responders[.queryModelsListener] as? QueryModelsResponder<M> {
             Task {
-                if let result = await responder.callback((modelType: modelType,
+                if let result = responder.callback((modelType: modelType,
                                                     where: predicate,
                                                     sort: sortInput,
                                                     paginate: paginationInput)) {
@@ -113,7 +113,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         notify("queryByPredicate")
         
         if let responder = responders[.queryModelsListener] as? QueryModelsResponder<M> {
-            if let result = await responder.callback((modelType: modelType,
+            if let result = responder.callback((modelType: modelType,
                                                   where: predicate,
                                                   sort: sortInput,
                                                   paginate: paginationInput)) {
@@ -136,7 +136,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
 
        if let responder = responders[.queryByIdListener] as? QueryByIdResponder<M> {
            Task {
-               if let callback = await responder.callback((modelType: modelType, id: id.stringValue)) {
+               if let callback = responder.callback((modelType: modelType, id: id.stringValue)) {
                    completion(callback)
                }
            }
@@ -158,7 +158,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
 
         if let responder = responders[.deleteByIdListener] as? DeleteByIdResponder<M> {
             Task {
-                if let callback = await responder.callback((modelType: modelType, id: id)) {
+                if let callback = responder.callback((modelType: modelType, id: id)) {
                     completion(callback)
                 }
             }
@@ -180,7 +180,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
 
         if let responder = responders[.deleteByIdListener] as? DeleteByIdResponder<M> {
             Task {
-                if let callback = await responder.callback((modelType: modelType, id: id)) {
+                if let callback = responder.callback((modelType: modelType, id: id)) {
                     completion(callback)
                 }
             }
@@ -202,7 +202,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
 
         if let responder = responders[.deleteByIdListener] as? DeleteByIdResponder<M> {
             Task {
-                if let callback = await responder.callback((modelType: modelType, id: id.stringValue)) {
+                if let callback = responder.callback((modelType: modelType, id: id.stringValue)) {
                     completion(callback)
                 }
             }
@@ -222,7 +222,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
 
         if let responder = responders[.deleteModelTypeListener] as? DeleteModelTypeResponder<M> {
             Task {
-                if let callback = await responder.callback((modelType: modelType, where: predicate)) {
+                if let callback = responder.callback((modelType: modelType, where: predicate)) {
                     completion(callback)
                 }
             }
@@ -241,7 +241,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
 
         if let responder = responders[.deleteModelListener] as? DeleteModelResponder<M> {
             Task {
-                if let callback = await responder.callback((model: model,
+                if let callback = responder.callback((model: model,
                                                       where: predicate)) {
                     completion(callback)
                 }
@@ -259,7 +259,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
 
         if let responder = responders[.clearListener] as? ClearResponder {
             Task {
-                if let callback = await responder.callback(()) {
+                if let callback = responder.callback(()) {
                     completion(callback)
                 }
             }
@@ -275,7 +275,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
 
         if let responder = responders[.clearListener] as? ClearResponder {
             Task {
-                if let callback = await responder.callback(()) {
+                if let callback = responder.callback(()) {
                     completion(callback)
                 }
             }
@@ -291,7 +291,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
 
         if let responder = responders[.stopListener] as? StopResponder {
             Task {
-                if let callback = await responder.callback(()) {
+                if let callback = responder.callback(()) {
                     completion(callback)
                 }
             }

--- a/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
@@ -394,7 +394,7 @@ class MockDispatchingStorageDownloadFileOperation: AmplifyInProcessReportingOper
     Progress,
     Void,
     StorageError
->, StorageDownloadFileOperation {
+>, StorageDownloadFileOperation, @unchecked Sendable {
     init(request: Request, progressListener: ProgressListener? = nil, resultListener: ResultListener? = nil) {
         super.init(categoryType: .storage,
                    eventName: HubPayload.EventName.Storage.downloadFile,
@@ -418,7 +418,7 @@ class MockDispatchingStorageDownloadDataOperation: AmplifyInProcessReportingOper
     Progress,
     Data,
     StorageError
->, StorageDownloadDataOperation {
+>, StorageDownloadDataOperation, @unchecked Sendable {
     init(request: Request, progressListener: ProgressListener? = nil, resultListener: ResultListener? = nil) {
         super.init(categoryType: .storage,
                    eventName: HubPayload.EventName.Storage.downloadData,
@@ -440,7 +440,7 @@ class MockDispatchingStorageGetURLOperation: AmplifyOperation<
     StorageGetURLRequest,
     URL,
     StorageError
->, StorageGetURLOperation {
+>, StorageGetURLOperation, @unchecked Sendable {
     init(request: Request, resultListener: ResultListener? = nil) {
         super.init(categoryType: .storage,
                    eventName: HubPayload.EventName.Storage.getURL,
@@ -457,7 +457,7 @@ class MockDispatchingStorageListOperation: AmplifyOperation<
     StorageListRequest,
     StorageListResult,
     StorageError
->, StorageListOperation {
+>, StorageListOperation, @unchecked Sendable {
     init(request: Request, resultListener: ResultListener? = nil) {
         super.init(categoryType: .storage,
                    eventName: HubPayload.EventName.Storage.list,
@@ -474,7 +474,7 @@ class MockDispatchingStorageRemoveOperation: AmplifyOperation<
     StorageRemoveRequest,
     String,
     StorageError
->, StorageRemoveOperation {
+>, StorageRemoveOperation, @unchecked Sendable {
     init(request: Request, resultListener: ResultListener? = nil) {
         super.init(categoryType: .storage,
                    eventName: HubPayload.EventName.Storage.remove,
@@ -493,7 +493,7 @@ class MockDispatchingStorageUploadDataOperation: AmplifyInProcessReportingOperat
     Progress,
     String,
     StorageError
->, StorageUploadDataOperation {
+>, StorageUploadDataOperation, @unchecked Sendable {
     init(request: Request, progressListener: ProgressListener? = nil, resultListener: ResultListener? = nil) {
         super.init(categoryType: .storage,
                    eventName: HubPayload.EventName.Storage.uploadData,
@@ -517,7 +517,7 @@ class MockDispatchingStorageUploadFileOperation: AmplifyInProcessReportingOperat
     Progress,
     String,
     StorageError
->, StorageUploadFileOperation {
+>, StorageUploadFileOperation, @unchecked Sendable {
     init(request: Request, progressListener: ProgressListener? = nil, resultListener: ResultListener? = nil) {
         super.init(categoryType: .storage,
                    eventName: HubPayload.EventName.Storage.uploadFile,
@@ -539,7 +539,7 @@ class NonListeningStorageListOperation: AmplifyOperation<
     StorageListRequest,
     StorageListResult,
     StorageError
->, StorageListOperation {
+>, StorageListOperation, @unchecked Sendable {
     init(request: Request) {
         super.init(categoryType: .storage,
                    eventName: HubPayload.EventName.Storage.downloadFile,

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginConcurrencyTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginConcurrencyTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import Amplify
+@testable @preconcurrency import Amplify
 @testable import AmplifyTestCommon
 
 class DefaultHubPluginConcurrencyTests: XCTestCase {

--- a/AmplifyTests/CoreTests/AmplifyInProcessReportingOperationCombineTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyInProcessReportingOperationCombineTests.swift
@@ -152,7 +152,7 @@ class MockPublisherInProcessOperation: AmplifyInProcessReportingOperation<
     String,
     Int,
     APIError
-> {
+>, @unchecked Sendable {
     typealias Responder = (MockPublisherInProcessOperation) -> Void
     let responder: Responder
 

--- a/AmplifyTests/CoreTests/AmplifyOperationCombineTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyOperationCombineTests.swift
@@ -265,7 +265,7 @@ extension HubPayloadEventName {
     static var mockPublisherOperation = "MockPublisherOperation"
 }
 
-class MockPublisherOperation: AmplifyOperation<MockPublisherRequest, Int, APIError> {
+class MockPublisherOperation: AmplifyOperation<MockPublisherRequest, Int, APIError>, @unchecked Sendable {
     typealias Responder = (MockPublisherOperation) -> Void
     let responder: Responder
 

--- a/AmplifyTests/CoreTests/Operations/FastOperation.swift
+++ b/AmplifyTests/CoreTests/Operations/FastOperation.swift
@@ -69,7 +69,7 @@ public enum FastOperationError: AmplifyError {
 public typealias FastOperationResult = Result<FastOperationSuccess, FastOperationError>
 public typealias FastOperationResultListener = (FastOperationResult) -> Void
 
-public class FastOperation: AmplifyOperation<FastOperationRequest, FastOperationSuccess, FastOperationError> {
+public class FastOperation: AmplifyOperation<FastOperationRequest, FastOperationSuccess, FastOperationError>, @unchecked Sendable {
     public typealias TaskAdapter = AmplifyOperationTaskAdapter<Request, Success, Failure>
 #if canImport(Combine)
     public typealias ResultPublisher = AnyPublisher<Success, Failure>

--- a/AmplifyTests/CoreTests/Operations/LongOperation.swift
+++ b/AmplifyTests/CoreTests/Operations/LongOperation.swift
@@ -70,7 +70,7 @@ public typealias LongOperationResult = Result<LongOperationSuccess, LongOperatio
 public typealias LongOperationProgressListener = (Progress) -> Void
 public typealias LongOperationResultListener = (LongOperationResult) -> Void
 
-public class LongOperation: AmplifyInProcessReportingOperation<LongOperationRequest, Progress, LongOperationSuccess, LongOperationError> {
+public class LongOperation: AmplifyInProcessReportingOperation<LongOperationRequest, Progress, LongOperationSuccess, LongOperationError>, @unchecked Sendable {
     public typealias TaskAdapter = AmplifyInProcessReportingOperationTaskAdapter<Request, InProcess, Success, Failure>
 #if canImport(Combine)
     public typealias ResultPublisher = AnyPublisher<Success, Failure>


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
None

## Description
<!-- Why is this change required? What problem does it solve? -->
This PR resolves a number of build warnings in Xcode 16 across the entire Amplify package and targets.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
