### PR TITLE
updated RefreshUserPoolTokens to use GetTokensFromRefreshToken API to…

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/CognitoUserPoolBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/CognitoUserPoolBehavior.swift
@@ -29,6 +29,9 @@ protocol CognitoUserPoolBehavior {
     /// Throws RevokeTokenOutputError
     func revokeToken(input: RevokeTokenInput) async throws -> RevokeTokenOutput
 
+    /// Throws GetTokensFromRefreshTokenOutputError
+    func getTokensFromRefreshToken(input: GetTokensFromRefreshTokenInput) async throws -> GetTokensFromRefreshTokenOutput
+
     // MARK: - User Attribute API's
 
     /// Throws GetUserAttributeVerificationCodeOutputError

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockIdentityProvider.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockIdentityProvider.swift
@@ -20,6 +20,9 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
     typealias MockInitiateAuthResponse = (InitiateAuthInput) async throws
     -> InitiateAuthOutput
 
+    typealias MockGetTokensFromRefreshTokenResponse = (GetTokensFromRefreshTokenInput) async throws
+    -> GetTokensFromRefreshTokenOutput
+
     typealias MockConfirmSignUpResponse = (ConfirmSignUpInput) async throws
     -> ConfirmSignUpOutput
 
@@ -88,6 +91,7 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
     let mockSignUpResponse: MockSignUpResponse?
     let mockRevokeTokenResponse: MockRevokeTokenResponse?
     let mockInitiateAuthResponse: MockInitiateAuthResponse?
+    let mockGetTokensFromRefreshTokenResponse: MockGetTokensFromRefreshTokenResponse?
     let mockGlobalSignOutResponse: MockGlobalSignOutResponse?
     let mockConfirmSignUpResponse: MockConfirmSignUpResponse?
     let mockRespondToAuthChallengeResponse: MockRespondToAuthChallengeResponse?
@@ -116,6 +120,7 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
         mockSignUpResponse: MockSignUpResponse? = nil,
         mockRevokeTokenResponse: MockRevokeTokenResponse? = nil,
         mockInitiateAuthResponse: MockInitiateAuthResponse? = nil,
+        mockGetTokensFromRefreshTokenResponse: MockGetTokensFromRefreshTokenResponse? = nil,
         mockGlobalSignOutResponse: MockGlobalSignOutResponse? = nil,
         mockConfirmSignUpResponse: MockConfirmSignUpResponse? = nil,
         mockRespondToAuthChallengeResponse: MockRespondToAuthChallengeResponse? = nil,
@@ -139,6 +144,7 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
         self.mockSignUpResponse = mockSignUpResponse
         self.mockRevokeTokenResponse = mockRevokeTokenResponse
         self.mockInitiateAuthResponse = mockInitiateAuthResponse
+        self.mockGetTokensFromRefreshTokenResponse = mockGetTokensFromRefreshTokenResponse
         self.mockGlobalSignOutResponse = mockGlobalSignOutResponse
         self.mockConfirmSignUpResponse = mockConfirmSignUpResponse
         self.mockRespondToAuthChallengeResponse = mockRespondToAuthChallengeResponse
@@ -190,6 +196,11 @@ struct MockIdentityProvider: CognitoUserPoolBehavior {
     /// Throws RevokeTokenOutputError
     func revokeToken(input: RevokeTokenInput) async throws -> RevokeTokenOutput {
         return try await mockRevokeTokenResponse!(input)
+    }
+
+    /// Throws GetTokensFromRefreshTokenOutputError
+    func getTokensFromRefreshToken(input: GetTokensFromRefreshTokenInput) async throws -> GetTokensFromRefreshTokenOutput {
+        return try await mockGetTokensFromRefreshTokenResponse!(input)
     }
 
     func getUserAttributeVerificationCode(input: GetUserAttributeVerificationCodeInput) async throws -> GetUserAttributeVerificationCodeOutput {

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-sdk-swift",
       "state" : {
-        "revision" : "f812c7441555058da0fcecf5314780c1770b11a1",
-        "version" : "1.5.14"
+        "revision" : "8b5336764297d34157bd580374b5f6e182746759",
+        "version" : "1.5.18"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "85bfbaff8a77ffc0415878de50186e6cfea30a04",
-        "version" : "0.151.0"
+        "revision" : "a6cac0739d76ef08e2d927febc682d9898e76fe2",
+        "version" : "0.152.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let platforms: [SupportedPlatform] = [
     .watchOS(.v9)
 ]
 let dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/awslabs/aws-sdk-swift", exact: "1.5.14"),
+    .package(url: "https://github.com/awslabs/aws-sdk-swift", exact: "1.5.18"),
     .package(url: "https://github.com/stephencelis/SQLite.swift.git", exact: "0.15.3"),
     .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting.git", from: "2.1.0"),
     .package(url: "https://github.com/aws-amplify/amplify-swift-utils-notifications.git", from: "1.1.0")


### PR DESCRIPTION
… enable refresh token rotation, also updated test mock clients and added unit tests

## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Build succeeds with all target using Swift Package Manager
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
