### PR TITLE
fix(auth): Refresh rejected identity ID

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/FetchAuthorizationSession/AWSCredentials/FetchAuthAWSCredentials.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/FetchAuthorizationSession/AWSCredentials/FetchAuthAWSCredentials.swift
@@ -32,6 +32,24 @@ struct FetchAuthAWSCredentials: Action {
             return
         }
 
+        await fetchCredentials(
+            withIdentityID: identityID,
+            canRetryWithFreshIdentityID: true,
+            client: client,
+            authZEnvironment: authZEnvironment,
+            dispatcher: dispatcher,
+            environment: environment
+        )
+    }
+
+    private func fetchCredentials(
+        withIdentityID identityID: String,
+        canRetryWithFreshIdentityID: Bool,
+        client: CognitoIdentityBehavior,
+        authZEnvironment: AuthorizationEnvironment,
+        dispatcher: EventDispatcher,
+        environment: Environment
+    ) async {
         let getCredentialsInput = GetCredentialsForIdentityInput(
             identityId: identityID,
             logins: loginsMap
@@ -68,10 +86,58 @@ struct FetchAuthAWSCredentials: Action {
             await dispatcher.send(event)
 
         } catch {
+            // Rejected identity ID: evict and retry via fresh GetId.
+            if canRetryWithFreshIdentityID, isStaleIdentityError(error) {
+                await retryWithFreshIdentityID(
+                    client: client,
+                    authZEnvironment: authZEnvironment,
+                    dispatcher: dispatcher,
+                    environment: environment
+                )
+                return
+            }
             let event = FetchAuthSessionEvent(eventType: .throwError(.service(error)))
             logVerbose("\(#fileID) Sending event \(event.type)", environment: environment)
             await dispatcher.send(event)
         }
+    }
+
+    private func retryWithFreshIdentityID(
+        client: CognitoIdentityBehavior,
+        authZEnvironment: AuthorizationEnvironment,
+        dispatcher: EventDispatcher,
+        environment: Environment
+    ) async {
+        let getIdInput = GetIdInput(
+            identityPoolId: authZEnvironment.identityPoolConfiguration.poolId,
+            logins: loginsMap
+        )
+        do {
+            let response = try await client.getId(input: getIdInput)
+            guard let freshIdentityID = response.identityId else {
+                let event = FetchAuthSessionEvent(eventType: .throwError(.invalidIdentityID))
+                await dispatcher.send(event)
+                return
+            }
+            await fetchCredentials(
+                withIdentityID: freshIdentityID,
+                canRetryWithFreshIdentityID: false,
+                client: client,
+                authZEnvironment: authZEnvironment,
+                dispatcher: dispatcher,
+                environment: environment
+            )
+        } catch {
+            let event = FetchAuthSessionEvent(eventType: .throwError(.service(error)))
+            logVerbose("\(#fileID) Sending event \(event.type)", environment: environment)
+            await dispatcher.send(event)
+        }
+    }
+
+    // Codes returned when the identity ID is stale.
+    private func isStaleIdentityError(_ error: Error) -> Bool {
+        error is AWSCognitoIdentity.NotAuthorizedException ||
+        error is AWSCognitoIdentity.ResourceNotFoundException
     }
 }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/FetchAuthorizationSession/AWSCredentials/FetchAuthAWSCredentials.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/FetchAuthorizationSession/AWSCredentials/FetchAuthAWSCredentials.swift
@@ -86,7 +86,7 @@ struct FetchAuthAWSCredentials: Action {
             await dispatcher.send(event)
 
         } catch {
-            // Rejected identity ID: evict and retry via fresh GetId.
+            // Retry once with a fresh identity ID.
             if canRetryWithFreshIdentityID, isStaleIdentityError(error) {
                 await retryWithFreshIdentityID(
                     client: client,
@@ -134,10 +134,18 @@ struct FetchAuthAWSCredentials: Action {
         }
     }
 
-    // Codes returned when the identity ID is stale.
+    // A stale identity ID always yields ResourceNotFoundException. NotAuthorized
+    // is only stale when Cognito reports the identity is forbidden; invalid or
+    // expired login-token errors must surface immediately without a GetId retry.
     private func isStaleIdentityError(_ error: Error) -> Bool {
-        error is AWSCognitoIdentity.NotAuthorizedException ||
-        error is AWSCognitoIdentity.ResourceNotFoundException
+        if error is AWSCognitoIdentity.ResourceNotFoundException {
+            return true
+        }
+        if let notAuthorized = error as? AWSCognitoIdentity.NotAuthorizedException,
+           let message = notAuthorized.properties.message {
+            return message.contains("Access to Identity") && message.contains("is forbidden")
+        }
+        return false
     }
 }
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchAWSCredentials/FetchAuthAWSCredentialsTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchAWSCredentials/FetchAuthAWSCredentialsTests.swift
@@ -193,4 +193,134 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
         )
     }
 
