### PR TITLE
feat(datastore)!: @Sendable DataStore callbacks

### DIFF
--- a/Amplify/Categories/DataStore/DataStoreCallback.swift
+++ b/Amplify/Categories/DataStore/DataStoreCallback.swift
@@ -31,4 +31,6 @@ public extension DataStoreResult {
 }
 
 /// Function type of every `DataStore` asynchronous API.
-public typealias DataStoreCallback<Result> = (DataStoreResult<Result>) -> Void
+/// - Note: `@Sendable` because every caller invokes this from asynchronous work — the storage
+///   engine, the sync engine, and the mutation queue all cross task boundaries before calling back.
+public typealias DataStoreCallback<Result> = @Sendable (DataStoreResult<Result>) -> Void

--- a/Amplify/Categories/DataStore/Internal/DataStoreCategory+Resettable.swift
+++ b/Amplify/Categories/DataStore/Internal/DataStoreCategory+Resettable.swift
@@ -10,12 +10,16 @@ import Foundation
 extension DataStoreCategory: Resettable {
 
     public func reset() async {
+        // Hoisted so the task closure below captures these Sendable values rather
+        // than a non-Sendable `self`, which is an error in the Swift 6 language mode.
+        let log = log
+        let categoryType = categoryType
         await withTaskGroup(of: Void.self) { taskGroup in
             for plugin in plugins.values {
-                taskGroup.addTask { [weak self] in
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
+                taskGroup.addTask {
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin")
                     await plugin.reset()
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin: finished")
                 }
             }
             await taskGroup.waitForAll()

--- a/Amplify/Categories/DataStore/Query/QueryOperator.swift
+++ b/Amplify/Categories/DataStore/Query/QueryOperator.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum QueryOperator: Encodable {
+public enum QueryOperator: Encodable, Sendable {
     case notEqual(_ value: Persistable?)
     case equals(_ value: Persistable?)
     case lessOrEqual(_ value: Persistable)

--- a/Amplify/Categories/DataStore/Query/QueryPaginationInput.swift
+++ b/Amplify/Categories/DataStore/Query/QueryPaginationInput.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 /// A simple struct that holds pagination information that can be applied queries.
-public struct QueryPaginationInput {
+// Explicit `Sendable`: Swift does not infer it for public types.
+public struct QueryPaginationInput: Sendable {
 
     /// The default page size.
     public static let defaultLimit: UInt = 100

--- a/Amplify/Categories/DataStore/Query/QueryPredicate.swift
+++ b/Amplify/Categories/DataStore/Query/QueryPredicate.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 /// Protocol that indicates concrete types conforming to it can be used a predicate member.
-public protocol QueryPredicate: Evaluable, Encodable {}
+/// - Note: `Sendable` because predicates are carried into the storage engine's async query paths.
+public protocol QueryPredicate: Evaluable, Encodable, Sendable {}
 
 public enum QueryPredicateGroupType: String, Encodable {
     case and
@@ -33,7 +34,10 @@ public enum QueryPredicateConstant: QueryPredicate, Encodable {
     }
 }
 
-public class QueryPredicateGroup: QueryPredicate, Encodable {
+/// - Note: `@unchecked Sendable` rather than `final`: `type` and `predicates` are mutated while a
+///   predicate is being composed, and leaving the class open avoids a source-breaking change for
+///   anyone who subclassed it.
+public class QueryPredicateGroup: QueryPredicate, Encodable, @unchecked Sendable {
     public internal(set) var type: QueryPredicateGroupType
     public internal(set) var predicates: [QueryPredicate]
 
@@ -124,7 +128,9 @@ public class QueryPredicateGroup: QueryPredicate, Encodable {
 
 }
 
-public class QueryPredicateOperation: QueryPredicate, Encodable {
+/// - Note: `@unchecked Sendable` rather than `final`, for the same reason as ``QueryPredicateGroup``.
+///   Both stored properties are immutable.
+public class QueryPredicateOperation: QueryPredicate, Encodable, @unchecked Sendable {
 
     public let field: String
     public let `operator`: QueryOperator

--- a/Amplify/Categories/DataStore/Query/QueryPredicate.swift
+++ b/Amplify/Categories/DataStore/Query/QueryPredicate.swift
@@ -34,9 +34,17 @@ public enum QueryPredicateConstant: QueryPredicate, Encodable {
     }
 }
 
-/// - Note: `@unchecked Sendable` rather than `final`: `type` and `predicates` are mutated while a
-///   predicate is being composed, and leaving the class open avoids a source-breaking change for
-///   anyone who subclassed it.
+/// - Note: `@unchecked Sendable`, and not `final`, so that anyone who subclassed this keeps compiling.
+///
+///   The conformance is a genuine assertion, not a checked fact. `and(_:)` and `or(_:)` mutate
+///   `predicates` **in place and return `self`** when the group type already matches, so two tasks
+///   composing onto the same group race on an array — and `predicates` is `public internal(set)`, so
+///   external code reads it directly and a lock here would not cover those reads without turning it into
+///   a computed property.
+///
+///   What makes this safe in practice is usage, not structure: a predicate is built up on one task and
+///   then handed to a query. Sharing a part-built group across tasks is unsupported, and nothing in the
+///   type enforces that. The exposure predates this annotation, which only stops the compiler asking.
 public class QueryPredicateGroup: QueryPredicate, Encodable, @unchecked Sendable {
     public internal(set) var type: QueryPredicateGroupType
     public internal(set) var predicates: [QueryPredicate]

--- a/Amplify/Categories/DataStore/Query/QuerySortInput.swift
+++ b/Amplify/Categories/DataStore/Query/QuerySortInput.swift
@@ -8,12 +8,13 @@
 import Foundation
 
 /// A simple enum that holding a sorting direction for a field that can be applied to queries.
-public enum QuerySortBy {
+public enum QuerySortBy: Sendable {
     case ascending(CodingKey)
     case descending(CodingKey)
 }
 
-public struct QuerySortInput {
+// Explicit `Sendable`: Swift does not infer it for public types.
+public struct QuerySortInput: Sendable {
     public let inputs: [QuerySortBy]
 
     public init(_ inputs: [QuerySortBy]) {

--- a/Amplify/Categories/DataStore/Subscribe/MutationEvent+MutationType.swift
+++ b/Amplify/Categories/DataStore/Subscribe/MutationEvent+MutationType.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 public extension MutationEvent {
-    enum MutationType: String, Codable {
+    // Explicit `Sendable`: Swift does not infer it for public types.
+    enum MutationType: String, Codable, Sendable {
         case create
         case update
         case delete


### PR DESCRIPTION
Slice **15 of 38** in the Swift 6 language-mode migration — 7 file(s).

Stacked on `swift6/14-lazy-loading-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.