### PR TITLE
fix(auth): make the tvOS and watchOS presentation-anchor placeholder Sendable

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/AuthUIPresentationAnchorPlaceholder.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/AuthUIPresentationAnchorPlaceholder.swift
@@ -14,7 +14,13 @@ typealias AuthUIPresentationAnchor = AuthUIPresentationAnchorPlaceholder
 /// This class serves as a placeholder for the AuthUIPresentationAnchor, which is not available in watchOS.
 /// It cannot be initialized and exists strictly to facilitate cross-platform compilation without requiring compiler
 /// checks thorughout the codebase.
-class AuthUIPresentationAnchorPlaceholder: Equatable {
+///
+/// - Note: `final` and `Sendable` — a fully checked conformance, not `@unchecked`, since the type has no
+///   stored properties and a private `init` so no instance can exist. Without it, `Sendable` inference
+///   failed for `HostedUIOptions` on tvOS and watchOS, which then cascaded through `SignInMethod`,
+///   `SignedInData` and every state-machine enum carrying them. On the other platforms this typealias
+///   resolves to `ASPresentationAnchor` instead, which is why the cascade never appeared on macOS.
+final class AuthUIPresentationAnchorPlaceholder: Equatable, Sendable {
 
     private init() {}
 


### PR DESCRIPTION
Slice **9 of 38** in the Swift 6 language-mode migration — 1 file(s).

Stacked on `swift6/08-watchos-reachability`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.