### PR TITLE
feat(core): Sendable for remaining Amplify core files

### DIFF
--- a/AmplifyFoundation/Sources/Logging/AmplifyLogging.swift
+++ b/AmplifyFoundation/Sources/Logging/AmplifyLogging.swift
@@ -11,7 +11,11 @@ public final class AmplifyLogging {
 
     /// Synchronize access to the log sinks
     static let concurrencyQueue = DispatchQueue(label: "com.amplify.foundation.AmplifyLogging")
-    static var registeredLogSinks: [String: any LogSinkBehavior] = [:]
+
+    /// Every read and write goes through `concurrencyQueue`, so access is already
+    /// serialized. `nonisolated(unsafe)` records that the safety is enforced by the
+    /// queue rather than by the compiler.
+    nonisolated(unsafe) static var registeredLogSinks: [String: any LogSinkBehavior] = [:]
 
     private init() {}
 


### PR DESCRIPTION
Slice **21 of 38** in the Swift 6 language-mode migration — 1 file(s).

Stacked on `swift6/20-default-plugins-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.