### PR TITLE
fix(core): report an unconfigured Auth category instead of aborting

### DIFF
--- a/Amplify/Categories/Auth/AuthCategory.swift
+++ b/Amplify/Categories/Auth/AuthCategory.swift
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-public final class AuthCategory: Category {
+/// - Note: `@unchecked Sendable` to satisfy the `Sendable` requirement that the category behavior
+///   protocol now carries. `plugins` is populated during `Amplify.configure()` and only read
+///   afterwards, and the conformance must be declared here because the behavior conformance lives
+///   in an extension in another file.
+public final class AuthCategory: Category, @unchecked Sendable {
 
     public let categoryType =  CategoryType.auth
 
@@ -41,6 +45,17 @@ public final class AuthCategory: Category {
     }
 
     var isConfigured = false
+
+    /// `true` when `Amplify.configure()` has run for this category and a plugin is registered.
+    ///
+    /// Reading ``plugin`` in either of the opposite states trips a `preconditionFailure`, which aborts
+    /// the process rather than failing the call. Exposed over `@_spi` so the AWS plugin modules can
+    /// report an error instead: they hold long-lived clients that can outlive `Amplify.reset()`, and for
+    /// those a missing Auth category is a recoverable condition, not a programmer error.
+    @_spi(InternalAmplifyConfiguration)
+    public var isConfiguredWithPlugin: Bool {
+        isConfigured && !plugins.isEmpty
+    }
 
     // MARK: - Plugin handling
 

--- a/Amplify/Categories/Auth/AuthCategory.swift
+++ b/Amplify/Categories/Auth/AuthCategory.swift
@@ -6,9 +6,15 @@
 //
 
 /// - Note: `@unchecked Sendable` to satisfy the `Sendable` requirement that the category behavior
-///   protocol now carries. `plugins` is populated during `Amplify.configure()` and only read
-///   afterwards, and the conformance must be declared here because the behavior conformance lives
-///   in an extension in another file.
+///   protocol now carries. The conformance must be declared here because the behavior conformance
+///   lives in an extension in another file.
+///
+///   The conformance is **unchecked in the literal sense**: `plugins` and `isConfigured` are plain
+///   mutable state with no lock, and `add(plugin:)` / `removePlugin(for:)` mutate `plugins` after
+///   configuration. In practice `Amplify.configure()` runs once during start-up and the state is
+///   read-only afterwards, but nothing in this type enforces that — a caller that adds or removes a
+///   plugin concurrently with category access races. That predates this annotation; the annotation
+///   only stops the compiler from asking about it.
 public final class AuthCategory: Category, @unchecked Sendable {
 
     public let categoryType =  CategoryType.auth
@@ -52,6 +58,12 @@ public final class AuthCategory: Category, @unchecked Sendable {
     /// the process rather than failing the call. Exposed over `@_spi` so the AWS plugin modules can
     /// report an error instead: they hold long-lived clients that can outlive `Amplify.reset()`, and for
     /// those a missing Auth category is a recoverable condition, not a programmer error.
+    ///
+    /// - Important: This is **advisory, not a guarantee**. It reads `isConfigured` and `plugins` without
+    ///   synchronization, and a caller acts on the result after it returns, so `Amplify.reset()` running
+    ///   in between still leads to the `preconditionFailure` it was meant to avoid. It narrows the window
+    ///   rather than closing it. Closing it would mean giving ``plugin`` a non-trapping counterpart, which
+    ///   is a larger change to the category contract.
     @_spi(InternalAmplifyConfiguration)
     public var isConfiguredWithPlugin: Bool {
         isConfigured && !plugins.isEmpty

--- a/Amplify/Categories/Auth/AuthCategory.swift
+++ b/Amplify/Categories/Auth/AuthCategory.swift
@@ -6,15 +6,13 @@
 //
 
 /// - Note: `@unchecked Sendable` to satisfy the `Sendable` requirement that the category behavior
-///   protocol now carries. The conformance must be declared here because the behavior conformance
-///   lives in an extension in another file.
+///   protocol now carries.
 ///
-///   The conformance is **unchecked in the literal sense**: `plugins` and `isConfigured` are plain
-///   mutable state with no lock, and `add(plugin:)` / `removePlugin(for:)` mutate `plugins` after
-///   configuration. In practice `Amplify.configure()` runs once during start-up and the state is
-///   read-only afterwards, but nothing in this type enforces that — a caller that adds or removes a
-///   plugin concurrently with category access races. That predates this annotation; the annotation
-///   only stops the compiler from asking about it.
+///   Unchecked in the literal sense: `plugins` and `isConfigured` are plain mutable state with no lock.
+///   `add(plugin:)` cannot race a configured category — it throws once `isConfigured` is set — but
+///   `removePlugin(for:)` mutates `plugins` with no such guard and no lock, so it can race a concurrent
+///   read. That exposure predates this annotation; the annotation only stops the compiler from asking
+///   about it.
 public final class AuthCategory: Category, @unchecked Sendable {
 
     public let categoryType =  CategoryType.auth
@@ -52,21 +50,26 @@ public final class AuthCategory: Category, @unchecked Sendable {
 
     var isConfigured = false
 
-    /// `true` when `Amplify.configure()` has run for this category and a plugin is registered.
+    /// The configured plugin, or `nil` when this category has no plugin to serve a request.
     ///
-    /// Reading ``plugin`` in either of the opposite states trips a `preconditionFailure`, which aborts
-    /// the process rather than failing the call. Exposed over `@_spi` so the AWS plugin modules can
-    /// report an error instead: they hold long-lived clients that can outlive `Amplify.reset()`, and for
-    /// those a missing Auth category is a recoverable condition, not a programmer error.
+    /// A non-trapping counterpart to ``plugin``. Reading ``plugin`` before configuration, or with no
+    /// plugin registered, trips a `preconditionFailure` and aborts the process. That is the right
+    /// behaviour for application code — it is a programmer error — but not for the AWS plugin modules,
+    /// which hold long-lived clients that can outlive `Amplify.reset()`. For those, a missing Auth
+    /// category is recoverable and should surface as a thrown error.
     ///
-    /// - Important: This is **advisory, not a guarantee**. It reads `isConfigured` and `plugins` without
-    ///   synchronization, and a caller acts on the result after it returns, so `Amplify.reset()` running
-    ///   in between still leads to the `preconditionFailure` it was meant to avoid. It narrows the window
-    ///   rather than closing it. Closing it would mean giving ``plugin`` a non-trapping counterpart, which
-    ///   is a larger change to the category contract.
+    /// Returning the plugin rather than a Boolean is what makes this safe to act on: the caller captures
+    /// the plugin once and invokes it directly, so a concurrent `Amplify.reset()` cannot land between a
+    /// check and a second read of `Amplify.Auth`. A Boolean flag would leave exactly that window open.
+    ///
+    /// More than one registered plugin still traps, deliberately — that is a genuine misconfiguration
+    /// rather than a state a client can be legitimately called in.
     @_spi(InternalAmplifyConfiguration)
-    public var isConfiguredWithPlugin: Bool {
-        isConfigured && !plugins.isEmpty
+    public var configuredPlugin: AuthCategoryPlugin? {
+        let registered = plugins
+        guard isConfigured, !registered.isEmpty else { return nil }
+        guard registered.count == 1 else { return plugin }
+        return registered.first?.value
     }
 
     // MARK: - Plugin handling

--- a/AmplifyPlugins/Core/AmplifyCredentials/AmplifyAWSCredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentials/AmplifyAWSCredentialsProvider.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Amplify
+@_spi(InternalAmplifyConfiguration) import Amplify
 import AwsCommonRuntimeKit
 import AWSPluginsCore
 import Foundation
@@ -14,8 +14,29 @@ import SmithyIdentity
 
 public class AmplifyAWSCredentialsProvider: AwsCommonRuntimeKit.CredentialsProviding, @unchecked Sendable {
 
+    /// Fetches the auth session, reporting an unconfigured Auth category as a thrown error.
+    ///
+    /// Reading `Amplify.Auth` with no plugin registered hits a `preconditionFailure`, which aborts the
+    /// process rather than failing the request. A credentials provider is reachable from long-lived
+    /// clients that can outlive `Amplify.reset()` — the cached `PinpointContext` in `AWSPinpointFactory`
+    /// is one, since nothing ever clears it — so this is a state the provider can genuinely be called in,
+    /// and it should surface as an error the caller can handle.
+    private static func fetchAuthSession() async throws -> AuthSession {
+        guard Amplify.Auth.isConfiguredWithPlugin else {
+            throw AuthError.configuration(
+                "The Auth category is not configured",
+                """
+                Call Amplify.configure() with a configuration that includes Auth before requesting AWS \
+                credentials. This can also happen when a client outlives Amplify.reset() and then makes \
+                a request.
+                """
+            )
+        }
+        return try await Amplify.Auth.fetchAuthSession()
+    }
+
     public func getCredentials() async throws -> AwsCommonRuntimeKit.Credentials {
-        let authSession = try await Amplify.Auth.fetchAuthSession()
+        let authSession = try await Self.fetchAuthSession()
         if let awsCredentialsProvider = authSession as? AuthAWSCredentialsProvider {
             let credentials = try awsCredentialsProvider.getAWSCredentials().get()
             return try credentials.toAWSSDKCredentials()
@@ -28,7 +49,7 @@ public class AmplifyAWSCredentialsProvider: AwsCommonRuntimeKit.CredentialsProvi
 
 extension AmplifyAWSCredentialsProvider: AWSCredentialIdentityResolver {
     public func getIdentity(identityProperties: Smithy.Attributes? = nil) async throws -> AWSCredentialIdentity {
-        let authSession = try await Amplify.Auth.fetchAuthSession()
+        let authSession = try await Self.fetchAuthSession()
         if let awsCredentialsProvider = authSession as? AuthAWSCredentialsProvider {
             let credentials = try awsCredentialsProvider.getAWSCredentials().get()
             return try credentials.toAWSCredentialIdentity()

--- a/AmplifyPlugins/Core/AmplifyCredentials/AmplifyAWSCredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentials/AmplifyAWSCredentialsProvider.swift
@@ -14,22 +14,19 @@ import SmithyIdentity
 
 public class AmplifyAWSCredentialsProvider: AwsCommonRuntimeKit.CredentialsProviding, @unchecked Sendable {
 
-    /// Fetches the auth session, reporting an already-unconfigured Auth category as a thrown error.
+    /// Fetches the auth session, reporting an unconfigured Auth category as a thrown error.
     ///
-    /// Reading `Amplify.Auth` with no plugin registered hits a `preconditionFailure`, which aborts the
-    /// process rather than failing the request. A credentials provider is reachable from long-lived
+    /// Reading `Amplify.Auth.plugin` with no plugin registered hits a `preconditionFailure`, which aborts
+    /// the process rather than failing the request. A credentials provider is reachable from long-lived
     /// clients that can outlive `Amplify.reset()` — the cached `PinpointContext` in `AWSPinpointFactory`
     /// is one, since nothing ever clears it — so this is a state the provider can genuinely be called in,
     /// and it should surface as an error the caller can handle.
     ///
-    /// - Important: This is **best-effort, not a guarantee.** The check and the subsequent
-    ///   `fetchAuthSession()` are not atomic, so an `Amplify.reset()` landing between them still reaches
-    ///   the `preconditionFailure`. It converts the common, deterministic case — a client used after
-    ///   reset, or before configuration — into a catchable error, and leaves a narrow race behind.
-    ///   Eliminating it needs a non-trapping way to reach the plugin, which is a change to the category
-    ///   contract rather than to this type.
+    /// The plugin is captured once and invoked directly. That is what makes this airtight rather than
+    /// best-effort: there is no second read of `Amplify.Auth` for a concurrent `Amplify.reset()` to slip
+    /// in front of, so the crash window is closed rather than merely narrowed.
     private static func fetchAuthSession() async throws -> AuthSession {
-        guard Amplify.Auth.isConfiguredWithPlugin else {
+        guard let plugin = Amplify.Auth.configuredPlugin else {
             throw AuthError.configuration(
                 "The Auth category is not configured",
                 """
@@ -39,7 +36,7 @@ public class AmplifyAWSCredentialsProvider: AwsCommonRuntimeKit.CredentialsProvi
                 """
             )
         }
-        return try await Amplify.Auth.fetchAuthSession()
+        return try await plugin.fetchAuthSession(options: nil)
     }
 
     public func getCredentials() async throws -> AwsCommonRuntimeKit.Credentials {

--- a/AmplifyPlugins/Core/AmplifyCredentials/AmplifyAWSCredentialsProvider.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentials/AmplifyAWSCredentialsProvider.swift
@@ -14,13 +14,20 @@ import SmithyIdentity
 
 public class AmplifyAWSCredentialsProvider: AwsCommonRuntimeKit.CredentialsProviding, @unchecked Sendable {
 
-    /// Fetches the auth session, reporting an unconfigured Auth category as a thrown error.
+    /// Fetches the auth session, reporting an already-unconfigured Auth category as a thrown error.
     ///
     /// Reading `Amplify.Auth` with no plugin registered hits a `preconditionFailure`, which aborts the
     /// process rather than failing the request. A credentials provider is reachable from long-lived
     /// clients that can outlive `Amplify.reset()` — the cached `PinpointContext` in `AWSPinpointFactory`
     /// is one, since nothing ever clears it — so this is a state the provider can genuinely be called in,
     /// and it should surface as an error the caller can handle.
+    ///
+    /// - Important: This is **best-effort, not a guarantee.** The check and the subsequent
+    ///   `fetchAuthSession()` are not atomic, so an `Amplify.reset()` landing between them still reaches
+    ///   the `preconditionFailure`. It converts the common, deterministic case — a client used after
+    ///   reset, or before configuration — into a catchable error, and leaves a narrow race behind.
+    ///   Eliminating it needs a non-trapping way to reach the plugin, which is a change to the category
+    ///   contract rather than to this type.
     private static func fetchAuthSession() async throws -> AuthSession {
         guard Amplify.Auth.isConfiguredWithPlugin else {
             throw AuthError.configuration(

--- a/AmplifyPlugins/Core/AmplifyCredentialsTests/Auth/AmplifyAWSCredentialsProviderTests.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentialsTests/Auth/AmplifyAWSCredentialsProviderTests.swift
@@ -1,0 +1,77 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+
+@_spi(InternalAmplifyConfiguration) @testable import Amplify
+@testable import InternalAmplifyCredentials
+
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyAWSCredentialsProviderTests: XCTestCase, @unchecked Sendable {
+
+    override func tearDown() async throws {
+        await Amplify.reset()
+    }
+
+    /// An unconfigured Auth category must surface as a thrown error rather than a process abort.
+    ///
+    /// Reading `Amplify.Auth.plugin` when the category has no plugin trips a `preconditionFailure`. A
+    /// credentials provider is reachable from long-lived AWS clients that can outlive
+    /// `Amplify.reset()` — the `PinpointContext` cached in `AWSPinpointFactory` is one, because nothing
+    /// ever clears that cache — so the provider can genuinely be called in this state and must not take
+    /// the whole process down with it.
+    ///
+    /// - Given: An `AmplifyAWSCredentialsProvider` and an Auth category with no plugin configured
+    /// - When:
+    ///    - `getCredentials()` is called
+    /// - Then:
+    ///    - It throws `AuthError.configuration` instead of aborting the process
+    ///
+    func testGetCredentials_withUnconfiguredAuthCategory_throwsConfigurationError() async {
+        XCTAssertFalse(
+            Amplify.Auth.isConfiguredWithPlugin,
+            "Precondition: Auth must be unconfigured for this test to exercise the guard"
+        )
+
+        do {
+            _ = try await AmplifyAWSCredentialsProvider().getCredentials()
+            XCTFail("Expected getCredentials() to throw when Auth is not configured")
+        } catch let error as AuthError {
+            guard case .configuration = error else {
+                XCTFail("Expected AuthError.configuration, got \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Expected AuthError.configuration, got \(error)")
+        }
+    }
+
+    /// Same contract for the `AWSCredentialIdentityResolver` entry point, which the AWS SDK calls.
+    ///
+    /// - Given: An `AmplifyAWSCredentialsProvider` and an Auth category with no plugin configured
+    /// - When:
+    ///    - `getIdentity(identityProperties:)` is called
+    /// - Then:
+    ///    - It throws `AuthError.configuration` instead of aborting the process
+    ///
+    func testGetIdentity_withUnconfiguredAuthCategory_throwsConfigurationError() async {
+        XCTAssertFalse(Amplify.Auth.isConfiguredWithPlugin)
+
+        do {
+            _ = try await AmplifyAWSCredentialsProvider().getIdentity()
+            XCTFail("Expected getIdentity() to throw when Auth is not configured")
+        } catch let error as AuthError {
+            guard case .configuration = error else {
+                XCTFail("Expected AuthError.configuration, got \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Expected AuthError.configuration, got \(error)")
+        }
+    }
+}

--- a/AmplifyPlugins/Core/AmplifyCredentialsTests/Auth/AmplifyAWSCredentialsProviderTests.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentialsTests/Auth/AmplifyAWSCredentialsProviderTests.swift
@@ -33,8 +33,8 @@ class AmplifyAWSCredentialsProviderTests: XCTestCase, @unchecked Sendable {
     ///    - It throws `AuthError.configuration` instead of aborting the process
     ///
     func testGetCredentials_withUnconfiguredAuthCategory_throwsConfigurationError() async {
-        XCTAssertFalse(
-            Amplify.Auth.isConfiguredWithPlugin,
+        XCTAssertNil(
+            Amplify.Auth.configuredPlugin,
             "Precondition: Auth must be unconfigured for this test to exercise the guard"
         )
 
@@ -60,7 +60,7 @@ class AmplifyAWSCredentialsProviderTests: XCTestCase, @unchecked Sendable {
     ///    - It throws `AuthError.configuration` instead of aborting the process
     ///
     func testGetIdentity_withUnconfiguredAuthCategory_throwsConfigurationError() async {
-        XCTAssertFalse(Amplify.Auth.isConfiguredWithPlugin)
+        XCTAssertNil(Amplify.Auth.configuredPlugin)
 
         do {
             _ = try await AmplifyAWSCredentialsProvider().getIdentity()


### PR DESCRIPTION
Slice **4 of 38** in the Swift 6 language-mode migration — 3 file(s).

Stacked on `swift6/03-async-sequence-cancellation`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.