### PR TITLE
feat(api): Sendable across the API plugin

### DIFF
--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/APIError+Unauthorized.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/APIError+Unauthorized.swift
@@ -31,10 +31,11 @@ extension APIError {
         rule.isUnauthorized(self)
     }
 
-    public struct UnauthorizedDetermining {
-        let isUnauthorized: (APIError) -> Bool
+    /// - Note: `Sendable` because `default` is a `static let`, which must be concurrency-safe.
+    public struct UnauthorizedDetermining: Sendable {
+        let isUnauthorized: @Sendable (APIError) -> Bool
 
-        public init(isUnauthenticated: @escaping (APIError) -> Bool) {
+        public init(isUnauthenticated: @escaping @Sendable (APIError) -> Bool) {
             self.isUnauthorized = isUnauthenticated
         }
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AWSAPIPlugin.swift
@@ -10,7 +10,10 @@ import AWSPluginsCore
 import Foundation
 import InternalAmplifyCredentials
 
-public final class AWSAPIPlugin: NSObject, APICategoryPlugin, AWSAPIAuthInformation {
+/// - Note: `@unchecked Sendable` to satisfy the `Sendable` requirement on `Plugin`. The service and
+///   configuration properties are populated during `configure(using:)` before any client call can
+///   reach them.
+public final class AWSAPIPlugin: NSObject, APICategoryPlugin, AWSAPIAuthInformation, @unchecked Sendable {
     /// Used for the default GraphQL API represented by the `data` category in `amplify_outputs.json`
     /// This constant is not used for APIs present in `amplifyconfiguration.json` since they always have names.
     public static let defaultGraphQLAPI = "defaultGraphQLAPI"

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeRequest.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeRequest.swift
@@ -9,12 +9,12 @@ import Amplify
 import Combine
 import Foundation
 
-public enum AppSyncRealTimeRequest {
+public enum AppSyncRealTimeRequest: Sendable {
     case connectionInit
     case start(StartRequest)
     case stop(String)
 
-    public struct StartRequest {
+    public struct StartRequest: Sendable {
         let id: String
         let data: String
         let auth: AppSyncRealTimeRequestAuth?

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeRequestAuth.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeRequestAuth.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum AppSyncRealTimeRequestAuth {
+public enum AppSyncRealTimeRequestAuth: Sendable {
     private static let jsonEncoder = JSONEncoder()
     private static let jsonDecoder = JSONDecoder()
 
@@ -15,18 +15,18 @@ public enum AppSyncRealTimeRequestAuth {
     case apiKey(ApiKey)
     case iam(IAM)
 
-    public struct AuthToken {
+    public struct AuthToken: Sendable {
         let host: String
         let authToken: String
     }
 
-    public struct ApiKey {
+    public struct ApiKey: Sendable {
         let host: String
         let apiKey: String
         let amzDate: String
     }
 
-    public struct IAM {
+    public struct IAM: Sendable {
         let host: String
         let authToken: String
         let securityToken: String

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeSubscription.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeSubscription.swift
@@ -18,7 +18,7 @@ import Foundation
 actor AppSyncRealTimeSubscription {
     static let jsonEncoder = JSONEncoder()
 
-    enum State {
+    enum State: Sendable {
         case none
         case subscribing
         case subscribed
@@ -28,7 +28,13 @@ actor AppSyncRealTimeSubscription {
     }
 
     /// internal state for tracking subscription status
-    private let state = CurrentValueSubject<State, Never>(.none)
+    /// Boxed because `CurrentValueSubject` is not `Sendable` and `deinit` is nonisolated, so it
+    /// cannot reach actor-isolated storage in the Swift 6 language mode.
+    private nonisolated let stateBox = UncheckedSendable(CurrentValueSubject<State, Never>(.none))
+
+    private nonisolated var state: CurrentValueSubject<State, Never> {
+        stateBox.value
+    }
 
     /// Set when subscribe() fails with a non-recoverable error (e.g. expired
     /// auth). A terminated subscription is not resubscribed on reconnect.

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeSubscription.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRealTimeSubscription.swift
@@ -28,8 +28,14 @@ actor AppSyncRealTimeSubscription {
     }
 
     /// internal state for tracking subscription status
-    /// Boxed because `CurrentValueSubject` is not `Sendable` and `deinit` is nonisolated, so it
-    /// cannot reach actor-isolated storage in the Swift 6 language mode.
+    ///
+    /// Boxed because `CurrentValueSubject` is not `Sendable` and `deinit` is nonisolated, so it cannot
+    /// reach actor-isolated storage in the Swift 6 language mode.
+    ///
+    /// The box is sound rather than merely convenient: `CurrentValueSubject` is documented as safe to
+    /// send values to and subscribe from concurrently, so the only thing the annotation suppresses is the
+    /// missing `Sendable` conformance, not an actual synchronization gap. The `let` also means the
+    /// reference itself never changes.
     private nonisolated let stateBox = UncheckedSendable(CurrentValueSubject<State, Never>(.none))
 
     private nonisolated var state: CurrentValueSubject<State, Never> {

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRequestInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncRequestInterceptor.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-protocol AppSyncRequestInterceptor {
+protocol AppSyncRequestInterceptor: Sendable {
     func interceptRequest(event: AppSyncRealTimeRequest, url: URL) async -> AppSyncRealTimeRequest
 }

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncWebSocketClientProtocol.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/AppSyncRealTimeClient/AppSyncWebSocketClientProtocol.swift
@@ -10,7 +10,9 @@ import Combine
 import Foundation
 @_spi(WebSocket) import AWSPluginsCore
 
-protocol AppSyncWebSocketClientProtocol: AnyObject {
+/// - Note: `Sendable` because the real-time client is an actor that holds this and drives it from
+///   detached tasks and nonisolated delegate callbacks.
+protocol AppSyncWebSocketClientProtocol: AnyObject, Sendable {
     var isConnected: Bool { get async }
     var publisher: AnyPublisher<WebSocketEvent, Never> { get async }
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListProvider.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Core/AppSyncListProvider.swift
@@ -10,7 +10,13 @@ import AWSPluginsCore
 import Foundation
 import Foundation
 
-public class AppSyncListProvider<Element: Model>: ModelListProvider {
+/// - Note: `@unchecked Sendable` because `Model` is `Sendable` and codegen'd models hold list
+///   providers, so this has to be `Sendable` for them to compile.
+///
+///   Same caveat as ``List`` and ``LazyReference``: `loadedState` and `limit` are mutated on load and
+///   are not synchronized, so two concurrent `load()` calls can both fetch. That predates this
+///   migration and is worth addressing on its own.
+public class AppSyncListProvider<Element: Model>: ModelListProvider, @unchecked Sendable {
 
     /// The API friendly name used to reference the API to call
     let apiName: String?

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/APIKeyAuthInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/APIKeyAuthInterceptor.swift
@@ -9,7 +9,9 @@ import Amplify
 import Foundation
 @_spi(WebSocket) import AWSPluginsCore
 
-class APIKeyAuthInterceptor {
+/// - Note: `final` and `@unchecked Sendable`: all state is `let`, but `getAuthHeader` is a
+///   non-`Sendable` closure produced by `authHeaderBuilder()`.
+final class APIKeyAuthInterceptor: @unchecked Sendable {
     private let apiKey: String
     private let getAuthHeader = authHeaderBuilder()
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/AuthTokenInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/AuthTokenInterceptor.swift
@@ -11,11 +11,12 @@ import Foundation
 
 /// General purpose authenticatication subscriptions interceptor for providers whose only
 /// requirement is to provide an authentication token via the "Authorization" header
-class AuthTokenInterceptor {
+/// - Note: `final` and `Sendable`: all state is `let` and the token closure is `@Sendable`.
+final class AuthTokenInterceptor: Sendable {
 
-    let getLatestAuthToken: () async throws -> String?
+    let getLatestAuthToken: @Sendable () async throws -> String?
 
-    init(getLatestAuthToken: @escaping () async throws -> String?) {
+    init(getLatestAuthToken: @escaping @Sendable () async throws -> String?) {
         self.getLatestAuthToken = getLatestAuthToken
     }
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Interceptor/SubscriptionInterceptor/IAMAuthInterceptor.swift
@@ -14,7 +14,9 @@ import InternalAmplifyCredentials
 import SmithyHTTPAPI
 import SmithyIdentity
 
-class IAMAuthInterceptor {
+/// - Note: `final` and `@unchecked Sendable`: all state is `let`, but
+///   `any AWSCredentialIdentityResolver` comes from the AWS SDK and is not declared `Sendable`.
+final class IAMAuthInterceptor: @unchecked Sendable {
 
     let authProvider: any AWSCredentialIdentityResolver
     let region: AWSRegionType

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/Operation/AWSGraphQLSubscriptionTaskRunner.swift
@@ -12,9 +12,13 @@ import Combine
 import InternalAmplifyCredentials
 
 
-public class AWSGraphQLSubscriptionTaskRunner<R>: InternalTaskRunner,
-                                                  InternalTaskAsyncThrowingSequence,
-                                                  InternalTaskThrowingChannel where R: Decodable, R: Sendable {
+/// - Note: `final` and `@unchecked Sendable` to satisfy `InternalTaskRunner`'s `Sendable`
+///   requirement. The mutable properties are established while starting the subscription and are
+///   not written concurrently thereafter.
+public final class AWSGraphQLSubscriptionTaskRunner<R>: InternalTaskRunner,
+                                                       InternalTaskAsyncThrowingSequence,
+                                                       InternalTaskThrowingChannel,
+                                                       @unchecked Sendable where R: Decodable, R: Sendable {
     public typealias Request = GraphQLOperationRequest<R>
     public typealias InProcess = GraphQLSubscriptionEvent<R>
 

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AWSOIDCAuthProvider.swift
@@ -8,9 +8,11 @@
 import AWSPluginsCore
 import Foundation
 
-class AWSOIDCAuthProvider {
+/// - Note: `final` and `Sendable` so `getLatestAuthToken` can be passed as a `@Sendable` closure
+///   to `AuthTokenInterceptor`.
+final class AWSOIDCAuthProvider: Sendable {
 
-    var authService: AWSAuthServiceBehavior
+    let authService: AWSAuthServiceBehavior
 
     init(authService: AWSAuthServiceBehavior) {
         self.authService = authService

--- a/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AppSyncRealTimeClientFactory.swift
+++ b/AmplifyPlugins/API/Sources/AWSAPIPlugin/SubscriptionFactory/AppSyncRealTimeClientFactory.swift
@@ -21,7 +21,7 @@ protocol AppSyncRealTimeClientFactoryProtocol {
     ) async throws -> AppSyncRealTimeClientProtocol
 }
 
-protocol AppSyncRealTimeClientProtocol {
+protocol AppSyncRealTimeClientProtocol: Sendable {
     func connect() async throws
     func disconnectWhenIdel() async
     func disconnect() async


### PR DESCRIPTION
Slice **26 of 38** in the Swift 6 language-mode migration — 14 file(s).

Stacked on `swift6/25-datastore-plugin-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.