### PR TITLE
feat(datastore)!: require Sendable on Model

### DIFF
--- a/Amplify/Categories/DataStore/Model/Internal/Embedded.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Embedded.swift
@@ -17,7 +17,8 @@ import Foundation
 ///   directly by host applications. The behavior of this may change without warning. Though it is not used by host
 ///   application making any change to these `public` types should be backward compatible, otherwise it will be a
 ///   breaking change.
-public protocol Embeddable: Codable {
+/// - Note: `Sendable` because embedded types are stored on models, and `Model` is `Sendable`.
+public protocol Embeddable: Codable, Sendable {
 
     /// A reference to the `ModelSchema` associated with this embedded type.
     static var schema: ModelSchema { get }

--- a/Amplify/Categories/DataStore/Model/Internal/Model+Enum.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Model+Enum.swift
@@ -22,7 +22,9 @@ import Foundation
 /// ```
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
-public protocol EnumPersistable: Codable {
+/// - Note: `Sendable` because codegen'd enums stored on models conform to this, and `Model` is
+///   `Sendable`. Raw-value enums satisfy it without change.
+public protocol EnumPersistable: Codable, Sendable {
 
     var rawValue: String { get }
 

--- a/Amplify/Categories/DataStore/Model/Internal/Persistable.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Persistable.swift
@@ -20,7 +20,10 @@ import Foundation
 /// - `Temporal.Time`
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
-public protocol Persistable: Encodable {}
+/// - Note: `Sendable` because persistable values are stored on models and carried inside query
+///   predicates, both of which cross task boundaries. The conforming standard-library and `Temporal`
+///   types are all value types.
+public protocol Persistable: Encodable, Sendable {}
 
 extension Bool: Persistable {}
 extension Double: Persistable {}

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/AuthRule.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/AuthRule.swift
@@ -7,7 +7,7 @@
 
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
-public enum AuthStrategy {
+public enum AuthStrategy: Sendable {
     case owner
     case groups
     case `private`
@@ -17,7 +17,7 @@ public enum AuthStrategy {
 
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
-public enum ModelOperation {
+public enum ModelOperation: Sendable {
     case create
     case update
     case delete
@@ -26,7 +26,7 @@ public enum ModelOperation {
 
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
-public enum AuthRuleProvider {
+public enum AuthRuleProvider: Sendable {
     case apiKey
     case oidc
     case iam
@@ -40,7 +40,7 @@ public typealias AuthRules = [AuthRule]
 
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
-public struct AuthRule {
+public struct AuthRule: Sendable {
     public let allow: AuthStrategy
     public let ownerField: String?
     public let identityClaim: String?

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelPrimaryKey.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelPrimaryKey.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-public struct ModelPrimaryKey {
+public struct ModelPrimaryKey: Sendable {
     public var fields: [ModelField] = []
     private var fieldsLookup: Set<ModelFieldName> = []
 

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema+Definition.swift
@@ -10,7 +10,7 @@ import Foundation
 /// Defines the type of a `Model` field.
 /// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
 ///   directly by host applications. The behavior of this may change without warning.
-public enum ModelFieldType {
+public enum ModelFieldType: Sendable {
 
     case string
     case int

--- a/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
+++ b/Amplify/Categories/DataStore/Model/Internal/Schema/ModelSchema.swift
@@ -11,7 +11,7 @@ public typealias ModelFieldName = String
 
 /// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
 ///   directly by host applications. The behavior of this may change without warning.
-public enum ModelAttribute: Equatable {
+public enum ModelAttribute: Equatable, Sendable {
     /// Represents a database index, often used for frequent query optimizations.
     case index(fields: [ModelFieldName], name: String?)
 
@@ -30,14 +30,14 @@ public enum ModelAttribute: Equatable {
 
 /// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
 ///   directly by host applications. The behavior of this may change without warning.
-public enum ModelFieldAttribute {
+public enum ModelFieldAttribute: Sendable {
     @available(*, deprecated, message: "Use the primaryKey member of the schema")
     case primaryKey
 }
 
 /// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
 ///   directly by host applications. The behavior of this may change without warning.
-public struct ModelField {
+public struct ModelField: Sendable {
 
     public let name: ModelFieldName
     public let type: ModelFieldType
@@ -84,7 +84,7 @@ public typealias ModelName = String
 
 /// - Warning: Although this has `public` access, it is intended for internal & codegen use and should not be used
 ///   directly by host applications. The behavior of this may change without warning.
-public struct ModelSchema {
+public struct ModelSchema: Sendable {
 
     public let name: String
 

--- a/Amplify/Categories/DataStore/Model/Model.swift
+++ b/Amplify/Categories/DataStore/Model/Model.swift
@@ -10,7 +10,11 @@ import Foundation
 // MARK: - Model
 
 /// All persistent models should conform to the Model protocol.
-public protocol Model: Codable {
+/// - Note: `Sendable` because models are carried between tasks throughout DataStore and API — the
+///   sync engine, the reconciliation queues, and the GraphQL layer all pass them across isolation
+///   boundaries. Codegen'd model types are structs of value-typed properties, so they satisfy this
+///   already; a hand-written conformance holding reference type state would need to be made safe.
+public protocol Model: Codable, Sendable {
     /// Alias of Model identifier (i.e. primary key)
     @available(*, deprecated, message: "Use ModelIdentifier")
     typealias Identifier = String

--- a/Amplify/Categories/DataStore/Model/Temporal/Temporal.swift
+++ b/Amplify/Categories/DataStore/Model/Temporal/Temporal.swift
@@ -19,7 +19,9 @@ public enum Temporal {}
 /// The `TemporalSpec` protocol defines an [ISO-8601](https://www.iso.org/iso-8601-date-and-time-format.html)
 /// formatted Date value. Types that conform to this protocol are responsible for providing
 /// the parsing and formatting logic with the correct granularity.
-public protocol TemporalSpec {
+/// - Note: `Sendable` because `Temporal.Date`/`Time`/`DateTime` are value types stored on models,
+///   and `Model` is `Sendable`.
+public protocol TemporalSpec: Sendable {
     /// A static builder that return an instance that represent the current point in time.
     static func now() -> Self
 


### PR DESCRIPTION
Slice **13 of 38** in the Swift 6 language-mode migration — 9 file(s).

Stacked on `swift6/12-core-support-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.