### PR TITLE
fix(ci): pass untrusted GitHub context via env to prevent workflow script injection

### DIFF
--- a/.github/workflows/api-breaking-changes-detection.yml
+++ b/.github/workflows/api-breaking-changes-detection.yml
@@ -20,13 +20,18 @@ jobs:
         fetch-depth: 1
 
     - name: Fetch the branchs
+      env:
+        HEAD_SHA: ${{ github.sha }}
       run: |
-        git fetch origin ${{ github.sha }}
+        git fetch origin "$HEAD_SHA"
 
 
     - name: Setup and Run Swift API Diff
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HEAD_SHA: ${{ github.sha }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_REF: ${{ github.head_ref }}
       run: |
         # Define the list of exceptions to filter out
         exceptions=(
@@ -76,8 +81,8 @@ jobs:
         echo "Modules: $modules"
         
         echo "Fetching old version..."
-        git fetch origin ${{ github.event.pull_request.base.sha }}
-        git checkout ${{ github.event.pull_request.base.sha }}
+        git fetch origin "$BASE_SHA"
+        git checkout "$BASE_SHA"
         built=false
         for module in $modules; do
           # If file doesn't exits in the old directory
@@ -99,7 +104,7 @@ jobs:
         done
         
         echo "Fetching new version..."
-        git checkout ${{ github.sha }}
+        git checkout "$HEAD_SHA"
         git log -1  # Print the commit info for debugging
         swift build> /dev/null 2>&1 || { echo "Failed to build new version"; exit 1; }
         for module in $modules; do
@@ -137,7 +142,7 @@ jobs:
 
         # Checkout to the branch associated with the pull request
         git stash --include-untracked
-        git checkout ${{ github.head_ref }}
+        git checkout "$HEAD_REF"
 
         if [ ! -d "api-dump" ]; then
             echo "api-dump folder does not exist. Creating it..."
@@ -190,7 +195,7 @@ jobs:
 
           if [ "$push_changes" = true ]; then
             git commit -m "Update API dumps for new version"
-            git push origin HEAD:${{ github.head_ref }}
+            git push origin "HEAD:$HEAD_REF"
           else
             echo "No changes to commit in the api-dump folder."
           fi

--- a/.github/workflows/build_amplify_swift_platforms.yml
+++ b/.github/workflows/build_amplify_swift_platforms.yml
@@ -57,14 +57,18 @@ jobs:
         with:
           fetch-depth: 0
       - id: sel
+        env:
+          IDENTIFIER: ${{ inputs.identifier }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
         run: |
           # Build the whole package unless the change is confined to non-source paths. Deploy
           # (workflow_call, passes identifier) and manual dispatch always build.
-          if [ -n "${{ inputs.identifier }}" ] || [ "${{ github.event_name }}" != "push" ]; then
+          if [ -n "$IDENTIFIER" ] || [ "$EVENT_NAME" != "push" ]; then
             echo "build=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          base='${{ github.event.pull_request.base.ref || 'main' }}'
+          base="$BASE_REF"
           git fetch --no-tags origin "$base" || true
           git diff --name-only "$(git merge-base HEAD "origin/$base")" HEAD > /tmp/changed.txt
           swift package dump-package > /tmp/package.json

--- a/.github/workflows/build_minimum_supported_swift_platforms.yml
+++ b/.github/workflows/build_minimum_supported_swift_platforms.yml
@@ -27,14 +27,17 @@ jobs:
         with:
           fetch-depth: 0
       - id: sel
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           # Build unless the change is confined to non-source paths. Pushes to main (post-merge)
           # and manual dispatch always build.
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ "$EVENT_NAME" != "pull_request" ]; then
             echo "build=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          base='${{ github.event.pull_request.base.ref }}'
+          base="$BASE_REF"
           git fetch --no-tags origin "$base" || true
           git diff --name-only "$(git merge-base HEAD "origin/$base")" HEAD > /tmp/changed.txt
           swift package dump-package > /tmp/package.json

--- a/.github/workflows/build_xcode_preview.yml
+++ b/.github/workflows/build_xcode_preview.yml
@@ -41,14 +41,17 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - id: sel
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           # Build unless the change is confined to non-source paths. Pushes to main (post-merge)
           # and manual dispatch always build.
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ "$EVENT_NAME" != "pull_request" ]; then
             echo "build=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          base='${{ github.event.pull_request.base.ref }}'
+          base="$BASE_REF"
           git fetch --no-tags origin "$base" || true
           git diff --name-only "$(git merge-base HEAD "origin/$base")" HEAD > /tmp/changed.txt
           swift package dump-package > /tmp/package.json

--- a/.github/workflows/integ_test.yml
+++ b/.github/workflows/integ_test.yml
@@ -34,16 +34,19 @@ jobs:
         with:
           fetch-depth: 0
       - id: sel
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
         run: |
           # Only gate on pull requests. Pushes to main (post-merge) and manual dispatch run all.
           categories=($(jq -r 'keys[]' scripts/python/integ_test_groups.json))
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ "$EVENT_NAME" != "pull_request" ]; then
             for c in "${categories[@]}"; do
               echo "$c=true" >> "$GITHUB_OUTPUT"
             done
             exit 0
           fi
-          base='${{ github.event.pull_request.base.ref || 'main' }}'
+          base="$BASE_REF"
           git fetch --no-tags origin "$base" || true
           git diff --name-only "$(git merge-base HEAD "origin/$base")" HEAD > /tmp/changed.txt
           swift package dump-package > /tmp/package.json

