### PR TITLE
feat(storage)!: @Sendable progress listeners

### DIFF
--- a/Amplify/Categories/Storage/Internal/StorageCategory+Resettable.swift
+++ b/Amplify/Categories/Storage/Internal/StorageCategory+Resettable.swift
@@ -10,12 +10,16 @@ import Foundation
 extension StorageCategory: Resettable {
 
     public func reset() async {
+        // Hoisted so the task closure below captures these Sendable values rather
+        // than a non-Sendable `self`, which is an error in the Swift 6 language mode.
+        let log = log
+        let categoryType = categoryType
         await withTaskGroup(of: Void.self) { taskGroup in
             for plugin in plugins.values {
-                taskGroup.addTask { [weak self] in
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
+                taskGroup.addTask {
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin")
                     await plugin.reset()
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin: finished")
                 }
             }
             await taskGroup.waitForAll()

--- a/Amplify/Categories/Storage/Result/ProgressListener.swift
+++ b/Amplify/Categories/Storage/Result/ProgressListener.swift
@@ -10,4 +10,6 @@ import Foundation
 /// Convenience typealias for a callback invoked with an asynchronous operation's `Progress`
 ///
 /// - Tag: ProgressListener
-public typealias ProgressListener = (Progress) -> Void
+/// - Note: `@Sendable` because progress is reported from the storage transfer machinery, off the
+///   thread that started the operation.
+public typealias ProgressListener = @Sendable (Progress) -> Void

--- a/Amplify/Categories/Storage/Result/StorageListResult.swift
+++ b/Amplify/Categories/Storage/Result/StorageListResult.swift
@@ -11,7 +11,8 @@ import Foundation
 /// [StorageCategoryBehavior.list](x-source-tag://StorageCategoryBehavior.list)
 ///
 /// - Tag: StorageListResult
-public struct StorageListResult {
+// Explicit `Sendable`: Swift does not infer it for public types.
+public struct StorageListResult: Sendable {
 
     /// This is meant to be called by plugins implementing
     /// [StorageCategoryBehavior.list](x-source-tag://StorageCategoryBehavior.list).
@@ -52,7 +53,10 @@ public struct StorageListResult {
 public extension StorageListResult {
 
     /// - Tag: StorageListResultItem
-    struct Item {
+    /// - Note: `@unchecked Sendable` rather than `Sendable`: `pluginResults` is `Any?`, which cannot
+    ///   be checked. Narrowing that type would be source-breaking for plugins that pass results
+    ///   through, so the guarantee is left to whatever is put in it.
+    struct Item: @unchecked Sendable {
 
         /// The path of the object in storage.
         ///

--- a/Amplify/Categories/Storage/StorageAccessLevel.swift
+++ b/Amplify/Categories/Storage/StorageAccessLevel.swift
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// - Tag: StorageAccessLevel
 @available(*, deprecated, message: "Use `path` in Storage API instead of `Options`")
-public enum StorageAccessLevel: String {
+public enum StorageAccessLevel: String, Sendable {
 
     /// Objects can be read or written by any user without authentication
     ///

--- a/Amplify/Categories/Storage/StoragePath.swift
+++ b/Amplify/Categories/Storage/StoragePath.swift
@@ -7,12 +7,14 @@
 
 import Foundation
 
-public typealias IdentityIDPathResolver = (String) -> String
+/// - Note: `@Sendable` because resolvers are invoked from the storage plugins async work.
+public typealias IdentityIDPathResolver = @Sendable (String) -> String
 
 /// Protocol that provides a closure to resolve the storage path.
 ///
 /// - Tag: StoragePath
-public protocol StoragePath {
+/// - Note: `Sendable` because paths are stored on storage requests, which cross task boundaries.
+public protocol StoragePath: Sendable {
     associatedtype Input
     var resolve: (Input) -> String { get }
 }
@@ -33,7 +35,7 @@ public extension StoragePath where Self == IdentityIDStoragePath {
 ///
 /// - Tag: StringStoragePath
 public struct StringStoragePath: StoragePath {
-    public let resolve: (String) -> String
+    public let resolve: @Sendable (String) -> String
 }
 
 /// Conforms to StoragePath protocol.

--- a/Amplify/Categories/Storage/StoragePath.swift
+++ b/Amplify/Categories/Storage/StoragePath.swift
@@ -13,10 +13,15 @@ public typealias IdentityIDPathResolver = @Sendable (String) -> String
 /// Protocol that provides a closure to resolve the storage path.
 ///
 /// - Tag: StoragePath
-/// - Note: `Sendable` because paths are stored on storage requests, which cross task boundaries.
+/// - Note: `Sendable` because paths are stored on storage requests, which cross task boundaries. The
+///   `resolve` requirement is `@Sendable` for the same reason: without it a conformer could satisfy a
+///   `Sendable` protocol with a closure capturing unsynchronized state, which would make the
+///   conformance meaningless. Both types in this file already supply `@Sendable` closures; the
+///   requirement now says so, which is source-breaking only for an external conformer that was
+///   supplying a non-`Sendable` one — exactly the case the guarantee needs to exclude.
 public protocol StoragePath: Sendable {
     associatedtype Input
-    var resolve: (Input) -> String { get }
+    var resolve: @Sendable (Input) -> String { get }
 }
 
 public extension StoragePath where Self == StringStoragePath {


### PR DESCRIPTION
Slice **17 of 38** in the Swift 6 language-mode migration — 5 file(s).

Stacked on `swift6/16-hub-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.