### PR TITLE
feat(datastore): annotate the lazy-loading types

### DIFF
--- a/Amplify/Categories/DataStore/Model/Lazy/LazyReference.swift
+++ b/Amplify/Categories/DataStore/Model/Lazy/LazyReference.swift
@@ -40,7 +40,9 @@ struct LazyReferenceModelIdentifier: ModelIdentifierProtocol {
 ///
 /// The default implementation `DefaultModelProvider` only handles in-memory data, therefore `get()` and
 /// `require()` will simply return the current `reference`.
-public class LazyReference<ModelType: Model>: Codable, _LazyReferenceValue {
+/// - Note: `@unchecked Sendable` for the same reason, and with the same caveat, as ``List``: the
+///   lazy-load transition on `loadedState` is not synchronized.
+public class LazyReference<ModelType: Model>: Codable, _LazyReferenceValue, @unchecked Sendable {
 
     /// Represents the data state of the `LazyModel`.
     enum LoadedState {

--- a/Amplify/Categories/DataStore/Model/Lazy/List+Model.swift
+++ b/Amplify/Categories/DataStore/Model/Lazy/List+Model.swift
@@ -14,7 +14,14 @@ import Foundation
 /// before returning the data to you. Consumers must be aware that multiple calls to the data source and then stored
 /// into this object will happen simultaneously if the object is used from different threads, thus not thread safe.
 /// Lazy loading is idempotent and will return the stored results on subsequent access.
-public class List<ModelType: Model>: Collection, Codable, ExpressibleByArrayLiteral, ModelListMarker {
+/// - Note: `@unchecked Sendable` because `Model` is `Sendable` and codegen'd models store `List`
+///   properties, so this has to be `Sendable` for them to compile.
+///
+///   Be aware this is an assertion, not a proof: `loadedState` is mutated on first load and is not
+///   synchronized, so two concurrent `load()` calls can both fetch. That race predates this
+///   migration; making it genuinely safe means putting the lazy-load transition behind a lock,
+///   which touches the `Collection` and `Codable` surface and is better done on its own.
+public class List<ModelType: Model>: Collection, Codable, ExpressibleByArrayLiteral, ModelListMarker, @unchecked Sendable {
     public typealias Index = Int
     public typealias Element = ModelType
 


### PR DESCRIPTION
Slice **14 of 38** in the Swift 6 language-mode migration — 2 file(s).

Stacked on `swift6/13-model-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.