### PR TITLE
chore(auth): update AppSyncSigner

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+AppSyncSigner.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin+AppSyncSigner.swift
@@ -31,8 +31,7 @@ extension AWSCognitoAuthPlugin {
         return { request in
             try await signAppSyncRequest(
                 request,
-
-                                         region: region
+                region: region
             )
         }
     }
@@ -113,8 +112,6 @@ extension AWSCognitoAuthPlugin {
         }
 
         var headers = urlRequest.allHTTPHeaderFields ?? [:]
-        headers.updateValue(host, forKey: "host")
-
         let httpMethod = (urlRequest.httpMethod?.uppercased())
             .flatMap(HTTPMethodType.init(rawValue:)) ?? .get
 


### PR DESCRIPTION
## Issue \#
<!-- If applicable, please link to issue(s) this change addresses -->
None

## Description
<!-- Why is this change required? What problem does it solve? -->
Update `AWSCognitoAuthPlugin+AppSyncSigner` signing logic to make it usable for both `aws-appsync-events-swift` and `aws-appsync-apollo-extensions-swift` repositories. The setting of `host` field in `URLRequest` headers before calling the SigV4 signing logic is now delegated to the individual repositories.

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [x] Build succeeds with all target using Swift Package Manager
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
