### PR TITLE
fix(api): stop AppSyncRealTimeClient's sink from inheriting actor isolation

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeClient.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeClient.swift
@@ -50,7 +50,13 @@ actor AppSyncRealTimeClient: AppSyncRealTimeClientProtocol {
     /// and connection-drop paths.
     private var isReconnecting = false
     /// Writable data stream convert WebSocketEvent to AppSyncRealTimeResponse
-    nonisolated let subject = PassthroughSubject<Result<AppSyncRealTimeResponse, Error>, Never>()
+    /// Backing store for ``subject``. `PassthroughSubject` is not `Sendable` but `send` is safe from
+    /// any thread, and this is `nonisolated` so it can be reached without hopping onto the actor.
+    private nonisolated let subjectBox = UncheckedSendable(PassthroughSubject<Result<AppSyncRealTimeResponse, Error>, Never>())
+
+    nonisolated var subject: PassthroughSubject<Result<AppSyncRealTimeResponse, Error>, Never> {
+        subjectBox.value
+    }
 
     var isConnected: Bool {
         state.value == .connected
@@ -81,10 +87,11 @@ actor AppSyncRealTimeClient: AppSyncRealTimeClientProtocol {
     }
 
     deinit {
+        // Only the subject is touched here: a nonisolated `deinit` cannot reach actor-isolated state
+        // in Swift 6 mode, and clearing the cancellable sets was already redundant because releasing
+        // the actor's storage deinitializes each `AnyCancellable`, which cancels it.
         log.debug("Deinit AppSyncRealTimeClient")
         subject.send(completion: .finished)
-        cancellables = Set()
-        cancellablesBindToConnection = Set()
     }
 
     /**
@@ -250,18 +257,22 @@ actor AppSyncRealTimeClient: AppSyncRealTimeClientProtocol {
 
     }
 
+    // Both closures are `@Sendable` so they do not inherit this actor's isolation. Combine calls them
+    // synchronously on whichever thread published the event, which would trip the isolation check at
+    // runtime if they were actor-isolated. Reaching `self` therefore goes through an explicit hop.
     private func subscribeToWebSocketEvent() async {
-        let cancellable = await webSocketClient.publisher.sink { [weak self] _ in
-            self?.log.debug("[AppSyncRealTimeClient] WebSocketClient terminated")
-        } receiveValue: { webSocketEvent in
-            Task { [weak self] in
-                let task = Task { [weak self] in
-                    await self?.onWebSocketEvent(webSocketEvent)
-                }
-                await self?.storeInCancellables(task.toAnyCancellable)
-            }
+        let cancellable = await webSocketClient.publisher.sink { @Sendable [weak self] _ in
+            Task { [weak self] in await self?.logWebSocketClientTerminated() }
+        } receiveValue: { @Sendable [weak self] webSocketEvent in
+            guard let self else { return }
+            let task = Task { await self.onWebSocketEvent(webSocketEvent) }
+            Task { await self.storeInCancellables(task.toAnyCancellable) }
         }
         storeInCancellables(cancellable)
+    }
+
+    private func logWebSocketClientTerminated() {
+        log.debug("[AppSyncRealTimeClient] WebSocketClient terminated")
     }
 
     private func resumeExistingSubscriptions() {

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeClient.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeClient.swift
@@ -259,20 +259,17 @@ actor AppSyncRealTimeClient: AppSyncRealTimeClientProtocol {
 
     // Both closures are `@Sendable` so they do not inherit this actor's isolation. Combine calls them
     // synchronously on whichever thread published the event, which would trip the isolation check at
-    // runtime if they were actor-isolated. Reaching `self` therefore goes through an explicit hop.
+    // runtime if they were actor-isolated. Reaching actor-isolated members therefore needs an explicit
+    // hop — but `log` is `nonisolated`, so logging stays a direct synchronous call as before.
     private func subscribeToWebSocketEvent() async {
         let cancellable = await webSocketClient.publisher.sink { @Sendable [weak self] _ in
-            Task { [weak self] in await self?.logWebSocketClientTerminated() }
+            self?.log.debug("[AppSyncRealTimeClient] WebSocketClient terminated")
         } receiveValue: { @Sendable [weak self] webSocketEvent in
             guard let self else { return }
             let task = Task { await self.onWebSocketEvent(webSocketEvent) }
             Task { await self.storeInCancellables(task.toAnyCancellable) }
         }
         storeInCancellables(cancellable)
-    }
-
-    private func logWebSocketClientTerminated() {
-        log.debug("[AppSyncRealTimeClient] WebSocketClient terminated")
     }
 
     private func resumeExistingSubscriptions() {


### PR DESCRIPTION
Slice **6 of 38** in the Swift 6 language-mode migration — 1 file(s).

Stacked on `swift6/05-activity-tracker-registration`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.