### PR TITLE
fix(api): stop AppSync reconnect and re-subscribe loop on non-recoverable errors

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeClient+HandleRequest.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeClient+HandleRequest.swift
@@ -79,6 +79,17 @@ extension AppSyncRealTimeClient {
             case (.connectionInit, .connectionAck):
                 return justTheResponse
 
+            case (.connectionInit, .connectionError):
+                // Surface connection-level errors (e.g. 401 UnauthorizedException)
+                // as a failure so connect()'s retry can stop on non-recoverable errors.
+                let errorsJson = response.payload?.errors
+                let errors = errorsJson?.asArray ?? errorsJson.map { [$0] } ?? []
+                let requestErrors = errors.compactMap(AppSyncRealTimeRequest.parseResponseError(error:))
+                return Fail(
+                    outputType: AppSyncRealTimeResponse.self,
+                    failure: requestErrors.first ?? .unknown(message: "connectionError", causedBy: nil, payload: nil)
+                ).eraseToAnyPublisher()
+
             case (.start(let startRequest), .startAck) where startRequest.id == response.id:
                 return justTheResponse
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeClient.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeClient.swift
@@ -358,7 +358,7 @@ actor AppSyncRealTimeClient: AppSyncRealTimeClientProtocol {
         return false
     }
 
-    private static func shouldRetryConnection(_ error: Swift.Error) -> Bool {
+    static func shouldRetryConnection(_ error: Swift.Error) -> Bool {
         // Cancellation is intentional; never retry it (avoids a busy-loop).
         if error is CancellationError {
             return false

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeClient.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeClient.swift
@@ -110,25 +110,14 @@ actor AppSyncRealTimeClient: AppSyncRealTimeClientProtocol {
         log.debug("[AppSyncRealTimeClient] client start connecting")
 
         do {
-            try await RetryWithJitter.execute(
-                shouldRetryOnError: { error in
-                    // Cancellation is intentional; never retry it (avoids a busy-loop).
-                    if error is CancellationError {
-                        return false
-                    }
-                    // Non-recoverable errors (auth/limits) can never succeed on retry;
-                    // retrying them just re-hammers AppSync with new connections.
-                    return !Self.isNonRecoverable(error)
-                },
-                { [weak self] in
-                    guard let self else { return }
-                    await webSocketClient.connect(
-                        autoConnectOnNetworkStatusChange: true,
-                        autoRetryOnConnectionFailure: true
-                    )
-                    try await sendRequest(.connectionInit)
-                }
-            )
+            try await RetryWithJitter.execute(shouldRetryOnError: Self.shouldRetryConnection) { [weak self] in
+                guard let self else { return }
+                await webSocketClient.connect(
+                    autoConnectOnNetworkStatusChange: true,
+                    autoRetryOnConnectionFailure: true
+                )
+                try await sendRequest(.connectionInit)
+            }
         } catch {
             // Give up on a non-recoverable error (e.g. expired auth): turn off the
             // socket's auto-retry so it stops reconnecting into the same failure.
@@ -367,6 +356,16 @@ actor AppSyncRealTimeClient: AppSyncRealTimeClientProtocol {
             }
         }
         return false
+    }
+
+    private static func shouldRetryConnection(_ error: Swift.Error) -> Bool {
+        // Cancellation is intentional; never retry it (avoids a busy-loop).
+        if error is CancellationError {
+            return false
+        }
+        // Non-recoverable errors (auth/limits) can never succeed on retry;
+        // retrying them just re-hammers AppSync with new connections.
+        return !isNonRecoverable(error)
     }
 
     private static func decodeAppSyncRealTimeResponseError(_ data: JSONValue?) -> [Error] {

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeClient.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeClient.swift
@@ -46,6 +46,9 @@ actor AppSyncRealTimeClient: AppSyncRealTimeClientProtocol {
 
     /// WebSocketClient offering connections at the WebSocket protocol level
     var webSocketClient: AppSyncWebSocketClientProtocol
+    /// Guards against overlapping reconnect attempts from the heartbeat-timeout
+    /// and connection-drop paths.
+    private var isReconnecting = false
     /// Writable data stream convert WebSocketEvent to AppSyncRealTimeResponse
     nonisolated let subject = PassthroughSubject<Result<AppSyncRealTimeResponse, Error>, Never>()
 
@@ -106,13 +109,36 @@ actor AppSyncRealTimeClient: AppSyncRealTimeClientProtocol {
         state.send(.connecting)
         log.debug("[AppSyncRealTimeClient] client start connecting")
 
-        try await RetryWithJitter.execute { [weak self] in
-            guard let self else { return }
-            await webSocketClient.connect(
-                autoConnectOnNetworkStatusChange: true,
-                autoRetryOnConnectionFailure: true
+        do {
+            try await RetryWithJitter.execute(
+                shouldRetryOnError: { error in
+                    // Cancellation is intentional; never retry it (avoids a busy-loop).
+                    if error is CancellationError {
+                        return false
+                    }
+                    // Non-recoverable errors (auth/limits) can never succeed on retry;
+                    // retrying them just re-hammers AppSync with new connections.
+                    return !Self.isNonRecoverable(error)
+                },
+                { [weak self] in
+                    guard let self else { return }
+                    await webSocketClient.connect(
+                        autoConnectOnNetworkStatusChange: true,
+                        autoRetryOnConnectionFailure: true
+                    )
+                    try await sendRequest(.connectionInit)
+                }
             )
-            try await sendRequest(.connectionInit)
+        } catch {
+            // Give up on a non-recoverable error (e.g. expired auth): turn off the
+            // socket's auto-retry so it stops reconnecting into the same failure.
+            // The error is surfaced to subscribers; a fresh subscribe() can reconnect.
+            if Self.isNonRecoverable(error) {
+                log.debug("[AppSyncRealTimeClient] Non-recoverable error, stopping reconnect")
+                await webSocketClient.disconnect()
+                state.send(.disconnected)
+            }
+            throw error
         }
     }
 
@@ -314,6 +340,14 @@ actor AppSyncRealTimeClient: AppSyncRealTimeClientProtocol {
     }
 
     private func reconnect() async {
+        // Single-flight: the heartbeat-timeout and connection-drop paths can both
+        // trigger a reconnect; without this guard each opens its own connection.
+        guard !isReconnecting else {
+            log.debug("[AppSyncRealTimeClient] Reconnect already in progress, skipping")
+            return
+        }
+        isReconnecting = true
+        defer { isReconnecting = false }
         do {
             log.debug("[AppSyncRealTimeClient] Reconnecting")
             await disconnect()
@@ -321,6 +355,18 @@ actor AppSyncRealTimeClient: AppSyncRealTimeClientProtocol {
         } catch {
             log.debug("[AppSyncRealTimeClient] Failed to reconnect, error: \(error)")
         }
+    }
+
+    static func isNonRecoverable(_ error: Swift.Error) -> Bool {
+        if let requestError = error as? AppSyncRealTimeRequest.Error {
+            switch requestError {
+            case .unauthorized, .maxSubscriptionsReached, .limitExceeded:
+                return true
+            case .timeout, .unknown:
+                return false
+            }
+        }
+        return false
     }
 
     private static func decodeAppSyncRealTimeResponseError(_ data: JSONValue?) -> [Error] {
@@ -368,9 +414,9 @@ extension AppSyncRealTimeClient {
                 log.debug("[AppSyncRealTimeClient] reconnecting appSyncClient after connection drop")
                 Task { [weak self] in
                     let task = Task { [weak self] in
-                        try? await self?.connect()
+                        await self?.reconnect()
                     }
-                    await self?.storeInConnectionCancellables(task.toAnyCancellable)
+                    await self?.storeInCancellables(task.toAnyCancellable)
                 }
             }
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeSubscription.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeSubscription.swift
@@ -30,6 +30,10 @@ actor AppSyncRealTimeSubscription {
     /// internal state for tracking subscription status
     private let state = CurrentValueSubject<State, Never>(.none)
 
+    /// Set when subscribe() fails with a non-recoverable error (e.g. expired
+    /// auth). A terminated subscription is not resubscribed on reconnect.
+    private var isTerminated = false
+
     /// publisher for monitoring subscription status
     var publisher: AnyPublisher<State, Never> {
         state.eraseToAnyPublisher()
@@ -52,6 +56,14 @@ actor AppSyncRealTimeSubscription {
     }
 
     func subscribe() async throws {
+        // A subscription that failed with a non-recoverable error (e.g. expired
+        // auth) must not be resubscribed on reconnect, otherwise it re-hammers
+        // AppSync with a subscription that can never succeed.
+        guard !isTerminated else {
+            log.debug("[AppSyncRealTimeSubscription-\(id)] Subscription terminated, not resubscribing")
+            return
+        }
+
         guard state.value != .subscribing else {
             log.debug("[AppSyncRealTimeSubscription-\(id)] Subscription already in subscribing state")
             return
@@ -76,6 +88,9 @@ actor AppSyncRealTimeSubscription {
             }
         } catch {
             log.debug("[AppSyncRealTimeSubscription-\(id)] Failed to subscribe, error: \(error)")
+            if AppSyncRealTimeClient.isNonRecoverable(error) {
+                isTerminated = true
+            }
             state.send(.failure)
             throw error
         }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeSubscription.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeSubscription.swift
@@ -88,7 +88,9 @@ actor AppSyncRealTimeSubscription {
             }
         } catch {
             log.debug("[AppSyncRealTimeSubscription-\(id)] Failed to subscribe, error: \(error)")
-            if AppSyncRealTimeClient.isNonRecoverable(error) {
+            // Only a hard auth failure is terminal. Transient errors (throttling,
+            // subscription limits) stay resumable on the next reconnect.
+            if (error as? AppSyncRealTimeRequest.Error) == .unauthorized {
                 isTerminated = true
             }
             state.send(.failure)

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AppSyncRealTimeClient/AppSyncRealTimeClientReconnectTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AppSyncRealTimeClient/AppSyncRealTimeClientReconnectTests.swift
@@ -49,6 +49,17 @@ class AppSyncRealTimeClientReconnectTests: XCTestCase {
         let webSocketClient = MockWebSocketClient()
         let client = makeClient(webSocketClient)
 
+        // Respond only once connectionInit has been written, so the request's
+        // listener is guaranteed to be subscribed first (avoids a timing race).
+        var cancellables = Set<AnyCancellable>()
+        await webSocketClient.actionSubject
+            .sink { action in
+                guard case .write(let message) = action,
+                      message.contains("connection_init") else { return }
+                client.subject.send(.success(self.unauthorizedConnectionError))
+            }
+            .store(in: &cancellables)
+
         let failed = expectation(description: "connectionInit fails with unauthorized")
         Task {
             do {
@@ -58,10 +69,6 @@ class AppSyncRealTimeClientReconnectTests: XCTestCase {
                 XCTAssertEqual(error as? AppSyncRealTimeRequest.Error, .unauthorized)
                 failed.fulfill()
             }
-        }
-        Task {
-            try await Task.sleep(nanoseconds: 80 * 1_000)
-            client.subject.send(.success(unauthorizedConnectionError))
         }
         await fulfillment(of: [failed], timeout: 3)
     }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AppSyncRealTimeClient/AppSyncRealTimeClientReconnectTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AppSyncRealTimeClient/AppSyncRealTimeClientReconnectTests.swift
@@ -1,0 +1,252 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Amplify
+@preconcurrency import Combine
+import XCTest
+@_spi(WebSocket) import AWSPluginsCore
+@testable import AWSAPIPlugin
+
+// Regression tests for the AppSync real-time connection/cost spike: a
+// session-expiry connection_error was swallowed, so connectionInit timed out and
+// connect() retried, opening a new connection on every retry.
+// https://github.com/aws-amplify/amplify-swift/issues/4007
+class AppSyncRealTimeClientReconnectTests: XCTestCase {
+
+    private func makeClient(
+        _ webSocketClient: MockWebSocketClient
+    ) -> AppSyncRealTimeClient {
+        AppSyncRealTimeClient(
+            endpoint: URL(string: "https://example.com")!,
+            requestInterceptor: MockAppSyncRequestInterceptor(),
+            webSocketClient: webSocketClient
+        )
+    }
+
+    private var unauthorizedConnectionError: AppSyncRealTimeResponse {
+        .init(
+            id: nil,
+            payload: .object([
+                "errors": .array([
+                    .object([
+                        "errorType": "UnauthorizedException",
+                        "message": "Unauthorized"
+                    ])
+                ])
+            ]),
+            type: .connectionError
+        )
+    }
+
+    // A connection_error received while waiting for connection_ack must fail the
+    // connectionInit request with the decoded error. Before the fix it was
+    // unhandled, so the request hung until it timed out.
+    func testConnectionInit_withUnauthorizedConnectionError_failsWithUnauthorized() async {
+        let webSocketClient = MockWebSocketClient()
+        let client = makeClient(webSocketClient)
+
+        let failed = expectation(description: "connectionInit fails with unauthorized")
+        Task {
+            do {
+                try await client.sendRequest(.connectionInit, timeout: 2)
+                XCTFail("connectionInit should have failed")
+            } catch {
+                XCTAssertEqual(error as? AppSyncRealTimeRequest.Error, .unauthorized)
+                failed.fulfill()
+            }
+        }
+        Task {
+            try await Task.sleep(nanoseconds: 80 * 1_000)
+            client.subject.send(.success(unauthorizedConnectionError))
+        }
+        await fulfillment(of: [failed], timeout: 3)
+    }
+
+    // A non-recoverable auth error must stop connect() immediately instead of
+    // retrying, otherwise every retry opens another connection to AppSync.
+    func testConnect_withUnauthorizedError_throwsWithoutRetrying() async {
+        let webSocketClient = MockWebSocketClient()
+        let client = makeClient(webSocketClient)
+
+        let lock = NSLock()
+        var connectionInitCount = 0
+        var cancellables = Set<AnyCancellable>()
+        await webSocketClient.actionSubject
+            .sink { action in
+                guard case .write(let message) = action,
+                      message.contains("connection_init") else { return }
+                lock.lock()
+                connectionInitCount += 1
+                lock.unlock()
+                client.subject.send(.success(self.unauthorizedConnectionError))
+            }
+            .store(in: &cancellables)
+
+        let failed = expectation(description: "connect fails with unauthorized")
+        Task {
+            do {
+                try await client.connect()
+                XCTFail("connect should have failed")
+            } catch {
+                XCTAssertEqual(error as? AppSyncRealTimeRequest.Error, .unauthorized)
+                failed.fulfill()
+            }
+        }
+        await fulfillment(of: [failed], timeout: 3)
+
+        lock.lock()
+        let count = connectionInitCount
+        lock.unlock()
+        XCTAssertEqual(count, 1, "connect() must not retry a non-recoverable auth error")
+    }
+
+    // The continuous connection spam comes from the socket auto-retrying into the
+    // same auth failure. On a non-recoverable error the client must disconnect the
+    // socket to turn that auto-retry off.
+    func testConnect_withUnauthorizedError_stopsSocketAutoRetry() async {
+        let webSocketClient = MockWebSocketClient()
+        let client = makeClient(webSocketClient)
+
+        let disconnected = expectation(description: "socket disconnected to stop auto-retry")
+        disconnected.assertForOverFulfill = false
+        var cancellables = Set<AnyCancellable>()
+        await webSocketClient.actionSubject
+            .sink { action in
+                switch action {
+                case .write(let message) where message.contains("connection_init"):
+                    client.subject.send(.success(self.unauthorizedConnectionError))
+                case .disconnect:
+                    disconnected.fulfill()
+                default:
+                    break
+                }
+            }
+            .store(in: &cancellables)
+
+        let failed = expectation(description: "connect fails with unauthorized")
+        Task {
+            do {
+                try await client.connect()
+                XCTFail("connect should have failed")
+            } catch {
+                XCTAssertEqual(error as? AppSyncRealTimeRequest.Error, .unauthorized)
+                failed.fulfill()
+            }
+        }
+        await fulfillment(of: [failed, disconnected], timeout: 3)
+    }
+
+    // Guards the give-up predicate: only auth/limit errors are non-recoverable.
+    // Recoverable errors (timeout, network, cancellation) must NOT trigger the
+    // give-up, otherwise normal reconnection would be broken.
+    func testIsNonRecoverable_classification() {
+        XCTAssertTrue(AppSyncRealTimeClient.isNonRecoverable(AppSyncRealTimeRequest.Error.unauthorized))
+        XCTAssertTrue(AppSyncRealTimeClient.isNonRecoverable(AppSyncRealTimeRequest.Error.maxSubscriptionsReached))
+        XCTAssertTrue(AppSyncRealTimeClient.isNonRecoverable(AppSyncRealTimeRequest.Error.limitExceeded))
+        XCTAssertFalse(AppSyncRealTimeClient.isNonRecoverable(AppSyncRealTimeRequest.Error.timeout))
+        XCTAssertFalse(AppSyncRealTimeClient.isNonRecoverable(
+            AppSyncRealTimeRequest.Error.unknown(payload: nil)
+        ))
+        XCTAssertFalse(AppSyncRealTimeClient.isNonRecoverable(CancellationError()))
+        XCTAssertFalse(AppSyncRealTimeClient.isNonRecoverable(URLError(.notConnectedToInternet)))
+    }
+
+    // A subscription that fails with a non-recoverable error must not be
+    // resubscribed on the next reconnect (resumeExistingSubscriptions), otherwise
+    // it re-sends `start` on every reconnect — the SubscribeClientError spike.
+    func testSubscription_afterNonRecoverableError_isNotResubscribed() async {
+        let webSocketClient = MockWebSocketClient()
+        let client = makeClient(webSocketClient)
+        let subscription = AppSyncRealTimeSubscription(
+            id: "sub-4007",
+            query: "subscription { onEvent { id } }",
+            appSyncRealTimeClient: client
+        )
+
+        let lock = NSLock()
+        var startCount = 0
+        var cancellables = Set<AnyCancellable>()
+        await webSocketClient.actionSubject
+            .sink { action in
+                guard case .write(let message) = action,
+                      message.contains("sub-4007") else { return }
+                lock.lock()
+                startCount += 1
+                lock.unlock()
+                client.subject.send(.success(.init(
+                    id: "sub-4007",
+                    payload: .object([
+                        "errors": .array([
+                            .object([
+                                "errorType": "UnauthorizedException",
+                                "message": "Unauthorized"
+                            ])
+                        ])
+                    ]),
+                    type: .error
+                )))
+            }
+            .store(in: &cancellables)
+
+        // First subscribe fails with a non-recoverable auth error -> terminated.
+        do {
+            try await subscription.subscribe()
+            XCTFail("subscribe should have failed")
+        } catch {
+            XCTAssertEqual(error as? AppSyncRealTimeRequest.Error, .unauthorized)
+        }
+
+        // Simulate resume-on-reconnect: it must NOT send another start.
+        try? await subscription.subscribe()
+
+        lock.lock()
+        let count = startCount
+        lock.unlock()
+        XCTAssertEqual(count, 1, "a non-recoverable subscription failure must not be resubscribed")
+    }
+
+    // The heartbeat-timeout and connection-drop paths can both fire a reconnect.
+    // While one reconnect is in flight (connect() blocked awaiting connection_ack)
+    // the other must be skipped, so only a single connection is opened.
+    func testConcurrentReconnects_areSingleFlight() async throws {
+        let webSocketClient = MockWebSocketClient()
+        let client = makeClient(webSocketClient)
+
+        let lock = NSLock()
+        var connectCount = 0
+        var cancellables = Set<AnyCancellable>()
+        await webSocketClient.actionSubject
+            .sink { action in
+                guard case .connect = action else { return }
+                lock.lock()
+                connectCount += 1
+                lock.unlock()
+            }
+            .store(in: &cancellables)
+
+        // Let the client subscribe to the WebSocket event publisher (init Task).
+        try await Task.sleep(nanoseconds: 200 * 1_000_000)
+
+        // First reconnect: connect() blocks (no connection_ack ever sent), so the
+        // reconnect stays in flight for the whole window.
+        await webSocketClient.subject.send(.disconnected(.normalClosure, nil))
+        try await Task.sleep(nanoseconds: 150 * 1_000_000)
+        await webSocketClient.subject.send(.connected)
+        try await Task.sleep(nanoseconds: 300 * 1_000_000)
+
+        // Second trigger while the first reconnect is still in flight.
+        await webSocketClient.subject.send(.disconnected(.normalClosure, nil))
+        try await Task.sleep(nanoseconds: 150 * 1_000_000)
+        await webSocketClient.subject.send(.connected)
+        try await Task.sleep(nanoseconds: 300 * 1_000_000)
+
+        lock.lock()
+        let count = connectCount
+        lock.unlock()
+        XCTAssertEqual(count, 1, "overlapping reconnects must collapse to a single connect()")
+    }
+}

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AppSyncRealTimeClient/AppSyncRealTimeClientReconnectTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AppSyncRealTimeClient/AppSyncRealTimeClientReconnectTests.swift
@@ -155,6 +155,15 @@ class AppSyncRealTimeClientReconnectTests: XCTestCase {
         XCTAssertFalse(AppSyncRealTimeClient.isNonRecoverable(URLError(.notConnectedToInternet)))
     }
 
+    // Guards the connect() retry predicate: cancellation and non-recoverable
+    // errors are not retried; everything else (e.g. timeout) is.
+    func testShouldRetryConnection_classification() {
+        XCTAssertFalse(AppSyncRealTimeClient.shouldRetryConnection(CancellationError()))
+        XCTAssertFalse(AppSyncRealTimeClient.shouldRetryConnection(AppSyncRealTimeRequest.Error.unauthorized))
+        XCTAssertTrue(AppSyncRealTimeClient.shouldRetryConnection(AppSyncRealTimeRequest.Error.timeout))
+        XCTAssertTrue(AppSyncRealTimeClient.shouldRetryConnection(URLError(.networkConnectionLost)))
+    }
+
     // A subscription that fails with a non-recoverable error must not be
     // resubscribed on the next reconnect (resumeExistingSubscriptions), otherwise
     // it re-sends `start` on every reconnect — the SubscribeClientError spike.
@@ -248,5 +257,58 @@ class AppSyncRealTimeClientReconnectTests: XCTestCase {
         let count = connectCount
         lock.unlock()
         XCTAssertEqual(count, 1, "overlapping reconnects must collapse to a single connect()")
+    }
+
+    // A transient error (e.g. LimitExceededError throttling) must NOT permanently
+    // terminate the subscription; it stays resumable on the next reconnect.
+    func testSubscription_afterLimitExceeded_isResubscribed() async {
+        let webSocketClient = MockWebSocketClient()
+        let client = makeClient(webSocketClient)
+        let subscription = AppSyncRealTimeSubscription(
+            id: "sub-limit",
+            query: "subscription { onEvent { id } }",
+            appSyncRealTimeClient: client
+        )
+
+        let lock = NSLock()
+        var startCount = 0
+        var cancellables = Set<AnyCancellable>()
+        await webSocketClient.actionSubject
+            .sink { action in
+                guard case .write(let message) = action,
+                      message.contains("sub-limit") else { return }
+                lock.lock()
+                startCount += 1
+                lock.unlock()
+                client.subject.send(.success(.init(
+                    id: "sub-limit",
+                    payload: .object([
+                        "errors": .array([
+                            .object([
+                                "errorType": "LimitExceededError",
+                                "message": "Rate exceeded"
+                            ])
+                        ])
+                    ]),
+                    type: .error
+                )))
+            }
+            .store(in: &cancellables)
+
+        // First subscribe fails with a transient limit error.
+        do {
+            try await subscription.subscribe()
+            XCTFail("subscribe should have failed")
+        } catch {
+            XCTAssertEqual(error as? AppSyncRealTimeRequest.Error, .limitExceeded)
+        }
+
+        // Resume-on-reconnect must send another start (not permanently terminated).
+        try? await subscription.subscribe()
+
+        lock.lock()
+        let count = startCount
+        lock.unlock()
+        XCTAssertEqual(count, 2, "a transient limitExceeded must be retried on resubscribe, not terminated")
     }
 }


### PR DESCRIPTION
## Description

On a non-recoverable auth error (e.g. an expired token, which AppSync returns as a `connection_error` with `UnauthorizedException`), the client kept reconnecting and re-subscribing instead of stopping, thus opening connections continuously. The error was never surfaced to `connect()`, so it timed out and retried as if transient.

Now the error is surfaced, so `connect()` stops retrying, the socket is disconnected to end its auto-reconnect, overlapping reconnects are single-flighted, and a subscription isn't resubscribed after a hard auth failure. Transient errors (throttling, limits) stay resumable.

**Note:** The related `noIdentityPool` auth-error masking mentioned in the issue (a signed-in user's session error surfacing as a configuration error) is a separate follow-up in the Auth plugin, not included here.

## Testing

- Regression tests covering each path, all failing on unpatched main: `connection_error` surfaced as `.unauthorized`, `connect()` does not retry, the socket disconnects on give-up, overlapping reconnects collapse to a single `connect()`, a hard auth failure is not resubscribed, and a transient `LimitExceededError` stays resumable.
- AWSAPIPlugin unit suite passing; `swiftformat` and `swiftlint` clean; builds on iOS, macOS, tvOS, watchOS.
- Couldn't reproduce the full-scale spike or run live e2e locally. No repro steps exist and it requires the reporter's setup.

Refs #4007