--- a/.github/workflows/integ_test_api.yml
+++ b/.github/workflows/integ_test_api.yml
@@ -27,13 +27,16 @@ jobs:
         with:
           fetch-depth: 0
       - id: sel
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
         run: |
           # Only gate on pull requests. Pushes to main (post-merge) and manual dispatch run all.
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ "$EVENT_NAME" != "pull_request" ]; then
             echo "api=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          base='${{ github.event.pull_request.base.ref || 'main' }}'
+          base="$BASE_REF"
           git fetch --no-tags origin "$base" || true
           git diff --name-only "$(git merge-base HEAD "origin/$base")" HEAD > /tmp/changed.txt
           swift package dump-package > /tmp/package.json

--- a/.github/workflows/integ_test_datastore.yml
+++ b/.github/workflows/integ_test_datastore.yml
@@ -27,13 +27,16 @@ jobs:
         with:
           fetch-depth: 0
       - id: sel
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
         run: |
           # Only gate on pull requests. Pushes to main (post-merge) and manual dispatch run all.
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ "$EVENT_NAME" != "pull_request" ]; then
             echo "datastore=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          base='${{ github.event.pull_request.base.ref || 'main' }}'
+          base="$BASE_REF"
           git fetch --no-tags origin "$base" || true
           git diff --name-only "$(git merge-base HEAD "origin/$base")" HEAD > /tmp/changed.txt
           swift package dump-package > /tmp/package.json

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -59,14 +59,18 @@ jobs:
         with:
           fetch-depth: 0
       - id: sel
+        env:
+          IDENTIFIER: ${{ inputs.identifier }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
         run: |
           # Gate only on a genuine feature-branch push. Deploy pipelines invoke this workflow via
           # workflow_call (which passes `identifier`), and manual runs use workflow_dispatch — both
           # must exercise the full matrix, so only an unqualified `push` event is change-gated.
-          if [ -n "${{ inputs.identifier }}" ] || [ "${{ github.event_name }}" != "push" ]; then
+          if [ -n "$IDENTIFIER" ] || [ "$EVENT_NAME" != "push" ]; then
             sel=$(jq -c 'keys' scripts/python/unit_test_groups.json)
           else
-            base='${{ github.event.pull_request.base.ref || 'main' }}'
+            base="$BASE_REF"
             git fetch --no-tags origin "$base" || true
             git diff --name-only "$(git merge-base HEAD "origin/$base")" HEAD > /tmp/changed.txt
             swift package dump-package > /tmp/package.json


### PR DESCRIPTION
## Issue \#

N/A — security hardening  no linked GitHub issue.

## Description

Fixes **script injection in GitHub Actions workflows**: several `detect` steps interpolated user-controllable GitHub context values directly into their `run:` shell body via `${{ … }}`. A value like the PR base ref or head ref is a branch name, which is attacker-controllable and can break out of the shell string to inject arbitrary commands into the runner.

**Fix.** Bind each context value to a step-level `env:` var and reference it as a quoted shell variable, so the Actions runner never re-parses attacker input as shell — GitHub's recommended mitigation.

Before:
```yaml
run: |
  base='${{ github.event.pull_request.base.ref || 'main' }}'
```
After:
```yaml
env:
  BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
run: |
  base="$BASE_REF"
```

**What changed.**

- `integ_test.yml`, `integ_test_api.yml`, `integ_test_datastore.yml`, `build_minimum_supported_swift_platforms.yml`, `build_xcode_preview.yml` — `detect` step now passes `github.event_name` (`EVENT_NAME`) and the PR base ref (`BASE_REF`) via `env:`.
- `unit_test.yml`, `build_amplify_swift_platforms.yml` — same, plus `inputs.identifier` (`IDENTIFIER`) via `env:`.
- `api-breaking-changes-detection.yml` — not part of the original scan but the same vulnerability class, and higher-risk (it has `contents: write` and pushes commits): `github.sha` (`HEAD_SHA`), `github.event.pull_request.base.sha` (`BASE_SHA`), and `github.head_ref` (`HEAD_REF`) now flow through `env:` before use in `git fetch`/`checkout`/`push`.

**Not changed (already safe).** Matrix `- platform: ${{ github.event.inputs.* == 'false' && … }}` entries evaluate to fixed literals (not shell); `issue_*`/`notify_release` workflows already use the `env:` pattern; `with: ref: ${{ github.head_ref }}` is an action input, not a shell splice.

**Behavior.** No functional change — the workflows compute the same merge-base diff and gating decisions as before; only how the context values reach the shell changed.

**Validation.** All eight workflow files parse as valid YAML. The `env:`-bound variables are drop-in replacements for the previous inline expressions.

## General Checklist

- [ ] ~~Added new tests to cover change, if needed~~ (N/A — CI workflow hardening)
- [ ] ~~Build succeeds with all target using Swift Package Manager~~ (N/A — no source/manifest changes)
- [ ] ~~All unit tests pass~~ (will be exercised by this PR's CI)
- [ ] ~~All integration tests pass~~ (will be exercised by this PR's CI)
- [x] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc) — untrusted GitHub context values are bound via `env:` rather than interpolated into `run:` scripts (fixes ACAT script-injection finding)
- [ ] ~~Documentation update for the change if required~~ (N/A)
- [x] PR title conforms to conventional commit style
- [ ] ~~New or updated tests include `Given When Then` inline code documentation and are named accordingly `testThing_condition_expectation()`~~ (N/A — no Swift tests changed)
- [ ] ~~If breaking change, documentation/changelog update with migration instructions~~ (not a breaking change)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
