### PR TITLE
feat(auth): Sendable across the Cognito state machine

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/LoginsMapProvider.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Data/LoginsMapProvider.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-protocol LoginsMapProvider {
+/// - Note: `Sendable` because logins maps are carried on state machine states, which are `Sendable`.
+protocol LoginsMapProvider: Sendable {
 
     var loginsMap: [String: String] { get }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/AuthEvents.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/AuthEvents.swift
@@ -9,7 +9,8 @@ import Foundation
 
 struct AuthEvent: StateMachineEvent {
 
-    enum EventType: Equatable {
+    // `Sendable` because the enclosing event conforms to `StateMachineEvent`, which is `Sendable`.
+    enum EventType: Equatable, Sendable {
 
         case configureAuth(AuthConfiguration)
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/AuthenticationEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/AuthenticationEvent.swift
@@ -9,7 +9,8 @@ import Foundation
 
 typealias InitiateAutoSignIn = Bool
 struct AuthenticationEvent: StateMachineEvent {
-    enum EventType: Equatable {
+    // `Sendable` because the enclosing event conforms to `StateMachineEvent`, which is `Sendable`.
+    enum EventType: Equatable, Sendable {
 
         /// Emitted at startup when the Authentication system is being initialized
         case configure(AuthConfiguration, AmplifyCredentials)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/AuthorizationEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/AuthorizationEvent.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 struct AuthorizationEvent: StateMachineEvent {
-    enum EventType: Equatable {
+    // `Sendable` because the enclosing event conforms to `StateMachineEvent`, which is `Sendable`.
+    enum EventType: Equatable, Sendable {
 
         case configure
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/CredentialStoreEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/CredentialStoreEvent.swift
@@ -22,7 +22,8 @@ enum CredentialStoreDataType: Codable, Equatable {
 
 struct CredentialStoreEvent: StateMachineEvent {
 
-    enum EventType: Equatable {
+    // `Sendable` because the enclosing event conforms to `StateMachineEvent`, which is `Sendable`.
+    enum EventType: Equatable, Sendable {
 
         case migrateLegacyCredentialStore
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/DeleteUserEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/DeleteUserEvent.swift
@@ -12,7 +12,8 @@ typealias AccessToken = String
 
 struct DeleteUserEvent: StateMachineEvent {
 
-    enum EventType {
+    // `Sendable` because the enclosing event conforms to `StateMachineEvent`, which is `Sendable`.
+    enum EventType: Sendable {
 
         case deleteUser(AccessToken)
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/FetchAuthSessionEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/FetchAuthSessionEvent.swift
@@ -11,7 +11,8 @@ typealias IdentityID = String
 typealias ForceRefresh = Bool
 
 struct FetchAuthSessionEvent: StateMachineEvent {
-    enum EventType {
+    // `Sendable` because the enclosing event conforms to `StateMachineEvent`, which is `Sendable`.
+    enum EventType: Sendable {
 
         case fetchUnAuthIdentityID
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/HostedUIEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/HostedUIEvent.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 struct HostedUIEvent: StateMachineEvent {
-    enum EventType {
+    // `Sendable` because the enclosing event conforms to `StateMachineEvent`, which is `Sendable`.
+    enum EventType: Sendable {
 
         case showHostedUI(HostedUISigningInState)
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/RefreshSessionEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/RefreshSessionEvent.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 struct RefreshSessionEvent: StateMachineEvent {
-    enum EventType {
+    // `Sendable` because the enclosing event conforms to `StateMachineEvent`, which is `Sendable`.
+    enum EventType: Sendable {
 
         case refreshUnAuthAWSCredentials(IdentityID)
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SetUpTOTPEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SetUpTOTPEvent.swift
@@ -12,7 +12,8 @@ typealias UserSession = String
 
 struct SetUpTOTPEvent: StateMachineEvent {
 
-    enum EventType {
+    // `Sendable` because the enclosing event conforms to `StateMachineEvent`, which is `Sendable`.
+    enum EventType: Sendable {
 
         case setUpTOTP(RespondToAuthChallenge)
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInChallengeEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInChallengeEvent.swift
@@ -10,7 +10,8 @@ import Foundation
 
 struct SignInChallengeEvent: StateMachineEvent {
 
-    enum EventType: Equatable {
+    // `Sendable` because the enclosing event conforms to `StateMachineEvent`, which is `Sendable`.
+    enum EventType: Equatable, Sendable {
 
         case waitForAnswer(RespondToAuthChallenge, SignInMethod, AuthSignInStep)
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignInEvent.swift
@@ -15,11 +15,14 @@ typealias Username = String
 typealias Password = String
 typealias ClientMetadata = [String: String]
 
-struct SignInEvent: StateMachineEvent {
+/// - Note: `@unchecked Sendable`: `StateMachineEvent` requires `Sendable`, but `data` is `Any?`,
+///   which the compiler cannot verify. The value stored there is always a `Sendable` payload.
+struct SignInEvent: StateMachineEvent, @unchecked Sendable {
 
     var data: Any?
 
-    enum EventType {
+    // `Sendable` because the enclosing event conforms to `StateMachineEvent`, which is `Sendable`.
+    enum EventType: Sendable {
 
         case initiateSignInWithSRP(SignInEventData, DeviceMetadata, RespondToAuthChallenge?)
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignOutEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignOutEvent.swift
@@ -8,10 +8,13 @@
 import AWSCognitoIdentityProvider
 import Foundation
 
-struct SignOutEvent: StateMachineEvent {
+/// - Note: `@unchecked Sendable`: `StateMachineEvent` requires `Sendable`, but `data` is `Any?`,
+///   which the compiler cannot verify. The value stored there is always a `Sendable` payload.
+struct SignOutEvent: StateMachineEvent, @unchecked Sendable {
     var data: Any?
 
-    enum EventType {
+    // `Sendable` because the enclosing event conforms to `StateMachineEvent`, which is `Sendable`.
+    enum EventType: Sendable {
         case signOutGlobally(
             SignedInData,
             hostedUIError: AWSCognitoHostedUIError? = nil

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignUpEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/SignUpEvent.swift
@@ -16,7 +16,8 @@ struct SignUpEvent: StateMachineEvent {
     var time: Date?
     let eventType: EventType
 
-    enum EventType {
+    // `Sendable` because the enclosing event conforms to `StateMachineEvent`, which is `Sendable`.
+    enum EventType: Sendable {
         case initiateSignUp(SignUpEventData, Password?, [AuthUserAttribute]?)
         case initiateSignUpComplete(SignUpEventData, AuthSignUpResult)
         case confirmSignUp(SignUpEventData, ConfirmationCode, ForceAliasCreation?)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/WebAuthnEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/CodeGen/Events/WebAuthnEvent.swift
@@ -11,7 +11,8 @@ import Foundation
 
 struct WebAuthnEvent: StateMachineEvent {
 
-    enum EventType: Equatable {
+    // `Sendable` because the enclosing event conforms to `StateMachineEvent`, which is `Sendable`.
+    enum EventType: Equatable, Sendable {
         case fetchCredentialOptions(Input)
         case assertCredentials(CredentialAssertionOptions, Input)
         case verifyCredentialsAndSignIn(String, Input)

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/hierarchical-state-machine-swift/Action.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/hierarchical-state-machine-swift/Action.swift
@@ -5,9 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-typealias BasicActionClosure = (EventDispatcher, Environment) async -> Void
+// `@Sendable` because `Action` is `Sendable` and executors run these in detached tasks.
+typealias BasicActionClosure = @Sendable (EventDispatcher, Environment) async -> Void
 
-protocol Action {
+/// - Note: `Sendable` because the executors run actions in detached tasks.
+protocol Action: Sendable {
     /// Used for deduping and cancelling actions
     var identifier: String { get }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/hierarchical-state-machine-swift/CancellableAsyncStream.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/hierarchical-state-machine-swift/CancellableAsyncStream.swift
@@ -7,7 +7,9 @@
 
 import Combine
 
-class CancellableAsyncStream<Element>: AsyncSequence {
+/// - Note: `final` and `@unchecked Sendable`: both stored properties are `let`, but `AnyCancellable`
+///   is not declared `Sendable`. The stream is awaited from the auth tasks, which are `Sendable`.
+final class CancellableAsyncStream<Element: Sendable>: AsyncSequence, @unchecked Sendable {
 
     typealias AsyncIterator = AsyncStream<Element>.AsyncIterator
     private let asyncStream: AsyncStream<Element>

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/hierarchical-state-machine-swift/Environment.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/hierarchical-state-machine-swift/Environment.swift
@@ -7,4 +7,6 @@
 
 /// A marker protocol to indicate the conforming type can be used as an
 /// Environment. Environments provide a way to access dependencies at runtime.
-protocol Environment { }
+/// - Note: `Sendable` because environments are captured by the actions the state machine runs in
+///   detached tasks.
+protocol Environment: Sendable { }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/hierarchical-state-machine-swift/EventDispatcher.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/hierarchical-state-machine-swift/EventDispatcher.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-protocol EventDispatcher {
+/// - Note: `Sendable` because the dispatcher is handed to actions that run concurrently.
+protocol EventDispatcher: Sendable {
     func send(_ event: StateMachineEvent) async
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/hierarchical-state-machine-swift/State.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/hierarchical-state-machine-swift/State.swift
@@ -163,7 +163,9 @@
 /// 10. The parent `AuthState` returns an Effect to dispatch an `authIsReady` event
 ///
 /// - seealso: `Effect`
-protocol State: Equatable {
+/// - Note: `Sendable` because states are read out of the actor-isolated state machine and passed
+///   between tasks.
+protocol State: Equatable, Sendable {
 
     var type: String { get }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/hierarchical-state-machine-swift/StateMachineEvent.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/StateMachine/hierarchical-state-machine-swift/StateMachineEvent.swift
@@ -9,7 +9,8 @@ import Foundation
 
 /// Inspired by CloudEvents spec
 /// - seealso: https://github.com/cloudevents/spec/blob/master/spec.md
-protocol StateMachineEvent {
+/// - Note: `Sendable` because events are sent into the actor-isolated `StateMachine.send`.
+protocol StateMachineEvent: Sendable {
     // MARK: - Required attributes
 
     /// Identifies the event. Producers MUST ensure that source + id is unique for each


### PR DESCRIPTION
Slice **23 of 38** in the Swift 6 language-mode migration — 21 file(s).

Stacked on `swift6/22-pluginscore-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.