### PR TITLE
feat(core): Sendable across AWSPluginsCore

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthModeStrategy.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthModeStrategy.swift
@@ -201,7 +201,7 @@ public class AWSMultiAuthModeStrategy: AuthModeStrategy {
 
     /// A predicate used to sort Auth rules according to above priority rules
     /// Use provider priority to sort if rules have the same strategy
-    private static let comparator = { (rule1: AuthRule, rule2: AuthRule) -> Bool in
+    private static let comparator = { @Sendable (rule1: AuthRule, rule2: AuthRule) -> Bool in
         if let providerRule1 = rule1.provider,
            let providerRule2 = rule2.provider, rule1.allow == rule2.allow {
             return priorityOf(authRuleProvider: providerRule1) < priorityOf(authRuleProvider: providerRule2)

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthService.swift
@@ -8,7 +8,10 @@
 import Amplify
 import Foundation
 
-public class AWSAuthService: AWSAuthServiceBehavior {
+/// - Note: `@unchecked Sendable` rather than `final`: the class has no stored state, so it is
+///   genuinely safe to share, and leaving it open avoids a source-breaking change for anyone who
+///   subclassed it.
+public class AWSAuthService: AWSAuthServiceBehavior, @unchecked Sendable {
 
     public init() {}
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthServiceBehavior.swift
@@ -8,7 +8,9 @@
 import Amplify
 import Foundation
 
-public protocol AWSAuthServiceBehavior: AnyObject {
+/// - Note: `Sendable` because auth services are held by plugins (themselves `Sendable`) and reached
+///   from concurrent request paths.
+public protocol AWSAuthServiceBehavior: AnyObject, Sendable {
 
     func getTokenClaims(tokenString: String) -> Result<[String: AnyObject], AuthError>
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthorizationType.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AWSAuthorizationType.swift
@@ -14,7 +14,7 @@ import Foundation
 /// GraphQL backend, or an Amazon API Gateway endpoint.
 ///
 /// - SeeAlso: [https://docs.aws.amazon.com/appsync/latest/devguide/security.html](AppSync Security)
-public enum AWSAuthorizationType: String, AuthorizationMode {
+public enum AWSAuthorizationType: String, AuthorizationMode, Sendable {
 
     /// For public APIs
     case none = "NONE"

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AmplifyAuthorizationType.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AmplifyAuthorizationType.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// - Warning: Although this has `public` access, it is intended for internal use and should not be used directly
 ///   by host applications. The behavior of this may change without warning.
-public enum AmplifyAuthorizationType {
+public enum AmplifyAuthorizationType: Sendable {
 
     /// Determine the authorization method based on the amplifyconfiguration.
     case inferred

--- a/AmplifyPlugins/Core/AWSPluginsCore/Auth/AuthCognitoTokensProvider.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Auth/AuthCognitoTokensProvider.swift
@@ -12,7 +12,8 @@ public protocol AuthCognitoTokensProvider {
     func getCognitoTokens() -> Result<AuthCognitoTokens, AuthError>
 }
 
-public protocol AuthCognitoTokens {
+/// - Note: `Sendable` because tokens are carried across task boundaries by the auth and API layers.
+public protocol AuthCognitoTokens: Sendable {
 
     var idToken: String {get}
 

--- a/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStore.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Keychain/KeychainStore.swift
@@ -10,7 +10,9 @@ import Amplify
 import Security
 
 // swiftlint:disable identifier_name
-public protocol KeychainStoreBehavior {
+/// - Note: `Sendable` because keychain stores are shared across concurrency domains by the auth and
+///   analytics plugins; the underlying Security framework calls are thread-safe.
+public protocol KeychainStoreBehavior: Sendable {
 
     /// Get a string value from the Keychain based on the key.
     /// This System Programming Interface (SPI) may have breaking changes in future updates.

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSync.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/MutationSync/MutationSync.swift
@@ -10,7 +10,10 @@ import Foundation
 
 /// Tuple-like type that holds a `Model` instance and its `MutationSyncMetadata`.
 /// THe sync metadata constains information about the model state in the backend.
-public struct MutationSync<ModelType: Model>: Decodable {
+// Explicit `Sendable` because Swift does not infer it for public types. Both stored
+// properties are already `Sendable`: `ModelType` via `Model`, and `MutationSyncMetadata` is a
+// value type.
+public struct MutationSync<ModelType: Model>: Decodable, Sendable {
 
     public let model: ModelType
     public let syncMetadata: MutationSyncMetadata

--- a/AmplifyPlugins/Core/AWSPluginsCore/Sync/PaginatedList.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/Sync/PaginatedList.swift
@@ -8,7 +8,9 @@
 import Amplify
 import Foundation
 
-public struct PaginatedList<ModelType: Model>: Decodable {
+// Explicit `Sendable`: Swift does not infer it for public types, and this is carried across
+// task boundaries by the sync engine.
+public struct PaginatedList<ModelType: Model>: Decodable, Sendable {
     public let items: [MutationSync<ModelType>]
     public let nextToken: String?
     public let startedAt: Int64?

--- a/AmplifyPlugins/Core/AWSPluginsCore/WebSocket/AmplifyNetworkMonitor.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/WebSocket/AmplifyNetworkMonitor.swift
@@ -8,10 +8,14 @@
 import Combine
 import Network
 
+/// - Note: `@unchecked Sendable` because both stored properties are `let` and each is safe to use
+///   concurrently — `NWPathMonitor` delivers on its own queue, and `PassthroughSubject.send` is
+///   safe from any thread. Neither type is declared `Sendable`, so the conformance cannot be
+///   checked, and it must be stated here rather than in the protocol's extension.
 @_spi(WebSocket)
-public final class AmplifyNetworkMonitor {
+public final class AmplifyNetworkMonitor: @unchecked Sendable {
 
-    public enum State {
+    public enum State: Sendable {
         case none
         case online
         case offline

--- a/AmplifyPlugins/Core/AWSPluginsCore/WebSocket/WebSocketClient.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/WebSocket/WebSocketClient.swift
@@ -26,8 +26,18 @@ public final actor WebSocketClient: NSObject {
     private let handshakeHttpHeaders: [String: String]
     /// Interceptor for appending additional info before makeing the connection
     private var interceptor: WebSocketInterceptor?
+    /// Backing store for ``subject``.
+    ///
+    /// `PassthroughSubject` is not `Sendable`, but `send` is safe from any thread and this is
+    /// deliberately `nonisolated` so the `URLSessionWebSocketDelegate` callbacks can publish without
+    /// hopping onto the actor. The box carries it across that boundary; the computed property below
+    /// keeps the call sites unchanged.
+    private nonisolated let subjectBox = UncheckedSendable(PassthroughSubject<WebSocketEvent, Never>())
+
     /// Internal wriable WebSocketEvent data stream
-    private nonisolated let subject = PassthroughSubject<WebSocketEvent, Never>()
+    private nonisolated var subject: PassthroughSubject<WebSocketEvent, Never> {
+        subjectBox.value
+    }
 
     private let retryWithJitter = RetryWithJitter()
 
@@ -48,7 +58,10 @@ public final actor WebSocketClient: NSObject {
     /// A flag indicating whether to automatically retry on connection failure
     private var autoRetryOnConnectionFailure: Bool
     /// Data stream for downstream subscribers to engage with
-    public var publisher: AnyPublisher<WebSocketEvent, Never> {
+    ///
+    /// `nonisolated` because `subject` is already `nonisolated` and Combine publishers are not
+    /// `Sendable`, so returning one from actor-isolated context is rejected in Swift 6 mode.
+    public nonisolated var publisher: AnyPublisher<WebSocketEvent, Never> {
         subject.eraseToAnyPublisher()
     }
 
@@ -88,10 +101,12 @@ public final actor WebSocketClient: NSObject {
     }
 
     deinit {
+        // Only the subject is touched here. A nonisolated `deinit` cannot reach actor-isolated
+        // state in the Swift 6 language mode, and the writes that used to be here were already
+        // no-ops at this point: nothing can observe the two flags once deallocation has begun,
+        // and clearing `cancelables` is redundant because releasing the actor's storage
+        // deinitializes each `AnyCancellable`, which cancels it.
         self.subject.send(completion: .finished)
-        self.autoConnectOnNetworkStatusChange = false
-        self.autoRetryOnConnectionFailure = false
-        cancelables = Set()
     }
 
     /**

--- a/AmplifyPlugins/Core/AWSPluginsCore/WebSocket/WebSocketEvent.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/WebSocket/WebSocketEvent.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @_spi(WebSocket)
-public enum WebSocketEvent {
+public enum WebSocketEvent: Sendable {
     case connected
     case disconnected(URLSessionWebSocketTask.CloseCode, String?)
     case data(Data)

--- a/AmplifyPlugins/Core/AWSPluginsCore/WebSocket/WebSocketInterceptor.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/WebSocket/WebSocketInterceptor.swift
@@ -7,8 +7,10 @@
 
 import Foundation
 
+/// - Note: `Sendable` because the interceptor is stored on the `WebSocketClient` actor and awaited
+///   across suspension points while building a connection.
 @_spi(WebSocket)
-public protocol WebSocketInterceptor {
+public protocol WebSocketInterceptor: Sendable {
     func interceptConnection(url: URL) async -> URL
 
     func interceptConnection(request: URLRequest) async -> URLRequest

--- a/AmplifyPlugins/Core/AWSPluginsCore/WebSocket/WebSocketNetworkMonitorProtocol.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/WebSocket/WebSocketNetworkMonitorProtocol.swift
@@ -8,8 +8,10 @@
 import Combine
 import Foundation
 
+/// - Note: `Sendable` because the monitor is held by the `WebSocketClient` actor and reached from
+///   nonisolated delegate callbacks, so it already crosses concurrency domains.
 @_spi(WebSocket)
-public protocol WebSocketNetworkMonitorProtocol {
+public protocol WebSocketNetworkMonitorProtocol: Sendable {
     var publisher: AnyPublisher<(AmplifyNetworkMonitor.State, AmplifyNetworkMonitor.State), Never> { get }
     func updateState(_ nextState: AmplifyNetworkMonitor.State) async
 }

--- a/AmplifyPlugins/Core/AmplifyCredentials/CustomHttpClientEngine/UserAgentSuffixAppender.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentials/CustomHttpClientEngine/UserAgentSuffixAppender.swift
@@ -5,13 +5,24 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import Foundation
 import Smithy
 import SmithyHTTPAPI
 
+/// - Note: `final` and `@unchecked Sendable` so it can satisfy `AWSPluginExtension`'s `Sendable`
+///   requirement. `target` is assigned by the plugin after construction, so it stays mutable and
+///   access is serialized by `lock`.
 @_spi(InternalAmplifyPluginExtension)
-public class UserAgentSuffixAppender: AWSPluginExtension {
+public final class UserAgentSuffixAppender: AWSPluginExtension, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _target: HTTPClient?
+
     @_spi(InternalHttpEngineProxy)
-    public var target: HTTPClient?
+    public var target: HTTPClient? {
+        get { lock.withLock { _target } }
+        set { lock.withLock { _target = newValue } }
+    }
+
     public let suffix: String
     private let userAgentKey = "User-Agent"
 

--- a/AmplifyPlugins/Core/AmplifyCredentials/ServiceConfiguration/AmplifyAWSServiceConfiguration+Platform.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentials/ServiceConfiguration/AmplifyAWSServiceConfiguration+Platform.swift
@@ -5,17 +5,29 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import Amplify
 import Foundation
 
 public extension AmplifyAWSServiceConfiguration {
 
-    internal static var platformMapping: [Platform: String] = [:]
+    /// Backed by `AtomicDictionary` rather than a plain `static var`: `addUserAgentPlatform` is
+    /// public API called by wrapper SDKs such as Amplify Flutter, so writes can arrive from any
+    /// thread and an unsynchronized global is an error in the Swift 6 language mode.
+    private static let platformMappingStorage = AtomicDictionary<Platform, String>()
 
-    static func addUserAgentPlatform(_ platform: Platform, version: String) {
-        platformMapping[platform] = version
+    internal static var platformMapping: [Platform: String] {
+        platformMappingStorage.keys.reduce(into: [Platform: String]()) { result, key in
+            if let version = platformMappingStorage.getValue(forKey: key) {
+                result[key] = version
+            }
+        }
     }
 
-    enum Platform: String {
+    static func addUserAgentPlatform(_ platform: Platform, version: String) {
+        platformMappingStorage.set(value: version, forKey: platform)
+    }
+
+    enum Platform: String, Sendable {
         case flutter = "amplify-flutter"
     }
 }

--- a/AmplifyPlugins/Core/AmplifyCredentials/ServiceConfiguration/AmplifyAWSServiceConfiguration+Platform.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentials/ServiceConfiguration/AmplifyAWSServiceConfiguration+Platform.swift
@@ -15,11 +15,16 @@ public extension AmplifyAWSServiceConfiguration {
     /// thread and an unsynchronized global is an error in the Swift 6 language mode.
     private static let platformMappingStorage = AtomicDictionary<Platform, String>()
 
+    /// Snapshots the storage in a single locked read.
+    ///
+    /// Reading `keys` and then calling `getValue(forKey:)` per key took the lock once per entry, so a
+    /// concurrent `addUserAgentPlatform` could land mid-loop and yield a snapshot that is missing the
+    /// newest entry — or, if a key were ever removed, one that drops it. Iterating instead goes through
+    /// `makeIterator()`, which takes the lock once and copies the whole dictionary, so the result is
+    /// always a consistent point-in-time view.
     internal static var platformMapping: [Platform: String] {
-        platformMappingStorage.keys.reduce(into: [Platform: String]()) { result, key in
-            if let version = platformMappingStorage.getValue(forKey: key) {
-                result[key] = version
-            }
+        platformMappingStorage.reduce(into: [Platform: String]()) { result, entry in
+            result[entry.key] = entry.value
         }
     }
 


### PR DESCRIPTION
Slice **22 of 38** in the Swift 6 language-mode migration — 16 file(s).

Stacked on `swift6/21-amplify-misc-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.