### PR TITLE
feat(storage): Sendable across the Storage plugin

### DIFF
--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/AWSS3StoragePlugin.swift
@@ -14,7 +14,9 @@ import InternalAmplifyCredentials
 /// Plugin APIs for AWS S3.
 ///
 /// - Tag: AWSS3StoragePlugin
-public final class AWSS3StoragePlugin: StorageCategoryPlugin {
+/// - Note: `@unchecked Sendable` to satisfy the `Sendable` requirement on `Plugin`. The service,
+///   auth, and bucket properties are populated during `configure(using:)`.
+public final class AWSS3StoragePlugin: StorageCategoryPlugin, @unchecked Sendable {
 
     /// The default S3 storage service.
     var defaultStorageService: AWSS3StorageServiceBehavior! {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3Adapter.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3Adapter.swift
@@ -17,7 +17,9 @@ import ClientRuntime
 /// This class acts as a wrapper to expose AWSS3 functionality through an instance over a singleton,
 /// and allows for mocking in unit tests. The methods contain no other logic other than calling the
 /// same method using the AWSS3 instance.
-class AWSS3Adapter: AWSS3Behavior {
+/// - Note: `@unchecked Sendable`: the adapter wraps an AWS SDK client that is safe to
+///   share, and it is reached from concurrent transfer work.
+class AWSS3Adapter: AWSS3Behavior, @unchecked Sendable {
     let awsS3: S3ClientProtocol
     let config: S3Client.S3ClientConfiguration
 
@@ -30,7 +32,7 @@ class AWSS3Adapter: AWSS3Behavior {
     /// - Parameters:
     ///   - request:: request identifying object
     ///   - completion: handle indicates when the operation is done
-    func deleteObject(_ request: AWSS3DeleteObjectRequest, completion: @escaping (Result<Void, StorageError>) -> Void) {
+    func deleteObject(_ request: AWSS3DeleteObjectRequest, completion: @escaping @Sendable (Result<Void, StorageError>) -> Void) {
         Task {
             let input = DeleteObjectInput(bucket: request.bucket, key: request.key)
             do {
@@ -46,7 +48,7 @@ class AWSS3Adapter: AWSS3Behavior {
     /// - Parameters:
     ///   - request: request identifying bucket and options
     ///   - completion: handle which return a result with list of items
-    func listObjectsV2(_ request: AWSS3ListObjectsV2Request, completion: @escaping (Result<StorageListResult, StorageError>) -> Void) {
+    func listObjectsV2(_ request: AWSS3ListObjectsV2Request, completion: @escaping @Sendable (Result<StorageListResult, StorageError>) -> Void) {
         Task {
             var finalPrefix: String?
             if let prefix = request.prefix {
@@ -80,7 +82,7 @@ class AWSS3Adapter: AWSS3Behavior {
     /// - Parameters:
     ///   - request: request
     ///   - completion: handler which returns a result with uploadId
-    func createMultipartUpload(_ request: CreateMultipartUploadRequest, completion: @escaping (Result<AWSS3CreateMultipartUploadResponse, StorageError>) -> Void) {
+    func createMultipartUpload(_ request: CreateMultipartUploadRequest, completion: @escaping @Sendable (Result<AWSS3CreateMultipartUploadResponse, StorageError>) -> Void) {
         Task {
             let input = CreateMultipartUploadInput(
                 bucket: request.bucket,
@@ -107,7 +109,7 @@ class AWSS3Adapter: AWSS3Behavior {
         }
     }
 
-    func listParts(bucket: String, key: String, uploadId: UploadID, completion: @escaping (Result<AWSS3ListUploadPartResponse, StorageError>) -> Void) {
+    func listParts(bucket: String, key: String, uploadId: UploadID, completion: @escaping @Sendable (Result<AWSS3ListUploadPartResponse, StorageError>) -> Void) {
         Task {
             let input = ListPartsInput(bucket: bucket, key: key, uploadId: uploadId)
             do {
@@ -127,7 +129,7 @@ class AWSS3Adapter: AWSS3Behavior {
     /// - Parameters:
     ///   - request: request which includes uploadId
     ///   - completion: handler which returns a result with object details
-    func completeMultipartUpload(_ request: AWSS3CompleteMultipartUploadRequest, completion: @escaping (Result<AWSS3CompleteMultipartUploadResponse, StorageError>) -> Void) {
+    func completeMultipartUpload(_ request: AWSS3CompleteMultipartUploadRequest, completion: @escaping @Sendable (Result<AWSS3CompleteMultipartUploadResponse, StorageError>) -> Void) {
         Task {
             let parts = request.parts.map {
                 S3ClientTypes.CompletedPart(eTag: $0.eTag, partNumber: $0.partNumber)
@@ -156,7 +158,7 @@ class AWSS3Adapter: AWSS3Behavior {
     /// - Parameters:
     ///   - request: request which includes uploadId
     ///   - completion: handler which indicates when the operation is done
-    func abortMultipartUpload(_ request: AWSS3AbortMultipartUploadRequest, completion: @escaping (Result<Void, StorageError>) -> Void) {
+    func abortMultipartUpload(_ request: AWSS3AbortMultipartUploadRequest, completion: @escaping @Sendable (Result<Void, StorageError>) -> Void) {
         Task {
             let input = AbortMultipartUploadInput(bucket: request.bucket, key: request.key, uploadId: request.uploadId)
             do {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3Behavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Dependency/AWSS3Behavior.swift
@@ -17,22 +17,22 @@ import ClientRuntime
 protocol AWSS3Behavior {
 
     // Deletes object.
-    func deleteObject(_ request: AWSS3DeleteObjectRequest, completion: @escaping (Result<Void, StorageError>) -> Void)
+    func deleteObject(_ request: AWSS3DeleteObjectRequest, completion: @escaping @Sendable (Result<Void, StorageError>) -> Void)
 
     // Lists objects in a bucket.
-    func listObjectsV2(_ request: AWSS3ListObjectsV2Request, completion: @escaping (Result<StorageListResult, StorageError>) -> Void)
+    func listObjectsV2(_ request: AWSS3ListObjectsV2Request, completion: @escaping @Sendable (Result<StorageListResult, StorageError>) -> Void)
 
     // Creates a Multipart Upload.
-    func createMultipartUpload(_ request: CreateMultipartUploadRequest, completion: @escaping (Result<AWSS3CreateMultipartUploadResponse, StorageError>) -> Void)
+    func createMultipartUpload(_ request: CreateMultipartUploadRequest, completion: @escaping @Sendable (Result<AWSS3CreateMultipartUploadResponse, StorageError>) -> Void)
 
     // Get list of uploaded parts (supports development)
-    func listParts(bucket: String, key: String, uploadId: UploadID, completion: @escaping (Result<ListPartsOutput, StorageError>) -> Void)
+    func listParts(bucket: String, key: String, uploadId: UploadID, completion: @escaping @Sendable (Result<ListPartsOutput, StorageError>) -> Void)
 
     // Completes a Multipart Upload.
-    func completeMultipartUpload(_ request: AWSS3CompleteMultipartUploadRequest, completion: @escaping (Result<AWSS3CompleteMultipartUploadResponse, StorageError>) -> Void)
+    func completeMultipartUpload(_ request: AWSS3CompleteMultipartUploadRequest, completion: @escaping @Sendable (Result<AWSS3CompleteMultipartUploadResponse, StorageError>) -> Void)
 
     // Aborts a Multipart Upload.
-    func abortMultipartUpload(_ request: AWSS3AbortMultipartUploadRequest, completion: @escaping (Result<Void, StorageError>) -> Void)
+    func abortMultipartUpload(_ request: AWSS3AbortMultipartUploadRequest, completion: @escaping @Sendable (Result<Void, StorageError>) -> Void)
 
     // Gets a client for AWS S3 Service.
     func getS3() -> S3ClientProtocol
@@ -40,7 +40,7 @@ protocol AWSS3Behavior {
 }
 
 extension AWSS3Behavior {
-    func listParts(bucket: String, key: String, uploadId: UploadID, completion: @escaping (Result<ListPartsOutput, StorageError>) -> Void) {
+    func listParts(bucket: String, key: String, uploadId: UploadID, completion: @escaping @Sendable (Result<ListPartsOutput, StorageError>) -> Void) {
         // do nothing
     }
 }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageService.swift
@@ -13,7 +13,9 @@ import Foundation
 @_spi(PluginHTTPClientEngine) import InternalAmplifyCredentials
 
 /// - Tag: AWSS3StorageService
-class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy {
+/// - Note: `@unchecked Sendable`: the service is held by the plugin and drives transfer
+///   work from detached tasks; its mutable state is established during configuration.
+class AWSS3StorageService: AWSS3StorageServiceBehavior, StorageServiceProxy, @unchecked Sendable {
 
     // resettable values
     private var authService: AWSAuthCredentialsProviderBehavior?

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageServiceBehavior.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Service/Storage/AWSS3StorageServiceBehavior.swift
@@ -11,26 +11,26 @@ import Foundation
 
 typealias AWSS3StorageServiceProvider = () throws -> AWSS3StorageServiceBehavior
 protocol AWSS3StorageServiceBehavior {
-    typealias StorageServiceDownloadEventHandler = (StorageServiceDownloadEvent) -> Void
+    typealias StorageServiceDownloadEventHandler = @Sendable (StorageServiceDownloadEvent) -> Void
     typealias StorageServiceDownloadEvent =
         StorageEvent<StorageTaskReference, Progress, Data?, StorageError>
 
     // swiftlint:disable:next type_name
-    typealias StorageServiceGetPreSignedURLEventHandler = (StorageServiceGetPreSignedURLEvent) -> Void
+    typealias StorageServiceGetPreSignedURLEventHandler = @Sendable (StorageServiceGetPreSignedURLEvent) -> Void
     typealias StorageServiceGetPreSignedURLEvent = StorageEvent<Void, Void, URL, StorageError>
 
-    typealias StorageServiceDeleteEventHandler = (StorageServiceDeleteEvent) -> Void
+    typealias StorageServiceDeleteEventHandler = @Sendable (StorageServiceDeleteEvent) -> Void
     typealias StorageServiceDeleteEvent = StorageEvent<Void, Void, Void, StorageError>
 
-    typealias StorageServiceListEventHandler = (StorageServiceListEvent) -> Void
+    typealias StorageServiceListEventHandler = @Sendable (StorageServiceListEvent) -> Void
     typealias StorageServiceListEvent = StorageEvent<Void, Void, StorageListResult, StorageError>
 
-    typealias StorageServiceUploadEventHandler = (StorageServiceUploadEvent) -> Void
+    typealias StorageServiceUploadEventHandler = @Sendable (StorageServiceUploadEvent) -> Void
     typealias StorageServiceUploadEvent =
         StorageEvent<StorageTaskReference, Progress, Void, StorageError>
 
     // swiftlint:disable:next type_name
-    typealias StorageServiceMultiPartUploadEventHandler = (StorageServiceMultiPartUploadEvent) -> Void
+    typealias StorageServiceMultiPartUploadEventHandler = @Sendable (StorageServiceMultiPartUploadEvent) -> Void
     typealias StorageServiceMultiPartUploadEvent =
         StorageEvent<StorageTaskReference, Progress, Void, StorageError>
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/DefaultStorageTransferDatabase.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/DefaultStorageTransferDatabase.swift
@@ -11,7 +11,8 @@ import Foundation
 // swiftlint:disable line_length
 
 /// Default database implementation for ``StorageTransferDatabase`` protocol.
-class DefaultStorageTransferDatabase {
+/// - Note: `@unchecked Sendable`: persistence work is serialized on its own queue.
+class DefaultStorageTransferDatabase: @unchecked Sendable {
     enum Failure: Error {
         case notExists(fileURL: URL)
         case noData(fileURL: URL)
@@ -59,7 +60,7 @@ class DefaultStorageTransferDatabase {
 
     func recover(
         urlSession: StorageURLSession = URLSession.shared,
-        completionHandler: @escaping (Result<StorageTransferTaskPairs, Error>) -> Void
+        completionHandler: @escaping @Sendable (Result<StorageTransferTaskPairs, Error>) -> Void
     ) {
         queue.async { [weak self] in
             guard let self else { fatalError("self cannot be weak") }
@@ -155,7 +156,7 @@ class DefaultStorageTransferDatabase {
 
     private func loadTasksAndLinkSessions(
         urlSession: StorageURLSession = URLSession.shared,
-        completionHandler: @escaping (Result<StorageTransferTaskPairs, Error>) -> Void
+        completionHandler: @escaping @Sendable (Result<StorageTransferTaskPairs, Error>) -> Void
     ) {
         dispatchPrecondition(condition: .notOnQueue(.main))
         dispatchPrecondition(condition: .onQueue(queue))
@@ -176,7 +177,7 @@ class DefaultStorageTransferDatabase {
         // to also link these task so that delegate methods send events into StorageMultipartUploadSession to update
         // the lifecycle so that the process can be completed.
 
-        let sessionTaskHandler: (StorageSessionTasks) -> Void = { [weak self] sessionTasks in
+        let sessionTaskHandler: @Sendable (StorageSessionTasks) -> Void = { [weak self] sessionTasks in
             guard let self else { fatalError("self cannot be weak") }
 
             let pairs = linkTasksWithSessions(persistableTransferTasks: persistableTransferTasks, sessionTasks: sessionTasks)

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/FileSystem.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/FileSystem.swift
@@ -24,7 +24,8 @@ import Foundation
 ///
 /// * [File System Programming Guide](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html)
 /// // swiftlint:enable line_length
-class FileSystem {
+/// - Note: `@unchecked Sendable`: file work is dispatched to its own queue.
+class FileSystem: @unchecked Sendable {
     enum Failure: Error {
         case fatalError(errorDescription: String)
     }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageBackgroundEventsRegistry.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageBackgroundEventsRegistry.swift
@@ -14,8 +14,11 @@ import Foundation
 ///    independently of the Amplify Storage plugin and this function will indiciate if it will handle the given identifier.
 class StorageBackgroundEventsRegistry {
     typealias StorageBackgroundEventsContinuation = CheckedContinuation<Bool, Never>
-    static var identifier: String?
-    static var continuation: StorageBackgroundEventsContinuation?
+    // `nonisolated(unsafe)`: this is a process-wide handoff for URLSession background events, set
+    // and read from the app delegate on the main thread. There is no lock to point at, so the
+    // annotation records that the safety is by convention rather than enforced.
+    nonisolated(unsafe) static var identifier: String?
+    nonisolated(unsafe) static var continuation: StorageBackgroundEventsContinuation?
 
     /// Handles background events for URLSession on iOS.
     /// - Parameters:

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadClient.swift
@@ -18,7 +18,7 @@ protocol StorageMultipartUploadClient {
     func completeMultipartUpload(uploadId: UploadID) throws
     func abortMultipartUpload(uploadId: UploadID, error: Error?) throws
 
-    func cancelUploadTasks(taskIdentifiers: [TaskIdentifier], done: @escaping () -> Void)
+    func cancelUploadTasks(taskIdentifiers: [TaskIdentifier], done: @escaping @Sendable () -> Void)
 }
 
 extension StorageMultipartUploadClient {
@@ -32,7 +32,9 @@ protocol StorageCreateMultipartUploadResponse {
     var uploadId: UploadID? { get }
 }
 
-class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
+/// - Note: `@unchecked Sendable`: upload part work is dispatched to tasks that reach
+///   back into the client, and its state is confined to a single upload session.
+class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient, @unchecked Sendable {
     weak var serviceProxy: StorageServiceProxy?
 
     let fileSystem: FileSystem
@@ -112,7 +114,8 @@ class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
                   fatalError("Part number is required")
               }
 
-        let startUploadPart: (URL, URL) async -> Void = { [weak self] partialFileURL, preSignedURL in
+        // `@Sendable` because the result handler below captures this and calls it from a `Task`.
+        let startUploadPart: @Sendable (URL, URL) async -> Void = { [weak self] partialFileURL, preSignedURL in
             guard let self else { return }
             var request = URLRequest(url: preSignedURL)
             request.cachePolicy = .reloadIgnoringLocalCacheData
@@ -142,7 +145,7 @@ class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
             uploadTask.resume()
         }
 
-        let partialFileResultHandler: (Result<URL, Error>) -> Void = { [weak self] result in
+        let partialFileResultHandler: @Sendable (Result<URL, Error>) -> Void = { [weak self] result in
             guard let self else { return }
             Task {
                 do {
@@ -209,7 +212,7 @@ class DefaultStorageMultipartUploadClient: StorageMultipartUploadClient {
         }
     }
 
-    func cancelUploadTasks(taskIdentifiers: [TaskIdentifier], done: @escaping () -> Void) {
+    func cancelUploadTasks(taskIdentifiers: [TaskIdentifier], done: @escaping @Sendable () -> Void) {
         guard let service = serviceProxy else { return }
         service.unregister(taskIdentifiers: taskIdentifiers)
         service.urlSession.getActiveTasks { tasks in

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadSession.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageMultipartUploadSession.swift
@@ -25,7 +25,9 @@ enum StorageMultipartUploadBehavior {
 }
 
 // swiftlint:disable type_body_length
-class StorageMultipartUploadSession {
+/// - Note: `@unchecked Sendable`: the session's state transitions are serialized by its
+///   own queue.
+class StorageMultipartUploadSession: @unchecked Sendable {
     enum Failure: Error {
         case invalidStateTransition
         case partsNotDone

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageOperationReference.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageOperationReference.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
-class StorageTaskReference {
+/// - Note: `@unchecked Sendable`: the wrapped `URLSessionTask` is thread-safe and this
+///   reference is handed to event callbacks that run off the calling thread.
+class StorageTaskReference: @unchecked Sendable {
     let task: StorageTask
 
     init(_ task: StorageTransferTask) {

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageServiceProxy.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageServiceProxy.swift
@@ -8,7 +8,9 @@
 import Amplify
 import Foundation
 
-protocol StorageServiceProxy: AnyObject {
+/// - Note: `Sendable` because the multipart upload client captures the proxy in the tasks it uses
+///   to upload parts.
+protocol StorageServiceProxy: AnyObject, Sendable {
     var preSignedURLBuilder: AWSS3PreSignedURLBuilderBehavior! { get }
     var awsS3: AWSS3Behavior! { get }
     var urlSession: URLSession { get }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageServiceSessionDelegate.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageServiceSessionDelegate.swift
@@ -12,7 +12,9 @@ import AWSPluginsCore
 
 // MARK: - StorageServiceSessionDelegate -
 
-class StorageServiceSessionDelegate: NSObject {
+/// - Note: `@unchecked Sendable`: mutable state is established during setup and not written
+///   concurrently with reads.
+class StorageServiceSessionDelegate: NSObject, @unchecked Sendable {
     let identifier: String
     let logger: Logger
     weak var storageService: AWSS3StorageService?

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageSessionTask.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageSessionTask.swift
@@ -11,7 +11,9 @@ import Foundation
 
 typealias StorageSessionTasks = [StorageSessionTask]
 
-protocol StorageSessionTask {
+/// - Note: `Sendable` because these are handed to `StorageURLSession.getActiveTasks` completions,
+///   which run off the calling thread. `URLSessionTask` is thread-safe.
+protocol StorageSessionTask: Sendable {
     var state: URLSessionTask.State { get }
     var taskIdentifier: TaskIdentifier { get }
 

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageTransferDatabase.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageTransferDatabase.swift
@@ -16,7 +16,8 @@ import Foundation
 // swiftlint:disable line_length
 
 /// Database protocol which supports the recovery process.
-protocol StorageTransferDatabase {
+/// - Note: `Sendable` because the transfer database is reached from URLSession delegate callbacks.
+protocol StorageTransferDatabase: Sendable {
     func insertTransferRequest(task: StorageTransferTask)
 
     func updateTransferRequest(task: StorageTransferTask)
@@ -27,7 +28,7 @@ protocol StorageTransferDatabase {
 
     func defaultTransferType(persistableTransferTask: StoragePersistableTransferTask) -> StorageTransferType?
 
-    func recover(urlSession: StorageURLSession, completionHandler: @escaping (Result<StorageTransferTaskPairs, Error>) -> Void)
+    func recover(urlSession: StorageURLSession, completionHandler: @escaping @Sendable (Result<StorageTransferTaskPairs, Error>) -> Void)
 
     func attachEventHandlers(
         onUpload: AWSS3StorageServiceBehavior.StorageServiceUploadEventHandler?,

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageTransferTask.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageTransferTask.swift
@@ -9,7 +9,10 @@ import Amplify
 import AWSPluginsCore
 import Foundation
 
-class StorageTransferTask {
+/// - Note: `@unchecked Sendable`: a transfer task is handed to URLSession delegate
+///   callbacks and to the multipart upload path, both of which run off the calling thread. Its
+///   mutable state is written while the transfer is being set up.
+class StorageTransferTask: @unchecked Sendable {
     typealias Action = () -> Void
 
     let transferID: String

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageTransferType.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageTransferType.swift
@@ -151,11 +151,11 @@ enum StorageTransferType {
             return result
         }
 
-        private static var defaultGetPreSignedURLEvent: AWSS3StorageServiceBehavior.StorageServiceGetPreSignedURLEventHandler = { _ in  }
-        private static var defaultDownloadEvent: AWSS3StorageServiceBehavior.StorageServiceDownloadEventHandler = { _ in  }
-        private static var defaultUploadEvent: AWSS3StorageServiceBehavior.StorageServiceUploadEventHandler = { _ in }
-        private static var defaultMultiPartUploadEvent: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler = { _ in }
-        private static var defaultListEvent: AWSS3StorageServiceBehavior.StorageServiceListEventHandler = { _ in  }
-        private static var defaultRemoveEvent: AWSS3StorageServiceBehavior.StorageServiceDeleteEventHandler = { _ in  }
+        private static let defaultGetPreSignedURLEvent: AWSS3StorageServiceBehavior.StorageServiceGetPreSignedURLEventHandler = { _ in  }
+        private static let defaultDownloadEvent: AWSS3StorageServiceBehavior.StorageServiceDownloadEventHandler = { _ in  }
+        private static let defaultUploadEvent: AWSS3StorageServiceBehavior.StorageServiceUploadEventHandler = { _ in }
+        private static let defaultMultiPartUploadEvent: AWSS3StorageServiceBehavior.StorageServiceMultiPartUploadEventHandler = { _ in }
+        private static let defaultListEvent: AWSS3StorageServiceBehavior.StorageServiceListEventHandler = { _ in  }
+        private static let defaultRemoveEvent: AWSS3StorageServiceBehavior.StorageServiceDeleteEventHandler = { _ in  }
     }
 }

--- a/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageURLSession.swift
+++ b/AmplifyPlugins/Storage/Sources/AWSS3StoragePlugin/Support/Internal/StorageURLSession.swift
@@ -7,13 +7,15 @@
 
 import Foundation
 
-protocol StorageURLSession {
+/// - Note: `Sendable` because the session is held by the transfer machinery and reached from
+///   URLSession delegate callbacks.
+protocol StorageURLSession: Sendable {
     static var shared: StorageURLSession { get }
-    func getActiveTasks(resultHandler: @escaping (StorageSessionTasks) -> Void)
+    func getActiveTasks(resultHandler: @escaping @Sendable (StorageSessionTasks) -> Void)
 }
 
 extension URLSession: StorageURLSession {
-    func getActiveTasks(resultHandler: @escaping (StorageSessionTasks) -> Void) {
+    func getActiveTasks(resultHandler: @escaping @Sendable (StorageSessionTasks) -> Void) {
         getAllTasks { tasks in
             resultHandler(tasks)
         }


### PR DESCRIPTION
Slice **27 of 38** in the Swift 6 language-mode migration — 18 file(s).

Stacked on `swift6/26-api-plugin-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.