### PR TITLE
refactor(kinesis): use withLock instead of paired lock and unlock calls

### DIFF
--- a/AmplifyClients/AmplifyFirehoseClient/Sources/AmplifyFirehoseClient.swift
+++ b/AmplifyClients/AmplifyFirehoseClient/Sources/AmplifyFirehoseClient.swift
@@ -61,9 +61,7 @@ public class AmplifyFirehoseClient {
     private var _isEnabled = true
 
     private var isEnabledLocked: Bool {
-        isEnabledLock.lock()
-        defer { isEnabledLock.unlock() }
-        return _isEnabled
+        isEnabledLock.withLock { _isEnabled }
     }
 
     /// Configuration options for AmplifyFirehoseClient
@@ -237,9 +235,7 @@ public class AmplifyFirehoseClient {
     }
 
     private func setEnabled(_ value: Bool) {
-        isEnabledLock.lock()
-        _isEnabled = value
-        isEnabledLock.unlock()
+        isEnabledLock.withLock { _isEnabled = value }
     }
 
     /// Clears all cached records

--- a/AmplifyClients/AmplifyKinesisClient/Sources/AmplifyKinesisClient.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Sources/AmplifyKinesisClient.swift
@@ -79,9 +79,7 @@ public class AmplifyKinesisClient {
     private var _isEnabled = true
 
     private var isEnabledLocked: Bool {
-        isEnabledLock.lock()
-        defer { isEnabledLock.unlock() }
-        return _isEnabled
+        isEnabledLock.withLock { _isEnabled }
     }
 
     /// Configuration options for AmplifyKinesisClient
@@ -262,9 +260,7 @@ public class AmplifyKinesisClient {
     }
 
     private func setEnabled(_ value: Bool) {
-        isEnabledLock.lock()
-        _isEnabled = value
-        isEnabledLock.unlock()
+        isEnabledLock.withLock { _isEnabled = value }
     }
 
     /// Clears all cached records


### PR DESCRIPTION
Slice **10 of 38** in the Swift 6 language-mode migration — 2 file(s).

Stacked on `swift6/09-anchor-placeholder-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.