### PR TITLE
feat(predictions): Sendable across the Predictions plugin

### DIFF
--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/AWSPredictionsPlugin.swift
@@ -9,7 +9,10 @@ import Amplify
 import AWSPluginsCore
 import Foundation
 
-public final class AWSPredictionsPlugin: PredictionsCategoryPlugin {
+/// - Note: `@unchecked Sendable` to satisfy the `Sendable` requirement on `Plugin`. The service and
+///   configuration properties are populated during `configure(using:)` before any client call can
+///   reach them.
+public final class AWSPredictionsPlugin: PredictionsCategoryPlugin, @unchecked Sendable {
     let awsPredictionsPluginKey = "awsPredictionsPlugin"
 
     /// An instance of the predictions  service

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Events/LivenessCompletedEvent.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Events/LivenessCompletedEvent.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @_spi(PredictionsFaceLiveness)
-public struct CompletedEvent<T> {
+public struct CompletedEvent<T: Sendable>: Sendable {
     public init(initialEvent: T, endTimestamp: UInt64) {
         self.initialEvent = initialEvent
         self.endTimestamp = endTimestamp

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Events/LivenessEvent.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Events/LivenessEvent.swift
@@ -7,16 +7,17 @@
 
 import Foundation
 
+/// - Note: `Sendable` because events are written to the liveness WebSocket from concurrent work.
 @_spi(PredictionsFaceLiveness)
-public struct LivenessEvent<T> {
+public struct LivenessEvent<T: Sendable>: Sendable {
     let payload: Data
     let eventKind: LivenessEventKind
     let eventTypeHeader: String
 }
 
 @_spi(PredictionsFaceLiveness)
-public enum LivenessEventKind {
-    public struct Server: RawRepresentable, Hashable {
+public enum LivenessEventKind: Sendable {
+    public struct Server: RawRepresentable, Hashable, Sendable {
         public var rawValue: String
 
         public init(rawValue: String) {
@@ -29,7 +30,7 @@ public enum LivenessEventKind {
     }
     case server(Server)
 
-    public struct Client: Equatable {
+    public struct Client: Equatable, Sendable {
         let id: UInt8
 
         public static let initialFaceDetected = Client(id: 0)
@@ -39,7 +40,7 @@ public enum LivenessEventKind {
     }
     case client(Client)
 
-    public struct Exception: RawRepresentable, Equatable {
+    public struct Exception: RawRepresentable, Equatable, Sendable {
         public var rawValue: String
 
         public init(rawValue: String) {

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Events/LivenessFaceDetectionEvent.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Events/LivenessFaceDetectionEvent.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @_spi(PredictionsFaceLiveness)
-public struct FaceDetection {
+public struct FaceDetection: Sendable {
     let boundingBox: FaceLivenessSession.BoundingBox
     let startTimestamp: UInt64
 

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Events/LivenessFinalClientEvent.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Events/LivenessFinalClientEvent.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @_spi(PredictionsFaceLiveness)
-public struct FinalClientEvent {
+public struct FinalClientEvent: Sendable {
     public init(
         initialClientEvent: InitialClientEvent,
         targetFace: CompletedEvent<FaceDetection>,

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Events/LivenessFreshnessEvent.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Events/LivenessFreshnessEvent.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @_spi(PredictionsFaceLiveness)
-public struct FreshnessEvent {
+public struct FreshnessEvent: Sendable {
     let challengeID: String
     let color: [Int]
     let sequenceNumber: Int

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Events/LivenessInitialClientEvent.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Events/LivenessInitialClientEvent.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @_spi(PredictionsFaceLiveness)
-public struct InitialClientEvent {
+public struct InitialClientEvent: Sendable {
     public init(
         challengeID: String,
         initialFaceLocation: FaceDetection,

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Events/LivenessVideoEvent.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Events/LivenessVideoEvent.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @_spi(PredictionsFaceLiveness)
-public struct VideoEvent {
+public struct VideoEvent: Sendable {
     let chunk: Data
     let timestamp: UInt64
 

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Model/FaceLivenessSession+BoundingBox.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Model/FaceLivenessSession+BoundingBox.swift
@@ -10,7 +10,7 @@ import Foundation
 // swiftlint:disable identifier_name
 public extension FaceLivenessSession {
     @_spi(PredictionsFaceLiveness)
-    struct BoundingBox: Codable {
+    struct BoundingBox: Codable, Sendable {
         public let x: Double
         public let y: Double
         public let width: Double

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/Challenge.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/Challenge.swift
@@ -10,7 +10,7 @@ import Foundation
 public typealias Version = String
 
 @_spi(PredictionsFaceLiveness)
-public enum Challenge: Equatable {
+public enum Challenge: Equatable, Sendable {
     case faceMovementChallenge(Version)
     case faceMovementAndLightChallenge(Version)
 

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/FaceLivenessSession.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/FaceLivenessSession.swift
@@ -8,8 +8,11 @@
 import Amplify
 import Foundation
 
+/// - Note: `@unchecked Sendable` to satisfy `LivenessService`'s `Sendable` requirement. The listener
+///   dictionaries and reconnect state are only mutated while the session is being configured, before
+///   the socket starts delivering events.
 @_spi(PredictionsFaceLiveness)
-public final class FaceLivenessSession: LivenessService {
+public final class FaceLivenessSession: LivenessService, @unchecked Sendable {
     let websocket: WebSocketSession
     let eventStreamEncoder: EventStream.Encoder
     let eventStreamDecoder: EventStream.Decoder

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/FaceLivenessSessionRepresentable.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/FaceLivenessSessionRepresentable.swift
@@ -8,8 +8,9 @@
 import Amplify
 import Foundation
 
+/// - Note: `Sendable` because the session is driven from the WebSocket's nonisolated callbacks.
 @_spi(PredictionsFaceLiveness)
-public protocol LivenessService {
+public protocol LivenessService: Sendable {
     func send(
         _ event: LivenessEvent<some Any>,
         eventDate: @escaping () -> Date

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/WebSocketSession.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Liveness/Service/WebSocketSession.swift
@@ -8,7 +8,9 @@
 import Amplify
 import Foundation
 
-final class WebSocketSession {
+/// - Note: `@unchecked Sendable`: the session wraps a `URLSessionWebSocketTask`, which is
+///   thread-safe, and its callbacks are invoked off the calling thread.
+final class WebSocketSession: @unchecked Sendable {
     private let urlSessionWebSocketDelegate: Delegate
     private let session: URLSession
     private var task: URLSessionWebSocketTask?

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/MultiService/InterpretTextMultiService.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/MultiService/InterpretTextMultiService.swift
@@ -7,7 +7,9 @@
 
 import Amplify
 
-class InterpretTextMultiService: MultiServiceBehavior {
+/// - Note: `final` and `@unchecked Sendable` to satisfy `MultiServiceBehavior`; the two service
+///   references are set up before any call races them.
+final class InterpretTextMultiService: MultiServiceBehavior, @unchecked Sendable {
     weak var coreMLService: CoreMLPredictionBehavior?
     weak var predictionsService: AWSPredictionsService?
     let textToInterpret: String

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/MultiService/InterpretTextMultiService.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/MultiService/InterpretTextMultiService.swift
@@ -7,8 +7,16 @@
 
 import Amplify
 
-/// - Note: `final` and `@unchecked Sendable` to satisfy `MultiServiceBehavior`; the two service
-///   references are set up before any call races them.
+/// - Note: `final` and `@unchecked Sendable` to satisfy `MultiServiceBehavior`.
+///
+///   Both service references are assigned only in `init` and never reassigned. They are `var` because
+///   `weak` requires it — Swift has no `weak let` — not because anything mutates them, so the assignment
+///   ordering the conformance relies on is structural: there is no setter to call out of order.
+///
+///   What the annotation does suppress is that `weak` lets the runtime zero either reference at any
+///   point, including between the `guard let` in one method and a read in another. Each accessor already
+///   re-checks for `nil` and throws `…ServiceUnavailable`, so a mid-flight teardown surfaces as that
+///   error rather than as a race.
 final class InterpretTextMultiService: MultiServiceBehavior, @unchecked Sendable {
     weak var coreMLService: CoreMLPredictionBehavior?
     weak var predictionsService: AWSPredictionsService?

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/MultiService/MultiServiceBehavior.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/MultiService/MultiServiceBehavior.swift
@@ -8,7 +8,9 @@
 import Amplify
 import Foundation
 
-protocol MultiServiceBehavior: AnyObject {
+/// - Note: `Sendable` because the default implementations below race the two services in a task
+///   group, which sends `self` across an isolation boundary.
+protocol MultiServiceBehavior: AnyObject, Sendable {
     associatedtype ServiceResult
 
     /// Fetch the result from the offline service

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Service/Predictions/AWSPredictionsService.swift
@@ -21,7 +21,10 @@ import Foundation
 @_spi(PluginHTTPClientEngine) import InternalAmplifyCredentials
 import SmithyIdentity
 
-class AWSPredictionsService {
+/// - Note: `final` and `@unchecked Sendable`: the service wraps AWS SDK clients that are safe to
+///   share, and `analyzeText` races several of its own methods with `async let`, which requires the
+///   receiver to be `Sendable`.
+final class AWSPredictionsService: @unchecked Sendable {
     var identifier: String!
     var awsTranslate: TranslateClientProtocol!
     var awsRekognition: RekognitionClientProtocol!

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Signing/SigV4Signer.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Signing/SigV4Signer.swift
@@ -116,7 +116,8 @@ import Foundation
                                                                                                         │
      └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
 */
-struct SigV4Signer {
+/// - Note: `Sendable` because the signer is captured by the liveness session's send path.
+struct SigV4Signer: Sendable {
     let credential: Credential
     // e.g. "rekognition"
     let serviceName: String
@@ -129,7 +130,9 @@ struct SigV4Signer {
     // previous signature (if it exists) to use
     // in subsequent signing requests as needed.
     let _storage = PreviousSignatureStorage()
-    final class PreviousSignatureStorage {
+    /// - Note: `@unchecked Sendable`: this is a one-slot cache written and read on the liveness
+    ///   session's own send path, which is serialized.
+    final class PreviousSignatureStorage: @unchecked Sendable {
         var previousSignature: String?
     }
 

--- a/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/PredictionsAWSServices.swift
+++ b/AmplifyPlugins/Predictions/AWSPredictionsPlugin/Support/PredictionsAWSServices.swift
@@ -12,8 +12,9 @@ import AWSTextract
 import AWSTranslate
 import Foundation
 
-public struct PredictionsAWSService<Client> {
-    let fetch: (AWSPredictionsService) -> Client
+/// - Note: `Sendable` because the `static let` service accessors below must be concurrency-safe.
+public struct PredictionsAWSService<Client>: Sendable {
+    let fetch: @Sendable (AWSPredictionsService) -> Client
 }
 
 public extension PredictionsAWSService where Client == RekognitionClientProtocol {

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/CoreMLPredictionsPlugin+ClientBehavior.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/CoreMLPredictionsPlugin+ClientBehavior.swift
@@ -89,14 +89,15 @@ public extension CoreMLPredictionsPlugin {
                 speechToText: input,
                 options: options
             )
+            // Hoisted so the task captures only this `URL` rather than the whole request, which
+            // is not `Sendable`.
+            let speechToText = request.speechToText
             let stream = AsyncThrowingStream<Predictions.Convert.SpeechToText.Result, Error> { continuation in
                 Task {
                     do {
-                        let result = try await coreMLSpeech.getTranscription(
-                            request.speechToText
-                        )
+                        let result = try await coreMLSpeech.getTranscription(speechToText)
                         continuation.yield(
-                            .init(transcription: result.bestTranscription.formattedString)
+                            .init(transcription: result.formattedString)
                         )
                         if result.isFinal {
                             continuation.finish()

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/CoreMLPredictionsPlugin.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/CoreMLPredictionsPlugin.swift
@@ -10,7 +10,10 @@ import Amplify
 import Foundation
 
 /// Predictions plugin that uses CoreML service to get results.
-public final class CoreMLPredictionsPlugin: PredictionsCategoryPlugin {
+/// - Note: `@unchecked Sendable` to satisfy the `Sendable` requirement on `Plugin`. The three
+///   behavior properties are implicitly-unwrapped and assigned once in `configure(using:)` before
+///   any client call can reach them, so they are effectively immutable for the plugin lifetime.
+public final class CoreMLPredictionsPlugin: PredictionsCategoryPlugin, @unchecked Sendable {
 
     let coreMLPredictionsPluginKey = "CoreMLPredictionsPlugin"
 

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLNaturalLanguageAdapter.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLNaturalLanguageAdapter.swift
@@ -9,7 +9,7 @@ import Amplify
 import Foundation
 import NaturalLanguage
 
-class CoreMLNaturalLanguageAdapter: CoreMLNaturalLanguageBehavior {
+final class CoreMLNaturalLanguageAdapter: CoreMLNaturalLanguageBehavior {
     func detectDominantLanguage(for text: String) -> Predictions.Language? {
         let languageRecognizer = NLLanguageRecognizer()
         languageRecognizer.processString(text)

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLNaturalLanguageBehavior.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLNaturalLanguageBehavior.swift
@@ -8,7 +8,7 @@
 import Amplify
 import Foundation
 
-protocol CoreMLNaturalLanguageBehavior: AnyObject {
+protocol CoreMLNaturalLanguageBehavior: AnyObject, Sendable {
 
     /// Detect dominant language using coreml
     ///

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLSpeechAdapter.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLSpeechAdapter.swift
@@ -10,8 +10,12 @@
 import Amplify
 import Speech
 
-class CoreMLSpeechAdapter: CoreMLSpeechBehavior {
-    func getTranscription(_ audioData: URL) async throws -> SFSpeechRecognitionResult {
+final class CoreMLSpeechAdapter: CoreMLSpeechBehavior {
+    // Returns `CoreMLSpeechTranscription` rather than the `SFSpeechRecognitionResult` itself:
+    // that type is not `Sendable`, so resuming a continuation with one is an error in the Swift 6
+    // language mode. Reading the two fields callers need inside the result handler keeps the
+    // non-Sendable Apple type from crossing the boundary at all.
+    func getTranscription(_ audioData: URL) async throws -> CoreMLSpeechTranscription {
         let request = SFSpeechURLRecognitionRequest(url: audioData)
         request.requiresOnDeviceRecognition = true
         guard let recognizer = SFSpeechRecognizer() else {
@@ -23,7 +27,7 @@ class CoreMLSpeechAdapter: CoreMLSpeechBehavior {
             )
         }
 
-        let result = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<SFSpeechRecognitionResult, Error>) in
+        let result = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<CoreMLSpeechTranscription, Error>) in
             recognizer.recognitionTask(
                 with: request,
                 resultHandler: { result, error in
@@ -44,7 +48,10 @@ class CoreMLSpeechAdapter: CoreMLSpeechBehavior {
                         return
                     }
 
-                    continuation.resume(with: .success(result))
+                    continuation.resume(with: .success(.init(
+                        formattedString: result.bestTranscription.formattedString,
+                        isFinal: result.isFinal
+                    )))
 
                 }
             )

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLSpeechBehavior.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLSpeechBehavior.swift
@@ -13,7 +13,17 @@ import Amplify
 import Foundation
 import Speech
 
-protocol CoreMLSpeechBehavior: AnyObject {
-    func getTranscription(_ audioData: URL) async throws -> SFSpeechRecognitionResult
+/// The part of `SFSpeechRecognitionResult` that callers actually use.
+///
+/// `SFSpeechRecognitionResult` is a non-`Sendable` Apple class, so returning one across an async
+/// boundary is an error in the Swift 6 language mode. Carrying just these two values keeps the
+/// Apple type inside the recognition callback that produced it.
+struct CoreMLSpeechTranscription: Sendable {
+    let formattedString: String
+    let isFinal: Bool
+}
+
+protocol CoreMLSpeechBehavior: AnyObject, Sendable {
+    func getTranscription(_ audioData: URL) async throws -> CoreMLSpeechTranscription
 }
 #endif

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLVisionAdapter.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLVisionAdapter.swift
@@ -9,7 +9,7 @@
 import Amplify
 import Vision
 
-class CoreMLVisionAdapter: CoreMLVisionBehavior {
+final class CoreMLVisionAdapter: CoreMLVisionBehavior {
 
     func detectLabels(_ imageURL: URL) throws -> Predictions.Identify.Labels.Result? {
         var labelsResult = [Predictions.Label]()

--- a/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLVisionBehavior.swift
+++ b/AmplifyPlugins/Predictions/CoreMLPredictionsPlugin/Dependency/CoreMLVisionBehavior.swift
@@ -8,7 +8,7 @@
 import Amplify
 import Foundation
 
-protocol CoreMLVisionBehavior: AnyObject {
+protocol CoreMLVisionBehavior: AnyObject, Sendable {
     func detectLabels(_ imageURL: URL) throws -> Predictions.Identify.Labels.Result?
     func detectText(_ imageURL: URL) throws -> Predictions.Identify.Text.Result?
     func detectEntities(_ imageURL: URL) throws -> Predictions.Identify.Entities.Result?


### PR DESCRIPTION
Slice **28 of 38** in the Swift 6 language-mode migration — 26 file(s).

Stacked on `swift6/27-storage-plugin-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.