### PR TITLE
fix(core): synchronize AmplifyAsyncSequence cancellation

### DIFF
--- a/Amplify/Core/Support/AmplifyAsyncSequence.swift
+++ b/Amplify/Core/Support/AmplifyAsyncSequence.swift
@@ -9,19 +9,30 @@ import Foundation
 
 public typealias WeakAmplifyAsyncSequenceRef<Element> = WeakRef<AmplifyAsyncSequence<Element>>
 
-public class AmplifyAsyncSequence<Element: Sendable>: AsyncSequence, Cancellable {
+/// - Note: `@unchecked Sendable` because `parent` and `isCancelled` are mutable but
+///   every access is serialized by `lock`. The compiler cannot verify that, so the
+///   guarantee is asserted here and enforced by the accessors below.
+public class AmplifyAsyncSequence<Element: Sendable>: AsyncSequence, Cancellable, @unchecked Sendable {
     public typealias Iterator = AsyncStream<Element>.Iterator
     private let asyncStream: AsyncStream<Element>
     private let continuation: AsyncStream<Element>.Continuation
-    private var parent: Cancellable?
 
-    public private(set) var isCancelled: Bool = false
+    /// Guards `_parent` and `_isCancelled`. `AsyncStream.Continuation` is itself
+    /// thread-safe, so `continuation` is deliberately not covered by this lock.
+    private let lock = NSLock()
+    private var _parent: Cancellable?
+    private var _isCancelled: Bool = false
+
+    /// Externally read-only, exactly as the previous `public private(set)` stored property was.
+    public var isCancelled: Bool {
+        lock.withLock { _isCancelled }
+    }
 
     public init(
         parent: Cancellable? = nil,
         bufferingPolicy: AsyncStream<Element>.Continuation.BufferingPolicy = .unbounded
     ) {
-        self.parent = parent
+        self._parent = parent
         (self.asyncStream, self.continuation) = AsyncStream.makeStream(of: Element.self, bufferingPolicy: bufferingPolicy)
     }
 
@@ -35,13 +46,20 @@ public class AmplifyAsyncSequence<Element: Sendable>: AsyncSequence, Cancellable
 
     public func finish() {
         continuation.finish()
-        parent = nil
+        lock.withLock { _parent = nil }
     }
 
     public func cancel() {
-        guard !isCancelled else { return }
-        isCancelled = true
-        parent?.cancel()
+        // Claim the cancellation under the lock so concurrent callers cannot both observe
+        // `false` and then cancel `parent` twice. Previously this was a check-then-set on
+        // unsynchronized state, so a double cancel was possible.
+        let claimed: (didClaim: Bool, parent: Cancellable?) = lock.withLock {
+            guard !_isCancelled else { return (false, nil) }
+            _isCancelled = true
+            return (true, _parent)
+        }
+        guard claimed.didClaim else { return }
+        claimed.parent?.cancel()
         finish()
     }
 }

--- a/Amplify/Core/Support/AmplifyAsyncThrowingSequence.swift
+++ b/Amplify/Core/Support/AmplifyAsyncThrowingSequence.swift
@@ -9,19 +9,28 @@ import Foundation
 
 public typealias WeakAmplifyAsyncThrowingSequenceRef<Element> = WeakRef<AmplifyAsyncThrowingSequence<Element>>
 
-public class AmplifyAsyncThrowingSequence<Element: Sendable>: AsyncSequence, Cancellable {
+/// - Note: `@unchecked Sendable` for the same reason as ``AmplifyAsyncSequence``: `_parent` and
+///   `_isCancelled` are mutable but every access is serialized by `lock`.
+public class AmplifyAsyncThrowingSequence<Element: Sendable>: AsyncSequence, Cancellable, @unchecked Sendable {
     public typealias Iterator = AsyncThrowingStream<Element, Error>.Iterator
     private let asyncStream: AsyncThrowingStream<Element, Error>
     private let continuation: AsyncThrowingStream<Element, Error>.Continuation
-    private var parent: Cancellable?
 
-    public private(set) var isCancelled: Bool = false
+    /// Guards `_parent` and `_isCancelled`. The stream continuation is already thread-safe.
+    private let lock = NSLock()
+    private var _parent: Cancellable?
+    private var _isCancelled: Bool = false
+
+    /// Externally read-only, exactly as the previous `public private(set)` stored property was.
+    public var isCancelled: Bool {
+        lock.withLock { _isCancelled }
+    }
 
     public init(
         parent: Cancellable? = nil,
         bufferingPolicy: AsyncThrowingStream<Element, Error>.Continuation.BufferingPolicy = .unbounded
     ) {
-        self.parent = parent
+        self._parent = parent
         (self.asyncStream, self.continuation) = AsyncThrowingStream.makeStream(of: Element.self, bufferingPolicy: bufferingPolicy)
     }
 
@@ -40,13 +49,19 @@ public class AmplifyAsyncThrowingSequence<Element: Sendable>: AsyncSequence, Can
 
     public func finish() {
         continuation.finish()
-        parent = nil
+        lock.withLock { _parent = nil }
     }
 
     public func cancel() {
-        guard !isCancelled else { return }
-        isCancelled = true
-        parent?.cancel()
+        // Claim the cancellation under the lock so concurrent callers cannot both observe
+        // `false` and then cancel `parent` twice, as the previous check-then-set allowed.
+        let claimed: (didClaim: Bool, parent: Cancellable?) = lock.withLock {
+            guard !_isCancelled else { return (false, nil) }
+            _isCancelled = true
+            return (true, _parent)
+        }
+        guard claimed.didClaim else { return }
+        claimed.parent?.cancel()
         finish()
     }
 

--- a/AmplifyTests/CoreTests/AmplifyAsyncSequenceTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyAsyncSequenceTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-final class AmplifyAsyncSequenceTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AmplifyAsyncSequenceTests: XCTestCase, @unchecked Sendable {
     enum Failure: Error {
         case unluckyNumber
     }
@@ -183,11 +185,12 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
         let steps = 10
         let delay = 0.01
         let request = LongOperationRequest(steps: steps, delay: delay)
-        var count = 0
+        // Counted from a `@Sendable` closure, so it cannot be a captured `var`.
+        let count = AtomicValue(initialValue: 0)
         let operation = LongOperation(request: request)
         let channel = AmplifyAsyncSequence<LongOperation.InProcess>(parent: operation)
         let token = operation.subscribe { (value: LongOperation.InProcess) in
-            count += 1
+            _ = count.increment()
             channel.send(value)
             if value.totalUnitCount == value.completedUnitCount {
                 channel.finish()
@@ -208,7 +211,7 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
         await fulfillment(of: [sent, received])
 
         XCTAssertFalse(operation.isCancelled)
-        XCTAssertGreaterThanOrEqual(count, steps)
+        XCTAssertGreaterThanOrEqual(count.get(), steps)
 
         Amplify.Hub.removeListener(token)
     }
@@ -219,11 +222,12 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
         let steps = 10
         let delay = 0.01
         let request = LongOperationRequest(steps: steps, delay: delay)
-        var count = 0
+        // Counted from a `@Sendable` closure, so it cannot be a captured `var`.
+        let count = AtomicValue(initialValue: 0)
         let operation = LongOperation(request: request)
         let channel = AmplifyAsyncSequence<LongOperation.InProcess>(parent: operation)
         let token = operation.subscribe { (value: LongOperation.InProcess) in
-            count += 1
+            _ = count.increment()
             channel.send(value)
             if value.completedUnitCount >= steps / 2 {
                 channel.cancel()
@@ -244,7 +248,7 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
         await fulfillment(of: [sent, received])
 
         XCTAssertTrue(operation.isCancelled)
-        XCTAssertLessThan(count, steps)
+        XCTAssertLessThan(count.get(), steps)
 
         Amplify.Hub.removeListener(token)
     }
@@ -255,11 +259,12 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
         let steps = 10
         let delay = 0.01
         let request = LongOperationRequest(steps: steps, delay: delay)
-        var count = 0
+        // Counted from a `@Sendable` closure, so it cannot be a captured `var`.
+        let count = AtomicValue(initialValue: 0)
         let operation = LongOperation(request: request)
         let channel = AmplifyAsyncThrowingSequence<LongOperation.InProcess>(parent: operation)
         let token = operation.subscribe { (value: LongOperation.InProcess) in
-            count += 1
+            _ = count.increment()
             channel.send(value)
             if value.totalUnitCount == value.completedUnitCount {
                 channel.finish()
@@ -280,7 +285,7 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
         await fulfillment(of: [sent, received])
 
         XCTAssertFalse(operation.isCancelled)
-        XCTAssertGreaterThanOrEqual(count, steps)
+        XCTAssertGreaterThanOrEqual(count.get(), steps)
 
         Amplify.Hub.removeListener(token)
     }
@@ -291,11 +296,12 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
         let steps = 10
         let delay = 0.01
         let request = LongOperationRequest(steps: steps, delay: delay)
-        var count = 0
+        // Counted from a `@Sendable` closure, so it cannot be a captured `var`.
+        let count = AtomicValue(initialValue: 0)
         let operation = LongOperation(request: request)
         let channel = AmplifyAsyncThrowingSequence<LongOperation.InProcess>(parent: operation)
         let token = operation.subscribe { (value: LongOperation.InProcess) in
-            count += 1
+            _ = count.increment()
             channel.send(value)
             if value.completedUnitCount >= steps / 2 {
                 channel.cancel()
@@ -316,7 +322,7 @@ final class AmplifyAsyncSequenceTests: XCTestCase {
         await fulfillment(of: [sent, received])
 
         XCTAssertTrue(operation.isCancelled)
-        XCTAssertLessThan(count, steps)
+        XCTAssertLessThan(count.get(), steps)
 
         Amplify.Hub.removeListener(token)
     }


### PR DESCRIPTION
Slice **3 of 38** in the Swift 6 language-mode migration — 3 file(s).

Stacked on `swift6/02-test-helpers`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.