### PR TITLE
chore(build): update setup-ruby github action for macos-15 runners

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -40,7 +40,7 @@ jobs:
         run: amplify init --quickstart --frontend ios
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
+        uses: ruby/setup-ruby@efbf473cab83af4468e8606cc33eca9281bb213f # v1.256.0
         with:
           ruby-version: '3.2.1'
           bundler-cache: true

--- a/.github/workflows/deploy_package.yml
+++ b/.github/workflows/deploy_package.yml
@@ -67,7 +67,7 @@ jobs:
           token: ${{steps.retrieve-token.outputs.token}}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
+        uses: ruby/setup-ruby@efbf473cab83af4468e8606cc33eca9281bb213f # v1.256.0
         with:
           ruby-version: '3.2.1'
           bundler-cache: true

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -63,7 +63,7 @@ jobs:
           token: ${{steps.retrieve-token.outputs.token}}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
+        uses: ruby/setup-ruby@efbf473cab83af4468e8606cc33eca9281bb213f # v1.256.0
         with:
           ruby-version: '3.2.1'
           bundler-cache: true

--- a/.github/workflows/deploy_unstable.yml
+++ b/.github/workflows/deploy_unstable.yml
@@ -63,7 +63,7 @@ jobs:
           token: ${{steps.retrieve-token.outputs.token}}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
+        uses: ruby/setup-ruby@efbf473cab83af4468e8606cc33eca9281bb213f # v1.256.0
         with:
           ruby-version: '3.2.1'
           bundler-cache: true

--- a/.github/workflows/release_doc.yml
+++ b/.github/workflows/release_doc.yml
@@ -36,7 +36,7 @@ jobs:
           token: ${{steps.retrieve-token.outputs.token}}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
+        uses: ruby/setup-ruby@efbf473cab83af4468e8606cc33eca9281bb213f # v1.256.0
         with:
           ruby-version: '3.2.1'
           bundler-cache: true


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
Github actions are failing for setup-ruby after updating runners to macos-latest which correspond to macos-15 now.
https://github.com/aws-amplify/amplify-swift/actions/runs/17246673926

## Description
<!-- Why is this change required? What problem does it solve? -->
Updating setup-ruby to `v1.256.0`.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
