### PR TITLE
fix(storage): serialize multipart upload state machine access to prevent thread-safety crashes

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/FileSystem.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/FileSystem.swift
@@ -164,11 +164,15 @@ class FileSystem {
     /// Returns the size in bytes of a file.
     /// - Parameter fileURL: URL of the file
     /// - Returns: size of file in bytes
-    func getFileSize(fileURL: URL) -> UInt64 {
+    /// - Throws: `StorageError.localFileNotFound` if the file's attributes cannot be read.
+    func getFileSize(fileURL: URL) throws -> UInt64 {
         guard let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
               let size = attributes[.size] as? UInt64
         else {
-            Fatal.require("File size should always be accessible")
+            throw StorageError.localFileNotFound(
+                "The file to upload could not be found or is no longer accessible at \(fileURL.path).",
+                "Ensure the file exists and remains available for the entire duration of the upload."
+            )
         }
         return size
     }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadSession.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadSession.swift
@@ -116,10 +116,11 @@ class StorageMultipartUploadSession {
     }
 
     func restart() {
-        guard let uploadFile = multipartUpload.uploadFile,
-              let uploadId = multipartUpload.uploadId,
-              let partSize = multipartUpload.partSize,
-              let parts = multipartUpload.parts
+        let snapshot = serialQueue.sync { multipartUpload }
+        guard let uploadFile = snapshot.uploadFile,
+              let uploadId = snapshot.uploadId,
+              let partSize = snapshot.partSize,
+              let parts = snapshot.parts
         else {
             return
         }
@@ -127,7 +128,7 @@ class StorageMultipartUploadSession {
     }
 
     func createSubTask(partNumber: PartNumber) -> StorageTransferTask {
-        guard let uploadId = multipartUpload.uploadId else {
+        guard let uploadId = serialQueue.sync(execute: { multipartUpload.uploadId }) else {
             fatalError()
         }
         let transferType: StorageTransferType = .multiPartUploadPart(uploadId: uploadId, partNumber: partNumber)
@@ -193,15 +194,24 @@ class StorageMultipartUploadSession {
     }
 
     var isPaused: Bool {
-        multipartUpload.isPaused
+        dispatchPrecondition(condition: .notOnQueue(serialQueue))
+        return serialQueue.sync {
+            multipartUpload.isPaused
+        }
     }
 
     var isAborted: Bool {
-        multipartUpload.isAborted
+        dispatchPrecondition(condition: .notOnQueue(serialQueue))
+        return serialQueue.sync {
+            multipartUpload.isAborted
+        }
     }
 
     var isCompleted: Bool {
-        multipartUpload.isCompleted
+        dispatchPrecondition(condition: .notOnQueue(serialQueue))
+        return serialQueue.sync {
+            multipartUpload.isCompleted
+        }
     }
 
     func part(for number: PartNumber) -> StorageUploadPart? {
@@ -260,8 +270,10 @@ class StorageMultipartUploadSession {
 
     func fail(error: Error) {
         logger.debug("Multipart Upload Failure: \(error)")
-        logger.debug("Multipart Upload: \(multipartUpload)")
-        multipartUpload.fail(error: error)
+        serialQueue.sync {
+            logger.debug("Multipart Upload: \(multipartUpload)")
+            multipartUpload.fail(error: error)
+        }
         onEvent(.failed(StorageError(error: error)))
     }
 
@@ -269,16 +281,19 @@ class StorageMultipartUploadSession {
         logger.debug("\(#function): \(multipartUploadEvent)")
 
         do {
-            let wasPaused = multipartUpload.isPaused
+            let wasPaused: Bool
+            let snapshot: StorageMultipartUpload
 
-            try serialQueue.sync {
+            (wasPaused, snapshot) = try serialQueue.sync {
+                let wasPaused = multipartUpload.isPaused
                 try multipartUpload.transition(multipartUploadEvent: multipartUploadEvent)
 
                 // update the transerTask with every state transition
                 transferTask.multipartUpload = multipartUpload
+                return (wasPaused, multipartUpload)
             }
 
-            switch multipartUpload {
+            switch snapshot {
             case .parts(let uploadId, let uploadFile, let partSize, let parts):
                 if wasPaused {
                     logger.debug("Resuming after being paused")
@@ -296,10 +311,11 @@ class StorageMultipartUploadSession {
                 cancelProgressStallTimer()
                 onEvent(.completed(()))
             case .aborting(_, let error):
-                cancelationError = error
+                serialQueue.sync { cancelationError = error }
                 cancelProgressStallTimer()
                 try abort()
             case .aborted(_, let error):
+                let cancelationError = serialQueue.sync { self.cancelationError }
                 onEvent(.failed(StorageError.unknown("Unable to upload", cancelationError ?? error)))
             case .failed(_, _, let error):
                 cancelProgressStallTimer()
@@ -307,7 +323,7 @@ class StorageMultipartUploadSession {
             default:
                 break
             }
-            logger.verbose("MultipartUpload State: \(multipartUpload)")
+            logger.verbose("MultipartUpload State: \(snapshot)")
         } catch {
             fail(error: error)
         }
@@ -318,19 +334,23 @@ class StorageMultipartUploadSession {
         logger.debug("\(#function): \(uploadPartEvent)")
 
         do {
-            if case .failed = multipartUpload {
-                logger.debug("Multipart Upload is failed and event cannot be handled: \(uploadPartEvent)")
-                return
-            } else if case .paused = multipartUpload {
-                logger.debug("Multipart Upload is paused and event cannot be handled: \(uploadPartEvent)")
-                return
-            }
-
-            try serialQueue.sync {
+            // Read state and transition under one lock; nil means the event was dropped (state was .failed/.paused).
+            let snapshot: StorageMultipartUpload? = try serialQueue.sync {
+                if case .failed = multipartUpload {
+                    logger.debug("Multipart Upload is failed and event cannot be handled: \(uploadPartEvent)")
+                    return nil
+                }
+                if case .paused = multipartUpload {
+                    logger.debug("Multipart Upload is paused and event cannot be handled: \(uploadPartEvent)")
+                    return nil
+                }
                 try multipartUpload.transition(uploadPartEvent: uploadPartEvent)
                 // update the transferTask with every state transition
                 transferTask.multipartUpload = multipartUpload
+                return multipartUpload
             }
+
+            guard let snapshot else { return }
 
             switch uploadPartEvent {
             case .progressUpdated, .completed:
@@ -341,7 +361,7 @@ class StorageMultipartUploadSession {
 
             if uploadPartEvent.isCompleted {
                 // report progress
-                if case .parts(_, _, _, let parts) = multipartUpload {
+                if case .parts(_, _, _, let parts) = snapshot {
                     let progress = Progress.discreteProgress(totalUnitCount: Int64(parts.totalBytes))
                     progress.completedUnitCount = Int64(parts.bytesTransferred)
                     onEvent(.inProcess(progress))
@@ -352,27 +372,27 @@ class StorageMultipartUploadSession {
 
             if case .queued = uploadPartEvent {
                 return
-            } else if case .paused = multipartUpload {
+            } else if case .paused = snapshot {
                 logger.debug("Multipart Upload is paused and part cannot be completed")
                 return
-            } else if isCompletedEvent && multipartUpload.hasPendingParts {
-                if case .parts(let uploadId, let uploadFile, let partSize, let parts) = multipartUpload {
+            } else if isCompletedEvent && snapshot.hasPendingParts {
+                if case .parts(let uploadId, let uploadFile, let partSize, let parts) = snapshot {
                     uploadParts(uploadFile: uploadFile, uploadId: uploadId, partSize: partSize, parts: parts)
                 } else {
-                    fatalError("Invalid state")
+                    throw Failure.invalidStateTransition
                 }
-            } else if partsCompleted {
+            } else if snapshot.partsCompleted {
                 do {
-                    try multipartUpload.validateForCompletion()
+                    try snapshot.validateForCompletion()
                 } catch {
                     fail(error: error)
                     return
                 }
 
-                if let uploadId = multipartUpload.uploadId {
+                if let uploadId = snapshot.uploadId {
                     try client.completeMultipartUpload(uploadId: uploadId)
                 } else {
-                    fatalError("Invalid state")
+                    throw Failure.invalidStateTransition
                 }
             } else if case .failed(let partNumber, let error) = uploadPartEvent {
                 retryPartUpload(partNumber: partNumber, error: error)
@@ -387,18 +407,24 @@ class StorageMultipartUploadSession {
             if transferTask.isBelowRetryLimit {
                 // increment retry count and move upload part back to pending
                 transferTask.incrementRetryCount()
-                if case .parts(let uploadId, let uploadFile, let partSize, var parts) = multipartUpload {
+
+                // Mutate state under the lock, then do the client call outside it to avoid holding the lock across async work.
+                let shouldTriggerReupload: Bool = try serialQueue.sync {
+                    guard case .parts(let uploadId, let uploadFile, let partSize, var parts) = multipartUpload else {
+                        throw Failure.invalidStateTransition
+                    }
                     let part = try parts.find(partNumber: partNumber)
                     let index = partNumber - 1
                     parts[index] = .pending(bytes: part.bytes)
                     multipartUpload = .parts(uploadId: uploadId, uploadFile: uploadFile, partSize: partSize, parts: parts)
                     let remainingParts = parts.filter { $0.inProgress }
-                    if remainingParts.isEmpty {
-                        // If there are no remaining parts in progress, manually trigger the reupload
-                        try client.uploadPart(partNumber: partNumber, multipartUpload: multipartUpload, subTask: createSubTask(partNumber: partNumber))
-                    }
-                } else {
-                    fatalError("Invalid state")
+                    return remainingParts.isEmpty
+                }
+
+                if shouldTriggerReupload {
+                    // If there are no remaining parts in progress, manually trigger the reupload
+                    let snapshot = serialQueue.sync { multipartUpload }
+                    try client.uploadPart(partNumber: partNumber, multipartUpload: snapshot, subTask: createSubTask(partNumber: partNumber))
                 }
             } else {
                 throw Failure.partsUploadRetryLimitExceeded(underlyingError: error)
@@ -409,11 +435,10 @@ class StorageMultipartUploadSession {
     }
 
     private func abort() throws {
-        if let uploadId = multipartUpload.uploadId {
-            try client.abortMultipartUpload(uploadId: uploadId)
-        } else {
-            fatalError("Invalid state")
+        guard let uploadId = serialQueue.sync(execute: { multipartUpload.uploadId }) else {
+            throw Failure.invalidStateTransition
         }
+        try client.abortMultipartUpload(uploadId: uploadId)
     }
 
     private func cancelInProgressParts(parts: StorageUploadParts) {
@@ -475,9 +500,10 @@ class StorageMultipartUploadSession {
         }
 
         do {
+            let snapshot = serialQueue.sync { multipartUpload }
             let pendingPartNumbers = getPendingPartNumbers()
             logger.debug("Pending parts: \(pendingPartNumbers)")
-            logger.debug("Multipart Upload: \(multipartUpload)")
+            logger.debug("Multipart Upload: \(snapshot)")
             if pendingPartNumbers.isEmpty {
                 return
             }
@@ -497,7 +523,7 @@ class StorageMultipartUploadSession {
                     // the next call does async work
                     let subTask = createSubTask(partNumber: partNumber)
                     logger.debug("Uploading part: \(partNumber)")
-                    try client.uploadPart(partNumber: partNumber, multipartUpload: multipartUpload, subTask: subTask)
+                    try client.uploadPart(partNumber: partNumber, multipartUpload: serialQueue.sync { multipartUpload }, subTask: subTask)
                 }
             }
         } catch {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/UploadSource.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/UploadSource.swift
@@ -16,10 +16,10 @@ enum UploadSource {
         switch self {
         case .data(let data):
             let fileURL = try FileSystem.default.createTemporaryFile(data: data)
-            let size = fileSystem.getFileSize(fileURL: fileURL)
+            let size = try fileSystem.getFileSize(fileURL: fileURL)
             uploadFile = .init(fileURL: fileURL, temporaryFileCreated: true, size: size)
         case .local(let fileURL):
-            let size = fileSystem.getFileSize(fileURL: fileURL)
+            let size = try fileSystem.getFileSize(fileURL: fileURL)
             uploadFile = .init(fileURL: fileURL, temporaryFileCreated: false, size: size)
         }
         return uploadFile

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileSystemTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileSystemTests.swift
@@ -120,9 +120,25 @@ class FileSystemTests: XCTestCase {
         defer {
             fs.removeDirectoryIfExists(directoryURL: directoryURL)
         }
-        let size = fs.getFileSize(fileURL: fileURL)
+        let size = try fs.getFileSize(fileURL: fileURL)
 
         XCTAssertEqual(UInt64(bytes.bytes), size)
+    }
+
+    /// Given: A file URL that does not exist
+    /// When: getFileSize is invoked
+    /// Then: It throws `StorageError.localFileNotFound` instead of crashing
+    func testGetFileSizeForMissingFileThrowsInsteadOfCrashing() {
+        let fs = FileSystem()
+        let missingURL = fs.createTemporaryDirectoryURL()
+            .appendingPathComponent("does-not-exist.bin", isDirectory: false)
+
+        XCTAssertThrowsError(try fs.getFileSize(fileURL: missingURL)) { error in
+            guard case StorageError.localFileNotFound = error else {
+                XCTFail("Expected StorageError.localFileNotFound, got \(error)")
+                return
+            }
+        }
     }
 
     func testGeneratingZeroBytes() throws {

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/MockMultipartUploadClient.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/MockMultipartUploadClient.swift
@@ -17,11 +17,18 @@ class MockMultipartUploadClient: StorageMultipartUploadClient {
         case mockFailure
     }
 
+    private let counterLock = NSLock()
     var uploadPartCount = 0
     var completeMultipartUploadCount = 0
     var abortMultipartUploadCount = 0
     var errorCount = 0
     var taskIdentifier = 100
+
+    private func increment(_ keyPath: ReferenceWritableKeyPath<MockMultipartUploadClient, Int>) {
+        counterLock.lock()
+        defer { counterLock.unlock() }
+        self[keyPath: keyPath] += 1
+    }
 
     let uploadFile: UploadFile
     var session: StorageMultipartUploadSession?
@@ -63,10 +70,10 @@ class MockMultipartUploadClient: StorageMultipartUploadClient {
         print("Upload Part \(partNumber)")
         guard let session else { throw Failure.sessionNotIntegrated }
 
-        uploadPartCount += 1
+        increment(\.uploadPartCount)
 
         defer {
-            taskIdentifier += 1
+            increment(\.taskIdentifier)
         }
 
         subTask.sessionTask = MockStorageSessionTask(taskIdentifier: taskIdentifier, state: .suspended)
@@ -96,7 +103,7 @@ class MockMultipartUploadClient: StorageMultipartUploadClient {
     func completeMultipartUpload(uploadId: UploadID) throws {
         guard let session else { throw Failure.sessionNotIntegrated }
 
-        completeMultipartUploadCount += 1
+        increment(\.completeMultipartUploadCount)
 
         session.handle(multipartUploadEvent: .completed(uploadId: uploadId))
         didCompleteMultipartUpload?(session, uploadId)
@@ -105,7 +112,7 @@ class MockMultipartUploadClient: StorageMultipartUploadClient {
     func abortMultipartUpload(uploadId: UploadID, error: Error?) throws {
         guard let session else { throw Failure.sessionNotIntegrated }
 
-        abortMultipartUploadCount += 1
+        increment(\.abortMultipartUploadCount)
 
         session.handle(multipartUploadEvent: .aborted(uploadId: uploadId, error: error))
         didAbortMultipartUpload?(session, uploadId)

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageMultipartUploadSessionConcurrencyTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageMultipartUploadSessionConcurrencyTests.swift
@@ -1,0 +1,93 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@testable import Amplify
+@testable import AWSS3StoragePlugin
+
+// The data races these tests target are reliably detected only under Thread Sanitizer:
+//   swift test --sanitize=thread --filter StorageMultipartUploadSessionConcurrencyTests
+class StorageMultipartUploadSessionConcurrencyTests: XCTestCase {
+    enum Failure: Error {
+        case mock
+    }
+
+    /// Given: A StorageMultipartUploadSession with parts in progress
+    /// When: `fail` is invoked concurrently with reads of the session state
+    /// Then: No data race occurs and access does not deadlock
+    func testConcurrentFailAndReadDoesNotRace() {
+        let client = MockMultipartUploadClient()
+        // Keep parts in-progress so the state stays live during the test
+        client.shouldStallPartUpload = true
+
+        let session = StorageMultipartUploadSession(
+            client: client,
+            bucket: "bucket",
+            key: "key",
+            onEvent: { _ in }
+        )
+        session.startUpload()
+
+        let iterations = 2_000
+        let group = DispatchGroup()
+
+        group.enter()
+        DispatchQueue.global().async {
+            for _ in 0 ..< iterations {
+                session.fail(error: Failure.mock)
+            }
+            group.leave()
+        }
+
+        for _ in 0 ..< 4 {
+            group.enter()
+            DispatchQueue.global().async {
+                for _ in 0 ..< iterations {
+                    _ = session.uploadId
+                    _ = session.isAborted
+                    _ = session.partsCount
+                }
+                group.leave()
+            }
+        }
+
+        XCTAssertEqual(group.wait(timeout: .now() + 30), .success, "Concurrent access deadlocked or hung")
+    }
+
+    /// Given: A StorageMultipartUploadSession with parts in progress
+    /// When: `.failed` part events are handled concurrently, driving retries
+    /// Then: The session does not crash and access does not deadlock
+    func testConcurrentRetryDoesNotCrash() {
+        let client = MockMultipartUploadClient()
+        client.shouldStallPartUpload = true
+
+        let session = StorageMultipartUploadSession(
+            client: client,
+            bucket: "bucket",
+            key: "key",
+            onEvent: { _ in }
+        )
+        session.startUpload()
+
+        let partsCount = max(session.partsCount, 1)
+        let group = DispatchGroup()
+
+        for _ in 0 ..< 8 {
+            group.enter()
+            DispatchQueue.global().async {
+                for partNumber in 1 ... partsCount {
+                    session.handle(uploadPartEvent: .failed(partNumber: partNumber, error: Failure.mock))
+                    _ = session.uploadId
+                }
+                group.leave()
+            }
+        }
+
+        XCTAssertEqual(group.wait(timeout: .now() + 30), .success, "Concurrent retry deadlocked or hung")
+    }
+}


### PR DESCRIPTION
## Description

`StorageMultipartUploadSession` accessed its `multipartUpload` state from multiple threads without synchronization, causing three crashes on large uploads: a `swift_retain` race on `uploadId`, a `fatalError("Invalid state")` in `retryPartUpload` under a concurrent cancel/pause, and a `Fatal.require` in `getFileSize` when the source file was deleted. This serializes all state access on the existing serial queue, throws `Failure.invalidStateTransition` instead of `fatalError`, and makes `getFileSize` throw `StorageError.localFileNotFound`.

## Testing

* `getFileSize` throws for a missing file instead of crashing (deterministic; fails on `main`).
* Ran the concurrency stress tests under Thread Sanitizer (`swift test --sanitize=thread --filter StorageMultipartUploadSessionConcurrencyTests`): passes on this branch, fails on unpatched `main` with 8 data-race warnings in `handle`/`fail`.
* Unit suite passing; `swiftformat`/`swiftlint` clean.

Refs #4138
Supersedes #4203
