### PR TITLE
feat(core): Sendable for the remaining category models

### DIFF
--- a/Amplify/Categories/API/APICategory.swift
+++ b/Amplify/Categories/API/APICategory.swift
@@ -6,7 +6,11 @@
 //
 
 /// The API category provides a solution for making HTTP requests to REST and GraphQL endpoints.
-public final class APICategory: Category {
+/// - Note: `@unchecked Sendable` to satisfy the `Sendable` requirement that the category behavior
+///   protocol now carries. `plugins` is populated during `Amplify.configure()` and only read
+///   afterwards, and the conformance must be declared here because the behavior conformance lives
+///   in an extension in another file.
+public final class APICategory: Category, @unchecked Sendable {
     /// The category type for API
     public var categoryType: CategoryType {
         .api

--- a/Amplify/Categories/API/APICategory.swift
+++ b/Amplify/Categories/API/APICategory.swift
@@ -7,9 +7,13 @@
 
 /// The API category provides a solution for making HTTP requests to REST and GraphQL endpoints.
 /// - Note: `@unchecked Sendable` to satisfy the `Sendable` requirement that the category behavior
-///   protocol now carries. `plugins` is populated during `Amplify.configure()` and only read
-///   afterwards, and the conformance must be declared here because the behavior conformance lives
-///   in an extension in another file.
+///   protocol now carries.
+///
+///   Unchecked in the literal sense: `plugins` and `isConfigured` are plain mutable state with no lock,
+///   and `isConfigured` is `public`, so callers can flip it. `add(plugin:)` cannot race a configured
+///   category — it throws once `isConfigured` is set — but `removePlugin(for:)` has no such guard, so it
+///   can race a concurrent read. The exposure predates this annotation, which only stops the compiler
+///   from asking about it.
 public final class APICategory: Category, @unchecked Sendable {
     /// The category type for API
     public var categoryType: CategoryType {

--- a/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
+++ b/Amplify/Categories/API/AuthProvider/APIAuthProviderFactory.swift
@@ -24,7 +24,9 @@ open class APIAuthProviderFactory {
     }
 }
 
-public protocol AmplifyAuthTokenProvider {
+/// - Note: `Sendable` because `getLatestAuthToken` is passed as a `@Sendable` closure into the
+///   subscription interceptors.
+public protocol AmplifyAuthTokenProvider: Sendable {
     typealias AuthToken = String
 
     func getLatestAuthToken() async throws -> String

--- a/Amplify/Categories/API/ClientBehavior/APICategoryGraphQLBehavior.swift
+++ b/Amplify/Categories/API/ClientBehavior/APICategoryGraphQLBehavior.swift
@@ -6,7 +6,9 @@
 //
 
 /// Behavior of the API category related to GraphQL operations
-public protocol APICategoryGraphQLBehavior: AnyObject {
+/// - Note: `Sendable` because the implementing plugin is `Sendable` (see `Plugin`) and DataStore
+///   holds this behavior across task boundaries throughout the sync engine.
+public protocol APICategoryGraphQLBehavior: AnyObject, Sendable {
 
     // MARK: - Request-based GraphQL Operations
 

--- a/Amplify/Categories/API/Internal/APICategory+Resettable.swift
+++ b/Amplify/Categories/API/Internal/APICategory+Resettable.swift
@@ -10,12 +10,16 @@ import Foundation
 extension APICategory: Resettable {
 
     public func reset() async {
+        // Hoisted so the task closure below captures these Sendable values rather
+        // than a non-Sendable `self`, which is an error in the Swift 6 language mode.
+        let log = log
+        let categoryType = categoryType
         await withTaskGroup(of: Void.self) { taskGroup in
             for plugin in plugins.values {
-                taskGroup.addTask { [weak self] in
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
+                taskGroup.addTask {
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin")
                     await plugin.reset()
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin: finished")
                 }
             }
             await taskGroup.waitForAll()

--- a/Amplify/Categories/API/Operation/NondeterminsticOperation.swift
+++ b/Amplify/Categories/API/Operation/NondeterminsticOperation.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import Foundation
 
 /**
  A non-deterministic operation offers multiple paths to accomplish its task.
@@ -16,15 +17,35 @@ enum NondeterminsticOperationError: Error {
     case cancelled
 }
 
-final class NondeterminsticOperation<T> {
+/// - Note: `@unchecked Sendable` because `_cancellables` and `_task` are mutable but every
+///   access is serialized by `lock`.
+final class NondeterminsticOperation<T: Sendable>: @unchecked Sendable {
     /// operation that to be eval
-    typealias Operation = () async throws -> T
-    typealias OnError = (Error) -> Bool
+    // Both closures are handed to a `Task` and yielded through an `AsyncStream`, so they
+    // must be `@Sendable` under the Swift 6 language mode.
+    typealias Operation = @Sendable () async throws -> T
+    typealias OnError = @Sendable (Error) -> Bool
 
     private let operations: AsyncStream<Operation>
-    private var shouldTryNextOnError: OnError = { _ in true }
-    private var cancellables = Set<AnyCancellable>()
-    private var task: Task<Void, Never>?
+
+    /// Immutable now that it is assigned once in `init`, which is what removes it from the
+    /// mutable state the lock below has to cover.
+    private let shouldTryNextOnError: OnError
+
+    /// Guards `_cancellables` and `_task`.
+    private let lock = NSLock()
+    private var _cancellables = Set<AnyCancellable>()
+    private var _task: Task<Void, Never>?
+
+    private var cancellables: Set<AnyCancellable> {
+        get { lock.withLock { _cancellables } }
+        set { lock.withLock { _cancellables = newValue } }
+    }
+
+    private var task: Task<Void, Never>? {
+        get { lock.withLock { _task } }
+        set { lock.withLock { _task = newValue } }
+    }
 
     deinit {
         cancel()
@@ -32,9 +53,7 @@ final class NondeterminsticOperation<T> {
 
     init(operations: AsyncStream<Operation>, shouldTryNextOnError: OnError? = nil) {
         self.operations = operations
-        if let shouldTryNextOnError {
-            self.shouldTryNextOnError = shouldTryNextOnError
-        }
+        self.shouldTryNextOnError = shouldTryNextOnError ?? { _ in true }
     }
 
     convenience init(
@@ -59,15 +78,18 @@ final class NondeterminsticOperation<T> {
     /// Synchronous version of executing the operations
     func execute() -> Future<T, Error> {
         Future { [weak self] promise in
+            // `Future.Promise` is not `Sendable`; Combine calls it at most once, so moving it
+            // into the task is safe.
+            let promise = UncheckedSendable(promise)
             self?.task = Task { [weak self] in
                 do {
                     if let self {
-                        try await promise(.success(run()))
+                        try await promise.value(.success(run()))
                     } else {
-                        promise(.failure(NondeterminsticOperationError.cancelled))
+                        promise.value(.failure(NondeterminsticOperationError.cancelled))
                     }
                 } catch {
-                    promise(.failure(error))
+                    promise.value(.failure(error))
                 }
             }
         }

--- a/Amplify/Categories/API/Operation/NondeterminsticOperation.swift
+++ b/Amplify/Categories/API/Operation/NondeterminsticOperation.swift
@@ -115,8 +115,17 @@ final class NondeterminsticOperation<T: Sendable>: @unchecked Sendable {
     }
 
     /// Cancel the operation
+    ///
+    /// Reads the task and clears the cancellables under a single lock acquisition. Going through the
+    /// `task` and `cancellables` accessors would take the lock twice, letting a concurrent `execute()`
+    /// install a new task in between — that task would then survive the cancel. The task is cancelled
+    /// after the lock is released, so cancellation never runs while holding it.
     func cancel() {
-        task?.cancel()
-        cancellables = Set<AnyCancellable>()
+        let taskToCancel: Task<Void, Never>? = lock.withLock {
+            let current = _task
+            _cancellables = Set<AnyCancellable>()
+            return current
+        }
+        taskToCancel?.cancel()
     }
 }

--- a/Amplify/Categories/API/Operation/RetryableGraphQLOperation.swift
+++ b/Amplify/Categories/API/Operation/RetryableGraphQLOperation.swift
@@ -10,13 +10,13 @@ import Foundation
 
 
 // MARK: - RetryableGraphQLOperation
-public final class RetryableGraphQLOperation<Payload: Decodable> {
+public final class RetryableGraphQLOperation<Payload: Decodable & Sendable> {
     public typealias Payload = Payload
 
     private let nondeterminsticOperation: NondeterminsticOperation<GraphQLTask<Payload>.Success>
 
     public init(
-        requestStream: AsyncStream<() async throws -> GraphQLTask<Payload>.Success>
+        requestStream: AsyncStream<@Sendable () async throws -> GraphQLTask<Payload>.Success>
     ) {
         self.nondeterminsticOperation = NondeterminsticOperation(
             operations: requestStream,
@@ -72,15 +72,27 @@ public final class RetryableGraphQLOperation<Payload: Decodable> {
 
 }
 
-public final class RetryableGraphQLSubscriptionOperation<Payload> where Payload: Decodable, Payload: Sendable {
+/// - Note: `@unchecked Sendable` because `_task` is mutable but every access is serialized by
+///   `lock`.
+public final class RetryableGraphQLSubscriptionOperation<Payload>: @unchecked Sendable
+    where Payload: Decodable, Payload: Sendable {
 
     public typealias Payload = Payload
     public typealias SubscriptionEvents = GraphQLSubscriptionEvent<Payload>
-    private var task: Task<Void, Never>?
+
+    /// Guards `_task`.
+    private let lock = NSLock()
+    private var _task: Task<Void, Never>?
+
+    private var task: Task<Void, Never>? {
+        get { lock.withLock { _task } }
+        set { lock.withLock { _task = newValue } }
+    }
+
     private let nondeterminsticOperation: NondeterminsticOperation<AmplifyAsyncThrowingSequence<SubscriptionEvents>>
 
     public init(
-        requestStream: AsyncStream<() async throws -> AmplifyAsyncThrowingSequence<SubscriptionEvents>>
+        requestStream: AsyncStream<@Sendable () async throws -> AmplifyAsyncThrowingSequence<SubscriptionEvents>>
     ) {
         self.nondeterminsticOperation = NondeterminsticOperation(operations: requestStream)
     }
@@ -91,7 +103,9 @@ public final class RetryableGraphQLSubscriptionOperation<Payload> where Payload:
 
     public func subscribe() -> AnyPublisher<SubscriptionEvents, APIError> {
         let subject = PassthroughSubject<SubscriptionEvents, APIError>()
-        task = Task { await self.trySubscribe(subject) }
+        // `PassthroughSubject` is not `Sendable`, but `send` is safe to call from any thread.
+        let boxedSubject = UncheckedSendable(subject)
+        task = Task { await self.trySubscribe(boxedSubject.value) }
         return subject.eraseToAnyPublisher()
     }
 
@@ -127,7 +141,9 @@ public final class RetryableGraphQLSubscriptionOperation<Payload> where Payload:
     }
 }
 
-private extension AsyncSequence {
+// The sequence is captured by a `Task` and its elements are yielded to a continuation, so
+// both must be `Sendable` in the Swift 6 language mode.
+private extension AsyncSequence where Self: Sendable, Element: Sendable {
     var asyncStream: AsyncStream<Self.Element> {
         AsyncStream { continuation in
             Task {

--- a/Amplify/Categories/API/Request/GraphQLOperationRequest.swift
+++ b/Amplify/Categories/API/Request/GraphQLOperationRequest.swift
@@ -6,7 +6,8 @@
 //
 
 /// GraphQL Operation Request
-public struct GraphQLOperationRequest<R: Decodable>: AmplifyOperationRequest {
+/// - Note: `@unchecked Sendable`: `variables` is `[String: Any]?`, which the compiler cannot verify.
+public struct GraphQLOperationRequest<R: Decodable>: AmplifyOperationRequest, @unchecked Sendable {
     /// The name of the API to perform the request against
     public let apiName: String?
 
@@ -17,6 +18,7 @@ public struct GraphQLOperationRequest<R: Decodable>: AmplifyOperationRequest {
     public let document: String
 
     /// The GraphQL variables used for the operation
+    // `[String: Any]?` cannot be `Sendable`-checked; the enclosing type is `@unchecked Sendable`.
     public let variables: [String: Any]?
 
     /// The type to decode to
@@ -55,7 +57,8 @@ public struct GraphQLOperationRequest<R: Decodable>: AmplifyOperationRequest {
 
 // MARK: GraphQLOperationRequest + Options
 public extension GraphQLOperationRequest {
-    struct Options {
+    struct Options: @unchecked Sendable {
+        // See `GraphQLRequest.Options` for why this is unchecked.
         public let pluginOptions: Any?
 
         public init(pluginOptions: Any?) {

--- a/Amplify/Categories/API/Request/GraphQLOperationType.swift
+++ b/Amplify/Categories/API/Request/GraphQLOperationType.swift
@@ -6,7 +6,7 @@
 //
 
 /// The type of a GraphQL operation
-public enum GraphQLOperationType: String {
+public enum GraphQLOperationType: String, Sendable {
     /// A GraphQL Query operation
     case query
 

--- a/Amplify/Categories/API/Request/GraphQLRequest.swift
+++ b/Amplify/Categories/API/Request/GraphQLRequest.swift
@@ -6,7 +6,8 @@
 //
 
 /// Empty protocol for plugins to define specific `AuthorizationMode` types for the request.
-public protocol AuthorizationMode { }
+/// - Note: `Sendable` because the auth mode is stored on requests that cross task boundaries.
+public protocol AuthorizationMode: Sendable { }
 
 /// GraphQL Request
 public struct GraphQLRequest<R: Decodable> {
@@ -57,7 +58,9 @@ public struct GraphQLRequest<R: Decodable> {
 // MARK: GraphQLRequest + Options
 
 public extension GraphQLRequest {
-    struct Options {
+    struct Options: @unchecked Sendable {
+        // `@unchecked`: `pluginOptions` is `Any?`, which cannot be checked. Narrowing it would be
+        // source-breaking for every plugin that passes options through.
         public let pluginOptions: Any?
 
         public init(pluginOptions: Any?) {

--- a/Amplify/Categories/API/Request/RESTOperationRequest.swift
+++ b/Amplify/Categories/API/Request/RESTOperationRequest.swift
@@ -53,7 +53,7 @@ public struct RESTOperationRequest: AmplifyOperationRequest {
 
 /// REST Operation Request options extension
 public extension RESTOperationRequest {
-    struct Options {
+    struct Options: Sendable {
 
         /// Empty initializer
         public init() { }

--- a/Amplify/Categories/API/Request/RESTOperationType.swift
+++ b/Amplify/Categories/API/Request/RESTOperationType.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// The type of API operation
-public enum RESTOperationType: String {
+public enum RESTOperationType: String, Sendable {
 
     /// GET operation
     case get = "GET"

--- a/Amplify/Categories/Analytics/AnalyticsProfile.swift
+++ b/Amplify/Categories/Analytics/AnalyticsProfile.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 /// User specific data
-public struct AnalyticsUserProfile {
+// Explicit `Sendable`: Swift does not infer it for public types, and profiles are passed into the
+// plugin's async endpoint-update path.
+public struct AnalyticsUserProfile: Sendable {
 
     /// Name of the user
     public var name: String?

--- a/Amplify/Categories/Analytics/AnalyticsPropertyValue.swift
+++ b/Amplify/Categories/Analytics/AnalyticsPropertyValue.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 /// Analytics properties can store values of common types
-public protocol AnalyticsPropertyValue {}
+/// - Note: `Sendable` because analytics properties are carried into the plugin's async recording
+///   paths. The conforming types are `String`, `Int`, `Double` and `Bool`.
+public protocol AnalyticsPropertyValue: Sendable {}
 
 extension String: AnalyticsPropertyValue {}
 extension Int: AnalyticsPropertyValue {}

--- a/Amplify/Categories/Analytics/Internal/AnalyticsCategory+Resettable.swift
+++ b/Amplify/Categories/Analytics/Internal/AnalyticsCategory+Resettable.swift
@@ -10,12 +10,16 @@ import Foundation
 extension AnalyticsCategory: Resettable {
 
     public func reset() async {
+        // Hoisted so the task closure below captures these Sendable values rather
+        // than a non-Sendable `self`, which is an error in the Swift 6 language mode.
+        let log = log
+        let categoryType = categoryType
         await withTaskGroup(of: Void.self) { taskGroup in
             for plugin in plugins.values {
-                taskGroup.addTask { [weak self] in
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
+                taskGroup.addTask {
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin")
                     await plugin.reset()
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin: finished")
                 }
             }
             await taskGroup.waitForAll()

--- a/Amplify/Categories/Geo/Internal/GeoCategory+Resettable.swift
+++ b/Amplify/Categories/Geo/Internal/GeoCategory+Resettable.swift
@@ -10,12 +10,16 @@ import Foundation
 extension GeoCategory: Resettable {
 
     public func reset() async {
+        // Hoisted so the task closure below captures these Sendable values rather
+        // than a non-Sendable `self`, which is an error in the Swift 6 language mode.
+        let log = log
+        let categoryType = categoryType
         await withTaskGroup(of: Void.self) { taskGroup in
             for plugin in plugins.values {
-                taskGroup.addTask { [weak self] in
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
+                taskGroup.addTask {
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin")
                     await plugin.reset()
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin: finished")
                 }
             }
             await taskGroup.waitForAll()

--- a/Amplify/Categories/Logging/Internal/BroadcastLogger.swift
+++ b/Amplify/Categories/Logging/Internal/BroadcastLogger.swift
@@ -15,7 +15,9 @@ final class BroadcastLogger {
     /// The default LogLevel used when no targets are available.
     ///
     /// - Tag: LogProxy.defaultLogLevel
-    var defaultLogLevel: Amplify.LogLevel = .error
+    // `let` rather than `var`: this is only ever read, so immutability is what lets
+    // `BroadcastLogger` satisfy the `Sendable` requirement on `Logger`.
+    let defaultLogLevel: Amplify.LogLevel = .error
 
     private let targets: [Logger]
 

--- a/Amplify/Categories/Logging/LogLevel.swift
+++ b/Amplify/Categories/Logging/LogLevel.swift
@@ -8,7 +8,8 @@
 /// Log levels are modeled as Ints to allow for easy comparison of levels
 ///
 public extension Amplify {
-    enum LogLevel: Int, Codable {
+    // Explicit `Sendable` because Swift does not infer it for public types.
+    enum LogLevel: Int, Codable, Sendable {
         case none
         case error
         case warn

--- a/Amplify/Categories/Logging/LoggingCategory.swift
+++ b/Amplify/Categories/Logging/LoggingCategory.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 /// AWS Amplify writes console logs through Logger. You can use Logger in your apps for the same purpose.
-public final class LoggingCategory: Category {
+/// - Note: `@unchecked Sendable` because `_logLevel` and the configuration state are
+///   mutable but every access is serialized by `lock`. The `Logger` conformance lives in
+///   an extension in another file, so the conformance must be declared here.
+public final class LoggingCategory: Category, @unchecked Sendable {
     enum ConfigurationState {
         /// Default configuration at initialization
         case `default`
@@ -20,7 +23,9 @@ public final class LoggingCategory: Category {
         case configured
     }
 
-    let lock: NSLocking = NSLock()
+    // Concrete `NSLock` rather than `any NSLocking`: the existential is not `Sendable`,
+    // which blocks the `Sendable` conformance this class needs.
+    let lock = NSLock()
 
     public let categoryType = CategoryType.logging
 

--- a/Amplify/Categories/Logging/LoggingCategory.swift
+++ b/Amplify/Categories/Logging/LoggingCategory.swift
@@ -8,9 +8,15 @@
 import Foundation
 
 /// AWS Amplify writes console logs through Logger. You can use Logger in your apps for the same purpose.
-/// - Note: `@unchecked Sendable` because `_logLevel` and the configuration state are
-///   mutable but every access is serialized by `lock`. The `Logger` conformance lives in
-///   an extension in another file, so the conformance must be declared here.
+/// - Note: `@unchecked Sendable`. The lock does **not** cover everything: only `_logLevel` goes through
+///   it. `configurationState` and `plugins` are plain mutable state, written by `add(plugin:)` and
+///   `removePlugin(for:)` after initialization, and read without the lock. So the locking discipline here
+///   is partial rather than complete.
+///
+///   In practice configuration happens once during start-up and the state is read-only afterwards, but
+///   nothing in this type enforces that. Bringing those two under the same lock would be the real fix and
+///   is worth doing separately — it needs care, because several accessors call each other and would
+///   deadlock on a non-recursive lock.
 public final class LoggingCategory: Category, @unchecked Sendable {
     enum ConfigurationState {
         /// Default configuration at initialization

--- a/Amplify/Categories/Logging/LoggingCategoryClientBehavior.swift
+++ b/Amplify/Categories/Logging/LoggingCategoryClientBehavior.swift
@@ -29,7 +29,10 @@ public protocol LoggingCategoryClientBehavior {
     func logger(forCategory category: String, forNamespace namespace: String) -> Logger
 }
 
-public protocol Logger {
+/// - Note: `Sendable` because loggers are captured by concurrent work throughout the
+///   library (task groups, detached tasks, actor bodies). Conformers are responsible for
+///   making their own state thread-safe.
+public protocol Logger: Sendable {
 
     /// The log level of the logger.
     var logLevel: LogLevel { get set }

--- a/Amplify/Categories/Notifications/PushNotifications/Internal/PushNotificationsCategory+Resettable.swift
+++ b/Amplify/Categories/Notifications/PushNotifications/Internal/PushNotificationsCategory+Resettable.swift
@@ -9,12 +9,16 @@ import Foundation
 
 extension PushNotificationsCategory: Resettable {
     public func reset() async {
+        // Hoisted so the task closure below captures these Sendable values rather
+        // than a non-Sendable `self`, which is an error in the Swift 6 language mode.
+        let log = log
+        let categoryType = categoryType
         await withTaskGroup(of: Void.self) { taskGroup in
             for plugin in plugins.values {
-                taskGroup.addTask { [weak self] in
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
+                taskGroup.addTask {
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin")
                     await plugin.reset()
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin: finished")
                 }
             }
             await taskGroup.waitForAll()

--- a/Amplify/Categories/Predictions/Internal/PredictionsCategory+Resettable.swift
+++ b/Amplify/Categories/Predictions/Internal/PredictionsCategory+Resettable.swift
@@ -10,12 +10,16 @@ import Foundation
 extension PredictionsCategory: Resettable {
 
     public func reset() async {
+        // Hoisted so the task closure below captures these Sendable values rather
+        // than a non-Sendable `self`, which is an error in the Swift 6 language mode.
+        let log = log
+        let categoryType = categoryType
         await withTaskGroup(of: Void.self) { taskGroup in
             for plugin in plugins.values {
-                taskGroup.addTask { [weak self] in
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin")
+                taskGroup.addTask {
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin")
                     await plugin.reset()
-                    self?.log.verbose("Resetting \(String(describing: self?.categoryType)) plugin: finished")
+                    log.verbose("Resetting \(String(describing: categoryType)) plugin: finished")
                 }
             }
             await taskGroup.waitForAll()


### PR DESCRIPTION
Slice **19 of 38** in the Swift 6 language-mode migration — 21 file(s).

Stacked on `swift6/18-auth-category-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.