### PR TITLE
chore(build): increase timeout on flaky unit tests

### DIFF
--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingMonitorTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingMonitorTests.swift
@@ -31,7 +31,7 @@ final class AWSCloudWatchLoggingMonitorTests: XCTestCase {
     /// Then: the delegate is autoamtically invoked
     func testDelegateIsInvokedOnInterval() async {
         monitor.setAutomaticFlushIntervals()
-        await fulfillment(of: [invokedExpectation], timeout: 3)
+        await fulfillment(of: [invokedExpectation], timeout: 10)
     }
 }
 

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingSessionControllerTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingSessionControllerTests.swift
@@ -69,7 +69,7 @@ final class AWSCloudWatchLoggingSessionControllerTests: XCTestCase {
         systemUnderTest.client = mockCloudWatchLogClient
         systemUnderTest.enable()
         try await systemUnderTest.flushLogs()
-        await fulfillment(of: [hubEventExpectation], timeout: 2)
+        await fulfillment(of: [hubEventExpectation], timeout: 10)
     }
 
     private func getLogFile() -> URL {

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/DefaultStorageTransferDatabaseTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/DefaultStorageTransferDatabaseTests.swift
@@ -217,7 +217,7 @@ class DefaultStorageTransferDatabaseTests: XCTestCase {
             }
             expectation.fulfill()
         }
-        await fulfillment(of: [expectation], timeout: 5)
+        await fulfillment(of: [expectation], timeout: 10)
     }
 
     /// Given: A DefaultStorageTransferDatabase
@@ -228,7 +228,7 @@ class DefaultStorageTransferDatabaseTests: XCTestCase {
         database.prepareForBackground() {
             expectation.fulfill()
         }
-        await fulfillment(of: [expectation], timeout: 5)
+        await fulfillment(of: [expectation], timeout: 10)
     }
 
     /// Given: The StorageTransferDatabase Type


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->

## Description
<!-- Why is this change required? What problem does it solve? -->
Increasing timeouts on following tests which keep failing on CI/CD but pass on local machines.
```
AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingMonitorTests.swift
- testDelegateIsInvokedOnInterval()

AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingSessionControllerTests.swift
- testConsumeFailureSendsHubEvent()

AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/DefaultStorageTransferDatabaseTests.swift
- func testLoadPersistableTasks()
- func testPrepareForBackground()
```

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
