### PR TITLE
feat(core)!: @Sendable Hub listeners and filters

### DIFF
--- a/Amplify/Categories/Hub/HubCategoryBehavior.swift
+++ b/Amplify/Categories/Hub/HubCategoryBehavior.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 /// Convenience typealias defining a closure that can be used to listen to Hub messages
-public typealias HubListener = (HubPayload) -> Void
+/// - Note: `@Sendable` because listeners are invoked on the Hub's dispatch queue.
+public typealias HubListener = @Sendable (HubPayload) -> Void
 
 /// Behavior of the Hub category that clients will use
 public protocol HubCategoryBehavior {

--- a/Amplify/Categories/Hub/HubChannel.swift
+++ b/Amplify/Categories/Hub/HubChannel.swift
@@ -8,7 +8,8 @@
 /// HubChannel represents the channels on which Amplify category messages will be dispatched. Apps can define their own
 /// channels for intra-app communication. Internally, Amplify uses the Hub for dispatching notifications about events
 /// associated with different categories.
-public enum HubChannel {
+// Explicit `Sendable`: Swift does not infer it for public types.
+public enum HubChannel: Sendable {
 
     case analytics
 

--- a/Amplify/Categories/Hub/HubFilter.swift
+++ b/Amplify/Categories/Hub/HubFilter.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 /// Convenience typealias defining a closure that can be used to filter Hub messages
-public typealias HubFilter = (HubPayload) -> Bool
+/// - Note: `@Sendable` because filters are evaluated on the Hub's dispatch queue, off the thread
+///   that registered them.
+public typealias HubFilter = @Sendable (HubPayload) -> Bool
 
 /// Convenience filters for common filtering use cases
 public enum HubFilters {

--- a/Amplify/Categories/Hub/HubPayload.swift
+++ b/Amplify/Categories/Hub/HubPayload.swift
@@ -6,7 +6,10 @@
 //
 
 /// The payload of a Hub message
-public struct HubPayload {
+/// - Note: `@unchecked Sendable` rather than `Sendable`: `context` and `data` are `Any?`, which
+///   cannot be checked. Narrowing those to a `Sendable` existential would be a source-breaking change
+///   to a widely used public type, so the guarantee is left to whatever is put in them.
+public struct HubPayload: @unchecked Sendable {
 
     /// Event names registered by Amplify Operations
     public struct EventName {}

--- a/Amplify/Categories/Hub/Internal/HubCategory+Resettable.swift
+++ b/Amplify/Categories/Hub/Internal/HubCategory+Resettable.swift
@@ -10,12 +10,16 @@ import Foundation
 extension HubCategory: Resettable {
 
     public func reset() async {
+        // Hoisted so the task closure below captures these Sendable values rather
+        // than a non-Sendable `self`, which is an error in the Swift 6 language mode.
+        let log = log
+        let categoryType = categoryType
         await withTaskGroup(of: Void.self) { taskGroup in
             for plugin in plugins.values {
-                taskGroup.addTask { [weak self] in
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
+                taskGroup.addTask {
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin")
                     await plugin.reset()
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin: finished")
                 }
             }
             await taskGroup.waitForAll()

--- a/Amplify/Categories/Hub/UnsubscribeToken.swift
+++ b/Amplify/Categories/Hub/UnsubscribeToken.swift
@@ -10,7 +10,8 @@ import Foundation
 /// Convenience typealias defining a closure that can be used to unsubscribe a Hub listener. Although UnsubscribeToken
 /// conforms to Hashable, only the `id` property is considered for equality and hash value; `channel` is used only for
 /// routing an unsubscribe request to the correct HubChannel.
-public struct UnsubscribeToken {
+// Explicit `Sendable`: both members are value types.
+public struct UnsubscribeToken: Sendable {
     let channel: HubChannel
     let id: UUID
 


### PR DESCRIPTION
Slice **16 of 38** in the Swift 6 language-mode migration — 6 file(s).

Stacked on `swift6/15-datastore-category-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.