### PR TITLE
feat(auth): Sendable for Auth category models

### DIFF
--- a/Amplify/Categories/Auth/AuthCategoryBehavior.swift
+++ b/Amplify/Categories/Auth/AuthCategoryBehavior.swift
@@ -13,7 +13,9 @@ public typealias AuthUIPresentationAnchor = ASPresentationAnchor
 #endif
 
 /// Behavior of the Auth category that clients will use
-public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDeviceBehavior, AuthCategoryWebAuthnBehaviour {
+/// - Note: `Sendable` for the same reason as `APICategoryGraphQLBehavior`: the implementing plugin
+///   is `Sendable` and this behavior is captured by concurrent sync work.
+public protocol AuthCategoryBehavior: AuthCategoryUserBehavior, AuthCategoryDeviceBehavior, AuthCategoryWebAuthnBehaviour, Sendable {
 
     /// SignUp a user with the authentication provider.
     ///

--- a/Amplify/Categories/Auth/Internal/AuthCategory+Resettable.swift
+++ b/Amplify/Categories/Auth/Internal/AuthCategory+Resettable.swift
@@ -10,12 +10,16 @@ import Foundation
 extension AuthCategory: Resettable {
 
     public func reset() async {
+        // Hoisted so the task closure below captures these Sendable values rather
+        // than a non-Sendable `self`, which is an error in the Swift 6 language mode.
+        let log = log
+        let categoryType = categoryType
         await withTaskGroup(of: Void.self) { taskGroup in
             for plugin in plugins.values {
-                taskGroup.addTask { [weak self] in
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
+                taskGroup.addTask {
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin")
                     await plugin.reset()
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin: finished")
                 }
             }
             await taskGroup.waitForAll()

--- a/Amplify/Categories/Auth/Models/AuthProvider.swift
+++ b/Amplify/Categories/Auth/Models/AuthProvider.swift
@@ -13,7 +13,7 @@ import Foundation
 /// federate them to the auth plugin's underlying service. For example in the api
 /// `Amplify.Auth.signInWithWebUI(for:presentationAnchor:)` you can pass in a provider
 /// in the `for:` parameter which will directly show a authentication view for the passed in auth provider.
-public enum AuthProvider {
+public enum AuthProvider: Sendable {
 
     public typealias ProviderName = String
 


### PR DESCRIPTION
Slice **18 of 38** in the Swift 6 language-mode migration — 3 file(s).

Stacked on `swift6/17-storage-category-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.