### PR TITLE
fix(analytics): keep ActivityTracker registration synchronous

### DIFF
--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Session/ActivityTracking/ActivityTracker.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Session/ActivityTracking/ActivityTracker.swift
@@ -61,12 +61,15 @@ extension ApplicationState: DefaultLogger {
     }
 }
 
-protocol ActivityTrackerBehaviour: AnyObject {
+/// - Note: `Sendable` because the session client holding this is `Sendable`.
+protocol ActivityTrackerBehaviour: AnyObject, Sendable {
     var backgroundTrackingTimeout: TimeInterval { get set }
     func beginActivityTracking(_ listener: @escaping (ApplicationState) -> Void)
 }
 
-class ActivityTracker: ActivityTrackerBehaviour {
+/// - Note: `final` and `@unchecked Sendable`: the background-tracking state is only touched from the
+///   main actor, and the state machine it forwards to is internally synchronized.
+final class ActivityTracker: ActivityTrackerBehaviour, @unchecked Sendable {
 
 #if canImport(UIKit) && !os(watchOS)
     private var backgroundTask: UIBackgroundTaskIdentifier = .invalid
@@ -81,7 +84,6 @@ class ActivityTracker: ActivityTrackerBehaviour {
     private let stateMachine: StateMachine<ApplicationState, ActivityEvent>
     private var stateMachineSubscriberToken: StateMachineSubscriberToken?
 
-    @MainActor
     private static let applicationDidMoveToBackgroundNotification: Notification.Name = {
 #if canImport(WatchKit)
     WKExtension.applicationDidEnterBackgroundNotification
@@ -92,7 +94,6 @@ class ActivityTracker: ActivityTrackerBehaviour {
 #endif
     }()
 
-    @MainActor
     private static let applicationWillMoveToForegoundNotification: Notification.Name = {
     #if canImport(WatchKit)
         WKExtension.applicationWillEnterForegroundNotification
@@ -103,8 +104,7 @@ class ActivityTracker: ActivityTrackerBehaviour {
     #endif
     }()
 
-    @MainActor
-    private static var applicationWillTerminateNotification: Notification.Name = {
+    private static let applicationWillTerminateNotification: Notification.Name = {
     #if canImport(WatchKit)
         // There's no willTerminateNotification on watchOS, so using applicationWillResignActive instead.
         WKExtension.applicationWillResignActiveNotification
@@ -115,7 +115,10 @@ class ActivityTracker: ActivityTrackerBehaviour {
     #endif
     }()
 
-    @MainActor
+    // These three were `@MainActor` before the Swift 6 migration, which forced observer registration
+    // off `init` and made it asynchronous — breaking callers that post a notification immediately after
+    // constructing a tracker. The annotation turned out to be unnecessary: the platform notification
+    // *names* are plain constants, so reading them needs no isolation and registration stays synchronous.
     private static let notifications = [
         applicationDidMoveToBackgroundNotification,
         applicationWillMoveToForegoundNotification,
@@ -143,13 +146,9 @@ class ActivityTracker: ActivityTrackerBehaviour {
     }
 
     deinit {
-        for notification in ActivityTracker.notifications {
-            NotificationCenter.default.removeObserver(
-                self,
-                name: notification,
-                object: nil
-            )
-        }
+        // Removes every observer registered for this object, which is equivalent to unregistering each
+        // name individually and keeps this nonisolated `deinit` from touching any of the type's state.
+        NotificationCenter.default.removeObserver(self)
         stateMachineSubscriberToken = nil
     }
 

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Session/ActivityTracking/ActivityTracker.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Session/ActivityTracking/ActivityTracker.swift
@@ -67,8 +67,20 @@ protocol ActivityTrackerBehaviour: AnyObject, Sendable {
     func beginActivityTracking(_ listener: @escaping (ApplicationState) -> Void)
 }
 
-/// - Note: `final` and `@unchecked Sendable`: the background-tracking state is only touched from the
-///   main actor, and the state machine it forwards to is internally synchronized.
+/// - Note: `final` and `@unchecked Sendable` to satisfy `ActivityTrackerBehaviour`. The claim is only
+///   partly true, so to be precise about which parts:
+///
+///   - `backgroundTask` and `backgroundTimer` are touched solely by `beginBackgroundTracking()` and
+///     `stopBackgroundTracking()`, both `@MainActor`, so those two are genuinely main-actor confined.
+///   - `backgroundTrackingTimeout` is **not**: the protocol requires it settable, so any context can
+///     write it while a main-actor method reads it.
+///   - `stateMachineSubscriberToken` is **not**: `beginActivityTracking(_:)` is nonisolated and `deinit`
+///     clears it.
+///   - The state machine it forwards to is internally synchronized.
+///
+///   Neither unsynchronized property is written after set-up in practice — the timeout is configured
+///   once and tracking begins once — but nothing here enforces that. The exposure predates this
+///   annotation, which only stops the compiler from asking.
 final class ActivityTracker: ActivityTrackerBehaviour, @unchecked Sendable {
 
 #if canImport(UIKit) && !os(watchOS)

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/ActivityTrackerTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/ActivityTrackerTests.swift
@@ -15,7 +15,9 @@ import UIKit
 import AppKit
 #endif
 
-class ActivityTrackerTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ActivityTrackerTests: XCTestCase, @unchecked Sendable {
     private var tracker: ActivityTracker!
     private var stateMachine: MockStateMachine!
     private var timeout: TimeInterval = 1
@@ -78,13 +80,18 @@ class ActivityTrackerTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 1)
     }
 
+    // `@MainActor` to match how these notifications actually arrive. `NotificationCenter` delivers
+    // synchronously on the posting thread, and the handler is main-actor-isolated because the platform
+    // posts the real notifications on the main thread. Posting from a background executor — as this test
+    // did before — trapped the main-actor check in the `@objc` thunk under the Swift 6 language mode.
+    @MainActor
     func testApplicationStateChanged_shouldReportProperEvent() async {
         stateMachine.processExpectation = expectation(description: "Application state changed")
         stateMachine.processExpectation?.expectedFulfillmentCount = 3
 
-        await NotificationCenter.default.post(Notification(name: Self.applicationDidMoveToBackgroundNotification))
-        await NotificationCenter.default.post(Notification(name: Self.applicationWillMoveToForegoundNotification))
-        await NotificationCenter.default.post(Notification(name: Self.applicationWillTerminateNotification))
+        NotificationCenter.default.post(Notification(name: Self.applicationDidMoveToBackgroundNotification))
+        NotificationCenter.default.post(Notification(name: Self.applicationWillMoveToForegoundNotification))
+        NotificationCenter.default.post(Notification(name: Self.applicationWillTerminateNotification))
 
         await fulfillment(of: [stateMachine.processExpectation!], timeout: 1)
         XCTAssertTrue(stateMachine.processedEvents.contains(.applicationDidMoveToBackground))


### PR DESCRIPTION
Slice **5 of 38** in the Swift 6 language-mode migration — 2 file(s).

Stacked on `swift6/04-credentials-unconfigured-auth`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.