### PR TITLE
test(auth): add TestCounter and TestBox helpers

### DIFF
--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/TestBox.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/TestBox.swift
@@ -1,0 +1,39 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// A thread-safe box for test state touched from `@Sendable` closures.
+///
+/// Exists for the same reason as ``TestCounter``: a plain `var` captured by a `@Sendable` closure is
+/// rejected in the Swift 6 language mode, and Amplify's `AtomicValue` cannot be referenced from these
+/// tests. `AWSCognitoAuthPlugin` declares its own internal `AtomicValue`, which `@testable import`
+/// makes visible alongside Amplify's, and the collision cannot be spelled away — `Amplify.AtomicValue`
+/// resolves against the `Amplify` *type* rather than the module, because the two share a name.
+///
+/// The method names mirror `AtomicValue` so call sites read the same either way.
+final class TestBox<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Value
+
+    init(_ initialValue: Value) {
+        self.value = initialValue
+    }
+
+    func get() -> Value {
+        lock.withLock { value }
+    }
+
+    func set(_ newValue: Value) {
+        lock.withLock { value = newValue }
+    }
+
+    /// Mutates the boxed value in place under the lock.
+    func with(_ body: (inout Value) -> Void) {
+        lock.withLock { body(&value) }
+    }
+}

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/TestCounter.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/TestCounter.swift
@@ -1,0 +1,47 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// A thread-safe `Int` box for test state touched from `@Sendable` closures.
+///
+/// Exists because a plain `var` captured by a `@Sendable` closure is rejected in the Swift 6 language
+/// mode, and neither available `AtomicValue` fits here: `AWSCognitoAuthPlugin` declares its own
+/// internal `AtomicValue` that `@testable import` makes visible alongside Amplify's, and the collision
+/// cannot be spelled away — `Amplify.AtomicValue` resolves against the `Amplify` *type* rather than the
+/// module, because the two share a name.
+///
+/// The method names deliberately mirror `AtomicValue` so call sites read the same either way.
+final class TestCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Int
+
+    init(_ initialValue: Int = 0) {
+        self.value = initialValue
+    }
+
+    func get() -> Int {
+        lock.withLock { value }
+    }
+
+    func set(_ newValue: Int) {
+        lock.withLock { value = newValue }
+    }
+
+    /// Sets `newValue` and returns what was there before, as one atomic step.
+    func getAndSet(_ newValue: Int) -> Int {
+        lock.withLock {
+            let previous = value
+            value = newValue
+            return previous
+        }
+    }
+
+    func increment() {
+        lock.withLock { value += 1 }
+    }
+}


### PR DESCRIPTION
Slice **2 of 38** in the Swift 6 language-mode migration — 2 file(s).

Stacked on `swift6/01-unchecked-sendable-helper`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.