### PR TITLE
fix(auth): preserve user pool tokens when no identity pool is configured

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/FetchAuthSessionOperationHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/FetchAuthSessionOperationHelper.swift
@@ -132,9 +132,12 @@ class FetchAuthSessionOperationHelper {
         }
 
         switch error {
-        case .sessionError(let fetchError, _):
+        case .sessionError(let fetchError, let credentials):
             if (fetchError == .notAuthorized || fetchError == .noCredentialsToRefresh) && !isSignedIn {
                 return AuthCognitoSignedOutSessionHelper.makeSessionWithNoGuestAccess()
+            } else if case .noIdentityPool = fetchError {
+                // A missing identity pool must not fail the user-pool token result.
+                return credentials.cognitoSession
             } else {
                 authError = fetchError.authError
             }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/FetchAuthSessionNoIdentityPoolTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/FetchAuthSessionNoIdentityPoolTests.swift
@@ -1,0 +1,73 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+import AWSPluginsCore
+import XCTest
+@testable import Amplify
+@testable import AWSCognitoAuthPlugin
+
+class FetchAuthSessionNoIdentityPoolTests: XCTestCase {
+
+    /// Test fetchAuthSession error mapping for a signed-in user without an identity pool
+    ///
+    /// - Given: A signed-in session that fails with a `.noIdentityPool` fetch error
+    /// - When:
+    ///    - The session result is built from that error
+    /// - Then:
+    ///    - getCognitoTokens() succeeds (user-pool tokens are unaffected)
+    ///    - getAWSCredentials() fails (no identity pool configured)
+    ///
+    func testNoIdentityPoolSessionError_whenSignedIn_preservesUserPoolTokens() async throws {
+        let helper = FetchAuthSessionOperationHelper()
+        let credentials = AmplifyCredentials.userPoolOnly(signedInData: .testData)
+        let error = AuthorizationError.sessionError(.noIdentityPool, credentials)
+
+        let session = try await helper.sessionResultWithError(
+            error,
+            authenticationState: .signedIn(.testData)
+        )
+
+        let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+        guard case .success = tokensResult else {
+            XCTFail("getCognitoTokens() should succeed, got \(String(describing: tokensResult))")
+            return
+        }
+
+        let awsResult = (session as? AuthAWSCredentialsProvider)?.getAWSCredentials()
+        guard case .failure = awsResult else {
+            XCTFail("getAWSCredentials() should fail without an identity pool")
+            return
+        }
+    }
+
+    /// Test that a non-`noIdentityPool` session error keeps its previous behavior
+    ///
+    /// - Given: A signed-in session that fails with a non-`noIdentityPool` error (`.invalidTokens`)
+    /// - When:
+    ///    - The session result is built from that error
+    /// - Then:
+    ///    - getCognitoTokens() still fails, so the fix only diverts the noIdentityPool case
+    ///
+    func testOtherSessionError_whenSignedIn_stillFailsTokenResult() async throws {
+        let helper = FetchAuthSessionOperationHelper()
+        let credentials = AmplifyCredentials.userPoolOnly(signedInData: .testData)
+        let error = AuthorizationError.sessionError(.invalidTokens, credentials)
+
+        let session = try await helper.sessionResultWithError(
+            error,
+            authenticationState: .signedIn(.testData)
+        )
+
+        let tokensResult = (session as? AuthCognitoTokensProvider)?.getCognitoTokens()
+        guard case .failure = tokensResult else {
+            XCTFail("non-noIdentityPool error should still fail the token result")
+            return
+        }
+    }
+}


### PR DESCRIPTION
## Description

`sessionResultWithError` applied a single error to all three session results, so a `.noIdentityPool` error failed `getCognitoTokens()` with `AuthError.configuration("No identity pool configuration found")` on user-pool-only apps. This returns the per-credential session for that case, so user pool tokens stay valid and only the identity and AWS credential results carry the error.

## Testing

- Regression test (fails on `main` without the fix): a signed-in `.noIdentityPool` session returns valid tokens and failing AWS credentials; a scoping test confirms other errors still fail.
- AWSCognitoAuthPlugin unit suite passing; `swiftformat`/`swiftlint` clean; builds on iOS, macOS, tvOS, watchOS.
- Couldn't reproduce the runtime trigger locally; verified against the error-mapping directly.

Refs #4007
