### PR TITLE
feat(core): Sendable for the built-in default plugins

### DIFF
--- a/Amplify/DefaultPlugins/AWSHubPlugin/Internal/FilteredListener.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/Internal/FilteredListener.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
-struct FilteredListener {
+/// - Note: `Sendable` now that `HubFilter` and `HubListener` are `@Sendable`; listeners are held in
+///   an `AtomicDictionary` and invoked from the dispatch queue.
+struct FilteredListener: Sendable {
     /// A unique identifier for this listener
     let id: UUID
 

--- a/Amplify/DefaultPlugins/AWSHubPlugin/Internal/HubChannelDispatcher.swift
+++ b/Amplify/DefaultPlugins/AWSHubPlugin/Internal/HubChannelDispatcher.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 /// A convenience class for managing an Operation Queue that dispatches Hub messages
-final class HubChannelDispatcher {
+/// - Note: `@unchecked Sendable` because both stored properties are `let` and each is already
+///   thread-safe on its own: `listenersById` is an `AtomicDictionary`, and `messageQueue` is a
+///   serial `OperationQueue`.
+final class HubChannelDispatcher: @unchecked Sendable {
     /// The message queue to which the message operations are added
     private let messageQueue: OperationQueue
 
@@ -130,7 +133,8 @@ final class HubDispatchOperation: Operation, @unchecked Sendable {
 }
 
 /// A Dispatcher fans out a single payload to a group of listeners
-protocol Dispatcher {
+/// - Note: `Sendable` because dispatchers are used from the Hub's operation queue.
+protocol Dispatcher: Sendable {
     var isCancelled: Bool { get set }
     func dispatch(to listeners: [FilteredListener])
 }

--- a/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/AWSUnifiedLoggingPlugin.swift
+++ b/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/AWSUnifiedLoggingPlugin.swift
@@ -9,7 +9,13 @@ import Foundation
 import os.log
 
 /// A Logging category plugin that forwards calls to the OS's Unified Logging system
-public final class AWSUnifiedLoggingPlugin: LoggingCategoryPlugin {
+/// - Note: `@unchecked Sendable` to satisfy the `Sendable` requirement on `Plugin`.
+///   `registeredLogs` is guarded, but inconsistently — `concurrencyQueue` on the caching and
+///   `reset` paths, `lock` in `enable()`/`disable()` — and `enabled` is not guarded at all.
+///   That predates the Swift 6 migration and is left as-is here rather than changed blind:
+///   `enabled` is read from inside `lock.execute`, so backing it with the same non-recursive
+///   lock would deadlock. Worth untangling separately.
+public final class AWSUnifiedLoggingPlugin: LoggingCategoryPlugin, @unchecked Sendable {
 
     /// Convenience property. Each instance of `AWSUnifiedLoggingPlugin` has the same key
     public static var key: String {

--- a/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/Internal/OSLogWrapper.swift
+++ b/Amplify/DefaultPlugins/AWSUnifiedLoggingPlugin/Internal/OSLogWrapper.swift
@@ -5,27 +5,42 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import Foundation
 import os.log
 
-final class OSLogWrapper: Logger {
+/// - Note: `@unchecked Sendable` because `enabled` and `getLogLevel` are mutable — both are
+///   reassigned after construction by `AWSUnifiedLoggingPlugin` — but every access goes
+///   through `lock`. `Logger` is `Sendable`, and a logger is shared across concurrency
+///   domains by nature, so the state genuinely needs synchronizing rather than annotating away.
+final class OSLogWrapper: Logger, @unchecked Sendable {
     private let osLog: OSLog
 
-    var enabled: Bool = true
+    private let lock = NSLock()
+    private var _enabled: Bool = true
+    private var _getLogLevel: () -> LogLevel
 
-    var getLogLevel: () -> LogLevel
+    var enabled: Bool {
+        get { lock.withLock { _enabled } }
+        set { lock.withLock { _enabled = newValue } }
+    }
+
+    var getLogLevel: () -> LogLevel {
+        get { lock.withLock { _getLogLevel } }
+        set { lock.withLock { _getLogLevel = newValue } }
+    }
 
     var logLevel: LogLevel {
         get {
             getLogLevel()
         }
         set {
-            getLogLevel = { newValue }
+            lock.withLock { _getLogLevel = { newValue } }
         }
     }
 
     init(osLog: OSLog, getLogLevel: @escaping () -> LogLevel) {
         self.osLog = osLog
-        self.getLogLevel = getLogLevel
+        self._getLogLevel = getLogLevel
     }
 
     func error(_ message: @autoclosure () -> String) {


### PR DESCRIPTION
Slice **20 of 38** in the Swift 6 language-mode migration — 4 file(s).

Stacked on `swift6/19-other-categories-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.