### PR TITLE
fix(api): omit nested hasOne from mutation selection sets

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncModelMetadata.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncModelMetadata.swift
@@ -123,6 +123,19 @@ public enum AppSyncModelMetadataUtils {
                 // otherwise do nothing to the data.
             }
 
+            // Scenario: `hasOne` whose nested object is absent (mutation responses omit it).
+            // Rebuild the lazy-load identifiers from the scalar foreign key so it can still load.
+            if let metadataJSON = hasOneForeignKeyMetadata(
+                modelField,
+                in: modelJSON,
+                apiName: apiName,
+                authMode: authMode,
+                source: source
+            ) {
+                Amplify.API.log.verbose("Adding [\(modelField.name): \(metadataJSON)]")
+                modelJSON.updateValue(metadataJSON, forKey: modelField.name)
+            }
+
             // Scenario: Has-Many eager loaded or empty payloads.
             if modelField.isArray && modelField.hasAssociation,
                let associatedModelName = modelField.associatedModelName {
@@ -185,6 +198,55 @@ public enum AppSyncModelMetadataUtils {
         }
 
         return JSONValue.object(modelJSON)
+    }
+
+    /// Builds lazy-load identifier metadata for a `hasOne` from its scalar foreign key, for when
+    /// the nested object is absent (e.g. mutation responses). Returns `nil` when not applicable.
+    /// https://github.com/aws-amplify/amplify-swift/issues/3913
+    static func hasOneForeignKeyMetadata(
+        _ modelField: ModelField,
+        in modelJSON: [String: JSONValue],
+        apiName: String?,
+        authMode: AWSAuthorizationType?,
+        source: String
+    ) -> JSONValue? {
+        guard modelJSON[modelField.name] == nil,
+              !modelField.isArray,
+              case .hasOne(_, _, let targetNames) = modelField.association,
+              !targetNames.isEmpty,
+              let associatedModelName = modelField.associatedModelName,
+              let associatedModelType = ModelRegistry.modelType(from: associatedModelName),
+              associatedModelType.rootPath != nil else {
+            return nil
+        }
+        let primaryKeyFields = associatedModelType.schema.primaryKey.fields
+        guard primaryKeyFields.count == targetNames.count else {
+            return nil
+        }
+        var identifiers = [LazyReferenceIdentifier]()
+        for (primaryKeyField, targetName) in zip(primaryKeyFields, targetNames) {
+            if case .string(let value) = modelJSON[targetName] {
+                identifiers.append(.init(name: primaryKeyField.name, value: value))
+            }
+        }
+        guard identifiers.count == targetNames.count else {
+            return nil
+        }
+        let metadata = AppSyncModelDecoder.Metadata(
+            identifiers: identifiers,
+            apiName: apiName,
+            authMode: authMode,
+            source: source
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = ModelDateFormatting.encodingStrategy
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = ModelDateFormatting.decodingStrategy
+        guard let serialized = try? encoder.encode(metadata),
+              let metadataJSON = try? decoder.decode(JSONValue.self, from: serialized) else {
+            return nil
+        }
+        return metadataJSON
     }
 
     /// Extract the identifiers from the `modelObject`. The number of identifiers extracted compared to the number of

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncModelMetadataHasOneForeignKeyTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncModelMetadataHasOneForeignKeyTests.swift
@@ -134,6 +134,53 @@ private struct CompositeFKParent: Model {
     static var rootPath: PropertyContainerPath? { Path() }
 }
 
+// Eager (pre-lazy) variant: the associated model declares no `rootPath`, so no lazy rebuild applies.
+private struct EagerFKChild: Model {
+    let id: String
+    init(id: String = UUID().uuidString) { self.id = id }
+
+    enum CodingKeys: String, ModelKey { case id }
+    static let keys = CodingKeys.self
+
+    static let schema = defineSchema { model in
+        model.fields(.id())
+    }
+}
+
+private struct EagerFKParent: Model {
+    let id: String
+    var childId: String
+    var child: EagerFKChild?
+
+    init(id: String = UUID().uuidString, childId: String, child: EagerFKChild? = nil) {
+        self.id = id
+        self.childId = childId
+        self.child = child
+    }
+
+    enum CodingKeys: String, ModelKey {
+        case id
+        case childId
+        case child
+    }
+    static let keys = CodingKeys.self
+
+    static let schema = defineSchema { model in
+        let parent = EagerFKParent.keys
+        model.fields(
+            .id(),
+            .field(parent.childId, is: .required, ofType: .string),
+            .hasOne(
+                parent.child,
+                is: .optional,
+                ofType: EagerFKChild.self,
+                associatedWith: EagerFKChild.keys.id,
+                targetName: "childId"
+            )
+        )
+    }
+}
+
 class HasOneForeignKeyMetadataTests: XCTestCase {
 
     override func setUp() {
@@ -141,9 +188,11 @@ class HasOneForeignKeyMetadataTests: XCTestCase {
         ModelRegistry.register(modelType: HasOneFKChild.self)
         ModelRegistry.register(modelType: CompositeFKParent.self)
         ModelRegistry.register(modelType: CompositeFKChild.self)
+        ModelRegistry.register(modelType: EagerFKParent.self)
+        ModelRegistry.register(modelType: EagerFKChild.self)
     }
 
-    override func tearDown() {
+    override class func tearDown() {
         ModelRegistry.reset()
     }
 
@@ -238,5 +287,31 @@ class HasOneForeignKeyMetadataTests: XCTestCase {
         let pairs = identifiers.compactMap(pair)
         XCTAssertTrue(pairs.contains(where: { $0 == ("teamId", "team-1") }), "\(pairs)")
         XCTAssertTrue(pairs.contains(where: { $0 == ("area", "emea") }), "\(pairs)")
+    }
+
+    /// - Given: an eager `hasOne` (associated model has no `rootPath`) whose nested object is absent
+    ///   but the foreign key is present.
+    /// - When: `addMetadata` processes the response.
+    /// - Then: no lazy-reference metadata is injected (eager models can't lazy-load), so the
+    ///   association decodes as `nil`. This matches amplify-android/js, where relation loading is
+    ///   unsupported on mutations; the related data must be re-queried.
+    func testAddMetadata_eagerHasOneMissingNestedObject_doesNotRebuild() {
+        let json: JSONValue = [
+            "id": "parent1",
+            "childId": "child1",
+            "__typename": "EagerFKParent"
+        ]
+
+        let result = AppSyncModelMetadataUtils.addMetadata(
+            toModel: json,
+            apiName: "apiName",
+            authMode: .amazonCognitoUserPools
+        )
+
+        if case .object(let object) = result {
+            XCTAssertNil(object["child"])
+        } else {
+            XCTFail("Expected an object result")
+        }
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncModelMetadataHasOneForeignKeyTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncModelMetadataHasOneForeignKeyTests.swift
@@ -1,0 +1,130 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@testable import Amplify
+@testable import AWSAPIPlugin
+
+// Minimal lazy models: a `hasOne` whose foreign key (`childId`) is on the source model — the same
+// shape as the issue's `Like.user`. Both declare `rootPath` so lazy loading applies.
+private struct HasOneFKChild: Model {
+    let id: String
+    init(id: String = UUID().uuidString) { self.id = id }
+
+    enum CodingKeys: String, ModelKey { case id }
+    static let keys = CodingKeys.self
+
+    static let schema = defineSchema { model in
+        model.fields(.id())
+    }
+
+    class Path: ModelPath<HasOneFKChild> {}
+    static var rootPath: PropertyContainerPath? { Path() }
+}
+
+private struct HasOneFKParent: Model {
+    let id: String
+    var childId: String
+    var child: HasOneFKChild?
+
+    init(id: String = UUID().uuidString, childId: String, child: HasOneFKChild? = nil) {
+        self.id = id
+        self.childId = childId
+        self.child = child
+    }
+
+    enum CodingKeys: String, ModelKey {
+        case id
+        case childId
+        case child
+    }
+    static let keys = CodingKeys.self
+
+    static let schema = defineSchema { model in
+        let parent = HasOneFKParent.keys
+        model.fields(
+            .id(),
+            .field(parent.childId, is: .required, ofType: .string),
+            .hasOne(
+                parent.child,
+                is: .optional,
+                ofType: HasOneFKChild.self,
+                associatedWith: HasOneFKChild.keys.id,
+                targetName: "childId"
+            )
+        )
+    }
+
+    class Path: ModelPath<HasOneFKParent> {}
+    static var rootPath: PropertyContainerPath? { Path() }
+}
+
+class HasOneForeignKeyMetadataTests: XCTestCase {
+
+    override func setUp() {
+        ModelRegistry.register(modelType: HasOneFKParent.self)
+        ModelRegistry.register(modelType: HasOneFKChild.self)
+    }
+
+    override func tearDown() {
+        ModelRegistry.reset()
+    }
+
+    /// - Given: a mutation response for a model with a `hasOne` whose foreign key is on the source,
+    ///   where the nested object is absent and only the scalar foreign key is present.
+    /// - When: `addMetadata` processes the response.
+    /// - Then: lazy-load identifier metadata is injected for the association, built from the
+    ///   foreign key, so the `hasOne` can still be lazy-loaded.
+    ///   Refs https://github.com/aws-amplify/amplify-swift/issues/3913
+    func testAddMetadata_hasOneMissingNestedObject_rebuildsLazyIdentifierFromForeignKey() {
+        let json: JSONValue = [
+            "id": "parent1",
+            "childId": "child1",
+            "__typename": "HasOneFKParent"
+        ]
+
+        let result = AppSyncModelMetadataUtils.addMetadata(
+            toModel: json,
+            apiName: "apiName",
+            authMode: .amazonCognitoUserPools
+        )
+
+        guard case .object(let childMetadata) = result["child"],
+              case .array(let identifiers) = childMetadata["identifiers"],
+              case .object(let identifier) = identifiers.first,
+              case .string(let name) = identifier["name"],
+              case .string(let value) = identifier["value"] else {
+            XCTFail("Expected lazy-load identifier metadata for `child`, rebuilt from the foreign key")
+            return
+        }
+        XCTAssertEqual(name, "id")
+        XCTAssertEqual(value, "child1")
+    }
+
+    /// - Given: the scalar foreign key is missing from the response.
+    /// - When: `addMetadata` processes the response.
+    /// - Then: no association metadata is injected (nothing to rebuild from).
+    func testAddMetadata_hasOneMissingForeignKey_doesNotInjectMetadata() {
+        let json: JSONValue = [
+            "id": "parent1",
+            "__typename": "HasOneFKParent"
+        ]
+
+        let result = AppSyncModelMetadataUtils.addMetadata(
+            toModel: json,
+            apiName: "apiName",
+            authMode: .amazonCognitoUserPools
+        )
+
+        if case .object(let object) = result {
+            XCTAssertNil(object["child"])
+        } else {
+            XCTFail("Expected an object result")
+        }
+    }
+}

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncModelMetadataHasOneForeignKeyTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncModelMetadataHasOneForeignKeyTests.swift
@@ -181,6 +181,45 @@ private struct EagerFKParent: Model {
     }
 }
 
+// Mismatch: a `hasOne` with a single foreign key pointing at a two-field composite-PK child, so the
+// rebuild's key count doesn't line up and no metadata is produced.
+private struct MismatchParent: Model {
+    let id: String
+    var childTeamId: String
+    var child: CompositeFKChild?
+
+    init(id: String = UUID().uuidString, childTeamId: String, child: CompositeFKChild? = nil) {
+        self.id = id
+        self.childTeamId = childTeamId
+        self.child = child
+    }
+
+    enum CodingKeys: String, ModelKey {
+        case id
+        case childTeamId
+        case child
+    }
+    static let keys = CodingKeys.self
+
+    static let schema = defineSchema { model in
+        let parent = MismatchParent.keys
+        model.fields(
+            .id(),
+            .field(parent.childTeamId, is: .required, ofType: .string),
+            .hasOne(
+                parent.child,
+                is: .optional,
+                ofType: CompositeFKChild.self,
+                associatedWith: CompositeFKChild.keys.teamId,
+                targetName: "childTeamId"
+            )
+        )
+    }
+
+    class Path: ModelPath<MismatchParent> {}
+    static var rootPath: PropertyContainerPath? { Path() }
+}
+
 class HasOneForeignKeyMetadataTests: XCTestCase {
 
     override func setUp() {
@@ -190,9 +229,10 @@ class HasOneForeignKeyMetadataTests: XCTestCase {
         ModelRegistry.register(modelType: CompositeFKChild.self)
         ModelRegistry.register(modelType: EagerFKParent.self)
         ModelRegistry.register(modelType: EagerFKChild.self)
+        ModelRegistry.register(modelType: MismatchParent.self)
     }
 
-    override class func tearDown() {
+    override func tearDown() {
         ModelRegistry.reset()
     }
 
@@ -300,6 +340,29 @@ class HasOneForeignKeyMetadataTests: XCTestCase {
             "id": "parent1",
             "childId": "child1",
             "__typename": "EagerFKParent"
+        ]
+
+        let result = AppSyncModelMetadataUtils.addMetadata(
+            toModel: json,
+            apiName: "apiName",
+            authMode: .amazonCognitoUserPools
+        )
+
+        if case .object(let object) = result {
+            XCTAssertNil(object["child"])
+        } else {
+            XCTFail("Expected an object result")
+        }
+    }
+
+    /// - Given: a `hasOne` whose single foreign key doesn't match the composite-PK child's key count.
+    /// - When: `addMetadata` processes the response.
+    /// - Then: no metadata is injected (the key counts don't line up), so the association stays nil.
+    func testAddMetadata_hasOneForeignKeyCountMismatch_doesNotRebuild() {
+        let json: JSONValue = [
+            "id": "parent1",
+            "childTeamId": "team-1",
+            "__typename": "MismatchParent"
         ]
 
         let result = AppSyncModelMetadataUtils.addMetadata(

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncModelMetadataHasOneForeignKeyTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncModelMetadataHasOneForeignKeyTests.swift
@@ -64,11 +64,83 @@ private struct HasOneFKParent: Model {
     static var rootPath: PropertyContainerPath? { Path() }
 }
 
+// Composite-key variant: the `hasOne` target has a two-field primary key, so the association is
+// backed by two foreign keys (`teamId` + `area`). Exercises the multi-identifier rebuild path.
+private struct CompositeFKChild: Model {
+    let teamId: String
+    let area: String
+    init(teamId: String = UUID().uuidString, area: String) {
+        self.teamId = teamId
+        self.area = area
+    }
+
+    enum CodingKeys: String, ModelKey {
+        case teamId
+        case area
+    }
+    static let keys = CodingKeys.self
+
+    static let schema = defineSchema { model in
+        let child = CompositeFKChild.keys
+        model.attributes(.primaryKey(fields: [child.teamId, child.area]))
+        model.fields(
+            .field(child.teamId, is: .required, ofType: .string),
+            .field(child.area, is: .required, ofType: .string)
+        )
+    }
+
+    class Path: ModelPath<CompositeFKChild> {}
+    static var rootPath: PropertyContainerPath? { Path() }
+}
+
+private struct CompositeFKParent: Model {
+    let id: String
+    var childTeamId: String
+    var childArea: String
+    var child: CompositeFKChild?
+
+    init(id: String = UUID().uuidString, childTeamId: String, childArea: String, child: CompositeFKChild? = nil) {
+        self.id = id
+        self.childTeamId = childTeamId
+        self.childArea = childArea
+        self.child = child
+    }
+
+    enum CodingKeys: String, ModelKey {
+        case id
+        case childTeamId
+        case childArea
+        case child
+    }
+    static let keys = CodingKeys.self
+
+    static let schema = defineSchema { model in
+        let parent = CompositeFKParent.keys
+        model.fields(
+            .id(),
+            .field(parent.childTeamId, is: .required, ofType: .string),
+            .field(parent.childArea, is: .required, ofType: .string),
+            .hasOne(
+                parent.child,
+                is: .optional,
+                ofType: CompositeFKChild.self,
+                associatedFields: [CompositeFKChild.keys.teamId, CompositeFKChild.keys.area],
+                targetNames: ["childTeamId", "childArea"]
+            )
+        )
+    }
+
+    class Path: ModelPath<CompositeFKParent> {}
+    static var rootPath: PropertyContainerPath? { Path() }
+}
+
 class HasOneForeignKeyMetadataTests: XCTestCase {
 
     override func setUp() {
         ModelRegistry.register(modelType: HasOneFKParent.self)
         ModelRegistry.register(modelType: HasOneFKChild.self)
+        ModelRegistry.register(modelType: CompositeFKParent.self)
+        ModelRegistry.register(modelType: CompositeFKChild.self)
     }
 
     override func tearDown() {
@@ -126,5 +198,45 @@ class HasOneForeignKeyMetadataTests: XCTestCase {
         } else {
             XCTFail("Expected an object result")
         }
+    }
+
+    /// - Given: a mutation response for a `hasOne` whose target has a composite (two-field) primary
+    ///   key, where the nested object is absent and both scalar foreign keys are present.
+    /// - When: `addMetadata` processes the response.
+    /// - Then: lazy-load metadata is rebuilt with BOTH identifiers, each mapping the target's
+    ///   primary-key field name to the corresponding foreign-key value.
+    func testAddMetadata_compositeKeyHasOneMissingNestedObject_rebuildsAllIdentifiers() {
+        let json: JSONValue = [
+            "id": "parent1",
+            "childTeamId": "team-1",
+            "childArea": "emea",
+            "__typename": "CompositeFKParent"
+        ]
+
+        let result = AppSyncModelMetadataUtils.addMetadata(
+            toModel: json,
+            apiName: "apiName",
+            authMode: .amazonCognitoUserPools
+        )
+
+        guard case .object(let childMetadata) = result["child"],
+              case .array(let identifiers) = childMetadata["identifiers"] else {
+            XCTFail("Expected lazy-load identifier metadata for `child`, rebuilt from the foreign keys")
+            return
+        }
+
+        XCTAssertEqual(identifiers.count, 2)
+
+        func pair(_ value: JSONValue) -> (String, String)? {
+            guard case .object(let identifier) = value,
+                  case .string(let name) = identifier["name"],
+                  case .string(let val) = identifier["value"] else {
+                return nil
+            }
+            return (name, val)
+        }
+        let pairs = identifiers.compactMap(pair)
+        XCTAssertTrue(pairs.contains(where: { $0 == ("teamId", "team-1") }), "\(pairs)")
+        XCTAssertTrue(pairs.contains(where: { $0 == ("area", "emea") }), "\(pairs)")
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLMutation.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLMutation.swift
@@ -31,11 +31,20 @@ public struct GraphQLMutation: SingleDirectiveGraphQLDocument {
     }
 
     public init(modelSchema: ModelSchema, primaryKeysOnly: Bool) {
-        // Omit nested `hasOne` objects on mutations (AppSync returns them null on the response).
+        self.init(
+            modelSchema: modelSchema,
+            primaryKeysOnly: primaryKeysOnly,
+            includeHasOneAssociations: true
+        )
+    }
+
+    /// API-category mutations pass `includeHasOneAssociations: false` to select a `hasOne`'s
+    /// foreign key instead of the nested object; DataStore keeps the default (nested).
+    init(modelSchema: ModelSchema, primaryKeysOnly: Bool, includeHasOneAssociations: Bool) {
         self.selectionSet = SelectionSet(
             fields: modelSchema.graphQLFields,
             primaryKeysOnly: primaryKeysOnly,
-            includeHasOneAssociations: false
+            includeHasOneAssociations: includeHasOneAssociations
         )
     }
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLMutation.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/GraphQLMutation.swift
@@ -31,7 +31,12 @@ public struct GraphQLMutation: SingleDirectiveGraphQLDocument {
     }
 
     public init(modelSchema: ModelSchema, primaryKeysOnly: Bool) {
-        self.selectionSet = SelectionSet(fields: modelSchema.graphQLFields, primaryKeysOnly: primaryKeysOnly)
+        // Omit nested `hasOne` objects on mutations (AppSync returns them null on the response).
+        self.selectionSet = SelectionSet(
+            fields: modelSchema.graphQLFields,
+            primaryKeysOnly: primaryKeysOnly,
+            includeHasOneAssociations: false
+        )
     }
 
     public var name: String = ""

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/ModelBasedGraphQLDocumentBuilder.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLDocument/ModelBasedGraphQLDocumentBuilder.swift
@@ -31,6 +31,22 @@ public struct ModelBasedGraphQLDocumentBuilder {
     }
 
     public init(modelSchema: ModelSchema, operationType: GraphQLOperationType, primaryKeysOnly: Bool = true) {
+        self.init(
+            modelSchema: modelSchema,
+            operationType: operationType,
+            primaryKeysOnly: primaryKeysOnly,
+            includeHasOneAssociations: true
+        )
+    }
+
+    /// Forwards `includeHasOneAssociations` to `GraphQLMutation` (API-category mutations set
+    /// it to `false`).
+    init(
+        modelSchema: ModelSchema,
+        operationType: GraphQLOperationType,
+        primaryKeysOnly: Bool,
+        includeHasOneAssociations: Bool
+    ) {
         self.modelSchema = modelSchema
         var primaryKeysOnly = primaryKeysOnly
         if primaryKeysOnly && ModelRegistry.modelType(from: modelSchema.name)?.rootPath == nil {
@@ -41,7 +57,11 @@ public struct ModelBasedGraphQLDocumentBuilder {
         case .query:
             self.document = GraphQLQuery(modelSchema: modelSchema, primaryKeysOnly: primaryKeysOnly)
         case .mutation:
-            self.document = GraphQLMutation(modelSchema: modelSchema, primaryKeysOnly: primaryKeysOnly)
+            self.document = GraphQLMutation(
+                modelSchema: modelSchema,
+                primaryKeysOnly: primaryKeysOnly,
+                includeHasOneAssociations: includeHasOneAssociations
+            )
         case .subscription:
             self.document = GraphQLSubscription(modelSchema: modelSchema, primaryKeysOnly: primaryKeysOnly)
         }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
@@ -288,7 +288,9 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
     ) -> GraphQLRequest<M> {
         var documentBuilder = ModelBasedGraphQLDocumentBuilder(
             modelSchema: modelSchema,
-            operationType: .mutation
+            operationType: .mutation,
+            primaryKeysOnly: true,
+            includeHasOneAssociations: false
         )
         documentBuilder.add(decorator: DirectiveNameDecorator(type: type))
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
@@ -298,7 +298,7 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
             let associations = includes(modelPath)
             // AppSync redacts (nulls) `hasOne` relational fields on mutation responses, so an
             // explicit `includes` of a `hasOne` would re-introduce the non-null decode failure
-            // (#3913). Drop top-level `hasOne` includes on mutations; queries are unaffected.
+            // (#3913). Drop top-level `hasOne` includes on mutations.
             let mutationSafeAssociations = associations.filter {
                 !$0.isTopLevelHasOne(on: modelSchema)
             }
@@ -465,8 +465,8 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
 }
 
 private extension PropertyContainerPath {
-    /// Whether this include path's top-level association (directly off the root model) is a `hasOne`.
-    /// Used to drop `hasOne` includes from mutations, whose responses AppSync redacts to null (#3913).
+    /// True if this `includes` path is a `hasOne` on the model itself (e.g. `Like.user`).
+    /// These are dropped on mutations, where AppSync returns the related object as null (#3913).
     func isTopLevelHasOne(on modelSchema: ModelSchema) -> Bool {
         var metadata = getMetadata()
         var topLevelName: String?

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/GraphQLRequest/GraphQLRequest+Model.swift
@@ -296,7 +296,13 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
 
         if let modelPath = M.rootPath as? ModelPath<M> {
             let associations = includes(modelPath)
-            documentBuilder.add(decorator: IncludeAssociationDecorator(associations))
+            // AppSync redacts (nulls) `hasOne` relational fields on mutation responses, so an
+            // explicit `includes` of a `hasOne` would re-introduce the non-null decode failure
+            // (#3913). Drop top-level `hasOne` includes on mutations; queries are unaffected.
+            let mutationSafeAssociations = associations.filter {
+                !$0.isTopLevelHasOne(on: modelSchema)
+            }
+            documentBuilder.add(decorator: IncludeAssociationDecorator(mutationSafeAssociations))
         }
 
         switch type {
@@ -455,5 +461,28 @@ extension GraphQLRequest: ModelGraphQLRequestFactory {
             decodePath: document.name,
             authMode: authMode
         )
+    }
+}
+
+private extension PropertyContainerPath {
+    /// Whether this include path's top-level association (directly off the root model) is a `hasOne`.
+    /// Used to drop `hasOne` includes from mutations, whose responses AppSync redacts to null (#3913).
+    func isTopLevelHasOne(on modelSchema: ModelSchema) -> Bool {
+        var metadata = getMetadata()
+        var topLevelName: String?
+        while metadata.name != "root" {
+            topLevelName = metadata.name
+            guard let parent = metadata.parent else { break }
+            metadata = parent.getMetadata()
+        }
+        guard let name = topLevelName,
+              let field = modelSchema.field(withName: name),
+              let association = field.association else {
+            return false
+        }
+        if case .hasOne = association {
+            return true
+        }
+        return false
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/ModelField+GraphQL.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/ModelField+GraphQL.swift
@@ -18,4 +18,16 @@ extension ModelField {
         }
         return name
     }
+
+    /// Foreign-key field name(s) backing a `belongsTo`/`hasOne` association; empty otherwise.
+    var _associationTargetNames: [String] { // swiftlint:disable:this identifier_name
+        switch association {
+        case let .belongsTo(_, targetNames):
+            return targetNames
+        case let .hasOne(_, _, targetNames):
+            return targetNames
+        default:
+            return []
+        }
+    }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Model/Support/SelectionSet.swift
@@ -36,13 +36,19 @@ public class SelectionSetField {
 
 extension SelectionSet {
 
-    /// Construct a `SelectionSet` with model fields
-    convenience init(fields: [ModelField], primaryKeysOnly: Bool = false) {
+    /// Construct a `SelectionSet` with model fields. For mutations, set `includeHasOneAssociations`
+    /// to `false` to select a `hasOne`'s foreign key instead of the nested object.
+    convenience init(fields: [ModelField], primaryKeysOnly: Bool = false, includeHasOneAssociations: Bool = true) {
         self.init(value: SelectionSetField(fieldType: .model))
-        withModelFields(fields, primaryKeysOnly: primaryKeysOnly)
+        withModelFields(fields, primaryKeysOnly: primaryKeysOnly, includeHasOneAssociations: includeHasOneAssociations)
     }
 
-    func withModelFields(_ fields: [ModelField], recursive: Bool = true, primaryKeysOnly: Bool) {
+    func withModelFields(
+        _ fields: [ModelField],
+        recursive: Bool = true,
+        primaryKeysOnly: Bool,
+        includeHasOneAssociations: Bool = true
+    ) {
         for field in fields {
             if field.isEmbeddedType, let embeddedTypeSchema = field.embeddedTypeSchema {
                 let child = SelectionSet(value: .init(name: field.name, fieldType: .embedded))
@@ -51,7 +57,20 @@ extension SelectionSet {
             } else if field._isBelongsToOrHasOne,
                       let associatedModelName = field.associatedModelName,
                       let schema = ModelRegistry.modelSchema(from: associatedModelName) {
-                if recursive {
+                let isHasOne: Bool
+                if case .hasOne = field.association {
+                    isHasOne = true
+                } else {
+                    isHasOne = false
+                }
+                if !includeHasOneAssociations && isHasOne {
+                    // AppSync nulls a `hasOne`'s nested object on a mutation response; keep its FK instead.
+                    // https://github.com/aws-amplify/amplify-swift/issues/3913
+                    for targetName in field._associationTargetNames
+                        where !fields.contains(where: { $0.name == targetName }) {
+                        addChild(settingParentOf: .init(value: .init(name: targetName, fieldType: .value)))
+                    }
+                } else if recursive {
                     var recursive = recursive
                     if field._isBelongsToOrHasOne {
                         recursive = false

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLHasOneMutationSelectionTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLHasOneMutationSelectionTests.swift
@@ -22,45 +22,44 @@ class GraphQLHasOneMutationSelectionTests: XCTestCase {
         ModelRegistry.reset()
     }
 
-    /// - Given: a `Project2V2` model whose `team` is a `hasOne` with its foreign key (`teamID`)
-    ///   declared on the source model — the same shape as the issue's model (`Like.user`).
-    /// - When: a `.create` mutation document is generated.
-    /// - Then: the nested `team { ... }` object is NOT selected (on a mutation response AppSync
-    ///   returns it as null, which previously caused "Cannot return null for non-nullable type"),
-    ///   while the scalar foreign key `teamID` IS selected so the association stays lazy-loadable.
-    ///   See https://github.com/aws-amplify/amplify-swift/issues/3913
-    func testCreateMutationForHasOneOmitsNestedObjectAndKeepsForeignKey() {
+    /// - Given: a `Project2V2` whose `team` is a `hasOne` with its foreign key (`teamID`) on the
+    ///   source model — the shape from the issue (`Like.user`).
+    /// - When: an API category `.create` mutation request is generated.
+    /// - Then: the nested `team { ... }` object is NOT selected (AppSync returns it null on a
+    ///   mutation response, which caused "Cannot return null for non-nullable type"), while the
+    ///   scalar foreign key `teamID` IS selected so the association stays lazy-loadable.
+    ///   https://github.com/aws-amplify/amplify-swift/issues/3913
+    func testApiCreateMutationForHasOneOmitsNestedObjectAndKeepsForeignKey() {
         let project = Project2V2(name: "name", teamID: "team-id")
-        var documentBuilder = ModelBasedGraphQLDocumentBuilder(
-            modelSchema: Project2V2.schema,
-            operationType: .mutation,
-            primaryKeysOnly: true
-        )
-        documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
-        documentBuilder.add(decorator: ModelDecorator(model: project, mutationType: .create))
-        let document = documentBuilder.build()
+        let request = GraphQLRequest<Project2V2>.create(project)
 
-        XCTAssertEqual(document.name, "createProject2V2")
-        XCTAssertFalse(document.stringValue.contains("team {"))
-        XCTAssertTrue(document.stringValue.contains("teamID"))
+        XCTAssertFalse(request.document.contains("team {"), request.document)
+        XCTAssertTrue(request.document.contains("teamID"), request.document)
     }
 
-    /// The same omission applies to `update` and `delete` (all mutation types share the selection).
-    func testUpdateAndDeleteMutationsForHasOneOmitNestedObjectAndKeepForeignKey() {
+    /// The same omission applies to API `update` and `delete` (all mutation types share the selection).
+    func testApiUpdateAndDeleteMutationsForHasOneOmitNestedObjectAndKeepForeignKey() {
         let project = Project2V2(name: "name", teamID: "team-id")
-        for type in [GraphQLMutationType.update, GraphQLMutationType.delete] {
-            var documentBuilder = ModelBasedGraphQLDocumentBuilder(
-                modelSchema: Project2V2.schema,
-                operationType: .mutation,
-                primaryKeysOnly: true
-            )
-            documentBuilder.add(decorator: DirectiveNameDecorator(type: type))
-            documentBuilder.add(decorator: ModelDecorator(model: project, mutationType: type))
-            let document = documentBuilder.build()
-
-            XCTAssertFalse(document.stringValue.contains("team {"), "\(type) should not nest the hasOne")
-            XCTAssertTrue(document.stringValue.contains("teamID"), "\(type) should keep the scalar FK")
+        let requests: [GraphQLRequest<Project2V2>] = [.update(project), .delete(project)]
+        for request in requests {
+            XCTAssertFalse(request.document.contains("team {"), request.document)
+            XCTAssertTrue(request.document.contains("teamID"), request.document)
         }
+    }
+
+    /// - Given: the same `hasOne` model.
+    /// - When: a DataStore sync mutation request is generated (`createMutation`).
+    /// - Then: the nested `team { ... }` object is STILL selected — the omission is scoped to the
+    ///   API category, so DataStore's sync/lazy-load selection is unchanged.
+    func testDataStoreSyncMutationForHasOneKeepsNestedObject() {
+        let project = Project2V2(name: "name", teamID: "team-id")
+        let request = GraphQLRequest<MutationSyncResult>.createMutation(
+            of: project,
+            modelSchema: Project2V2.schema,
+            version: 1
+        )
+
+        XCTAssertTrue(request.document.contains("team {"), request.document)
     }
 
     /// - Given: the same `hasOne` model.
@@ -75,6 +74,6 @@ class GraphQLHasOneMutationSelectionTests: XCTestCase {
         documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
         let document = documentBuilder.build()
 
-        XCTAssertTrue(document.stringValue.contains("team {"))
+        XCTAssertTrue(document.stringValue.contains("team {"), document.stringValue)
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLHasOneMutationSelectionTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLHasOneMutationSelectionTests.swift
@@ -76,4 +76,17 @@ class GraphQLHasOneMutationSelectionTests: XCTestCase {
 
         XCTAssertTrue(document.stringValue.contains("team {"), document.stringValue)
     }
+
+    /// - Given: the same `hasOne` model.
+    /// - When: a `GraphQLMutation` is built through its public initializers.
+    /// - Then: the nested `team { ... }` object is selected (the public inits default to including
+    ///   `hasOne` associations; only the API-category path opts out).
+    func testGraphQLMutationPublicInitsIncludeNestedHasOne() {
+        XCTAssertTrue(
+            GraphQLMutation(modelSchema: Project2V2.schema, primaryKeysOnly: true).stringValue.contains("team {")
+        )
+        XCTAssertTrue(
+            GraphQLMutation(modelType: Project2V2.self, primaryKeysOnly: true).stringValue.contains("team {")
+        )
+    }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLHasOneMutationSelectionTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLHasOneMutationSelectionTests.swift
@@ -1,0 +1,80 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@testable import Amplify
+@testable import AmplifyTestCommon
+@testable import AWSPluginsCore
+
+class GraphQLHasOneMutationSelectionTests: XCTestCase {
+
+    override func setUp() {
+        ModelRegistry.register(modelType: Project2V2.self)
+        ModelRegistry.register(modelType: Team2V2.self)
+    }
+
+    override func tearDown() {
+        ModelRegistry.reset()
+    }
+
+    /// - Given: a `Project2V2` model whose `team` is a `hasOne` with its foreign key (`teamID`)
+    ///   declared on the source model — the same shape as the issue's model (`Like.user`).
+    /// - When: a `.create` mutation document is generated.
+    /// - Then: the nested `team { ... }` object is NOT selected (on a mutation response AppSync
+    ///   returns it as null, which previously caused "Cannot return null for non-nullable type"),
+    ///   while the scalar foreign key `teamID` IS selected so the association stays lazy-loadable.
+    ///   See https://github.com/aws-amplify/amplify-swift/issues/3913
+    func testCreateMutationForHasOneOmitsNestedObjectAndKeepsForeignKey() {
+        let project = Project2V2(name: "name", teamID: "team-id")
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(
+            modelSchema: Project2V2.schema,
+            operationType: .mutation,
+            primaryKeysOnly: true
+        )
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .create))
+        documentBuilder.add(decorator: ModelDecorator(model: project, mutationType: .create))
+        let document = documentBuilder.build()
+
+        XCTAssertEqual(document.name, "createProject2V2")
+        XCTAssertFalse(document.stringValue.contains("team {"))
+        XCTAssertTrue(document.stringValue.contains("teamID"))
+    }
+
+    /// The same omission applies to `update` and `delete` (all mutation types share the selection).
+    func testUpdateAndDeleteMutationsForHasOneOmitNestedObjectAndKeepForeignKey() {
+        let project = Project2V2(name: "name", teamID: "team-id")
+        for type in [GraphQLMutationType.update, GraphQLMutationType.delete] {
+            var documentBuilder = ModelBasedGraphQLDocumentBuilder(
+                modelSchema: Project2V2.schema,
+                operationType: .mutation,
+                primaryKeysOnly: true
+            )
+            documentBuilder.add(decorator: DirectiveNameDecorator(type: type))
+            documentBuilder.add(decorator: ModelDecorator(model: project, mutationType: type))
+            let document = documentBuilder.build()
+
+            XCTAssertFalse(document.stringValue.contains("team {"), "\(type) should not nest the hasOne")
+            XCTAssertTrue(document.stringValue.contains("teamID"), "\(type) should keep the scalar FK")
+        }
+    }
+
+    /// - Given: the same `hasOne` model.
+    /// - When: a `.query` document is generated.
+    /// - Then: queries are unaffected — the nested `team { ... }` object is still selected.
+    func testGetQueryForHasOneStillSelectsNestedObject() {
+        var documentBuilder = ModelBasedGraphQLDocumentBuilder(
+            modelSchema: Project2V2.schema,
+            operationType: .query,
+            primaryKeysOnly: true
+        )
+        documentBuilder.add(decorator: DirectiveNameDecorator(type: .get))
+        let document = documentBuilder.build()
+
+        XCTAssertTrue(document.stringValue.contains("team {"))
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/HasOneMutationSelectionEdgeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/HasOneMutationSelectionEdgeTests.swift
@@ -14,10 +14,24 @@ import XCTest
 
 private struct MFKTeam: Model {
     let id: String
-    init(id: String = UUID().uuidString) { self.id = id }
-    enum CodingKeys: String, ModelKey { case id }
+    let region: String
+    init(id: String = UUID().uuidString, region: String = "na") {
+        self.id = id
+        self.region = region
+    }
+    enum CodingKeys: String, ModelKey { case id, region }
     static let keys = CodingKeys.self
-    static let schema = defineSchema { model in model.fields(.id()) }
+    static let schema = defineSchema { model in
+        let team = MFKTeam.keys
+        model.attributes(.primaryKey(fields: [team.id, team.region]))
+        model.fields(
+            .field(team.id, is: .required, ofType: .string),
+            .field(team.region, is: .required, ofType: .string)
+        )
+    }
+
+    class Path: ModelPath<MFKTeam> {}
+    static var rootPath: PropertyContainerPath? { Path() }
 }
 
 private struct MFKProject: Model {
@@ -39,9 +53,14 @@ private struct MFKProject: Model {
             .id(),
             .field(project.teamId, is: .required, ofType: .string),
             .field(project.teamName, is: .required, ofType: .string),
-            .hasOne(project.team, is: .optional, ofType: MFKTeam.self, associatedWith: MFKTeam.keys.id, targetNames: ["teamId", "teamName"])
+            .hasOne(project.team, is: .optional, ofType: MFKTeam.self, associatedFields: [MFKTeam.keys.id, MFKTeam.keys.region], targetNames: ["teamId", "teamName"])
         )
     }
+
+    class Path: ModelPath<MFKProject> {
+        var team: ModelPath<MFKTeam> { MFKTeam.Path(name: "team", parent: self) }
+    }
+    static var rootPath: PropertyContainerPath? { Path() }
 }
 
 // MARK: - `hasOne` whose foreign key is part of a composite primary key (the issue's `Like.user` shape)
@@ -114,5 +133,20 @@ class HasOneMutationSelectionEdgeTests: XCTestCase {
         let occurrences = doc.components(separatedBy: "userId").count - 1
         XCTAssertGreaterThanOrEqual(occurrences, 1, doc)
         XCTAssertEqual(doc.components(separatedBy: "\n").count(where: { $0.contains("userId") }), 1, "userId should be selected on exactly one line\n\(doc)")
+    }
+
+    /// - Given: an API `.create` mutation that explicitly `includes` a `hasOne` association.
+    /// - When: the request document is generated.
+    /// - Then: the nested object is still omitted (the hasOne include is dropped, since AppSync
+    ///   redacts it to null on a mutation response) while the scalar foreign keys remain.
+    func testHasOneIncludeOnApiMutationIsDroppedAndNestedObjectStaysOmitted() {
+        let project = MFKProject(teamId: "t-id", teamName: "t-name")
+        let doc = GraphQLRequest<MFKProject>.create(project) { path in
+            (path as? MFKProject.Path).map { [$0.team] } ?? []
+        }.document
+
+        XCTAssertFalse(doc.contains("team {"), doc)
+        XCTAssertTrue(doc.contains("teamId"), doc)
+        XCTAssertTrue(doc.contains("teamName"), doc)
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/HasOneMutationSelectionEdgeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/HasOneMutationSelectionEdgeTests.swift
@@ -1,0 +1,118 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@testable import Amplify
+@testable import AWSPluginsCore
+
+// MARK: - Multi-field foreign-key `hasOne`
+
+private struct MFKTeam: Model {
+    let id: String
+    init(id: String = UUID().uuidString) { self.id = id }
+    enum CodingKeys: String, ModelKey { case id }
+    static let keys = CodingKeys.self
+    static let schema = defineSchema { model in model.fields(.id()) }
+}
+
+private struct MFKProject: Model {
+    let id: String
+    var teamId: String
+    var teamName: String
+    var team: MFKTeam?
+    init(id: String = UUID().uuidString, teamId: String, teamName: String, team: MFKTeam? = nil) {
+        self.id = id
+        self.teamId = teamId
+        self.teamName = teamName
+        self.team = team
+    }
+    enum CodingKeys: String, ModelKey { case id, teamId, teamName, team }
+    static let keys = CodingKeys.self
+    static let schema = defineSchema { model in
+        let project = MFKProject.keys
+        model.fields(
+            .id(),
+            .field(project.teamId, is: .required, ofType: .string),
+            .field(project.teamName, is: .required, ofType: .string),
+            .hasOne(project.team, is: .optional, ofType: MFKTeam.self, associatedWith: MFKTeam.keys.id, targetNames: ["teamId", "teamName"])
+        )
+    }
+}
+
+// MARK: - `hasOne` whose foreign key is part of a composite primary key (the issue's `Like.user` shape)
+
+private struct CPKUser: Model {
+    let id: String
+    init(id: String = UUID().uuidString) { self.id = id }
+    enum CodingKeys: String, ModelKey { case id }
+    static let keys = CodingKeys.self
+    static let schema = defineSchema { model in model.fields(.id()) }
+}
+
+private struct CPKLike: Model {
+    let id: String
+    var userId: String
+    var user: CPKUser?
+    init(id: String = UUID().uuidString, userId: String, user: CPKUser? = nil) {
+        self.id = id
+        self.userId = userId
+        self.user = user
+    }
+    enum CodingKeys: String, ModelKey { case id, userId, user }
+    static let keys = CodingKeys.self
+    static let schema = defineSchema { model in
+        let like = CPKLike.keys
+        model.fields(
+            .id(),
+            .field(like.userId, is: .required, ofType: .string),
+            .hasOne(like.user, is: .optional, ofType: CPKUser.self, associatedWith: CPKUser.keys.id, targetName: "userId")
+        )
+        model.attributes(.primaryKey(fields: [like.id, like.userId]))
+    }
+}
+
+class HasOneMutationSelectionEdgeTests: XCTestCase {
+
+    override func setUp() {
+        ModelRegistry.register(modelType: MFKProject.self)
+        ModelRegistry.register(modelType: MFKTeam.self)
+        ModelRegistry.register(modelType: CPKUser.self)
+        ModelRegistry.register(modelType: CPKLike.self)
+    }
+
+    override func tearDown() {
+        ModelRegistry.reset()
+    }
+
+    /// - Given: a `hasOne` backed by a multi-field foreign key (`targetNames: ["teamId","teamName"]`).
+    /// - When: an API `.create` mutation is generated.
+    /// - Then: the nested object is omitted and BOTH scalar foreign-key fields are selected.
+    func testMultiFieldForeignKeyHasOne_apiMutationOmitsNestedAndKeepsAllForeignKeys() {
+        let project = MFKProject(teamId: "t-id", teamName: "t-name")
+        let doc = GraphQLRequest<MFKProject>.create(project).document
+
+        XCTAssertFalse(doc.contains("team {"), doc)
+        XCTAssertTrue(doc.contains("teamId"), doc)
+        XCTAssertTrue(doc.contains("teamName"), doc)
+    }
+
+    /// - Given: a `hasOne` whose foreign key (`userId`) is also a sort field of the composite
+    ///   primary key — the same shape as the issue's `Like.user`.
+    /// - When: an API `.create` mutation is generated.
+    /// - Then: the nested object is omitted, and the foreign key is still selected exactly once.
+    func testCompositeKeyForeignKeyHasOne_apiMutationOmitsNestedAndKeepsForeignKeyOnce() {
+        let like = CPKLike(userId: "u-id")
+        let doc = GraphQLRequest<CPKLike>.create(like).document
+
+        XCTAssertFalse(doc.contains("user {"), doc)
+        // FK present, and not duplicated (it is already a selected primary-key scalar).
+        let occurrences = doc.components(separatedBy: "userId").count - 1
+        XCTAssertGreaterThanOrEqual(occurrences, 1, doc)
+        XCTAssertEqual(doc.components(separatedBy: "\n").filter { $0.contains("userId") }.count, 1, "userId should be selected on exactly one line\n\(doc)")
+    }
+}

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/HasOneMutationSelectionEdgeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/HasOneMutationSelectionEdgeTests.swift
@@ -95,6 +95,44 @@ private struct CPKLike: Model {
     }
 }
 
+// belongsTo variant: used to verify a non-`hasOne` association is not stripped on mutations.
+private struct BTChild: Model {
+    let id: String
+    init(id: String = UUID().uuidString) { self.id = id }
+    enum CodingKeys: String, ModelKey { case id }
+    static let keys = CodingKeys.self
+    static let schema = defineSchema { model in model.fields(.id()) }
+
+    class Path: ModelPath<BTChild> {}
+    static var rootPath: PropertyContainerPath? { Path() }
+}
+
+private struct BTParent: Model {
+    let id: String
+    var parentId: String
+    var parent: BTChild?
+    init(id: String = UUID().uuidString, parentId: String, parent: BTChild? = nil) {
+        self.id = id
+        self.parentId = parentId
+        self.parent = parent
+    }
+    enum CodingKeys: String, ModelKey { case id, parentId, parent }
+    static let keys = CodingKeys.self
+    static let schema = defineSchema { model in
+        let btParent = BTParent.keys
+        model.fields(
+            .id(),
+            .field(btParent.parentId, is: .required, ofType: .string),
+            .belongsTo(btParent.parent, is: .optional, ofType: BTChild.self, targetName: "parentId")
+        )
+    }
+
+    class Path: ModelPath<BTParent> {
+        var parent: ModelPath<BTChild> { BTChild.Path(name: "parent", parent: self) }
+    }
+    static var rootPath: PropertyContainerPath? { Path() }
+}
+
 class HasOneMutationSelectionEdgeTests: XCTestCase {
 
     override func setUp() {
@@ -102,6 +140,8 @@ class HasOneMutationSelectionEdgeTests: XCTestCase {
         ModelRegistry.register(modelType: MFKTeam.self)
         ModelRegistry.register(modelType: CPKUser.self)
         ModelRegistry.register(modelType: CPKLike.self)
+        ModelRegistry.register(modelType: BTParent.self)
+        ModelRegistry.register(modelType: BTChild.self)
     }
 
     override func tearDown() {
@@ -148,5 +188,24 @@ class HasOneMutationSelectionEdgeTests: XCTestCase {
         XCTAssertFalse(doc.contains("team {"), doc)
         XCTAssertTrue(doc.contains("teamId"), doc)
         XCTAssertTrue(doc.contains("teamName"), doc)
+    }
+
+    /// - Given: an API `.create` mutation that explicitly `includes` a `belongsTo` association.
+    /// - When: the request document is generated.
+    /// - Then: the nested object is kept — only `hasOne` includes are dropped on mutations.
+    func testBelongsToIncludeOnApiMutationIsKept() {
+        let btParent = BTParent(parentId: "p-id")
+        let doc = GraphQLRequest<BTParent>.create(btParent) { path in
+            (path as? BTParent.Path).map { [$0.parent] } ?? []
+        }.document
+
+        XCTAssertTrue(doc.contains("parent {"), doc)
+    }
+
+    /// Verifies `_associationTargetNames` returns the foreign key(s) for a `belongsTo` and an
+    /// empty array for a non-association field.
+    func testAssociationTargetNamesForBelongsToAndScalar() {
+        XCTAssertEqual(BTParent.schema.field(withName: "parent")?._associationTargetNames, ["parentId"])
+        XCTAssertEqual(BTParent.schema.field(withName: "parentId")?._associationTargetNames, [])
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/HasOneMutationSelectionEdgeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/HasOneMutationSelectionEdgeTests.swift
@@ -113,6 +113,6 @@ class HasOneMutationSelectionEdgeTests: XCTestCase {
         // FK present, and not duplicated (it is already a selected primary-key scalar).
         let occurrences = doc.components(separatedBy: "userId").count - 1
         XCTAssertGreaterThanOrEqual(occurrences, 1, doc)
-        XCTAssertEqual(doc.components(separatedBy: "\n").filter { $0.contains("userId") }.count, 1, "userId should be selected on exactly one line\n\(doc)")
+        XCTAssertEqual(doc.components(separatedBy: "\n").count(where: { $0.contains("userId") }), 1, "userId should be selected on exactly one line\n\(doc)")
     }
 }


### PR DESCRIPTION
## Description

On a mutation, AppSync returns a nested `hasOne` as null when it cannot confirm the child has the same auth as the parent, so `user { id }` is null and mutations fail to decode on owner-protected models. Related data should be fetched with a separate query: https://docs.amplify.aws/gen1/swift/build-a-backend/graphqlapi/relational-models/

The fix selects the foreign key instead of the nested object on API mutations and rebuilds the lazy reference from it. Eager models return `nil` (cannot rebuild), consistent with amplify-android/js. DataStore sync is unaffected: it only fails on transport errors and reconciles the partial response.

## Testing

- Verified mutations omit the nested `hasOne` and keep its foreign key (single-key, multi-field, composite-key), and that an explicit `hasOne` in `includes` is also dropped.
- Verified queries and DataStore sync still nest the `hasOne`, and that decode rebuilds the lazy reference from the FK for lazy models (skips eager).
- Confirmed each test fails on `main` without the fix.
- swiftformat clean; builds on macOS. Live-backend e2e not re-run (no backend access).

## Follow-ups
- Subscriptions: same redaction on pushed results; `GraphQLSubscription` unchanged (separate PR).
- belongsTo under owner auth: different root cause (aws-amplify/amplify-category-api#2859).

Refs #3913
