### PR TITLE
feat(auth): Sendable across the rest of the Auth plugin

### DIFF
--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/AWSCognitoAuthPlugin.swift
@@ -9,7 +9,10 @@ import Amplify
 import AWSPluginsCore
 import Foundation
 
-public final class AWSCognitoAuthPlugin: AWSCognitoAuthPluginBehavior {
+/// - Note: `@unchecked Sendable` to satisfy the `Sendable` requirement on `Plugin`. The service and
+///   configuration properties are populated during `configure(using:)` before any client call can
+///   reach them.
+public final class AWSCognitoAuthPlugin: AWSCognitoAuthPluginBehavior, @unchecked Sendable {
 
     var authEnvironment: AuthEnvironment!
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/HostedUI/ShowHostedUISignIn.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/HostedUI/ShowHostedUISignIn.swift
@@ -9,9 +9,11 @@ import Amplify
 import AuthenticationServices
 import Foundation
 
-class ShowHostedUISignIn: NSObject, Action {
+/// - Note: `final` and `@unchecked Sendable` to satisfy `Action`'s `Sendable` requirement. The
+///   hosted UI session state is established before the action runs.
+final class ShowHostedUISignIn: NSObject, Action, @unchecked Sendable {
 
-    var identifier: String = "ShowHostedUISignIn"
+    let identifier: String = "ShowHostedUISignIn"
 
     let signingInData: HostedUISigningInState
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/WebAuthn/PlatformWebAuthnCredentials.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignIn/WebAuthn/PlatformWebAuthnCredentials.swift
@@ -10,7 +10,9 @@ import Amplify
 import AuthenticationServices
 import Foundation
 
-protocol WebAuthnCredentialsProtocol {
+/// - Note: `Sendable` because the WebAuthn actions holding these conform to `Action`, which is
+///   `Sendable`.
+protocol WebAuthnCredentialsProtocol: Sendable {
     var presentationAnchor: AuthUIPresentationAnchor? { get }
 }
 
@@ -25,8 +27,11 @@ protocol CredentialAsserterProtocol: WebAuthnCredentialsProtocol {
 }
 
 // - MARK: WebAuthnCredentialsProtocol
+/// - Note: `final` and `@unchecked Sendable`: the two continuations are set immediately before the
+///   platform WebAuthn controller is presented and resumed from its delegate callbacks, so only one
+///   is live at a time.
 @available(iOS 17.4, macOS 13.5, visionOS 1.0, *)
-class PlatformWebAuthnCredentials: NSObject, WebAuthnCredentialsProtocol {
+final class PlatformWebAuthnCredentials: NSObject, WebAuthnCredentialsProtocol, @unchecked Sendable {
     private enum OperationType: String {
         case assert
         case register

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignOut/ShowHostedUISignOut.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Actions/SignOut/ShowHostedUISignOut.swift
@@ -9,9 +9,10 @@ import Amplify
 import AuthenticationServices
 import Foundation
 
-class ShowHostedUISignOut: NSObject, Action {
+/// - Note: `final` and `@unchecked Sendable` to satisfy `Action`'s `Sendable` requirement.
+final class ShowHostedUISignOut: NSObject, Action, @unchecked Sendable {
 
-    var identifier: String = "ShowHostedUISignOut"
+    let identifier: String = "ShowHostedUISignOut"
 
     let signOutEvent: SignOutEventData
     let signInData: SignedInData

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/CredentialStoreOperationClient.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/CredentialStorage/CredentialStoreOperationClient.swift
@@ -9,7 +9,9 @@ import Amplify
 import Foundation
 @_spi(KeychainStore) import AWSPluginsCore
 
-protocol CredentialStoreStateBehavior {
+/// - Note: `Sendable` because the plugin holds this across task boundaries; the concrete client
+///   serializes all CRUD through a `TaskQueue`.
+protocol CredentialStoreStateBehavior: Sendable {
 
     func fetchData(type: CredentialStoreDataType) async throws -> CredentialStoreData
     func storeData(data: CredentialStoreData) async throws
@@ -17,7 +19,7 @@ protocol CredentialStoreStateBehavior {
 
 }
 
-class CredentialStoreOperationClient: CredentialStoreStateBehavior {
+final class CredentialStoreOperationClient: CredentialStoreStateBehavior {
 
     private let credentialStoreStateMachine: CredentialStoreStateMachine
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/AuthorizationEnvironment.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/AuthorizationEnvironment.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol AuthorizationEnvironment: Environment {
 
-    typealias CognitoIdentityFactory = () throws -> CognitoIdentityBehavior
+    typealias CognitoIdentityFactory = @Sendable () throws -> CognitoIdentityBehavior
     var identityPoolConfiguration: IdentityPoolConfigurationData { get }
     var cognitoIdentityFactory: CognitoIdentityFactory { get }
     var eventIDFactory: EventIDFactory { get }
@@ -18,7 +18,7 @@ protocol AuthorizationEnvironment: Environment {
 
 struct BasicAuthorizationEnvironment: AuthorizationEnvironment {
 
-    typealias CognitoIdentityFactory = () throws -> CognitoIdentityBehavior
+    typealias CognitoIdentityFactory = @Sendable () throws -> CognitoIdentityBehavior
 
     // Required
     let identityPoolConfiguration: IdentityPoolConfigurationData

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/CredentialStoreEnvironment.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/CredentialStoreEnvironment.swift
@@ -15,8 +15,8 @@ struct CredentialEnvironment: Environment, LoggerProvider {
 }
 
 protocol CredentialStoreEnvironment: Environment {
-    typealias AmplifyAuthCredentialStoreFactory = () -> AmplifyAuthCredentialStoreBehavior
-    typealias KeychainStoreFactory = (_ service: String) -> KeychainStoreBehavior
+    typealias AmplifyAuthCredentialStoreFactory = @Sendable () -> AmplifyAuthCredentialStoreBehavior
+    typealias KeychainStoreFactory = @Sendable (_ service: String) -> KeychainStoreBehavior
 
     var amplifyCredentialStoreFactory: AmplifyAuthCredentialStoreFactory { get }
     var legacyKeychainStoreFactory: KeychainStoreFactory { get }
@@ -25,8 +25,8 @@ protocol CredentialStoreEnvironment: Environment {
 
 struct BasicCredentialStoreEnvironment: CredentialStoreEnvironment {
 
-    typealias AmplifyAuthCredentialStoreFactory = () -> AmplifyAuthCredentialStoreBehavior
-    typealias KeychainStoreFactory = (_ service: String) -> KeychainStoreBehavior
+    typealias AmplifyAuthCredentialStoreFactory = @Sendable () -> AmplifyAuthCredentialStoreBehavior
+    typealias KeychainStoreFactory = @Sendable (_ service: String) -> KeychainStoreBehavior
 
     // Required
     let amplifyCredentialStoreFactory: AmplifyAuthCredentialStoreFactory

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/HostedUIEnvironemt.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/HostedUIEnvironemt.swift
@@ -9,11 +9,11 @@ import Foundation
 
 protocol HostedUIEnvironment: Environment {
 
-    typealias HostedUISessionFactory = () -> HostedUISessionBehavior
+    typealias HostedUISessionFactory = @Sendable () -> HostedUISessionBehavior
 
-    typealias URLSessionFactory = () -> URLSession
+    typealias URLSessionFactory = @Sendable () -> URLSession
 
-    typealias RandomStringFactory = () -> RandomStringBehavior
+    typealias RandomStringFactory = @Sendable () -> RandomStringBehavior
 
     var configuration: HostedUIConfigurationData { get }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/IDFactory.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/IDFactory.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-typealias EventIDFactory = () -> String
+/// - Note: `@Sendable` because the factory lives on a `Sendable` environment.
+typealias EventIDFactory = @Sendable () -> String
 
 enum UUIDFactory {
     nonisolated(unsafe) static let factory: EventIDFactory = { UUID().uuidString }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/SRPAuthEnvironment.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/SRPAuthEnvironment.swift
@@ -7,8 +7,8 @@
 
 struct BasicSRPAuthEnvironment: SRPAuthEnvironment {
 
-    typealias SRPClientFactory = (String, String) throws -> SRPClientBehavior
-    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+    typealias SRPClientFactory = @Sendable (String, String) throws -> SRPClientBehavior
+    typealias CognitoUserPoolFactory = @Sendable () throws -> CognitoUserPoolBehavior
 
     // Required
     let userPoolConfiguration: UserPoolConfigurationData
@@ -55,7 +55,7 @@ enum SRPCommonConfig {
 }
 
 protocol SRPAuthEnvironment: Environment {
-    typealias SRPClientFactory = (String, String) throws -> SRPClientBehavior
+    typealias SRPClientFactory = @Sendable (String, String) throws -> SRPClientBehavior
 
     var eventIDFactory: EventIDFactory { get }
     var srpClientFactory: SRPClientFactory { get }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/UserPoolEnvironment.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Environment/UserPoolEnvironment.swift
@@ -9,11 +9,11 @@ import Foundation
 
 protocol UserPoolEnvironment: Environment {
 
-    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+    typealias CognitoUserPoolFactory = @Sendable () throws -> CognitoUserPoolBehavior
 
-    typealias CognitoUserPoolASFFactory = () -> AdvancedSecurityBehavior
+    typealias CognitoUserPoolASFFactory = @Sendable () -> AdvancedSecurityBehavior
 
-    typealias CognitoUserPoolAnalyticsHandlerFactory = () -> UserPoolAnalyticsBehavior
+    typealias CognitoUserPoolAnalyticsHandlerFactory = @Sendable () -> UserPoolAnalyticsBehavior
 
     var userPoolConfiguration: UserPoolConfigurationData { get }
     var cognitoUserPoolFactory: CognitoUserPoolFactory { get }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/HubEvents/AuthHubEventBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/HubEvents/AuthHubEventBehavior.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-protocol AuthHubEventBehavior {
+/// - Note: `Sendable` because the handler is stored on the plugin, which is `Sendable`.
+protocol AuthHubEventBehavior: Sendable {
 
     func sendUserSignedInEvent()
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/HubEvents/AuthHubEventHandler.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/HubEvents/AuthHubEventHandler.swift
@@ -8,7 +8,9 @@
 import Amplify
 import AWSPluginsCore
 
-class AuthHubEventHandler: AuthHubEventBehavior {
+/// - Note: `final` and `@unchecked Sendable`: the handler is held by the plugin and its listener
+///   token state is set up once during configuration.
+final class AuthHubEventHandler: AuthHubEventBehavior, @unchecked Sendable {
 
     var lastSendEventName: HubPayloadEventName?
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmSignInOptions.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Models/Options/AWSAuthConfirmSignInOptions.swift
@@ -7,7 +7,9 @@
 
 import Amplify
 
-public struct AWSAuthConfirmSignInOptions {
+// Explicit `Sendable`: Swift does not infer it for public types, and options are carried into the
+// plugin's async confirm-sign-in path.
+public struct AWSAuthConfirmSignInOptions: Sendable {
 
     /// User attributes to be passed in when confirming a sign with NEW_PASSWORD_REQUIRED challenge
     public let userAttributes: [AuthUserAttribute]?

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/FetchAuthSessionOperationHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/FetchAuthSessionOperationHelper.swift
@@ -10,7 +10,9 @@ import Amplify
 import AWSPluginsCore
 import Foundation
 
-class FetchAuthSessionOperationHelper {
+/// - Note: `final` and `@unchecked Sendable`: the helper is used from detached auth tasks and its
+///   state is confined to a single fetch.
+final class FetchAuthSessionOperationHelper: @unchecked Sendable {
 
     typealias FetchAuthSessionCompletion = (Result<AuthSession, AuthError>) -> Void
     var environment: Environment?

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/UpdateAttributesOperationHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Operations/Helpers/UpdateAttributesOperationHelper.swift
@@ -11,7 +11,7 @@ import AWSPluginsCore
 
 enum UpdateAttributesOperationHelper {
 
-    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+    typealias CognitoUserPoolFactory = @Sendable () throws -> CognitoUserPoolBehavior
 
     static func update(
         attributes: [AuthUserAttribute],

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Request/AuthClearFederationToIdentityPoolRequest.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Request/AuthClearFederationToIdentityPoolRequest.swift
@@ -21,7 +21,7 @@ public struct AuthClearFederationToIdentityPoolRequest: AmplifyOperationRequest 
 
 public extension AuthClearFederationToIdentityPoolRequest {
 
-    struct Options {
+    struct Options: Sendable {
 
         public init() { }
     }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Request/AuthFederateToIdentityPoolRequest.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Request/AuthFederateToIdentityPoolRequest.swift
@@ -31,7 +31,7 @@ public struct AuthFederateToIdentityPoolRequest: AmplifyOperationRequest {
 
 public extension AuthFederateToIdentityPoolRequest {
 
-    struct Options {
+    struct Options: Sendable {
 
         public let developerProvidedIdentityID: String?
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/CognitoUserPoolBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/CognitoUserPoolBehavior.swift
@@ -8,7 +8,9 @@
 import AWSCognitoIdentityProvider
 import ClientRuntime
 
-protocol CognitoUserPoolBehavior {
+/// - Note: `Sendable` because the environment holding this factory is `Sendable` and actions reach
+///   the client from detached tasks.
+protocol CognitoUserPoolBehavior: Sendable {
 
     /// Throws InitiateAuthOutputError
     func initiateAuth(input: InitiateAuthInput) async throws -> InitiateAuthOutput

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/AuthErrorConvertible.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/ErrorMapping/AuthErrorConvertible.swift
@@ -10,7 +10,8 @@ import Foundation
 
 /// A type that can be represented as an AuthError
 ///
-protocol AuthErrorConvertible {
+/// - Note: `Sendable` because these errors are thrown out of actor-isolated auth work.
+protocol AuthErrorConvertible: Sendable {
     var authError: AuthError { get }
 }
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/Helpers/SignInResponseBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Service/Helpers/SignInResponseBehavior.swift
@@ -8,7 +8,9 @@
 import Amplify
 import AWSCognitoIdentityProvider
 
-protocol SignInResponseBehavior {
+/// - Note: `Sendable` because sign-in responses are carried on state machine events, which are
+///   `Sendable`.
+protocol SignInResponseBehavior: Sendable {
 
     /// The result returned by the server in response to the request to respond to the authentication challenge.
     var authenticationResult: CognitoIdentityProviderClientTypes.AuthenticationResultType? { get }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/CustomEndpoint/AWSEndpointResolving.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/CustomEndpoint/AWSEndpointResolving.swift
@@ -13,13 +13,14 @@ struct AWSEndpointResolving: AWSCognitoIdentityProvider.EndpointResolver {
         try endpoint()
     }
 
-    let endpoint: () throws -> SmithyHTTPAPI.Endpoint
+    // `@Sendable` so this resolver can satisfy the AWS SDK's `Sendable` requirement.
+    let endpoint: @Sendable () throws -> SmithyHTTPAPI.Endpoint
 
-    init(_ endpoint: @escaping () throws -> SmithyHTTPAPI.Endpoint) {
+    init(_ endpoint: @escaping @Sendable () throws -> SmithyHTTPAPI.Endpoint) {
         self.endpoint = endpoint
     }
 
-    init(_ endpoint: @escaping @autoclosure () throws -> SmithyHTTPAPI.Endpoint) {
+    init(_ endpoint: @escaping @autoclosure @Sendable () throws -> SmithyHTTPAPI.Endpoint) {
         self.endpoint = endpoint
     }
 }

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUIASWebAuthenticationSession.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUIASWebAuthenticationSession.swift
@@ -11,7 +11,9 @@ import Foundation
 @preconcurrency import AuthenticationServices
 #endif
 
-class HostedUIASWebAuthenticationSession: NSObject, HostedUISessionBehavior {
+/// - Note: `final` and `@unchecked Sendable` to satisfy `HostedUISessionBehavior`. The presentation
+///   anchor and session factory are assigned before the session is shown.
+final class HostedUIASWebAuthenticationSession: NSObject, HostedUISessionBehavior, @unchecked Sendable {
 
     weak var webPresentation: AuthUIPresentationAnchor?
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUISessionBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/HostedUISessionBehavior.swift
@@ -9,7 +9,9 @@ import Amplify
 import AuthenticationServices
 import Foundation
 
-protocol HostedUISessionBehavior {
+/// - Note: `Sendable` for the same reason as `RandomStringBehavior`: the session is produced by a
+///   `@Sendable` factory on the HostedUI environment.
+protocol HostedUISessionBehavior: Sendable {
 
     func showHostedUI(
         url: URL,

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/RandomStringBehavior.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Support/HostedUI/RandomStringBehavior.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
-protocol RandomStringBehavior {
+/// - Note: `Sendable` because the generator is produced by a `@Sendable` factory on the HostedUI
+///   environment, which is itself `Sendable`.
+protocol RandomStringBehavior: Sendable {
 
     func generateUUID() -> String
 

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthAutoSignInTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthAutoSignInTask.swift
@@ -9,7 +9,8 @@ import Amplify
 import AWSCognitoIdentityProvider
 import Foundation
 
-class AWSAuthAutoSignInTask: AuthAutoSignInTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthAutoSignInTask: AuthAutoSignInTask, DefaultLogger, @unchecked Sendable {
     private let request: AuthAutoSignInRequest
     private let authStateMachine: AuthStateMachine
     private let taskHelper: AWSAuthTaskHelper

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthChangePasswordTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthChangePasswordTask.swift
@@ -10,8 +10,9 @@ import AWSCognitoIdentityProvider
 import AWSPluginsCore
 import Foundation
 
-class AWSAuthChangePasswordTask: AuthChangePasswordTask, DefaultLogger {
-    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthChangePasswordTask: AuthChangePasswordTask, DefaultLogger, @unchecked Sendable {
+    typealias CognitoUserPoolFactory = @Sendable () throws -> CognitoUserPoolBehavior
 
     private let request: AuthChangePasswordRequest
     private let authStateMachine: AuthStateMachine

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthClearFederationToIdentityPoolTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthClearFederationToIdentityPoolTask.swift
@@ -18,8 +18,10 @@ public extension HubPayload.EventName.Auth {
     static let clearedFederationToIdentityPoolAPI = "Auth.federationToIdentityPoolCleared"
 }
 
-public class AWSAuthClearFederationToIdentityPoolTask: AuthClearFederationToIdentityPoolTask,
-                                                       DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+public final class AWSAuthClearFederationToIdentityPoolTask: AuthClearFederationToIdentityPoolTask,
+                                                             DefaultLogger,
+                                                             @unchecked Sendable {
     private let authStateMachine: AuthStateMachine
     private let clearFederationHelper: ClearFederationOperationHelper
     private let taskHelper: AWSAuthTaskHelper

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmResetPasswordTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmResetPasswordTask.swift
@@ -11,7 +11,8 @@ import AWSPluginsCore
 import ClientRuntime
 import Foundation
 
-class AWSAuthConfirmResetPasswordTask: AuthConfirmResetPasswordTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthConfirmResetPasswordTask: AuthConfirmResetPasswordTask, DefaultLogger, @unchecked Sendable {
     private let request: AuthConfirmResetPasswordRequest
     private let environment: AuthEnvironment
     private let authConfiguration: AuthConfiguration

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignInTask.swift
@@ -9,7 +9,8 @@ import Amplify
 import AWSPluginsCore
 import Foundation
 
-class AWSAuthConfirmSignInTask: AuthConfirmSignInTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthConfirmSignInTask: AuthConfirmSignInTask, DefaultLogger, @unchecked Sendable {
 
     private let request: AuthConfirmSignInRequest
     private let authStateMachine: AuthStateMachine

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignUpTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthConfirmSignUpTask.swift
@@ -9,7 +9,8 @@ import Amplify
 import AWSCognitoIdentityProvider
 import Foundation
 
-class AWSAuthConfirmSignUpTask: AuthConfirmSignUpTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthConfirmSignUpTask: AuthConfirmSignUpTask, DefaultLogger, @unchecked Sendable {
 
     private let request: AuthConfirmSignUpRequest
     private let authStateMachine: AuthStateMachine

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthDeleteUserTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthDeleteUserTask.swift
@@ -9,7 +9,8 @@ import Amplify
 import AWSPluginsCore
 import Foundation
 
-class AWSAuthDeleteUserTask: AuthDeleteUserTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthDeleteUserTask: AuthDeleteUserTask, DefaultLogger, @unchecked Sendable {
     private let authStateMachine: AuthStateMachine
     private let taskHelper: AWSAuthTaskHelper
     private let configuration: AuthConfiguration

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFederateToIdentityPoolTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFederateToIdentityPoolTask.swift
@@ -17,7 +17,8 @@ public extension HubPayload.EventName.Auth {
     static let federateToIdentityPoolAPI = "Auth.federatedToIdentityPool"
 }
 
-public class AWSAuthFederateToIdentityPoolTask: AuthFederateToIdentityPoolTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+public final class AWSAuthFederateToIdentityPoolTask: AuthFederateToIdentityPoolTask, DefaultLogger, @unchecked Sendable {
 
     private let request: AuthFederateToIdentityPoolRequest
     private let authStateMachine: AuthStateMachine

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFetchSessionTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthFetchSessionTask.swift
@@ -9,7 +9,8 @@ import Amplify
 import Foundation
 @_spi(KeychainStore) import AWSPluginsCore
 
-class AWSAuthFetchSessionTask: AuthFetchSessionTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthFetchSessionTask: AuthFetchSessionTask, DefaultLogger, @unchecked Sendable {
     private let request: AuthFetchSessionRequest
     private let authStateMachine: AuthStateMachine
     private let fetchAuthSessionHelper: FetchAuthSessionOperationHelper

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResendSignUpCodeTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResendSignUpCodeTask.swift
@@ -11,7 +11,8 @@ import AWSPluginsCore
 import ClientRuntime
 import Foundation
 
-class AWSAuthResendSignUpCodeTask: AuthResendSignUpCodeTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthResendSignUpCodeTask: AuthResendSignUpCodeTask, DefaultLogger, @unchecked Sendable {
     private let request: AuthResendSignUpCodeRequest
     private let environment: AuthEnvironment
     private let authConfiguration: AuthConfiguration

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResetPasswordTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthResetPasswordTask.swift
@@ -11,7 +11,8 @@ import AWSPluginsCore
 import ClientRuntime
 import Foundation
 
-class AWSAuthResetPasswordTask: AuthResetPasswordTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthResetPasswordTask: AuthResetPasswordTask, DefaultLogger, @unchecked Sendable {
 
     private let request: AuthResetPasswordRequest
     private let environment: AuthEnvironment

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignInTask.swift
@@ -9,7 +9,8 @@ import Amplify
 import AWSPluginsCore
 import Foundation
 
-class AWSAuthSignInTask: AuthSignInTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthSignInTask: AuthSignInTask, DefaultLogger, @unchecked Sendable {
 
     private let request: AuthSignInRequest
     private let authStateMachine: AuthStateMachine

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignOutTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignOutTask.swift
@@ -8,7 +8,8 @@
 import Amplify
 import Foundation
 
-class AWSAuthSignOutTask: AuthSignOutTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthSignOutTask: AuthSignOutTask, DefaultLogger, @unchecked Sendable {
 
     private let request: AuthSignOutRequest
     private let authStateMachine: AuthStateMachine

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignUpTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthSignUpTask.swift
@@ -9,7 +9,8 @@ import Amplify
 import AWSCognitoIdentityProvider
 import Foundation
 
-class AWSAuthSignUpTask: AuthSignUpTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthSignUpTask: AuthSignUpTask, DefaultLogger, @unchecked Sendable {
 
     private let request: AuthSignUpRequest
     private let authStateMachine: AuthStateMachine

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthWebUISignInTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AWSAuthWebUISignInTask.swift
@@ -10,7 +10,8 @@ import Amplify
 import AWSPluginsCore
 import Foundation
 
-class AWSAuthWebUISignInTask: AuthWebUISignInTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthWebUISignInTask: AuthWebUISignInTask, DefaultLogger, @unchecked Sendable {
 
     private let helper: HostedUISignInHelper
     private let request: AuthWebUISignInRequest

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AssociateWebAuthnCredentialTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/AssociateWebAuthnCredentialTask.swift
@@ -11,8 +11,9 @@ import AuthenticationServices
 import AWSCognitoIdentityProvider
 import Foundation
 
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
 @available(iOS 17.4, macOS 13.5, visionOS 1.0, *)
-class AssociateWebAuthnCredentialTask: NSObject, AuthAssociateWebAuthnCredentialTask, DefaultLogger {
+final class AssociateWebAuthnCredentialTask: NSObject, AuthAssociateWebAuthnCredentialTask, DefaultLogger, @unchecked Sendable {
     private let request: AuthAssociateWebAuthnCredentialRequest
     private let authStateMachine: AuthStateMachine
     private let userPoolFactory: UserPoolEnvironment.CognitoUserPoolFactory

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeleteWebAuthnCredentialTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeleteWebAuthnCredentialTask.swift
@@ -10,7 +10,8 @@ import AWSCognitoIdentityProvider
 import AWSPluginsCore
 import Foundation
 
-class DeleteWebAuthnCredentialTask: AuthDeleteWebAuthnCredentialTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class DeleteWebAuthnCredentialTask: AuthDeleteWebAuthnCredentialTask, DefaultLogger, @unchecked Sendable {
     private let request: AuthDeleteWebAuthnCredentialRequest
     private let authStateMachine: AuthStateMachine
     private let userPoolFactory: UserPoolEnvironment.CognitoUserPoolFactory

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthFetchDevicesTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthFetchDevicesTask.swift
@@ -11,8 +11,9 @@ import AWSPluginsCore
 import ClientRuntime
 import Foundation
 
-class AWSAuthFetchDevicesTask: AuthFetchDevicesTask, DefaultLogger {
-    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthFetchDevicesTask: AuthFetchDevicesTask, DefaultLogger, @unchecked Sendable {
+    typealias CognitoUserPoolFactory = @Sendable () throws -> CognitoUserPoolBehavior
 
     private let request: AuthFetchDevicesRequest
     private let authStateMachine: AuthStateMachine

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthForgetDeviceTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthForgetDeviceTask.swift
@@ -11,7 +11,8 @@ import AWSPluginsCore
 import ClientRuntime
 import Foundation
 
-class AWSAuthForgetDeviceTask: AuthForgetDeviceTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthForgetDeviceTask: AuthForgetDeviceTask, DefaultLogger, @unchecked Sendable {
 
     private let request: AuthForgetDeviceRequest
     private let authStateMachine: AuthStateMachine

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthRememberDeviceTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/DeviceTasks/AWSAuthRememberDeviceTask.swift
@@ -11,7 +11,8 @@ import AWSPluginsCore
 import ClientRuntime
 import Foundation
 
-class AWSAuthRememberDeviceTask: AuthRememberDeviceTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthRememberDeviceTask: AuthRememberDeviceTask, DefaultLogger, @unchecked Sendable {
 
     private let request: AuthRememberDeviceRequest
     private let authStateMachine: AuthStateMachine

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/FetchMFAPreferenceTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/FetchMFAPreferenceTask.swift
@@ -20,9 +20,10 @@ public extension HubPayload.EventName.Auth {
     static let fetchMFAPreferenceAPI = "Auth.fetchMFAPreferenceAPI"
 }
 
-class FetchMFAPreferenceTask: AuthFetchMFAPreferenceTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class FetchMFAPreferenceTask: AuthFetchMFAPreferenceTask, DefaultLogger, @unchecked Sendable {
 
-    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+    typealias CognitoUserPoolFactory = @Sendable () throws -> CognitoUserPoolBehavior
 
     private let authStateMachine: AuthStateMachine
     private let userPoolFactory: CognitoUserPoolFactory

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/Helpers/AWSAuthTaskHelper.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/Helpers/AWSAuthTaskHelper.swift
@@ -10,7 +10,8 @@ import AWSCognitoIdentityProvider
 import AWSPluginsCore
 import Foundation
 
-class AWSAuthTaskHelper: DefaultLogger {
+/// - Note: `final` and `Sendable`: the helper only holds a state machine reference.
+final class AWSAuthTaskHelper: DefaultLogger, Sendable {
 
     private let authStateMachine: AuthStateMachine
     private let fetchAuthSessionHelper: FetchAuthSessionOperationHelper

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/ListWebAuthnCredentialsTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/ListWebAuthnCredentialsTask.swift
@@ -10,7 +10,8 @@ import AWSCognitoIdentityProvider
 import AWSPluginsCore
 import Foundation
 
-class ListWebAuthnCredentialsTask: AuthListWebAuthnCredentialsTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class ListWebAuthnCredentialsTask: AuthListWebAuthnCredentialsTask, DefaultLogger, @unchecked Sendable {
     private let request: AuthListWebAuthnCredentialsRequest
     private let authStateMachine: AuthStateMachine
     private let userPoolFactory: UserPoolEnvironment.CognitoUserPoolFactory

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/Protocols/AmplifyAuthTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/Protocols/AmplifyAuthTask.swift
@@ -8,7 +8,9 @@
 import Amplify
 import Foundation
 
-protocol AmplifyAuthTask {
+/// - Note: `Sendable` because tasks are executed from detached tasks by the plugin's client
+///   behavior layer.
+protocol AmplifyAuthTask: Sendable {
 
     associatedtype Success
     associatedtype Request

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/Protocols/AmplifyAuthTaskNonThrowing.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/Protocols/AmplifyAuthTaskNonThrowing.swift
@@ -8,7 +8,8 @@
 import Amplify
 import Foundation
 
-protocol AmplifyAuthTaskNonThrowing {
+/// - Note: `Sendable` for the same reason as `AmplifyAuthTask`.
+protocol AmplifyAuthTaskNonThrowing: Sendable {
 
     associatedtype Success
     associatedtype Request

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/SetUpTOTPTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/SetUpTOTPTask.swift
@@ -11,9 +11,10 @@ import AWSPluginsCore
 import ClientRuntime
 import Foundation
 
-class SetUpTOTPTask: AuthSetUpTOTPTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class SetUpTOTPTask: AuthSetUpTOTPTask, DefaultLogger, @unchecked Sendable {
 
-    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+    typealias CognitoUserPoolFactory = @Sendable () throws -> CognitoUserPoolBehavior
 
     private let authStateMachine: AuthStateMachine
     private let userPoolFactory: CognitoUserPoolFactory

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UpdateMFAPreferenceTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UpdateMFAPreferenceTask.swift
@@ -20,9 +20,10 @@ public extension HubPayload.EventName.Auth {
     static let updateMFAPreferenceAPI = "Auth.updateMFAPreferenceAPI"
 }
 
-class UpdateMFAPreferenceTask: AuthUpdateMFAPreferenceTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class UpdateMFAPreferenceTask: AuthUpdateMFAPreferenceTask, DefaultLogger, @unchecked Sendable {
 
-    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+    typealias CognitoUserPoolFactory = @Sendable () throws -> CognitoUserPoolBehavior
 
     private let smsPreference: MFAPreference?
     private let totpPreference: MFAPreference?

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthAttributeResendConfirmationCodeTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthAttributeResendConfirmationCodeTask.swift
@@ -10,8 +10,9 @@ import AWSCognitoIdentityProvider
 import AWSPluginsCore
 import Foundation
 
-class AWSAuthAttributeResendConfirmationCodeTask: AuthAttributeResendConfirmationCodeTask, DefaultLogger {
-    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthAttributeResendConfirmationCodeTask: AuthAttributeResendConfirmationCodeTask, DefaultLogger, @unchecked Sendable {
+    typealias CognitoUserPoolFactory = @Sendable () throws -> CognitoUserPoolBehavior
 
     private let request: AuthAttributeResendConfirmationCodeRequest
     private let authStateMachine: AuthStateMachine

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthConfirmUserAttributeTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthConfirmUserAttributeTask.swift
@@ -11,8 +11,9 @@ import AWSPluginsCore
 import ClientRuntime
 import Foundation
 
-class AWSAuthConfirmUserAttributeTask: AuthConfirmUserAttributeTask, DefaultLogger {
-    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthConfirmUserAttributeTask: AuthConfirmUserAttributeTask, DefaultLogger, @unchecked Sendable {
+    typealias CognitoUserPoolFactory = @Sendable () throws -> CognitoUserPoolBehavior
 
     private let request: AuthConfirmUserAttributeRequest
     private let authStateMachine: AuthStateMachine

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthFetchUserAttributeTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthFetchUserAttributeTask.swift
@@ -11,8 +11,9 @@ import AWSPluginsCore
 import ClientRuntime
 import Foundation
 
-class AWSAuthFetchUserAttributeTask: AuthFetchUserAttributeTask, DefaultLogger {
-    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthFetchUserAttributeTask: AuthFetchUserAttributeTask, DefaultLogger, @unchecked Sendable {
+    typealias CognitoUserPoolFactory = @Sendable () throws -> CognitoUserPoolBehavior
 
     private let request: AuthFetchUserAttributesRequest
     private let authStateMachine: AuthStateMachine

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthSendUserAttributeVerificationCodeTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthSendUserAttributeVerificationCodeTask.swift
@@ -10,8 +10,9 @@ import AWSCognitoIdentityProvider
 import AWSPluginsCore
 import Foundation
 
-class AWSAuthSendUserAttributeVerificationCodeTask: AuthSendUserAttributeVerificationCodeTask, DefaultLogger {
-    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthSendUserAttributeVerificationCodeTask: AuthSendUserAttributeVerificationCodeTask, DefaultLogger, @unchecked Sendable {
+    typealias CognitoUserPoolFactory = @Sendable () throws -> CognitoUserPoolBehavior
 
     private let request: AuthSendUserAttributeVerificationCodeRequest
     private let authStateMachine: AuthStateMachine

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthUpdateUserAttributeTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthUpdateUserAttributeTask.swift
@@ -10,8 +10,9 @@ import AWSCognitoIdentityProvider
 import AWSPluginsCore
 import Foundation
 
-class AWSAuthUpdateUserAttributeTask: AuthUpdateUserAttributeTask, DefaultLogger {
-    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthUpdateUserAttributeTask: AuthUpdateUserAttributeTask, DefaultLogger, @unchecked Sendable {
+    typealias CognitoUserPoolFactory = @Sendable () throws -> CognitoUserPoolBehavior
 
     private let request: AuthUpdateUserAttributeRequest
     private let authStateMachine: AuthStateMachine

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthUpdateUserAttributesTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/UserTasks/AWSAuthUpdateUserAttributesTask.swift
@@ -10,8 +10,9 @@ import AWSCognitoIdentityProvider
 import AWSPluginsCore
 import Foundation
 
-class AWSAuthUpdateUserAttributesTask: AuthUpdateUserAttributesTask, DefaultLogger {
-    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class AWSAuthUpdateUserAttributesTask: AuthUpdateUserAttributesTask, DefaultLogger, @unchecked Sendable {
+    typealias CognitoUserPoolFactory = @Sendable () throws -> CognitoUserPoolBehavior
 
     private let request: AuthUpdateUserAttributesRequest
     private let authStateMachine: AuthStateMachine

--- a/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/VerifyTOTPSetupTask.swift
+++ b/AmplifyPlugins/Auth/Sources/AWSCognitoAuthPlugin/Task/VerifyTOTPSetupTask.swift
@@ -11,9 +11,10 @@ import AWSPluginsCore
 import ClientRuntime
 import Foundation
 
-class VerifyTOTPSetupTask: AuthVerifyTOTPSetupTask, DefaultLogger {
+/// - Note: `final` and `@unchecked Sendable`: the task is constructed, run once, and discarded.
+final class VerifyTOTPSetupTask: AuthVerifyTOTPSetupTask, DefaultLogger, @unchecked Sendable {
 
-    typealias CognitoUserPoolFactory = () throws -> CognitoUserPoolBehavior
+    typealias CognitoUserPoolFactory = @Sendable () throws -> CognitoUserPoolBehavior
 
     private let request: VerifyTOTPSetupRequest
     private let authStateMachine: AuthStateMachine


### PR DESCRIPTION
Slice **24 of 38** in the Swift 6 language-mode migration — 59 file(s).

Stacked on `swift6/23-auth-statemachine-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.