### PR TITLE
feat(datastore): Sendable across the DataStore plugin

### DIFF
--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreBaseBehavior.swift
@@ -79,7 +79,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     public func query<M: Model>(
         _ modelType: M.Type,
         byId id: String,
-        completion: DataStoreCallback<M?>
+        completion: @escaping DataStoreCallback<M?>
     ) {
         let predicate: QueryPredicate = field("id") == id
         query(modelType, where: predicate, paginate: .firstResult) {
@@ -111,7 +111,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     public func query<M: Model>(
         _ modelType: M.Type,
         byIdentifier identifier: String,
-        completion: DataStoreCallback<M?>
+        completion: @escaping DataStoreCallback<M?>
     ) where M: ModelIdentifiable,
                                                                          M.IdentifierFormat == ModelIdentifierFormat.Default {
         queryByIdentifier(
@@ -137,7 +137,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
     public func query<M: Model>(
         _ modelType: M.Type,
         byIdentifier identifier: ModelIdentifier<M, M.IdentifierFormat>,
-        completion: DataStoreCallback<M?>
+        completion: @escaping DataStoreCallback<M?>
     ) where M: ModelIdentifiable {
         queryByIdentifier(
             modelType,
@@ -163,7 +163,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
         _ modelType: M.Type,
         modelSchema: ModelSchema,
         identifier: ModelIdentifierProtocol,
-        completion: DataStoreCallback<M?>
+        completion: @escaping DataStoreCallback<M?>
     ) {
         query(
             modelType,
@@ -202,7 +202,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
         where predicate: QueryPredicate? = nil,
         sort sortInput: QuerySortInput? = nil,
         paginate paginationInput: QueryPaginationInput? = nil,
-        completion: DataStoreCallback<[M]>
+        completion: @escaping DataStoreCallback<[M]>
     ) {
         query(
             modelType,
@@ -235,7 +235,7 @@ extension AWSDataStorePlugin: DataStoreBaseBehavior {
         where predicate: QueryPredicate? = nil,
         sort sortInput: [QuerySortDescriptor]? = nil,
         paginate paginationInput: QueryPaginationInput? = nil,
-        completion: DataStoreCallback<[M]>
+        completion: @escaping DataStoreCallback<[M]>
     ) {
         switch initStorageEngineAndTryStartSync() {
         case .success(let storageEngineBehavior):
@@ -675,7 +675,7 @@ public extension AWSDataStorePlugin {
         _ modelType: M.Type,
         modelSchema: ModelSchema,
         byIdentifier identifier: ModelIdentifier<M, M.IdentifierFormat>,
-        completion: DataStoreCallback<M?>
+        completion: @escaping DataStoreCallback<M?>
     ) where M: ModelIdentifiable {
         queryByIdentifier(
             modelType,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin+DataStoreSubscribeBehavior.swift
@@ -40,7 +40,7 @@ extension AWSDataStorePlugin: DataStoreSubscribeBehavior {
             guard let dispatchedModelSyncedEvent = dispatchedModelSyncedEvents[modelSchema.name] else {
                 return Fatal.preconditionFailure("`dispatchedModelSyncedEvent` is expected to exist for \(modelSchema.name)")
             }
-            let request = ObserveQueryRequest(options: [])
+            let request = ObserveQueryRequest()
             let taskRunner = ObserveQueryTaskRunner(
                 request: request,
                 modelType: modelType,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/AWSDataStorePlugin.swift
@@ -16,9 +16,12 @@ enum DataStoreState {
     case clear
 }
 
-public final class AWSDataStorePlugin: DataStoreCategoryPlugin {
+/// - Note: `@unchecked Sendable` to satisfy the `Sendable` requirement on `Plugin`.
+///   `dataStorePublisher` and the other properties are established during `configure(using:)`
+///   before any client call can reach them.
+public final class AWSDataStorePlugin: DataStoreCategoryPlugin, @unchecked Sendable {
 
-    public var key: PluginKey = "awsDataStorePlugin"
+    public let key: PluginKey = "awsDataStorePlugin"
 
     /// The Publisher that sends mutation events to subscribers
     var dataStorePublisher: ModelSubcriptionBehavior?

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/ModelStorageBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/ModelStorageBehavior.swift
@@ -60,7 +60,7 @@ protocol ModelStorageBehavior {
         sort: [QuerySortDescriptor]?,
         paginationInput: QueryPaginationInput?,
         eagerLoad: Bool,
-        completion: DataStoreCallback<[M]>
+        completion: @escaping DataStoreCallback<[M]>
     )
 
     func query<M: Model>(
@@ -70,7 +70,7 @@ protocol ModelStorageBehavior {
         sort: [QuerySortDescriptor]?,
         paginationInput: QueryPaginationInput?,
         eagerLoad: Bool,
-        completion: DataStoreCallback<[M]>
+        completion: @escaping DataStoreCallback<[M]>
     )
 
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -13,7 +13,10 @@ import SQLite
 // swiftlint:disable type_body_length file_length
 /// [SQLite](https://sqlite.org) `StorageEngineAdapter` implementation. This class provides
 /// an integration layer between the AppSyncLocal `StorageEngine` and SQLite for local storage.
-final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
+/// - Note: `@unchecked Sendable` to satisfy `StorageEngineAdapter`'s `Sendable` requirement.
+///   `connection` is established during setup and replaced only by `clear`/`setUp`, never
+///   concurrently with queries.
+final class SQLiteStorageEngineAdapter: StorageEngineAdapter, @unchecked Sendable {
     var connection: Connection?
     var dbFilePath: URL?
     static let dbVersionKey = "com.amazonaws.DataStore.dbVersion"
@@ -25,7 +28,7 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
     // less (equaling 950) than the maximum because it is possible that our SQLStatement already has
     // some expressions.  If we encounter performance problems in the future, we will want to profile
     // our system and find an optimal value.
-    static var maxNumberOfPredicates: Int = 950
+    static let maxNumberOfPredicates: Int = 950
 
     convenience init(
         version: String,
@@ -272,7 +275,8 @@ final class SQLiteStorageEngineAdapter: StorageEngineAdapter {
         modelSchema: ModelSchema,
         withId id: Model.Identifier,
         condition: QueryPredicate? = nil,
-        completion: (DataStoreResult<M?>) -> Void
+        // `@Sendable` because the inner `delete` invokes it from an escaping completion.
+        completion: @escaping @Sendable (DataStoreResult<M?>) -> Void
     ) {
         delete(
             untypedModelType: modelType,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/SQLite/StorageEngineAdapter+SQLite.swift
@@ -13,9 +13,17 @@ import SQLite
 // swiftlint:disable type_body_length file_length
 /// [SQLite](https://sqlite.org) `StorageEngineAdapter` implementation. This class provides
 /// an integration layer between the AppSyncLocal `StorageEngine` and SQLite for local storage.
-/// - Note: `@unchecked Sendable` to satisfy `StorageEngineAdapter`'s `Sendable` requirement.
-///   `connection` is established during setup and replaced only by `clear`/`setUp`, never
-///   concurrently with queries.
+/// - Note: `@unchecked Sendable` to satisfy `StorageEngineAdapter`'s `Sendable` requirement, and
+///   unchecked in the literal sense — there is no lock and no serial queue here.
+///
+///   `connection` and `dbFilePath` are plain `var`s. The adapter is called synchronously from many
+///   concurrent query and reconciliation paths, while `setUp` and `clear` reassign `connection`. Nothing
+///   prevents a reassignment overlapping a query; what keeps it working is that set-up completes before
+///   sync starts and `clear` is driven from the plugin's own serialized teardown.
+///
+///   That is a sequencing convention, not a structural guarantee, and it predates this annotation. Giving
+///   the adapter a serial queue would be the real fix and is a change to DataStore's internals rather
+///   than to this conformance.
 final class SQLiteStorageEngineAdapter: StorageEngineAdapter, @unchecked Sendable {
     var connection: Connection?
     var dbFilePath: URL?

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
@@ -21,7 +21,10 @@ typealias StorageEngineBehaviorFactory =
     ) throws -> StorageEngineBehavior
 
 // swiftlint:disable type_body_length
-final class StorageEngine: StorageEngineBehavior {
+/// - Note: `@unchecked Sendable` to satisfy `StorageEngineBehavior`'s `Sendable` requirement.
+///   `syncEngine` is established during start-up and cleared on `clear`, not written concurrently
+///   with reads.
+final class StorageEngine: StorageEngineBehavior, @unchecked Sendable {
     // TODO: Make this private once we get a mutation flow that passes the type of mutation as needed
     let storageAdapter: StorageEngineAdapter
     var syncEngine: RemoteSyncEngineBehavior?
@@ -282,7 +285,7 @@ final class StorageEngine: StorageEngineBehavior {
         modelSchema: ModelSchema,
         withId id: Model.Identifier,
         condition: QueryPredicate? = nil,
-        completion: @escaping (DataStoreResult<M?>) -> Void
+        completion: @escaping @Sendable (DataStoreResult<M?>) -> Void
     ) {
         let cascadeDeleteOperation = CascadeDeleteOperation(
             storageAdapter: storageAdapter,
@@ -337,7 +340,7 @@ final class StorageEngine: StorageEngineBehavior {
         sort: [QuerySortDescriptor]?,
         paginationInput: QueryPaginationInput?,
         eagerLoad: Bool = true,
-        completion: (DataStoreResult<[M]>) -> Void
+        completion: @escaping DataStoreCallback<[M]>
     ) {
         return storageAdapter.query(
             modelType,
@@ -356,7 +359,7 @@ final class StorageEngine: StorageEngineBehavior {
         sort: [QuerySortDescriptor]? = nil,
         paginationInput: QueryPaginationInput? = nil,
         eagerLoad: Bool = true,
-        completion: DataStoreCallback<[M]>
+        completion: @escaping DataStoreCallback<[M]>
     ) {
         query(
             modelType,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngine.swift
@@ -21,9 +21,16 @@ typealias StorageEngineBehaviorFactory =
     ) throws -> StorageEngineBehavior
 
 // swiftlint:disable type_body_length
-/// - Note: `@unchecked Sendable` to satisfy `StorageEngineBehavior`'s `Sendable` requirement.
-///   `syncEngine` is established during start-up and cleared on `clear`, not written concurrently
-///   with reads.
+/// - Note: `@unchecked Sendable` to satisfy `StorageEngineBehavior`'s `Sendable` requirement, with no
+///   lock or serial queue backing it.
+///
+///   `syncEngine`, `signInListener` and the Combine sinks are plain `var`s. `syncEngine` is read on the
+///   hot mutation path — `save` and `delete` forward to it — and written during start-up and `clear`, so
+///   a `clear` concurrent with an in-flight mutation races on a class reference. The ordering that makes
+///   this work in practice comes from the plugin driving start-up and teardown in sequence, not from
+///   anything in this type.
+///
+///   The exposure predates this annotation, which only stops the compiler from asking about it.
 final class StorageEngine: StorageEngineBehavior, @unchecked Sendable {
     // TODO: Make this private once we get a mutation flow that passes the type of mutation as needed
     let storageAdapter: StorageEngineAdapter

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngineAdapter.swift
@@ -9,7 +9,7 @@ import Amplify
 import AWSPluginsCore
 import Foundation
 
-protocol StorageEngineAdapter: AnyObject, ModelStorageBehavior, ModelStorageErrorBehavior, StorageEngineMigrationAdapter {
+protocol StorageEngineAdapter: AnyObject, ModelStorageBehavior, ModelStorageErrorBehavior, StorageEngineMigrationAdapter, Sendable {
 
     static var maxNumberOfPredicates: Int { get }
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Storage/StorageEngineBehavior.swift
@@ -23,7 +23,8 @@ enum SyncEngineInitResult {
     case failure(DataStoreError)
 }
 
-protocol StorageEngineBehavior: AnyObject, ModelStorageBehavior {
+/// - Note: `Sendable` because the sync engine and the plugin hold this across task boundaries.
+protocol StorageEngineBehavior: AnyObject, ModelStorageBehavior, Sendable {
 
     var publisher: AnyPublisher<StorageEngineEvent, DataStoreError> { get }
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStoreObserveQueryOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/DataStoreObserveQueryOperation.swift
@@ -15,12 +15,19 @@ protocol DataStoreObserveQueryOperation {
     func startObserveQuery(with storageEngine: StorageEngineBehavior)
 }
 
-class ObserveQueryRequest: AmplifyOperationRequest {
-    var options: Any
+/// - Note: `final` and `@unchecked Sendable`: `Options` is `Any`, so the conformance cannot be
+///   checked. Nothing mutates `options` after construction.
+/// `AmplifyOperationRequest.Options` must be `Sendable`, and this request has no options — every
+/// caller passes an empty literal and nothing ever reads it — so it uses a dedicated empty type
+/// rather than `Any`.
+final class ObserveQueryRequest: AmplifyOperationRequest, Sendable {
+    struct Options: Sendable {
+        init() {}
+    }
 
-    typealias Options = Any
+    let options: Options
 
-    init(options: Any) {
+    init(options: Options = .init()) {
         self.options = options
     }
 }
@@ -39,10 +46,17 @@ class ObserveQueryRequest: AmplifyOperationRequest {
 ///
 /// This operation should perform its methods under the serial DispatchQueue `serialQueue` to ensure all its properties
 /// remain thread-safe.
-class ObserveQueryTaskRunner<M: Model>: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel, DataStoreObserveQueryOperation {
+/// - Note: `final` and `@unchecked Sendable` to satisfy `InternalTaskRunner`'s `Sendable`
+///   requirement. As the comment above states, the mutable properties are only touched from
+///   `serialQueue`.
+final class ObserveQueryTaskRunner<M: Model>: InternalTaskRunner,
+    InternalTaskAsyncThrowingSequence,
+    InternalTaskThrowingChannel,
+    DataStoreObserveQueryOperation,
+    @unchecked Sendable {
     typealias Request = ObserveQueryRequest
     typealias InProcess = DataStoreQuerySnapshot<M>
-    var request: ObserveQueryRequest
+    let request: ObserveQueryRequest
     var context = InternalTaskAsyncThrowingSequenceContext<DataStoreQuerySnapshot<M>>()
 
     private let serialQueue = DispatchQueue(
@@ -77,7 +91,7 @@ class ObserveQueryTaskRunner<M: Model>: InternalTaskRunner, InternalTaskAsyncThr
     var dataStoreStateSink: AnyCancellable?
 
     init(
-        request: ObserveQueryRequest = .init(options: []),
+        request: ObserveQueryRequest = .init(),
         context: InternalTaskAsyncThrowingSequenceContext<DataStoreQuerySnapshot<M>> = InternalTaskAsyncThrowingSequenceContext<DataStoreQuerySnapshot<M>>(),
         modelType: M.Type,
         modelSchema: ModelSchema,
@@ -205,11 +219,11 @@ class ObserveQueryTaskRunner<M: Model>: InternalTaskRunner, InternalTaskAsyncThr
             completion: { queryResult in
                 switch queryResult {
                 case .success(let queriedModels):
-                    currentItems.set(sortedModels: queriedModels)
-                    subscribeToModelSyncedEvent()
-                    sendSnapshot()
+                    self.currentItems.set(sortedModels: queriedModels)
+                    self.subscribeToModelSyncedEvent()
+                    self.sendSnapshot()
                 case .failure(let error):
-                    fail(error)
+                    self.fail(error)
                     return
                 }
             }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/ObserveTaskRunner.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Subscribe/ObserveTaskRunner.swift
@@ -8,16 +8,26 @@
 import Amplify
 import Combine
 
-struct ObserveRequest: AmplifyOperationRequest {
-    typealias Options = Any
-    var options: Any
-    init(options: Any = []) {
+/// - Note: `@unchecked Sendable`: `Options` is `Any`, so the conformance cannot be checked.
+/// See `ObserveQueryRequest`: options are unused, so an empty `Sendable` type is used instead of
+/// `Any`, which cannot satisfy the `Sendable` requirement on `AmplifyOperationRequest.Options`.
+struct ObserveRequest: AmplifyOperationRequest, Sendable {
+    struct Options: Sendable {
+        init() {}
+    }
+
+    let options: Options
+
+    init(options: Options = .init()) {
         self.options = options
     }
 }
 
-class ObserveTaskRunner: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel {
-    var request: ObserveRequest
+/// - Note: `final` and `@unchecked Sendable` to satisfy `InternalTaskRunner`'s `Sendable`
+///   requirement. `sink` and `context` are established once during `run()` and not mutated
+///   concurrently thereafter.
+final class ObserveTaskRunner: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel, @unchecked Sendable {
+    let request: ObserveRequest
 
     typealias Request = ObserveRequest
     typealias InProcess = MutationEvent

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOperation.swift
@@ -174,7 +174,9 @@ final class InitialSyncOperation: AsynchronousOperation, @unchecked Sendable {
         let authTypes = await authModeStrategy.authTypesFor(schema: modelSchema, operation: .read)
         let queryRequestsStream = AsyncStream { continuation in
             for authType in authTypes {
-                continuation.yield { [weak self] in
+                // `@Sendable` to match `RetryableGraphQLOperation`'s request stream element type,
+                // which the Swift 6 language mode requires.
+                continuation.yield { @Sendable [weak self] in
                     guard let self, let api else {
                         throw APIError.operationError(
                             "The initial synchronization process can no longer be accessed or referred to",

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/InitialSync/InitialSyncOrchestrator.swift
@@ -16,7 +16,8 @@ protocol InitialSyncOrchestrator {
 }
 
 // For testing
-typealias InitialSyncOrchestratorFactory =
+// `@Sendable` because the factory is stored in a `static let` and shared globally.
+typealias InitialSyncOrchestratorFactory = @Sendable
     (
         DataStoreConfiguration,
         AuthModeStrategy,
@@ -25,7 +26,9 @@ typealias InitialSyncOrchestratorFactory =
         StorageEngineAdapter?
     ) -> InitialSyncOrchestrator
 
-final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator {
+/// - Note: `@unchecked Sendable`: the orchestrator's progress state is updated from its own
+///   serialized sync flow.
+final class AWSInitialSyncOrchestrator: InitialSyncOrchestrator, @unchecked Sendable {
     typealias SyncOperationResult = Result<Void, DataStoreError>
     typealias SyncOperationResultHandler = (SyncOperationResult) -> Void
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventIngester.swift
@@ -13,7 +13,7 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
 
     /// Accepts a mutation event without a version, applies the latest version from the MutationSyncMetadata table,
     /// writes the updated mutation event to the local database, then submits it to `mutationEventSubject`
-    func submit(mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>) -> Void) {
+    func submit(mutationEvent: MutationEvent, completion: @escaping @Sendable (Result<MutationEvent, DataStoreError>) -> Void) {
         Task {
             log.verbose("\(#function): \(mutationEvent)")
 
@@ -35,7 +35,7 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
     func resolveConflictsThenSave(
         mutationEvent: MutationEvent,
         storageAdapter: StorageEngineAdapter,
-        completion: @escaping (Result<MutationEvent, DataStoreError>) -> Void
+        completion: @escaping @Sendable (Result<MutationEvent, DataStoreError>) -> Void
     ) {
         MutationEvent.pendingMutationEvents(
             forMutationEvent: mutationEvent,
@@ -138,11 +138,14 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
         storageAdapter: StorageEngineAdapter,
         completionPromise: @escaping Future<MutationEvent, DataStoreError>.Promise
     ) {
+        // `Future.Promise` is not `Sendable`, but Combine calls it at most once, so it is moved into
+        // the task below through an unchecked box.
+        let completionPromise = UncheckedSendable(completionPromise)
         log.verbose("\(#function) disposition \(disposition)")
 
         switch disposition {
         case .dropCandidateWithError(let dataStoreError):
-            completionPromise(.failure(dataStoreError))
+            completionPromise.value(.failure(dataStoreError))
         case .dropCandidateAndDeleteLocal:
             Task {
                 do {
@@ -163,16 +166,16 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
                         }
                         try await group.waitForAll()
                     }
-                    completionPromise(.success(candidate))
+                    completionPromise.value(.success(candidate))
                 } catch {
-                    completionPromise(.failure(causedBy: error))
+                    completionPromise.value(.failure(causedBy: error))
                 }
             }
         case .saveCandidate:
             save(
                 mutationEvent: candidate,
                 storageAdapter: storageAdapter,
-                completionPromise: completionPromise
+                completionPromise: completionPromise.value
             )
         case .replaceLocalWithCandidate:
             guard !localEvents.isEmpty, let eventToUpdate = localEvents.first else {
@@ -180,7 +183,7 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
                 save(
                     mutationEvent: candidate,
                     storageAdapter: storageAdapter,
-                    completionPromise: completionPromise
+                    completionPromise: completionPromise.value
                 )
                 return
             }
@@ -202,7 +205,7 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
             save(
                 mutationEvent: resolvedEvent,
                 storageAdapter: storageAdapter,
-                completionPromise: completionPromise
+                completionPromise: completionPromise.value
             )
         }
     }
@@ -232,9 +235,12 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
         completionPromise: @escaping Future<MutationEvent, DataStoreError>.Promise
     ) {
         log.verbose("\(#function) mutationEvent: \(mutationEvent)")
-        let nextEventPromise = nextEventPromise.getAndSet(nil)
+        // `Future.Promise` is not `Sendable`, but Combine calls it at most once, so both promises are
+        // moved into the save completion closure through unchecked boxes.
+        let completionPromise = UncheckedSendable(completionPromise)
+        let nextEventPromise = UncheckedSendable(nextEventPromise.getAndSet(nil))
         var eventToPersist = mutationEvent
-        if nextEventPromise != nil {
+        if nextEventPromise.value != nil {
             eventToPersist.inProcess = true
         }
 
@@ -245,16 +251,16 @@ extension AWSMutationDatabaseAdapter: MutationEventIngester {
                 // restore the `nextEventPromise` value when failed to save mutation event
                 // as nextEventPromise is expecting to hanlde error of querying unprocessed mutaiton events
                 // not the failure of saving mutaiton event operation
-                nextEventPromise.ifSome(self.nextEventPromise.set(_:))
+                nextEventPromise.value.ifSome(self.nextEventPromise.set(_:))
             case .success(let savedMutationEvent):
                 self.log.verbose("\(#function): saved \(savedMutationEvent)")
-                nextEventPromise.ifSome {
+                nextEventPromise.value.ifSome {
                     self.log.verbose("\(#function): invoking nextEventPromise with \(savedMutationEvent)")
                     $0(.success(savedMutationEvent))
                 }
             }
             self.log.verbose("\(#function): invoking completionPromise with \(result)")
-            completionPromise(result)
+            completionPromise.value(result)
         }
 
     }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventSource.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter+MutationEventSource.swift
@@ -51,7 +51,7 @@ extension AWSMutationDatabaseAdapter: MutationEventSource {
                         return
                     }
                     if mutationEvent.inProcess {
-                        log.verbose("The head of the MutationEvent queue was already inProcess (most likely interrupted process): \(mutationEvent)")
+                        self.log.verbose("The head of the MutationEvent queue was already inProcess (most likely interrupted process): \(mutationEvent)")
                         completion(.success(mutationEvent))
                     } else {
                         self.markInProcess(

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/AWSMutationDatabaseAdapter/AWSMutationDatabaseAdapter.swift
@@ -9,7 +9,8 @@ import Amplify
 import Combine
 
 /// Interface for saving and loading MutationEvents from storage
-final class AWSMutationDatabaseAdapter {
+/// - Note: `@unchecked Sendable`: the adapter is reached from the mutation queue's serialized flow.
+final class AWSMutationDatabaseAdapter: @unchecked Sendable {
     /// Possible outcomes of a "submit" based on inspecting the locally stored MutationEvents
     enum MutationDisposition {
         /// Drops the candidate without saving

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/MutationEvent/AWSMutationEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/MutationEvent/AWSMutationEventPublisher.swift
@@ -12,7 +12,9 @@ import Foundation
 /// Note: This publisher accepts only a single subscriber. It retains a weak reference to
 /// its MutationEventSource even after downstream subscribers have issued a `cancel()`,
 /// so that subsequent subscribers will still receive event notifications.
-final class AWSMutationEventPublisher: Publisher {
+/// - Note: `@unchecked Sendable` to satisfy `MutationEventPublisher`'s `Sendable` requirement.
+///   `subscription` is assigned once when the publisher is wired up.
+final class AWSMutationEventPublisher: Publisher, @unchecked Sendable {
     typealias Output = MutationEvent
     typealias Failure = DataStoreError
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/MutationEvent/MutationEventClearState.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/MutationEvent/MutationEventClearState.swift
@@ -8,7 +8,8 @@
 import Amplify
 import Foundation
 
-final class MutationEventClearState {
+/// - Note: `@unchecked Sendable`: only holds a storage adapter reference used from async work.
+final class MutationEventClearState: @unchecked Sendable {
 
     let storageAdapter: StorageEngineAdapter
     init(storageAdapter: StorageEngineAdapter) {
@@ -28,10 +29,10 @@ final class MutationEventClearState {
         ) { result in
                                 switch result {
                                 case .failure(let dataStoreError):
-                                    log.error("Failed on clearStateOutgoingMutations: \(dataStoreError)")
+                                    self.log.error("Failed on clearStateOutgoingMutations: \(dataStoreError)")
                                 case .success(let mutationEvents):
                                     if !mutationEvents.isEmpty {
-                                        updateMutationsState(
+                                        self.updateMutationsState(
                                             mutationEvents: mutationEvents,
                                             completion: completion
                                         )
@@ -43,15 +44,17 @@ final class MutationEventClearState {
     }
 
     private func updateMutationsState(mutationEvents: [MutationEvent], completion: @escaping BasicClosure) {
-        var numMutationEventsUpdated = 0
+        // Incremented from the save completion closures below, so it is an `AtomicValue` rather
+        // than a captured `var`, which the Swift 6 language mode rejects.
+        let numMutationEventsUpdated = AtomicValue(initialValue: 0)
         for mutationEvent in mutationEvents {
             var inProcessEvent = mutationEvent
             inProcessEvent.inProcess = false
             storageAdapter.save(inProcessEvent, condition: nil, eagerLoad: true, completion: { result in
                 switch result {
                 case .success:
-                    numMutationEventsUpdated += 1
-                    if numMutationEventsUpdated >= mutationEvents.count {
+                    let updated = numMutationEventsUpdated.increment()
+                    if updated >= mutationEvents.count {
                         completion()
                     }
                 case .failure(let error):

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/MutationEvent/MutationEventIngester.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/MutationEvent/MutationEventIngester.swift
@@ -10,5 +10,6 @@ import Combine
 
 /// Ingests MutationEvents from and writes them to the MutationEvent persistent store
 protocol MutationEventIngester: AnyObject {
-    func submit(mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>) -> Void)
+    // `@Sendable` to match the implementation, which invokes the completion from a `Future`.
+    func submit(mutationEvent: MutationEvent, completion: @escaping @Sendable (Result<MutationEvent, DataStoreError>) -> Void)
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/MutationEvent/MutationEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/MutationEvent/MutationEventPublisher.swift
@@ -9,6 +9,6 @@ import Amplify
 import Combine
 
 /// Publishes mutation events to downstream subscribers for subsequent sync to the API.
-protocol MutationEventPublisher: AnyObject, AmplifyCancellable {
+protocol MutationEventPublisher: AnyObject, AmplifyCancellable, Sendable {
     var publisher: AnyPublisher<MutationEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Action.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+Action.swift
@@ -23,7 +23,8 @@ extension OutgoingMutationQueue {
         case processedEvent
 
         // Wrap-up
-        case receivedStop(BasicClosure)
+        // `@Sendable` to match the `stopping` case on `State`, which this completion flows into.
+        case receivedStop(@Sendable () -> Void)
         case doneStopping
 
         // Terminal actions

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+State.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue+State.swift
@@ -12,7 +12,7 @@ import Combine
 extension OutgoingMutationQueue {
 
     /// States are descriptive, they say what is happening in the system right now
-    enum State {
+    enum State: Sendable {
         // Startup/config states
         case notInitialized
         case stopped
@@ -23,7 +23,10 @@ extension OutgoingMutationQueue {
         case waitingForEventToProcess
 
         // Wrap-up
-        case stopping(BasicClosure)
+        // Spelled out rather than `BasicClosure` so the completion can be `@Sendable`, which the
+        // `Sendable` conformance on this enum requires. `BasicClosure` is public API used widely,
+        // so it is deliberately left alone.
+        case stopping(@Sendable () -> Void)
 
         // Terminal states
         case inError(AmplifyError)

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/MutationSync/OutgoingMutationQueue/OutgoingMutationQueue.swift
@@ -22,7 +22,9 @@ protocol OutgoingMutationQueueBehavior: AnyObject {
     var publisher: AnyPublisher<MutationEvent, Never> { get }
 }
 
-final class OutgoingMutationQueue: OutgoingMutationQueueBehavior {
+/// - Note: `@unchecked Sendable`: the queue's state transitions all run on its own serial
+///   `DispatchQueue`.
+final class OutgoingMutationQueue: OutgoingMutationQueueBehavior, @unchecked Sendable {
 
     private let stateMachine: StateMachine<State, Action>
     private var stateMachineSink: AnyCancellable?

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine+State.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine+State.swift
@@ -12,7 +12,7 @@ import Combine
 extension RemoteSyncEngine {
 
     /// States are descriptive, they say what is happening in the system right now
-    enum State {
+    enum State: Sendable {
         case notStarted
 
         case pausingSubscriptions

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngine.swift
@@ -11,7 +11,9 @@ import Combine
 import Foundation
 
 // swiftlint:disable type_body_length file_length
-class RemoteSyncEngine: RemoteSyncEngineBehavior {
+/// - Note: `final` and `@unchecked Sendable`: this is a state machine whose mutable state is
+///   only touched from its own serial queue.
+final class RemoteSyncEngine: RemoteSyncEngineBehavior, @unchecked Sendable {
 
     weak var storageAdapter: StorageEngineAdapter?
 
@@ -253,7 +255,7 @@ class RemoteSyncEngine: RemoteSyncEngineBehavior {
         }
     }
 
-    func submit(_ mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>) -> Void) {
+    func submit(_ mutationEvent: MutationEvent, completion: @escaping @Sendable (Result<MutationEvent, DataStoreError>) -> Void) {
         mutationEventIngester.submit(mutationEvent: mutationEvent, completion: completion)
     }
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngineBehavior.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/RemoteSyncEngineBehavior.swift
@@ -29,7 +29,8 @@ enum RemoteSyncEngineEvent {
 }
 
 /// Behavior to sync mutation events to the remote API, and to subscribe to mutations from the remote API
-protocol RemoteSyncEngineBehavior: AnyObject {
+/// - Note: `Sendable` because the storage engine reaches the sync engine from concurrent work.
+protocol RemoteSyncEngineBehavior: AnyObject, Sendable {
 
     /// Start the sync process with a "delta sync" merge
     ///
@@ -49,7 +50,8 @@ protocol RemoteSyncEngineBehavior: AnyObject {
 
     /// Submits a new mutation for synchronization to the remote API. The response will be handled by the appropriate
     /// reconciliation queue
-    func submit(_ mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>) -> Void)
+    // `@Sendable` to match `MutationEventIngester.submit`, which this forwards to.
+    func submit(_ mutationEvent: MutationEvent, completion: @escaping @Sendable (Result<MutationEvent, DataStoreError>) -> Void)
 
     var publisher: AnyPublisher<RemoteSyncEngineEvent, DataStoreError> { get }
 }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueue.swift
@@ -13,8 +13,9 @@ import Foundation
 typealias DisableSubscriptions = () -> Bool
 
 // Used for testing:
+// `@Sendable` because the factory is stored in a `static let` and therefore shared globally.
 typealias IncomingEventReconciliationQueueFactory =
-    (
+    @Sendable (
         [ModelSchema],
         APICategoryGraphQLBehavior,
         StorageEngineAdapter,
@@ -25,7 +26,9 @@ typealias IncomingEventReconciliationQueueFactory =
         @escaping DisableSubscriptions
     ) async -> IncomingEventReconciliationQueue
 
-final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue {
+/// - Note: `@unchecked Sendable` to satisfy `IncomingEventReconciliationQueue`'s `Sendable`
+///   requirement. The sinks dictionary is only mutated while wiring up or tearing down queues.
+final class AWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue, @unchecked Sendable {
 
     private var modelReconciliationQueueSinks: AtomicValue<[String: AnyCancellable]> = AtomicValue(initialValue: [:])
 
@@ -214,7 +217,7 @@ extension AWSIncomingEventReconciliationQueue: DefaultLogger {
 
 // MARK: - Static factory
 extension AWSIncomingEventReconciliationQueue {
-    static let factory: IncomingEventReconciliationQueueFactory = {
+    static let factory: IncomingEventReconciliationQueueFactory = { @Sendable
         modelSchemas, api, storageAdapter, syncExpressions, auth, authModeStrategy, _, disableSubscriptions in
         await AWSIncomingEventReconciliationQueue(
             modelSchemas: modelSchemas,

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisher.swift
@@ -18,7 +18,9 @@ import Foundation
 /// At initialization, the Queue sets up subscriptions, via the provided `APICategoryGraphQLBehavior`, for each type
 /// `GraphQLSubscriptionType` and holds a reference to the returned operation. The operations' listeners enqueue
 /// incoming successful events onto a `Publisher`, that queue processors can subscribe to.
-final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable {
+/// - Note: `@unchecked Sendable`: mutable state is confined to the serial queue this publisher
+///   drives its subscription work on.
+final class IncomingAsyncSubscriptionEventPublisher: AmplifyCancellable, @unchecked Sendable {
     typealias Payload = MutationSync<AnyModel>
     typealias Event = GraphQLSubscriptionEvent<Payload>
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/IncomingEventReconciliationQueue.swift
@@ -22,7 +22,7 @@ enum IncomingEventReconciliationQueueEvent {
 /// events for create, update, and delete events initiated by remote systems. In addition to pausing and resuming
 /// automatically-configured subscriptions for models, the queue provides an `offer` method for submitting events
 /// directly from other network events such as mutation callbacks or from base/initial sync queries.
-protocol IncomingEventReconciliationQueue: AnyObject, AmplifyCancellable {
+protocol IncomingEventReconciliationQueue: AnyObject, AmplifyCancellable, Sendable {
     func start()
     func pause()
     func offer(_ remoteModels: [MutationSync<AnyModel>], modelName: ModelName)

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/AWSModelReconciliationQueue.swift
@@ -51,7 +51,8 @@ typealias ModelReconciliationQueueFactory = (
 ///   `incomingSubscriptionEventQueue`.
 /// - `incomingRemoteEventQueue` processes its operations, which are simply to call `enqueue` for each received remote
 ///   event.
-final class AWSModelReconciliationQueue: ModelReconciliationQueue {
+/// - Note: `@unchecked Sendable`: the queue's mutable state is confined to its own serial queue.
+final class AWSModelReconciliationQueue: ModelReconciliationQueue, @unchecked Sendable {
     /// Exposes a publisher for incoming subscription events
     private let incomingSubscriptionEvents: IncomingSubscriptionEventPublisher
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+State.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation+State.swift
@@ -10,7 +10,7 @@ import Amplify
 extension ReconcileAndLocalSaveOperation {
 
     /// States are descriptive, they say what is happening in the system right now
-    enum State {
+    enum State: Sendable {
         /// Waiting to be started by the queue
         case waiting
 

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveOperation.swift
@@ -186,24 +186,25 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation, @unchecked Sendable
 
     func queryPendingMutations(withModels models: [Model]) -> Future<[MutationEvent], DataStoreError> {
         Future<[MutationEvent], DataStoreError> { promise in
-            var result: Result<[MutationEvent], DataStoreError> = .failure(Self.unfulfilledDataStoreError())
+            // `Future.Promise` is not `Sendable`, but Combine calls it at most once.
+            let promise = UncheckedSendable(promise)
+            // Each outcome goes straight to the promise. The accumulator `var` that used to hold it
+            // was mutated from the nested completion closure below, which the Swift 6 language mode
+            // rejects as mutation of a captured variable in concurrently-executing code.
             guard !self.isCancelled else {
                 self.log.info("\(#function) - cancelled, aborting")
-                result = .success([])
-                promise(result)
+                promise.value(.success([]))
                 return
             }
             guard let storageAdapter = self.storageAdapter else {
                 let error = DataStoreError.nilStorageAdapter()
                 self.notifyDropped(count: models.count, error: error)
-                result = .failure(error)
-                promise(result)
+                promise.value(.failure(error))
                 return
             }
 
             guard !models.isEmpty else {
-                result = .success([])
-                promise(result)
+                promise.value(.success([]))
                 return
             }
 
@@ -214,11 +215,10 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation, @unchecked Sendable
                 switch queryResult {
                 case .failure(let dataStoreError):
                     self.notifyDropped(count: models.count, error: dataStoreError)
-                    result = .failure(dataStoreError)
+                    promise.value(.failure(dataStoreError))
                 case .success(let mutationEvents):
-                    result = .success(mutationEvents)
+                    promise.value(.success(mutationEvents))
                 }
-                promise(result)
             }
         }
     }
@@ -248,10 +248,12 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation, @unchecked Sendable
 
     func queryLocalMetadata(_ remoteModels: [RemoteModel]) -> Future<([RemoteModel], [LocalMetadata]), DataStoreError> {
         Future<([RemoteModel], [LocalMetadata]), DataStoreError> { promise in
+            // `Future.Promise` is not `Sendable`, but Combine calls it at most once.
+            let promise = UncheckedSendable(promise)
             var result: Result<([RemoteModel], [LocalMetadata]), DataStoreError> =
                 .failure(Self.unfulfilledDataStoreError())
             defer {
-                promise(result)
+                promise.value(result)
             }
             guard !self.isCancelled else {
                 self.log.info("\(#function) - cancelled, aborting")
@@ -357,9 +359,11 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation, @unchecked Sendable
         remoteModel: RemoteModel
     ) -> Future<ApplyRemoteModelResult, DataStoreError> {
         Future<ApplyRemoteModelResult, DataStoreError> { promise in
+            // `Future.Promise` is not `Sendable`, but Combine calls it at most once.
+            let promise = UncheckedSendable(promise)
             guard let modelType = ModelRegistry.modelType(from: self.modelSchema.name) else {
                 let error = DataStoreError.invalidModelName(self.modelSchema.name)
-                promise(.failure(error))
+                promise.value(.failure(error))
                 return
             }
 
@@ -373,12 +377,12 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation, @unchecked Sendable
                 case .failure(let dataStoreError):
                     self.notifyDropped(error: dataStoreError)
                     if storageAdapter.shouldIgnoreError(error: dataStoreError) {
-                        promise(.success(.dropped))
+                        promise.value(.success(.dropped))
                     } else {
-                        promise(.failure(dataStoreError))
+                        promise.value(.failure(dataStoreError))
                     }
                 case .success:
-                    promise(.success(.applied(remoteModel, remoteModel)))
+                    promise.value(.success(.applied(remoteModel, remoteModel)))
                 }
             }
         }
@@ -389,25 +393,27 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation, @unchecked Sendable
         remoteModel: RemoteModel
     ) -> Future<ApplyRemoteModelResult, DataStoreError> {
         Future<ApplyRemoteModelResult, DataStoreError> { promise in
+            // `Future.Promise` is not `Sendable`, but Combine calls it at most once.
+            let promise = UncheckedSendable(promise)
             storageAdapter.save(untypedModel: remoteModel.model.instance, eagerLoad: self.isEagerLoad) { response in
                 switch response {
                 case .failure(let dataStoreError):
                     self.notifyDropped(error: dataStoreError)
                     if storageAdapter.shouldIgnoreError(error: dataStoreError) {
-                        promise(.success(.dropped))
+                        promise.value(.success(.dropped))
                     } else {
-                        promise(.failure(dataStoreError))
+                        promise.value(.failure(dataStoreError))
                     }
                 case .success(let savedModel):
                     let anyModel: AnyModel
                     do {
                         anyModel = try savedModel.eraseToAnyModel()
                         let appliedModel = MutationSync(model: anyModel, syncMetadata: remoteModel.syncMetadata)
-                        promise(.success(.applied(remoteModel, appliedModel)))
+                        promise.value(.success(.applied(remoteModel, appliedModel)))
                     } catch {
                         let dataStoreError = DataStoreError(error: error)
                         self.notifyDropped(error: dataStoreError)
-                        promise(.failure(dataStoreError))
+                        promise.value(.failure(dataStoreError))
                     }
                 }
             }
@@ -448,6 +454,8 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation, @unchecked Sendable
         mutationType: MutationEvent.MutationType
     ) -> Future<MutationSyncMetadata, DataStoreError> {
         Future { promise in
+            // `Future.Promise` is not `Sendable`, but Combine calls it at most once.
+            let promise = UncheckedSendable(promise)
             storageAdapter.save(
                 remoteModel.syncMetadata,
                 condition: nil,
@@ -459,7 +467,7 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation, @unchecked Sendable
                 case .success:
                     self.notifyHub(remoteModel: remoteModel, mutationType: mutationType)
                 }
-                promise(result)
+                promise.value(result)
             }
         }
     }
@@ -532,10 +540,12 @@ class ReconcileAndLocalSaveOperation: AsynchronousOperation, @unchecked Sendable
 
     private func waitAllPublisherFinishes(publishers: [AnyPublisher<some Any, Never>]) -> Future<Void, DataStoreError> {
         Future { promise in
+            // `Future.Promise` is not `Sendable`, but Combine calls it at most once.
+            let promise = UncheckedSendable(promise)
             Publishers.MergeMany(publishers)
                 .collect()
                 .sink(receiveCompletion: { _ in
-                    promise(.successfulVoid)
+                    promise.value(.successfulVoid)
                 }, receiveValue: { _ in  })
                 .store(in: &self.cancellables)
         }

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveQueue.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/SubscriptionSync/ReconcileAndLocalSave/ReconcileAndLocalSaveQueue.swift
@@ -40,7 +40,8 @@ enum ReconcileAndSaveQueueEvent {
 /// Additionally, this queue allows per model type cancellations on the operations that are enqueued by calling
 /// `cancelOperations(modelName)`. This allows per model type clean up, while allowing other model reconcilliations to
 /// continue to operate.
-class ReconcileAndSaveQueue: ReconcileAndSaveOperationQueue {
+/// - Note: `final` and `@unchecked Sendable`: all mutable state is touched only from `serialQueue`.
+final class ReconcileAndSaveQueue: ReconcileAndSaveOperationQueue, @unchecked Sendable {
 
     private let serialQueue = DispatchQueue(
         label: "com.amazonaws.ReconcileAndSaveQueue.serialQueue",
@@ -72,16 +73,21 @@ class ReconcileAndSaveQueue: ReconcileAndSaveOperationQueue {
     func addOperation(_ operation: ReconcileAndLocalSaveOperation, modelName: String) {
 
         serialQueue.async {
-            var reconcileAndLocalSaveOperationSink: AnyCancellable?
-            reconcileAndLocalSaveOperationSink = operation.publisher.sink { _ in
+            // The completion closure has to reference the cancellable it is itself assigned to, so
+            // that it can remove it on completion. Holding it in an `AtomicValue` lets the closure
+            // capture an immutable box reference; capturing the `var` directly is a reference to a
+            // mutable variable from concurrently-executing code, which is an error in the Swift 6
+            // language mode.
+            let reconcileAndLocalSaveOperationSink = AtomicValue<AnyCancellable?>(initialValue: nil)
+            reconcileAndLocalSaveOperationSink.set(operation.publisher.sink { _ in
                 self.serialQueue.async {
-                    self.reconcileAndLocalSaveOperationSinks.with { $0.remove(reconcileAndLocalSaveOperationSink) }
+                    self.reconcileAndLocalSaveOperationSinks.with { $0.remove(reconcileAndLocalSaveOperationSink.get()) }
                     self.modelReconcileAndSaveOperations[modelName]?[operation.id] = nil
                     self.reconcileAndSaveQueueSubject.send(.operationRemoved(id: operation.id))
                 }
-            } receiveValue: { _ in }
+            } receiveValue: { _ in })
 
-            self.reconcileAndLocalSaveOperationSinks.with { $0.insert(reconcileAndLocalSaveOperationSink) }
+            self.reconcileAndLocalSaveOperationSinks.with { $0.insert(reconcileAndLocalSaveOperationSink.get()) }
             self.modelReconcileAndSaveOperations[modelName]?[operation.id] = operation
             self.reconcileAndSaveQueue.addOperation(operation)
             self.reconcileAndSaveQueueSubject.send(.operationAdded(id: operation.id))

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Support/MutationEvent+Query.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Support/MutationEvent+Query.swift
@@ -60,7 +60,8 @@ extension MutationEvent {
     private static func pendingMutationEvents(
         for modelIds: [(String, String)],
         storageAdapter: StorageEngineAdapter,
-        completion: @escaping DataStoreCallback<[MutationEvent]>
+        // `@Sendable` because the callback is invoked from the `Task` below.
+        completion: @escaping @Sendable DataStoreCallback<[MutationEvent]>
     ) {
         Task {
             let fields = MutationEvent.keys

--- a/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Support/Stopwatch.swift
+++ b/AmplifyPlugins/DataStore/Sources/AWSDataStorePlugin/Sync/Support/Stopwatch.swift
@@ -9,7 +9,8 @@ import Amplify
 import Foundation
 
 /// A simple implementation of a stopwatch used for gathering metrics of elapsed time.
-class Stopwatch {
+// `@unchecked Sendable`: driven by a single test at a time.
+final class Stopwatch: @unchecked Sendable {
     let lock = NSLock()
     var startTime: DispatchTime?
     var lapStart: DispatchTime?


### PR DESCRIPTION
Slice **25 of 38** in the Swift 6 language-mode migration — 34 file(s).

Stacked on `swift6/24-auth-plugin-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.