+    /// NotAuthorized evicts the stale identity ID and retries via fresh GetId.
+    func testNotAuthorizedEvictsIdentityAndRetries() async {
+        await assertStaleIdentityRecovery(
+            firstError: AWSCognitoIdentity.NotAuthorizedException()
+        )
+    }
+
+    /// Same recovery for the `ResourceNotFoundException` variant.
+    func testResourceNotFoundEvictsIdentityAndRetries() async {
+        await assertStaleIdentityRecovery(
+            firstError: AWSCognitoIdentity.ResourceNotFoundException()
+        )
+    }
+
+    private func assertStaleIdentityRecovery(firstError: Error) async {
+        let recovered = expectation(description: "recoveredWithFreshIdentity")
+        let freshIdentityID = "freshIdentityId"
+
+        let credentialsCallCount = CallCounter()
+        let getIdCalled = CallCounter()
+
+        let identityProviderFactory: BasicAuthorizationEnvironment.CognitoIdentityFactory = {
+            MockIdentity(
+                mockGetIdResponse: { _ in
+                    _ = getIdCalled.increment()
+                    return GetIdOutput(identityId: freshIdentityID)
+                },
+                mockGetCredentialsResponse: { input in
+                    if credentialsCallCount.increment() == 1 {
+                        XCTAssertEqual(input.identityId, "staleIdentityId")
+                        throw firstError
+                    }
+                    XCTAssertEqual(input.identityId, freshIdentityID)
+                    return GetCredentialsForIdentityOutput(
+                        credentials: CognitoIdentityClientTypes.Credentials(
+                            accessKeyId: "accessKey",
+                            expiration: Date(),
+                            secretKey: "secretKey",
+                            sessionToken: "sessionToken"
+                        ),
+                        identityId: freshIdentityID
+                    )
+                })
+        }
+        let authorizationEnvironment = BasicAuthorizationEnvironment(
+            identityPoolConfiguration: IdentityPoolConfigurationData.testData,
+            cognitoIdentityFactory: identityProviderFactory
+        )
+        let authEnvironment = Defaults.makeDefaultAuthEnvironment(
+            authZEnvironment: authorizationEnvironment)
+
+        let action = FetchAuthAWSCredentials(loginsMap: [:], identityID: "staleIdentityId")
+
+        await action.execute(
+            withDispatcher: MockDispatcher { event in
+                guard let event = event as? FetchAuthSessionEvent else { return }
+                if case let .fetchedAWSCredentials(identityID, _) = event.eventType {
+                    XCTAssertEqual(identityID, freshIdentityID)
+                    recovered.fulfill()
+                }
+                if case .throwError = event.eventType {
+                    XCTFail("Should recover instead of surfacing an error")
+                }
+            },
+            environment: authEnvironment
+        )
+
+        await fulfillment(of: [recovered], timeout: 0.1)
+        XCTAssertEqual(getIdCalled.count, 1)
+        XCTAssertEqual(credentialsCallCount.count, 2)
+    }
+
+    /// Retry is bounded: a second rejection surfaces a terminal error with no extra GetId.
+    func testStaleIdentityRetryIsBoundedToSingleAttempt() async {
+        let errored = expectation(description: "terminalError")
+        let getIdCalled = CallCounter()
+        let credentialsCallCount = CallCounter()
+
+        let identityProviderFactory: BasicAuthorizationEnvironment.CognitoIdentityFactory = {
+            MockIdentity(
+                mockGetIdResponse: { _ in
+                    _ = getIdCalled.increment()
+                    return GetIdOutput(identityId: "freshIdentityId")
+                },
+                mockGetCredentialsResponse: { _ in
+                    _ = credentialsCallCount.increment()
+                    throw AWSCognitoIdentity.ResourceNotFoundException()
+                })
+        }
+        let authorizationEnvironment = BasicAuthorizationEnvironment(
+            identityPoolConfiguration: IdentityPoolConfigurationData.testData,
+            cognitoIdentityFactory: identityProviderFactory
+        )
+        let authEnvironment = Defaults.makeDefaultAuthEnvironment(
+            authZEnvironment: authorizationEnvironment)
+
+        let action = FetchAuthAWSCredentials(loginsMap: [:], identityID: "staleIdentityId")
+
+        await action.execute(
+            withDispatcher: MockDispatcher { event in
+                guard let event = event as? FetchAuthSessionEvent else { return }
+                if case .throwError = event.eventType {
+                    errored.fulfill()
+                }
+            },
+            environment: authEnvironment
+        )
+
+        await fulfillment(of: [errored], timeout: 0.1)
+        XCTAssertEqual(getIdCalled.count, 1)
+        XCTAssertEqual(credentialsCallCount.count, 2)
+    }
+
+}
+
+private final class CallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    @discardableResult
+    func increment() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        value += 1
+        return value
+    }
+
+    var count: Int {
+        lock.lock(); defer { lock.unlock() }
+        return value
+    }
 }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchAWSCredentials/FetchAuthAWSCredentialsTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchAWSCredentials/FetchAuthAWSCredentialsTests.swift
