### PR TITLE
feat(core)!: require Sendable on Plugin and Category

### DIFF
--- a/Amplify/Core/Category/CategoryType.swift
+++ b/Amplify/Core/Category/CategoryType.swift
@@ -17,7 +17,9 @@ public protocol CategoryTypeable {
 /// Amplify supports these Category types
 ///
 /// - Tag: CategoryType
-public enum CategoryType: String {
+// `Sendable` is explicit rather than inferred: Swift only infers it for non-public
+// types, so a public enum must state it even when every case is payload-free.
+public enum CategoryType: String, Sendable {
     /// Record app metrics and analytics data
     ///
     /// - Tag: CategoryType.analytics

--- a/Amplify/Core/Plugin/Plugin.swift
+++ b/Amplify/Core/Plugin/Plugin.swift
@@ -8,7 +8,10 @@
 /// CategoryPlugins implement the behavior defined by the category. The `Plugin` protocol defines behavior common to
 /// all plugins, but each category will also define client API behavior and optionally, plugin API behavior to describe
 /// the contract to which the plugin must conform.
-public protocol Plugin: CategoryTypeable, Resettable {
+/// - Note: `Sendable` because a plugin is registered once and then shared for the lifetime of
+///   the process, reached concurrently from any task that touches its category. Conformers are
+///   responsible for making their own state thread-safe.
+public protocol Plugin: CategoryTypeable, Resettable, Sendable {
     /// The key under which the plugin is registered in the Amplify configuration. Keys must be unique within the
     /// category configuration section.
     var key: PluginKey { get }


### PR DESCRIPTION
Slice **11 of 38** in the Swift 6 language-mode migration — 2 file(s).

Stacked on `swift6/10-kinesis-withlock`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.