### PR TITLE
fix(core): make DevMenu concurrency-safe

### DIFF
--- a/Amplify/DevMenu/Logging/PersistentLogWrapper.swift
+++ b/Amplify/DevMenu/Logging/PersistentLogWrapper.swift
@@ -9,10 +9,21 @@
 import Foundation
 
 /// Class that wraps another `Logger` and saves the logs in memory
-class PersistentLogWrapper: Logger {
-    var logLevel: LogLevel
+///
+/// - Note: `final` and `@unchecked Sendable` because `Logger` is `Sendable`. The mutable state really is
+///   shared — log calls arrive from whichever thread emitted them — so `lock` guards every access to it
+///   rather than the conformance simply asserting safety.
+final class PersistentLogWrapper: Logger, @unchecked Sendable {
+    private let lock = NSLock()
 
-    var wrapper: Logger
+    private var _logLevel: LogLevel
+
+    var logLevel: LogLevel {
+        get { lock.withLock { _logLevel } }
+        set { lock.withLock { _logLevel = newValue } }
+    }
+
+    private let wrapper: Logger
 
     /// Array of `LogEntry` containing the history of logs
     private var logHistory: [LogEntryItem] = []
@@ -22,7 +33,7 @@ class PersistentLogWrapper: Logger {
 
     init(logWrapper: Logger) {
         self.wrapper = logWrapper
-        self.logLevel = logWrapper.logLevel
+        self._logLevel = logWrapper.logLevel
     }
 
     func error(_ message: @autoclosure () -> String) {
@@ -56,15 +67,17 @@ class PersistentLogWrapper: Logger {
     }
 
     func getLogHistory() -> [LogEntryItem] {
-        return logHistory
+        return lock.withLock { logHistory }
     }
 
     private func addToLogHistory(logItem: LogEntryItem) {
-        if logHistory.count == PersistentLogWrapper.logLimit {
-            logHistory.removeFirst()
-        }
+        lock.withLock {
+            if logHistory.count == PersistentLogWrapper.logLimit {
+                logHistory.removeFirst()
+            }
 
-        logHistory.append(logItem)
+            logHistory.append(logItem)
+        }
     }
 
 }

--- a/Amplify/DevMenu/Logging/PersistentLoggingPlugin.swift
+++ b/Amplify/DevMenu/Logging/PersistentLoggingPlugin.swift
@@ -9,10 +9,15 @@
 import Foundation
 
 /// `LoggingCategoryPlugin` that wraps another`LoggingCategoryPlugin` and saves the logs in memory
-public class PersistentLoggingPlugin: LoggingCategoryPlugin {
+///
+/// - Note: `@unchecked Sendable` because `Plugin` is `Sendable` and the lazily-created wrapper is mutable
+///   state; `lock` guards it. Deliberately not `final` — this type is public API, and `@unchecked
+///   Sendable` does not require `final`, so marking it so would needlessly break any subclass.
+public class PersistentLoggingPlugin: LoggingCategoryPlugin, @unchecked Sendable {
 
-    var plugin: LoggingCategoryPlugin
-    var persistentLogWrapper: PersistentLogWrapper?
+    private let lock = NSLock()
+    let plugin: LoggingCategoryPlugin
+    private var _persistentLogWrapper: PersistentLogWrapper?
 
     public let key: String = DevMenuStringConstants.persistentLoggingPluginKey
 
@@ -45,7 +50,7 @@ public class PersistentLoggingPlugin: LoggingCategoryPlugin {
     }
 
     public func reset() async {
-        persistentLogWrapper = nil
+        lock.withLock { _persistentLogWrapper = nil }
         await plugin.reset()
     }
 
@@ -54,11 +59,19 @@ public class PersistentLoggingPlugin: LoggingCategoryPlugin {
     }
 
     public var `default`: Logger {
-        if persistentLogWrapper == nil {
-            persistentLogWrapper = PersistentLogWrapper(logWrapper: plugin.default)
+        if let existing = lock.withLock({ _persistentLogWrapper }) {
+            return existing
         }
-
-        return persistentLogWrapper!
+        // Built outside the lock so we never call into the wrapped plugin while holding it. Two racing
+        // callers may each build one; the loser's is discarded and both see the same wrapper.
+        let created = PersistentLogWrapper(logWrapper: plugin.default)
+        return lock.withLock {
+            if let existing = _persistentLogWrapper {
+                return existing
+            }
+            _persistentLogWrapper = created
+            return created
+        }
     }
 }
 

--- a/Amplify/DevMenu/Trigger/LongPressGestureRecognizer.swift
+++ b/Amplify/DevMenu/Trigger/LongPressGestureRecognizer.swift
@@ -10,7 +10,13 @@ import Foundation
 import UIKit
 
 /// A class for recognizing long press gesture which notifies a `TriggerDelegate` of the event
-class LongPressGestureRecognizer: NSObject, TriggerRecognizer, UIGestureRecognizerDelegate {
+///
+/// - Note: `@preconcurrency` on the `TriggerRecognizer` conformance: this type is main-actor-isolated
+///   because it holds and configures UIKit objects, while `TriggerRecognizer` is not isolated, so the
+///   conformance crosses isolation. Gesture callbacks only ever arrive on the main thread. This matches
+///   the `@preconcurrency` conformances already on `AmplifyDevMenu`, and avoids isolating the public
+///   `TriggerRecognizer` protocol.
+class LongPressGestureRecognizer: NSObject, @preconcurrency TriggerRecognizer, UIGestureRecognizerDelegate {
 
     weak var triggerDelegate: TriggerDelegate?
     weak var uiWindow: UIWindow?

--- a/Amplify/DevMenu/Trigger/LongPressGestureRecognizer.swift
+++ b/Amplify/DevMenu/Trigger/LongPressGestureRecognizer.swift
@@ -11,11 +11,12 @@ import UIKit
 
 /// A class for recognizing long press gesture which notifies a `TriggerDelegate` of the event
 ///
-/// - Note: `@preconcurrency` on the `TriggerRecognizer` conformance: this type is main-actor-isolated
-///   because it holds and configures UIKit objects, while `TriggerRecognizer` is not isolated, so the
-///   conformance crosses isolation. Gesture callbacks only ever arrive on the main thread. This matches
-///   the `@preconcurrency` conformances already on `AmplifyDevMenu`, and avoids isolating the public
-///   `TriggerRecognizer` protocol.
+/// - Note: `@preconcurrency` on the `TriggerRecognizer` conformance. The class is not itself annotated
+///   `@MainActor`; the isolation comes from the members it inherits and the `@MainActor` UIKit API it
+///   touches, which is enough for the compiler to treat the conformance as crossing isolation.
+///   `@preconcurrency` defers that to a runtime check, which holds because gesture callbacks only ever
+///   arrive on the main thread. This matches the `@preconcurrency` conformances already on
+///   `AmplifyDevMenu`, and avoids isolating the public `TriggerRecognizer` protocol.
 class LongPressGestureRecognizer: NSObject, @preconcurrency TriggerRecognizer, UIGestureRecognizerDelegate {
 
     weak var triggerDelegate: TriggerDelegate?

--- a/Amplify/DevMenu/Trigger/LongPressGestureRecognizer.swift
+++ b/Amplify/DevMenu/Trigger/LongPressGestureRecognizer.swift
@@ -11,12 +11,14 @@ import UIKit
 
 /// A class for recognizing long press gesture which notifies a `TriggerDelegate` of the event
 ///
-/// - Note: `@preconcurrency` on the `TriggerRecognizer` conformance. The class is not itself annotated
-///   `@MainActor`; the isolation comes from the members it inherits and the `@MainActor` UIKit API it
-///   touches, which is enough for the compiler to treat the conformance as crossing isolation.
-///   `@preconcurrency` defers that to a runtime check, which holds because gesture callbacks only ever
-///   arrive on the main thread. This matches the `@preconcurrency` conformances already on
-///   `AmplifyDevMenu`, and avoids isolating the public `TriggerRecognizer` protocol.
+/// - Note: `@preconcurrency` on the `TriggerRecognizer` conformance. `UIGestureRecognizerDelegate` is
+///   declared `NS_SWIFT_UI_ACTOR`, so conforming to it here infers `@MainActor` for this whole class —
+///   there is no explicit annotation to find, and neither `NSObject` nor the UIKit calls in the body are
+///   what causes it. `TriggerRecognizer` is nonisolated, so `updateTriggerDelegate(delegate:)` becomes a
+///   main-actor witness for a nonisolated requirement, which is the isolation crossing the compiler
+///   objects to. `@preconcurrency` turns that into a runtime check, and the check holds: the only caller
+///   through the protocol is `AmplifyDevMenu`, which is itself `@MainActor`, and gesture callbacks arrive
+///   on the main thread. Isolating the public `TriggerRecognizer` protocol instead would be an API change.
 class LongPressGestureRecognizer: NSObject, @preconcurrency TriggerRecognizer, UIGestureRecognizerDelegate {
 
     weak var triggerDelegate: TriggerDelegate?

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Session/ActivityTracking/ActivityTracker.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Session/ActivityTracking/ActivityTracker.swift
@@ -70,17 +70,25 @@ protocol ActivityTrackerBehaviour: AnyObject, Sendable {
 /// - Note: `final` and `@unchecked Sendable` to satisfy `ActivityTrackerBehaviour`. The claim is only
 ///   partly true, so to be precise about which parts:
 ///
-///   - `backgroundTask` and `backgroundTimer` are touched solely by `beginBackgroundTracking()` and
-///     `stopBackgroundTracking()`, both `@MainActor`, so those two are genuinely main-actor confined.
-///   - `backgroundTrackingTimeout` is **not**: the protocol requires it settable, so any context can
-///     write it while a main-actor method reads it.
-///   - `stateMachineSubscriberToken` is **not**: `beginActivityTracking(_:)` is nonisolated and `deinit`
-///     clears it.
-///   - The state machine it forwards to is internally synchronized.
+///   - `backgroundTask` is only touched inside `beginBackgroundTracking()` / `stopBackgroundTracking()`,
+///     both `@MainActor`, and the `beginBackgroundTask` expiration handler inherits that isolation — so
+///     it is main-actor confined and the compiler enforces it.
+///   - `backgroundTimer` is touched by the same two methods, but `stopBackgroundTracking()` is also
+///     called from the `Timer.scheduledTimer` block, which is `@Sendable` and therefore nonisolated.
+///     Swift 6 only warns there because `NSTimer`'s block is imported preconcurrency, so this
+///     confinement rests on the run-loop convention, not on the compiler.
+///   - `backgroundTrackingTimeout` is **not** confined: the protocol requires it settable, and
+///     `SessionClient.startTrackingSessions` writes it from a nonisolated context.
+///   - `stateMachineSubscriberToken` is **not** confined: `beginActivityTracking(_:)` is nonisolated and
+///     `deinit` clears it.
+///   - `StateMachine.process` serializes on its own queue, but `subscribe`/`unsubscribe` touch the
+///     publisher without it, so "internally synchronized" is only true of `process`.
 ///
-///   Neither unsynchronized property is written after set-up in practice — the timeout is configured
-///   once and tracking begins once — but nothing here enforces that. The exposure predates this
-///   annotation, which only stops the compiler from asking.
+///   Do not read this as "written once at set-up". `AWSPinpointFactory` caches its `PinpointContext`
+///   forever, so an `Amplify.reset()` followed by reconfiguration calls `startTrackingSessions` again —
+///   writing the timeout a second time and replacing the subscriber token. That is the same cache that
+///   makes the credentials crash in `AmplifyAWSCredentialsProvider` reachable. Nothing here enforces
+///   single-assignment; the exposure predates this annotation, which only stops the compiler from asking.
 final class ActivityTracker: ActivityTrackerBehaviour, @unchecked Sendable {
 
 #if canImport(UIKit) && !os(watchOS)


### PR DESCRIPTION
Slice **7 of 38** in the Swift 6 language-mode migration — 3 file(s).

Stacked on `swift6/06-appsync-sink-isolation`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.