@@ -193,10 +193,14 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
         )
     }
 
-    /// NotAuthorized evicts the stale identity ID and retries via fresh GetId.
+    /// Authenticated NotAuthorized with a forbidden identity message evicts the
+    /// stale identity ID and retries via fresh GetId.
     func testNotAuthorizedEvictsIdentityAndRetries() async {
         await assertStaleIdentityRecovery(
-            firstError: AWSCognitoIdentity.NotAuthorizedException()
+            firstError: AWSCognitoIdentity.NotAuthorizedException(
+                message: "Access to Identity 'us-east-1:stale' is forbidden."
+            ),
+            loginsMap: ["provider.com": "token"]
         )
     }
 
@@ -207,7 +211,10 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
         )
     }
 
-    private func assertStaleIdentityRecovery(firstError: Error) async {
+    private func assertStaleIdentityRecovery(
+        firstError: Error,
+        loginsMap: [String: String] = [:]
+    ) async {
         let recovered = expectation(description: "recoveredWithFreshIdentity")
         let freshIdentityID = "freshIdentityId"
 
@@ -244,7 +251,7 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
         let authEnvironment = Defaults.makeDefaultAuthEnvironment(
             authZEnvironment: authorizationEnvironment)
 
-        let action = FetchAuthAWSCredentials(loginsMap: [:], identityID: "staleIdentityId")
+        let action = FetchAuthAWSCredentials(loginsMap: loginsMap, identityID: "staleIdentityId")
 
         await action.execute(
             withDispatcher: MockDispatcher { event in
@@ -306,6 +313,50 @@ class FetchAuthAWSCredentialsTests: XCTestCase {
         XCTAssertEqual(credentialsCallCount.count, 2)
     }
 
+    /// Authenticated NotAuthorized from an invalid/expired login token surfaces
+    /// immediately: no GetId retry, single GetCredentials call.
+    func testAuthenticatedInvalidTokenNotAuthorizedSurfacesImmediately() async {
+        let errored = expectation(description: "terminalError")
+        let getIdCalled = CallCounter()
+        let credentialsCallCount = CallCounter()
+
+        let identityProviderFactory: BasicAuthorizationEnvironment.CognitoIdentityFactory = {
+            MockIdentity(
+                mockGetIdResponse: { _ in
+                    _ = getIdCalled.increment()
+                    return GetIdOutput(identityId: "freshIdentityId")
+                },
+                mockGetCredentialsResponse: { _ in
+                    _ = credentialsCallCount.increment()
+                    throw AWSCognitoIdentity.NotAuthorizedException(
+                        message: "Invalid login token. Token expired."
+                    )
+                })
+        }
+        let authorizationEnvironment = BasicAuthorizationEnvironment(
+            identityPoolConfiguration: IdentityPoolConfigurationData.testData,
+            cognitoIdentityFactory: identityProviderFactory
+        )
+        let authEnvironment = Defaults.makeDefaultAuthEnvironment(
+            authZEnvironment: authorizationEnvironment)
+
+        let action = FetchAuthAWSCredentials(
+            loginsMap: ["provider.com": "token"], identityID: "identityID")
+
+        await action.execute(
+            withDispatcher: MockDispatcher { event in
+                guard let event = event as? FetchAuthSessionEvent else { return }
+                if case .throwError = event.eventType {
+                    errored.fulfill()
+                }
+            },
+            environment: authEnvironment
+        )
+
+        await fulfillment(of: [errored], timeout: 0.1)
+        XCTAssertEqual(getIdCalled.count, 0)
+        XCTAssertEqual(credentialsCallCount.count, 1)
+    }
 }
 
 private final class CallCounter: @unchecked Sendable {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchAWSCredentials/FetchAuthAWSCredentialsTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchAWSCredentials/FetchAuthAWSCredentialsTests.swift
@@ -314,13 +314,15 @@ private final class CallCounter: @unchecked Sendable {
 
     @discardableResult
     func increment() -> Int {
-        lock.lock(); defer { lock.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
         value += 1
         return value
     }
 
     var count: Int {
-        lock.lock(); defer { lock.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
         return value
     }
 }


### PR DESCRIPTION
## Issue #
Fixes #4278

## Description
Refresh rejected cached identity IDs with a new `GetId` request, then retry credential fetching once. This prevents signed-in sessions from remaining wedged after `NotAuthorizedException` or `ResourceNotFoundException`.

## Testing
- `FetchAuthAWSCredentialsTests`: 8 passed
- iOS Simulator: recovered with a new identity after deleting the cached identity