### PR TITLE
fix(storage): address multipart upload thread safety and file-size crashes

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/FileSystem.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/FileSystem.swift
@@ -164,11 +164,11 @@ class FileSystem {
     /// Returns the size in bytes of a file.
     /// - Parameter fileURL: URL of the file
     /// - Returns: size of file in bytes
-    func getFileSize(fileURL: URL) -> UInt64 {
-        guard let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
-              let size = attributes[.size] as? UInt64
-        else {
-            Fatal.require("File size should always be accessible")
+    /// - Throws: an error if the file is missing or its size attribute cannot be read.
+    func getFileSize(fileURL: URL) throws -> UInt64 {
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        guard let size = attributes[.size] as? UInt64 else {
+            throw Failure.fatalError(errorDescription: "File size not available for \(fileURL.lastPathComponent)")
         }
         return size
     }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadSession.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadSession.swift
@@ -116,10 +116,11 @@ class StorageMultipartUploadSession {
     }
 
     func restart() {
-        guard let uploadFile = multipartUpload.uploadFile,
-              let uploadId = multipartUpload.uploadId,
-              let partSize = multipartUpload.partSize,
-              let parts = multipartUpload.parts
+        let snapshot = serialQueue.sync { multipartUpload }
+        guard let uploadFile = snapshot.uploadFile,
+              let uploadId = snapshot.uploadId,
+              let partSize = snapshot.partSize,
+              let parts = snapshot.parts
         else {
             return
         }
@@ -127,7 +128,7 @@ class StorageMultipartUploadSession {
     }
 
     func createSubTask(partNumber: PartNumber) -> StorageTransferTask {
-        guard let uploadId = multipartUpload.uploadId else {
+        guard let uploadId = (serialQueue.sync { multipartUpload.uploadId }) else {
             fatalError()
         }
         let transferType: StorageTransferType = .multiPartUploadPart(uploadId: uploadId, partNumber: partNumber)
@@ -193,15 +194,15 @@ class StorageMultipartUploadSession {
     }
 
     var isPaused: Bool {
-        multipartUpload.isPaused
+        serialQueue.sync { multipartUpload.isPaused }
     }
 
     var isAborted: Bool {
-        multipartUpload.isAborted
+        serialQueue.sync { multipartUpload.isAborted }
     }
 
     var isCompleted: Bool {
-        multipartUpload.isCompleted
+        serialQueue.sync { multipartUpload.isCompleted }
     }
 
     func part(for number: PartNumber) -> StorageUploadPart? {
@@ -259,9 +260,12 @@ class StorageMultipartUploadSession {
     }
 
     func fail(error: Error) {
+        dispatchPrecondition(condition: .notOnQueue(serialQueue))
         logger.debug("Multipart Upload Failure: \(error)")
-        logger.debug("Multipart Upload: \(multipartUpload)")
-        multipartUpload.fail(error: error)
+        serialQueue.sync {
+            logger.debug("Multipart Upload: \(multipartUpload)")
+            multipartUpload.fail(error: error)
+        }
         onEvent(.failed(StorageError(error: error)))
     }
 
@@ -269,16 +273,17 @@ class StorageMultipartUploadSession {
         logger.debug("\(#function): \(multipartUploadEvent)")
 
         do {
-            let wasPaused = multipartUpload.isPaused
-
-            try serialQueue.sync {
+            // Capture pre-transition flag and post-transition state under the
+            // serial queue so we never read `multipartUpload` outside the lock.
+            // Subsequent branching operates on the captured snapshot.
+            let (wasPaused, snapshot): (Bool, StorageMultipartUpload) = try serialQueue.sync {
+                let wasPaused = multipartUpload.isPaused
                 try multipartUpload.transition(multipartUploadEvent: multipartUploadEvent)
-
-                // update the transerTask with every state transition
                 transferTask.multipartUpload = multipartUpload
+                return (wasPaused, multipartUpload)
             }
 
-            switch multipartUpload {
+            switch snapshot {
             case .parts(let uploadId, let uploadFile, let partSize, let parts):
                 if wasPaused {
                     logger.debug("Resuming after being paused")
@@ -295,10 +300,10 @@ class StorageMultipartUploadSession {
             case .completed:
                 cancelProgressStallTimer()
                 onEvent(.completed(()))
-            case .aborting(_, let error):
+            case .aborting(let uploadId, let error):
                 cancelationError = error
                 cancelProgressStallTimer()
-                try abort()
+                try client.abortMultipartUpload(uploadId: uploadId)
             case .aborted(_, let error):
                 onEvent(.failed(StorageError.unknown("Unable to upload", cancelationError ?? error)))
             case .failed(_, _, let error):
@@ -307,7 +312,7 @@ class StorageMultipartUploadSession {
             default:
                 break
             }
-            logger.verbose("MultipartUpload State: \(multipartUpload)")
+            logger.verbose("MultipartUpload State: \(snapshot)")
         } catch {
             fail(error: error)
         }
@@ -318,19 +323,25 @@ class StorageMultipartUploadSession {
         logger.debug("\(#function): \(uploadPartEvent)")
 
         do {
-            if case .failed = multipartUpload {
-                logger.debug("Multipart Upload is failed and event cannot be handled: \(uploadPartEvent)")
-                return
-            } else if case .paused = multipartUpload {
-                logger.debug("Multipart Upload is paused and event cannot be handled: \(uploadPartEvent)")
-                return
+            // Capture post-transition state under the serial queue. A sentinel
+            // `nil` result means the pre-transition state was .failed/.paused
+            // and we should drop the event. All subsequent branching operates
+            // on the local snapshot, never on `self.multipartUpload`.
+            let snapshot: StorageMultipartUpload? = try serialQueue.sync {
+                if case .failed = multipartUpload {
+                    logger.debug("Multipart Upload is failed and event cannot be handled: \(uploadPartEvent)")
+                    return nil
+                }
+                if case .paused = multipartUpload {
+                    logger.debug("Multipart Upload is paused and event cannot be handled: \(uploadPartEvent)")
+                    return nil
+                }
+                try multipartUpload.transition(uploadPartEvent: uploadPartEvent)
+                transferTask.multipartUpload = multipartUpload
+                return multipartUpload
             }
 
-            try serialQueue.sync {
-                try multipartUpload.transition(uploadPartEvent: uploadPartEvent)
-                // update the transferTask with every state transition
-                transferTask.multipartUpload = multipartUpload
-            }
+            guard let snapshot else { return }
 
             switch uploadPartEvent {
             case .progressUpdated, .completed:
@@ -339,41 +350,32 @@ class StorageMultipartUploadSession {
                 break
             }
 
-            if uploadPartEvent.isCompleted {
-                // report progress
-                if case .parts(_, _, _, let parts) = multipartUpload {
-                    let progress = Progress.discreteProgress(totalUnitCount: Int64(parts.totalBytes))
-                    progress.completedUnitCount = Int64(parts.bytesTransferred)
-                    onEvent(.inProcess(progress))
-                }
+            if uploadPartEvent.isCompleted,
+               case .parts(_, _, _, let parts) = snapshot {
+                let progress = Progress.discreteProgress(totalUnitCount: Int64(parts.totalBytes))
+                progress.completedUnitCount = Int64(parts.bytesTransferred)
+                onEvent(.inProcess(progress))
             }
-
-            let isCompletedEvent = uploadPartEvent.isCompleted
 
             if case .queued = uploadPartEvent {
                 return
-            } else if case .paused = multipartUpload {
+            }
+            if case .paused = snapshot {
                 logger.debug("Multipart Upload is paused and part cannot be completed")
                 return
-            } else if isCompletedEvent && multipartUpload.hasPendingParts {
-                if case .parts(let uploadId, let uploadFile, let partSize, let parts) = multipartUpload {
-                    uploadParts(uploadFile: uploadFile, uploadId: uploadId, partSize: partSize, parts: parts)
-                } else {
-                    fatalError("Invalid state")
-                }
-            } else if partsCompleted {
-                do {
-                    try multipartUpload.validateForCompletion()
-                } catch {
-                    fail(error: error)
-                    return
-                }
+            }
 
-                if let uploadId = multipartUpload.uploadId {
-                    try client.completeMultipartUpload(uploadId: uploadId)
-                } else {
-                    fatalError("Invalid state")
+            if uploadPartEvent.isCompleted && snapshot.hasPendingParts {
+                guard case .parts(let uploadId, let uploadFile, let partSize, let parts) = snapshot else {
+                    throw Failure.invalidStateTransition
                 }
+                uploadParts(uploadFile: uploadFile, uploadId: uploadId, partSize: partSize, parts: parts)
+            } else if snapshot.partsCompleted {
+                try snapshot.validateForCompletion()
+                guard let uploadId = snapshot.uploadId else {
+                    throw Failure.invalidStateTransition
+                }
+                try client.completeMultipartUpload(uploadId: uploadId)
             } else if case .failed(let partNumber, let error) = uploadPartEvent {
                 retryPartUpload(partNumber: partNumber, error: error)
             }
@@ -384,35 +386,32 @@ class StorageMultipartUploadSession {
 
     private func retryPartUpload(partNumber: PartNumber, error: Error) {
         do {
-            if transferTask.isBelowRetryLimit {
-                // increment retry count and move upload part back to pending
-                transferTask.incrementRetryCount()
-                if case .parts(let uploadId, let uploadFile, let partSize, var parts) = multipartUpload {
-                    let part = try parts.find(partNumber: partNumber)
-                    let index = partNumber - 1
-                    parts[index] = .pending(bytes: part.bytes)
-                    multipartUpload = .parts(uploadId: uploadId, uploadFile: uploadFile, partSize: partSize, parts: parts)
-                    let remainingParts = parts.filter { $0.inProgress }
-                    if remainingParts.isEmpty {
-                        // If there are no remaining parts in progress, manually trigger the reupload
-                        try client.uploadPart(partNumber: partNumber, multipartUpload: multipartUpload, subTask: createSubTask(partNumber: partNumber))
-                    }
-                } else {
-                    fatalError("Invalid state")
-                }
-            } else {
+            guard transferTask.isBelowRetryLimit else {
                 throw Failure.partsUploadRetryLimitExceeded(underlyingError: error)
             }
+            // increment retry count and move upload part back to pending
+            transferTask.incrementRetryCount()
+
+            // Mutate state under the serial queue and capture what the
+            // post-lock side effect needs. A nil result means state no longer
+            // matches .parts (e.g. a concurrent cancel swapped it) so there is
+            // nothing to retry; the abort path will run via the next event.
+            let retryInputs: (StorageMultipartUpload, Bool)? = try serialQueue.sync {
+                guard case .parts(let uploadId, let uploadFile, let partSize, var parts) = multipartUpload else {
+                    return nil
+                }
+                let part = try parts.find(partNumber: partNumber)
+                let index = partNumber - 1
+                parts[index] = .pending(bytes: part.bytes)
+                multipartUpload = .parts(uploadId: uploadId, uploadFile: uploadFile, partSize: partSize, parts: parts)
+                let noneInProgress = parts.filter { $0.inProgress }.isEmpty
+                return (multipartUpload, noneInProgress)
+            }
+
+            guard let (snapshot, shouldReupload) = retryInputs, shouldReupload else { return }
+            try client.uploadPart(partNumber: partNumber, multipartUpload: snapshot, subTask: createSubTask(partNumber: partNumber))
         } catch {
             handle(multipartUploadEvent: .aborting(error: error))
-        }
-    }
-
-    private func abort() throws {
-        if let uploadId = multipartUpload.uploadId {
-            try client.abortMultipartUpload(uploadId: uploadId)
-        } else {
-            fatalError("Invalid state")
         }
     }
 
@@ -477,7 +476,6 @@ class StorageMultipartUploadSession {
         do {
             let pendingPartNumbers = getPendingPartNumbers()
             logger.debug("Pending parts: \(pendingPartNumbers)")
-            logger.debug("Multipart Upload: \(multipartUpload)")
             if pendingPartNumbers.isEmpty {
                 return
             }
@@ -494,10 +492,12 @@ class StorageMultipartUploadSession {
                 // then start upload
                 for partNumber in numbers {
                     guard !isAborted else { return }
+                    let snapshot = serialQueue.sync { multipartUpload }
+                    logger.debug("Multipart Upload: \(snapshot)")
                     // the next call does async work
                     let subTask = createSubTask(partNumber: partNumber)
                     logger.debug("Uploading part: \(partNumber)")
-                    try client.uploadPart(partNumber: partNumber, multipartUpload: multipartUpload, subTask: subTask)
+                    try client.uploadPart(partNumber: partNumber, multipartUpload: snapshot, subTask: subTask)
                 }
             }
         } catch {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/UploadSource.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/UploadSource.swift
@@ -16,10 +16,10 @@ enum UploadSource {
         switch self {
         case .data(let data):
             let fileURL = try FileSystem.default.createTemporaryFile(data: data)
-            let size = fileSystem.getFileSize(fileURL: fileURL)
+            let size = try fileSystem.getFileSize(fileURL: fileURL)
             uploadFile = .init(fileURL: fileURL, temporaryFileCreated: true, size: size)
         case .local(let fileURL):
-            let size = fileSystem.getFileSize(fileURL: fileURL)
+            let size = try fileSystem.getFileSize(fileURL: fileURL)
             uploadFile = .init(fileURL: fileURL, temporaryFileCreated: false, size: size)
         }
         return uploadFile

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileSystemTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileSystemTests.swift
@@ -120,7 +120,7 @@ class FileSystemTests: XCTestCase {
         defer {
             fs.removeDirectoryIfExists(directoryURL: directoryURL)
         }
-        let size = fs.getFileSize(fileURL: fileURL)
+        let size = try fs.getFileSize(fileURL: fileURL)
 
         XCTAssertEqual(UInt64(bytes.bytes), size)
     }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageMultipartUploadSafetyTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageMultipartUploadSafetyTests.swift
@@ -1,0 +1,154 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Regression tests for GitHub issue #4138 — multipart upload crashes in
+// StorageMultipartUploadSession. Each test targets one of the three stack
+// traces reported on Amplify 2.53.3. On the unfixed code, the tests either
+// fail to compile (because they call throwing APIs that weren't throwing yet)
+// or reproduce the crash/race. After the fix they pass.
+
+import XCTest
+
+@testable import Amplify
+@testable import AWSS3StoragePlugin
+
+final class StorageMultipartUploadSafetyTests: XCTestCase {
+
+    // MARK: - Crash 3: FileSystem.getFileSize on a missing file -------------
+
+    /// Reproduces the `Fatal.require` crash at `FileSystem.getFileSize` when
+    /// the source file has been deleted between selection and upload start.
+    /// Pre-fix: `getFileSize` is non-throwing and terminates the process.
+    /// Post-fix: it throws and this test asserts the throw.
+    func testGetFileSize_missingFile_throwsInsteadOfCrashing() throws {
+        let fs = FileSystem()
+        let missingURL = fs.createTemporaryFileURL()
+        XCTAssertFalse(fs.fileExists(atURL: missingURL))
+        XCTAssertThrowsError(try fs.getFileSize(fileURL: missingURL))
+    }
+
+    /// Reproduces the upload-time pathway: a local upload source whose file
+    /// has been deleted should surface a Swift error through `UploadSource.getFile`
+    /// (which is already `throws`) rather than crashing the process.
+    func testUploadSource_localSource_missingFile_propagatesError() {
+        let fs = FileSystem()
+        let missingURL = fs.createTemporaryFileURL()
+        let source = UploadSource.local(missingURL)
+        XCTAssertThrowsError(try source.getFile(fileSystem: fs))
+    }
+
+    // MARK: - Crash 2: data race between fail() and handle() ----------------
+
+    /// Stress test that alternates `fail(error:)` and `handle(uploadPartEvent:)`
+    /// on the same session across many threads. Pre-fix, `fail(error:)` reads
+    /// and mutates `multipartUpload` without acquiring the serial queue, while
+    /// `handle(...)` mutates it on the serial queue.
+    ///
+    /// Reliable reproduction requires Thread Sanitizer:
+    ///
+    ///     Xcode → Product → Scheme → Edit Scheme → Test → Diagnostics
+    ///     → Thread Sanitizer ✓, then run this test.
+    ///
+    /// Under TSan this test reports a data race on `multipartUpload` between
+    /// `fail(error:)` and `handle(...)`, matching the Crash 2 stack
+    /// (swift_retain on `StorageMultipartUpload.uploadId.getter`). Without
+    /// TSan the race is latent — the test runs to completion and serves as a
+    /// functional regression guard (it also occasionally surfaces the race as
+    /// an ARC crash under load, but not deterministically on every run).
+    ///
+    /// Note: `swift test --sanitize=thread` is broken on Xcode 26 / macOS 26
+    /// due to TSan dylib code-signing policy. Run from the Xcode UI with the
+    /// scheme diagnostic enabled instead.
+    func testConcurrentFailAndHandle_doesNotRace() {
+        let client = MockMultipartUploadClient()
+        // Stop the mock's automatic part completion so the session stays in
+        // `.parts` while we hammer it from multiple threads.
+        client.shouldFailPartUpload = { _, _ in false }
+
+        let session = StorageMultipartUploadSession(
+            client: client,
+            bucket: "b",
+            key: "k",
+            onEvent: { _ in }
+        )
+
+        // Advance the session to `.parts` so `multipartUpload` has non-nil
+        // associated values (uploadId, uploadFile, parts). This is the state
+        // that tears under concurrent access.
+        try? client.createMultipartUpload()
+
+        let iterations = 500
+        DispatchQueue.concurrentPerform(iterations: iterations) { i in
+            if i.isMultiple(of: 2) {
+                session.fail(error: NSError(domain: "test", code: i))
+            } else {
+                session.handle(uploadPartEvent: .progressUpdated(
+                    partNumber: 1,
+                    bytesTransferred: UInt64(i),
+                    taskIdentifier: i
+                ))
+            }
+        }
+        // Success criteria: no TSan report, no ARC crash. If the test
+        // completes without the process being terminated, the race is gone.
+    }
+
+    // MARK: - Crash 1: retryPartUpload fatalError("Invalid state") ----------
+
+    /// Reproduces the `fatalError("Invalid state")` at
+    /// `StorageMultipartUploadSession.swift:350`. The race: the URLSession
+    /// delegate thread is inside `handle(uploadPartEvent: .failed)` → `retryPartUpload`,
+    /// which expects `multipartUpload` to be `.parts(...)`. A concurrent
+    /// `cancel()` swaps the state to `.aborting` after the sync block
+    /// releases, so the `case .parts` check falls through to fatalError.
+    ///
+    /// This test drives the scenario by cancelling from the mock's
+    /// `didStartPartUpload` callback and immediately injecting a `.failed`
+    /// part event on a different queue.
+    func testConcurrentCancelAndFailedPartEvent_doesNotCrash() {
+        let exp = expectation(description: "terminal event")
+        exp.assertForOverFulfill = false
+
+        let client = MockMultipartUploadClient()
+        let onEvent: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler = { event in
+            switch event {
+            case .failed, .completed:
+                exp.fulfill()
+            default:
+                break
+            }
+        }
+
+        let session = StorageMultipartUploadSession(
+            client: client,
+            bucket: "b",
+            key: "k",
+            onEvent: onEvent
+        )
+
+        // When part 3 starts, race a cancel against an injected failed event.
+        weak var weakSession = session
+        client.didStartPartUpload = { _, partNumber in
+            guard partNumber == 3 else { return }
+            DispatchQueue.global(qos: .userInitiated).async {
+                weakSession?.cancel()
+            }
+            DispatchQueue.global(qos: .default).async {
+                weakSession?.handle(uploadPartEvent: .failed(
+                    partNumber: 3,
+                    error: NSError(domain: "t", code: 1)
+                ))
+            }
+        }
+
+        session.startUpload()
+
+        // Pre-fix: process is killed by `fatalError` before this returns.
+        // Post-fix: session aborts or completes cleanly and fulfills the exp.
+        wait(for: [exp], timeout: 30.0)
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the three crashes reported in #4138 on `AWSS3StoragePlugin` v2.53.3.

- Serialize all access to `StorageMultipartUploadSession.multipartUpload` on the existing serial queue. `handle(multipartUploadEvent:)`, `handle(uploadPartEvent:)`, `retryPartUpload`, `restart`, `createSubTask`, and `uploadParts` now read and mutate the state under the lock, then branch on a captured snapshot instead of re-reading the property after the lock releases. Eliminates the torn-read race that surfaced as `swift_retain` in `StorageMultipartUpload.uploadId.getter` (Crash 2) and the `fatalError(\"Invalid state\")` at `StorageMultipartUploadSession.swift:350` (Crash 1).
- Replace three `fatalError` sites that fire when a concurrent cancel/pause swaps the state between the sync block and a subsequent re-read with a thrown `Failure.invalidStateTransition` routed through the existing `fail(error:)` path, so the upload surfaces a `StorageError` instead of crashing the process.
- Make `FileSystem.getFileSize` throw instead of `Fatal.require` and propagate through `UploadSource.getFile` (which is already `throws` and already wrapped in `attempt(..., fail:)` at the upload call sites). Fixes Crash 3 where deleting the source file between selection and upload start crashed the app.
- Preserves the progress-stall-timer plumbing from #4162 (reset/cancel calls intact across all state transitions).

## Test plan
TDD-first: regression tests reproduce each crash against unfixed code, then turn green after the fix.

New `StorageMultipartUploadSafetyTests`:
- [x] `testConcurrentCancelAndFailedPartEvent_doesNotCrash` — reproduces Crash 1 (`fatalError(\"Invalid state\")`) against unfixed code; passes after fix
- [x] `testConcurrentFailAndHandle_doesNotRace` — stress test for Crash 2; reliable repro under Thread Sanitizer (documented in the test; `swift test --sanitize=thread` is broken on Xcode 26 CLI, run with the Xcode scheme diagnostic)
- [x] `testGetFileSize_missingFile_throwsInsteadOfCrashing` — reproduces Crash 3 against unfixed code; passes after fix
- [x] `testUploadSource_localSource_missingFile_propagatesError` — end-to-end variant of Crash 3

Regression suite:
- [x] All existing `StorageMultipartUploadSessionTests` pass (including `testProgressStallTimeoutWhenNoProgressFailsWithStallError` added in #4162)
- [x] Full Storage unit-test suite: 1018 passed, 0 failed
- [ ] TSan run of `testConcurrentFailAndHandle_doesNotRace` from Xcode UI on reviewer's machine

Closes #4138