### PR TITLE
feat(core): Sendable for core support and task types

### DIFF
--- a/Amplify/Core/Model/UserProfile.swift
+++ b/Amplify/Core/Model/UserProfile.swift
@@ -26,7 +26,8 @@ public protocol UserProfile {
 }
 
 /// Contains specific data for a Location
-public struct UserProfileLocation {
+// Explicit `Sendable`: Swift does not infer it for public types.
+public struct UserProfileLocation: Sendable {
 
     /// The user's latitude
     public var latitude: Double?

--- a/Amplify/Core/Model/UserProfilePropertyValue.swift
+++ b/Amplify/Core/Model/UserProfilePropertyValue.swift
@@ -14,7 +14,9 @@ import Foundation
 ///
 /// If the underlying service does not support one of these, it is expected that the plugin will
 /// cast it to another supported type. For example, casting a `Bool` to a `String`.
-public protocol UserProfilePropertyValue {}
+/// - Note: `Sendable` for the same reason as `AnalyticsPropertyValue`: profile properties are
+///   carried into async plugin work. Conformers are `String`, `Int`, `Double` and `Bool`.
+public protocol UserProfilePropertyValue: Sendable {}
 
 extension String: UserProfilePropertyValue {}
 extension Int: UserProfilePropertyValue {}

--- a/Amplify/Core/Support/Amplify+Publisher.swift
+++ b/Amplify/Core/Support/Amplify+Publisher.swift
@@ -33,17 +33,20 @@ public extension Amplify {
         ///
         /// - Parameter operation: The Task for which to create the Publisher.
         /// - Returns: The Publisher for the given Task.
-        public static func create<Success>(
+        public static func create<Success: Sendable>(
             _ operation: @escaping @Sendable () async throws -> Success
         ) -> AnyPublisher<Success, Error> {
             let task = Task(operation: operation)
             return Future { promise in
+                // `Future.Promise` is not `Sendable`, but Combine guarantees it is called
+                // at most once, so moving it into the task is safe.
+                let promise = UncheckedSendable(promise)
                 Task {
                     do {
                         let value = try await task.value
-                        promise(.success(value))
+                        promise.value(.success(value))
                     } catch {
-                        promise(.failure(error))
+                        promise.value(.failure(error))
                     }
                 }
             }
@@ -65,14 +68,17 @@ public extension Amplify {
         ///
         /// - Parameter operation: The Task for which to create the Publisher.
         /// - Returns: The Publisher for the given Task.
-        public static func create<Success>(
+        public static func create<Success: Sendable>(
             _ operation: @escaping @Sendable () async -> Success
         ) -> AnyPublisher<Success, Never> {
             let task = Task(operation: operation)
             return Future { promise in
+                // See the throwing overload above: `Future.Promise` is not `Sendable` but
+                // is called at most once.
+                let promise = UncheckedSendable(promise)
                 Task {
                     let value = await task.value
-                    promise(.success(value))
+                    promise.value(.success(value))
                 }
             }
             .handleEvents(receiveCancel: { task.cancel() })
@@ -97,11 +103,18 @@ public extension Amplify {
         ///
         /// - Parameter sequence: The AsyncSequence for which to create the Publisher.
         /// - Returns: The Publisher for the given AsyncSequence.
-        public static func create<Sequence: AsyncSequence>(
+        // `Sequence` is captured by the `onCancel` closure and its elements are sent
+        // through a Combine subject from inside a `Task`, so both the sequence and its
+        // element type must be `Sendable` in the Swift 6 language mode.
+        public static func create<Sequence: AsyncSequence & Sendable>(
             _ sequence: Sequence
-        ) -> AnyPublisher<Sequence.Element, Error> {
+        ) -> AnyPublisher<Sequence.Element, Error> where Sequence.Element: Sendable {
             let subject = PassthroughSubject<Sequence.Element, Error>()
+            // `PassthroughSubject` is not `Sendable`, but `send` is documented as safe to
+            // call from any thread, so it can be driven from the task below.
+            let boxedSubject = UncheckedSendable(subject)
             let task = Task {
+                let subject = boxedSubject.value
                 do {
                     // If the Task is cancelled, this will allow the onCancel closure to be called immediately.
                     // This is necessary to prevent continuing to wait until another value is received from

--- a/Amplify/Core/Support/AmplifyInProcessReportingOperation.swift
+++ b/Amplify/Core/Support/AmplifyInProcessReportingOperation.swift
@@ -64,7 +64,9 @@ open class AmplifyInProcessReportingOperation<
         let channel = HubChannel(from: categoryType)
         let filterById = HubFilters.forOperation(self)
 
-        var inProcessListenerToken: UnsubscribeToken!
+        // See `InternalTask+Hub`: the listener removes itself, so the token is held in an
+        // `AtomicValue` box rather than a `var` captured before assignment.
+        let tokenBox = AtomicValue<UnsubscribeToken?>(initialValue: nil)
         let inProcessHubListener: HubListener = { payload in
             if let inProcessData = payload.data as? InProcess {
                 inProcessListener(inProcessData)
@@ -72,15 +74,16 @@ open class AmplifyInProcessReportingOperation<
             }
             // Remove listener if we see a result come through
             if payload.data is OperationResult {
-                Amplify.Hub.removeListener(inProcessListenerToken)
+                if let token = tokenBox.get() { Amplify.Hub.removeListener(token) }
             }
         }
 
-        inProcessListenerToken = Amplify.Hub.listen(
+        let inProcessListenerToken = Amplify.Hub.listen(
             to: channel,
             isIncluded: filterById,
             listener: inProcessHubListener
         )
+        tokenBox.set(inProcessListenerToken)
 
         return inProcessListenerToken
     }
@@ -109,7 +112,7 @@ open class AmplifyInProcessReportingOperation<
 
 public extension AmplifyInProcessReportingOperation {
     /// Convenience typealias for the `inProcessListener` callback submitted during Operation creation
-    typealias InProcessListener = (InProcess) -> Void
+    typealias InProcessListener = @Sendable (InProcess) -> Void
 
     /// Dispatches an event to the hub. Internally, creates an
     /// `AmplifyOperationContext` object from the operation's `id`, and `request`

--- a/Amplify/Core/Support/AmplifyOperation.swift
+++ b/Amplify/Core/Support/AmplifyOperation.swift
@@ -31,7 +31,7 @@ open class AmplifyOperation<Request: AmplifyOperationRequest, Success, Failure: 
     public typealias OperationResult = Result<Success, Failure>
 
     /// Convenience typealias for the `listener` callback submitted during Operation creation
-    public typealias ResultListener = (OperationResult) -> Void
+    public typealias ResultListener = @Sendable (OperationResult) -> Void
 
     /// The unique ID of the operation. In categories where operations are persisted for future processing, this id can
     /// be used to identify previously-scheduled work for progress tracking or other functions.
@@ -123,7 +123,9 @@ open class AmplifyOperation<Request: AmplifyOperationRequest, Success, Failure: 
         let channel = HubChannel(from: categoryType)
         let filterById = HubFilters.forOperation(self)
 
-        var token: UnsubscribeToken?
+        // See `InternalTask+Hub`: the listener removes itself, so the token is held in an
+        // `AtomicValue` box rather than a `var` captured before assignment.
+        let tokenBox = AtomicValue<UnsubscribeToken?>(initialValue: nil)
         let resultHubListener: HubListener = { payload in
             guard let result = payload.data as? OperationResult else {
                 return
@@ -132,16 +134,16 @@ open class AmplifyOperation<Request: AmplifyOperationRequest, Success, Failure: 
             resultListener(result)
 
             // Automatically unsubscribe when event is received
-            guard let token else {
+            guard let token = tokenBox.get() else {
                 return
             }
             Amplify.Hub.removeListener(token)
         }
 
-        token = Amplify.Hub.listen(to: channel, isIncluded: filterById, listener: resultHubListener)
+        let token = Amplify.Hub.listen(to: channel, isIncluded: filterById, listener: resultHubListener)
+        tokenBox.set(token)
 
-        // We know that `token` is assigned by `Amplify.Hub.listen` so it's safe to force-unwrap
-        return token!
+        return token
     }
 
     /// Classes that override this method must emit a completion to the `resultPublisher` upon cancellation
@@ -204,9 +206,11 @@ extension AmplifyOperation: HubPayloadEventNameable { }
 extension AmplifyOperation: Cancellable { }
 
 /// Describes the parameters that are passed during the creation of an AmplifyOperation
-public protocol AmplifyOperationRequest {
+/// - Note: `Sendable` because requests and their metatypes are captured by the operations and tasks
+///   that carry them across isolation boundaries.
+public protocol AmplifyOperationRequest: Sendable {
     /// The concrete Options type that adjusts the behavior of the request type
-    associatedtype Options
+    associatedtype Options: Sendable
 
     /// Options to adjust the behavior of this request, including plugin options
     var options: Options { get }

--- a/Amplify/Core/Support/AmplifyTask+OperationTaskAdapters.swift
+++ b/Amplify/Core/Support/AmplifyTask+OperationTaskAdapters.swift
@@ -12,7 +12,7 @@ import Combine
 
 public class AmplifyOperationTaskAdapter<
     Request: AmplifyOperationRequest,
-    Success,
+    Success: Sendable,
     Failure: AmplifyError
 >: AmplifyTask, @unchecked Sendable {
     let operation: AmplifyOperation<Request, Success, Failure>
@@ -68,8 +68,8 @@ public class AmplifyOperationTaskAdapter<
 
 public class AmplifyInProcessReportingOperationTaskAdapter<
     Request: AmplifyOperationRequest,
-    InProcess,
-    Success,
+    InProcess: Sendable,
+    Success: Sendable,
     Failure: AmplifyError
 >: AmplifyTask, AmplifyInProcessReportingTask, @unchecked Sendable {
     let operation: AmplifyInProcessReportingOperation<Request, InProcess, Success, Failure>

--- a/Amplify/Core/Support/AmplifyTask.swift
+++ b/Amplify/Core/Support/AmplifyTask.swift
@@ -17,7 +17,9 @@ import Combine
 /// - Tag: AmplifyTask
 public protocol AmplifyTask {
     associatedtype Request
-    associatedtype Success
+    // `Success` crosses task and actor boundaries (`value`, `resultPublisher`), so it
+    // must be `Sendable` in the Swift 6 language mode.
+    associatedtype Success: Sendable
     associatedtype Failure: AmplifyError
 
     /// Blocks until the receiver has successfully collected a result or throws if an error was encountered.
@@ -51,7 +53,9 @@ public protocol AmplifyTask {
 ///
 /// - Tag: AmplifyInProcessReportingTask
 public protocol AmplifyInProcessReportingTask {
-    associatedtype InProcess
+    // Carried through `AmplifyAsyncSequence` and a Combine publisher, both of which
+    // require their element to be `Sendable` under the Swift 6 language mode.
+    associatedtype InProcess: Sendable
 
     /// An async sequence that is able to report on the progress of the work represented by the receiver.
     ///

--- a/Amplify/Core/Support/AmplifyTaskGateway.swift
+++ b/Amplify/Core/Support/AmplifyTaskGateway.swift
@@ -12,15 +12,16 @@
 import Foundation
 
 // Supports Hub and Async API
-protocol AmplifyTaskGateway {
+/// - Note: `Sendable` because the Hub listeners built in the extensions below close over `self`.
+protocol AmplifyTaskGateway: Sendable {
     associatedtype Request: AmplifyOperationRequest
     associatedtype InProcess: Sendable
-    associatedtype Success
+    associatedtype Success: Sendable
     associatedtype Failure: AmplifyError
 
     typealias TaskResult = Result<Success, Failure>
-    typealias ResultListener = (TaskResult) -> Void
-    typealias InProcessListener = (InProcess) -> Void
+    typealias ResultListener = @Sendable (TaskResult) -> Void
+    typealias InProcessListener = @Sendable (InProcess) -> Void
 
     var id: UUID { get }
     var request: Request { get }
@@ -65,23 +66,25 @@ extension AmplifyTaskGateway {
         let channel = HubChannel(from: categoryType)
         let filterById = idFilter
 
-        var unsubscribe: (() -> Void)?
+        // The listener has to be able to remove itself, which means referencing a token that
+        // does not exist until it is registered. Holding it in an `AtomicValue` lets the closure
+        // capture an immutable box; capturing a `var` assigned afterwards is a reference to a
+        // mutable variable from concurrently-executing code, rejected in Swift 6 language mode.
+        let tokenBox = AtomicValue<UnsubscribeToken?>(initialValue: nil)
         let resultHubListener: HubListener = { payload in
             guard let result = payload.data as? TaskResult else {
                 return
             }
             resultListener(result)
             // Automatically unsubscribe when event is received
-            unsubscribe?()
+            if let token = tokenBox.get() { Amplify.Hub.removeListener(token) }
         }
         let token = Amplify.Hub.listen(
             to: channel,
             isIncluded: filterById,
             listener: resultHubListener
         )
-        unsubscribe = {
-            Amplify.Hub.removeListener(token)
-        }
+        tokenBox.set(token)
         return token
     }
 
@@ -89,7 +92,11 @@ extension AmplifyTaskGateway {
         let channel = HubChannel(from: categoryType)
         let filterById = idFilter
 
-        var unsubscribe: (() -> Void)?
+        // The listener has to be able to remove itself, which means referencing a token that
+        // does not exist until it is registered. Holding it in an `AtomicValue` lets the closure
+        // capture an immutable box; capturing a `var` assigned afterwards is a reference to a
+        // mutable variable from concurrently-executing code, rejected in Swift 6 language mode.
+        let tokenBox = AtomicValue<UnsubscribeToken?>(initialValue: nil)
         let inProcessHubListener: HubListener = { payload in
             if let inProcessData = payload.data as? InProcess {
                 inProcessListener(inProcessData)
@@ -98,7 +105,7 @@ extension AmplifyTaskGateway {
 
             // Remove listener if we see a result come through
             if payload.data is TaskResult {
-                unsubscribe?()
+                if let token = tokenBox.get() { Amplify.Hub.removeListener(token) }
             }
         }
         let token = Amplify.Hub.listen(
@@ -106,9 +113,7 @@ extension AmplifyTaskGateway {
             isIncluded: filterById,
             listener: inProcessHubListener
         )
-        unsubscribe = {
-            Amplify.Hub.removeListener(token)
-        }
+        tokenBox.set(token)
         return token
     }
 

--- a/Amplify/Core/Support/AtomicDictionary.swift
+++ b/Amplify/Core/Support/AtomicDictionary.swift
@@ -7,8 +7,12 @@
 
 import Foundation
 
-public final class AtomicDictionary<Key: Hashable, Value> {
-    private let lock: NSLocking
+/// - Note: `@unchecked Sendable` because `value` is mutable but every access below is serialized by
+///   `lock`. `Key`/`Value` are deliberately unconstrained so existing callers keep working; as
+///   before, whether the *elements* are safe to use across domains remains the caller's concern.
+public final class AtomicDictionary<Key: Hashable, Value>: @unchecked Sendable {
+    // Concrete `NSLock` rather than the `any NSLocking` existential, which is not `Sendable`.
+    private let lock: NSLock
     private var value: [Key: Value]
 
     public init(initialValue: [Key: Value] = [Key: Value]()) {

--- a/Amplify/Core/Support/BasicClosure.swift
+++ b/Amplify/Core/Support/BasicClosure.swift
@@ -6,6 +6,8 @@
 //
 
 /// Convenience typealias
-public typealias BasicClosure = () -> Void
+/// - Note: `@Sendable` because callers pass these into tasks and dispatch queues throughout the
+///   library.
+public typealias BasicClosure = @Sendable () -> Void
 
 public typealias BasicThrowableClosure = () throws -> Void

--- a/Amplify/Core/Support/ChildTask.swift
+++ b/Amplify/Core/Support/ChildTask.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Takes a Parent Operation which conforms to Cancellable so that if the
 /// Child Task is cancelled it will also cancel the parent.
-actor ChildTask<InProcess, Success, Failure: Error>: BufferingSequence {
+actor ChildTask<InProcess: Sendable, Success: Sendable, Failure: Error>: BufferingSequence {
     typealias Element = InProcess
     private let parent: Cancellable
     private var inProcessChannel: AmplifyAsyncSequence<InProcess>?

--- a/Amplify/Core/Support/Internal/InternalTask+Hub.swift
+++ b/Amplify/Core/Support/Internal/InternalTask+Hub.swift
@@ -51,23 +51,25 @@ public extension InternalTaskHubResult where Self: InternalTaskIdentifiable & In
     func subscribe(resultListener: @escaping ResultListener) -> UnsubscribeToken {
         let channel = HubChannel(from: categoryType)
 
-        var unsubscribe: (() -> Void)?
+        // The listener has to be able to remove itself, which means referencing a token that
+        // does not exist until it is registered. Holding it in an `AtomicValue` lets the closure
+        // capture an immutable box; capturing a `var` assigned afterwards is a reference to a
+        // mutable variable from concurrently-executing code, rejected in Swift 6 language mode.
+        let tokenBox = AtomicValue<UnsubscribeToken?>(initialValue: nil)
         let resultHubListener: HubListener = { payload in
             guard let result = payload.data as? TaskResult else {
                 return
             }
             resultListener(result)
             // Automatically unsubscribe when event is received
-            unsubscribe?()
+            if let token = tokenBox.get() { Amplify.Hub.removeListener(token) }
         }
         let token = Amplify.Hub.listen(
             to: channel,
             isIncluded: idFilter,
             listener: resultHubListener
         )
-        unsubscribe = {
-            Amplify.Hub.removeListener(token)
-        }
+        tokenBox.set(token)
         return token
     }
 
@@ -123,7 +125,12 @@ public extension InternalTaskHubInProcess where Self: InternalTaskIdentifiable &
     func subscribe(inProcessListener: @escaping InProcessListener) -> UnsubscribeToken {
         let channel = HubChannel(from: categoryType)
 
-        var unsubscribe: (() -> Void)?
+        // The listener has to be able to remove itself, which means referencing a token that does
+        // not exist until after the listener is registered. The token is held in an `AtomicValue`
+        // so the closure captures an immutable box; capturing a `var` that is assigned afterwards
+        // is a reference to a mutable variable from concurrently-executing code, which is an error
+        // in the Swift 6 language mode.
+        let tokenBox = AtomicValue<UnsubscribeToken?>(initialValue: nil)
         let inProcessHubListener: HubListener = { payload in
             if let inProcessData = payload.data as? InProcess {
                 inProcessListener(inProcessData)
@@ -131,8 +138,8 @@ public extension InternalTaskHubInProcess where Self: InternalTaskIdentifiable &
             }
 
             // Remove listener if we see a result come through
-            if payload.data is TaskResult {
-                unsubscribe?()
+            if payload.data is TaskResult, let token = tokenBox.get() {
+                Amplify.Hub.removeListener(token)
             }
         }
         let token = Amplify.Hub.listen(
@@ -140,9 +147,7 @@ public extension InternalTaskHubInProcess where Self: InternalTaskIdentifiable &
             isIncluded: idFilter,
             listener: inProcessHubListener
         )
-        unsubscribe = {
-            Amplify.Hub.removeListener(token)
-        }
+        tokenBox.set(token)
         return token
     }
 
@@ -190,7 +195,11 @@ public extension InternalTaskHubInProcess where Self: InternalTaskIdentifiable &
         let channel = HubChannel(from: categoryType)
         let filterById = idFilter
 
-        var unsubscribe: (() -> Void)?
+        // The listener has to be able to remove itself, which means referencing a token that
+        // does not exist until it is registered. Holding it in an `AtomicValue` lets the closure
+        // capture an immutable box; capturing a `var` assigned afterwards is a reference to a
+        // mutable variable from concurrently-executing code, rejected in Swift 6 language mode.
+        let tokenBox = AtomicValue<UnsubscribeToken?>(initialValue: nil)
         let inProcessHubListener: HubListener = { payload in
             if let inProcessData = payload.data as? InProcess {
                 inProcessListener(inProcessData)
@@ -199,7 +208,7 @@ public extension InternalTaskHubInProcess where Self: InternalTaskIdentifiable &
 
             // Remove listener if we see a result come through
             if payload.data is TaskResult {
-                unsubscribe?()
+                if let token = tokenBox.get() { Amplify.Hub.removeListener(token) }
             }
         }
         let token = Amplify.Hub.listen(
@@ -207,9 +216,7 @@ public extension InternalTaskHubInProcess where Self: InternalTaskIdentifiable &
             isIncluded: filterById,
             listener: inProcessHubListener
         )
-        unsubscribe = {
-            Amplify.Hub.removeListener(token)
-        }
+        tokenBox.set(token)
         return token
     }
 

--- a/Amplify/Core/Support/Internal/InternalTask.swift
+++ b/Amplify/Core/Support/Internal/InternalTask.swift
@@ -107,7 +107,11 @@ public protocol InternalTaskThrowingChannel {
 
 // MARK: - Control -
 
-public protocol InternalTaskRunner: AnyObject, AmplifyCancellable {
+/// - Note: `Sendable` because the whole point of a runner is that `run()` is driven from a
+///   detached `Task`, so conformers already cross concurrency domains. Requiring it here is
+///   what lets `InternalTask+AsyncSequence` start that task without sending a non-`Sendable`
+///   `self`.
+public protocol InternalTaskRunner: AnyObject, AmplifyCancellable, Sendable {
     associatedtype Request: AmplifyOperationRequest
     var request: Request { get }
 
@@ -123,7 +127,8 @@ public protocol InternalTaskController {
 
 // MARK: - Hub Support -
 
-public protocol InternalTaskIdentifiable {
+/// - Note: `Sendable` because `idFilter` builds a `@Sendable` Hub filter that closes over `self`.
+public protocol InternalTaskIdentifiable: Sendable {
     associatedtype Request: AmplifyOperationRequest
     var id: UUID { get }
     var request: Request { get }
@@ -131,13 +136,14 @@ public protocol InternalTaskIdentifiable {
     var eventName: HubPayloadEventName { get }
 }
 
-public protocol InternalTaskHubResult {
+/// - Note: `Sendable` because the Hub listener built below closes over `self`.
+public protocol InternalTaskHubResult: Sendable {
     associatedtype Request: AmplifyOperationRequest
     associatedtype Success
     associatedtype Failure: AmplifyError
 
     typealias OperationResult = Result<Success, Failure>
-    typealias ResultListener = (OperationResult) -> Void
+    typealias ResultListener = @Sendable (OperationResult) -> Void
 
     /// Subscribe for result
     /// - Parameter resultListener: result listener
@@ -153,11 +159,12 @@ public protocol InternalTaskHubResult {
     func dispatch(result: OperationResult)
 }
 
-public protocol InternalTaskHubInProcess {
+/// - Note: `Sendable` for the same reason as `InternalTaskHubResult`.
+public protocol InternalTaskHubInProcess: Sendable {
     associatedtype Request: AmplifyOperationRequest
     associatedtype InProcess: Sendable
 
-    typealias InProcessListener = (InProcess) -> Void
+    typealias InProcessListener = @Sendable (InProcess) -> Void
 
     /// Subscribe for result
     /// - Parameter resultListener: result listener

--- a/Amplify/Core/Support/TaskQueue.swift
+++ b/Amplify/Core/Support/TaskQueue.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 /// A helper for executing asynchronous work serially.
-public class TaskQueue<Success> {
+/// - Note: `Sendable` because the only stored property is a `let` `AsyncStream.Continuation`,
+///   which is itself thread-safe.
+public final class TaskQueue<Success>: Sendable {
     typealias Block = @Sendable () async -> Void
     private let streamContinuation: AsyncStream<Block>.Continuation
 


### PR DESCRIPTION
Slice **12 of 38** in the Swift 6 language-mode migration — 14 file(s).

Stacked on `swift6/11-plugin-category-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.