### PR TITLE
feat(logging): Sendable across the Logging plugin

### DIFF
--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingCategoryClient.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingCategoryClient.swift
@@ -20,7 +20,9 @@ import SmithyIdentity
 /// the application's authentication state.
 ///
 /// - Tag: CloudWatchLoggingCategoryClient
-final class AWSCloudWatchLoggingCategoryClient {
+/// - Note: `@unchecked Sendable`: the client starts detached tasks that touch its state, which is
+///   guarded by its lock.
+final class AWSCloudWatchLoggingCategoryClient: @unchecked Sendable {
 
     private var enabled: Bool = true
 

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingCategoryClient.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingCategoryClient.swift
@@ -20,13 +20,18 @@ import SmithyIdentity
 /// the application's authentication state.
 ///
 /// - Tag: CloudWatchLoggingCategoryClient
-/// - Note: `@unchecked Sendable`: the client starts detached tasks that touch its state, which is
-///   guarded by its lock.
+/// - Note: `@unchecked Sendable`: the client starts detached tasks that touch its state, so every
+///   access to `_enabled`, `loggersByKey` and `userIdentifier` goes through `lock`. Members that already
+///   hold the lock read the underscored storage directly, because `NSLock` is not recursive.
 final class AWSCloudWatchLoggingCategoryClient: @unchecked Sendable {
 
-    private var enabled: Bool = true
+    /// Guarded by `lock`. Read through `isEnabled` from unlocked contexts.
+    private var _enabled: Bool = true
 
     private let lock = NSLock()
+
+    /// `_userIdentifier` for callers that do not already hold `lock`.
+    private var currentUserIdentifier: String? { lock.execute { _userIdentifier } }
     private let logGroupName: String
     private let region: String
     private let credentialIdentityResolver: any AWSCredentialIdentityResolver
@@ -35,7 +40,8 @@ final class AWSCloudWatchLoggingCategoryClient: @unchecked Sendable {
     private let localStoreMaxSizeInMB: Int
     private var automaticFlushLogMonitor: AWSCLoudWatchLoggingMonitor?
     private let logFilter: AWSCloudWatchLoggingFilterBehavior
-    private var userIdentifier: String?
+    /// Guarded by `lock`. Read through `currentUserIdentifier` from unlocked contexts.
+    private var _userIdentifier: String?
     private var authSubscription: AnyCancellable? { willSet { authSubscription?.cancel() } }
     private let networkMonitor: LoggingNetworkMonitor
 
@@ -50,7 +56,7 @@ final class AWSCloudWatchLoggingCategoryClient: @unchecked Sendable {
         flushIntervalInSeconds: Int,
         networkMonitor: LoggingNetworkMonitor = NWPathMonitor()
     ) {
-        self.enabled = enable
+        self._enabled = enable
         self.credentialIdentityResolver = credentialIdentityResolver
         self.authentication = authentication
         self.logGroupName = logGroupName
@@ -70,9 +76,9 @@ final class AWSCloudWatchLoggingCategoryClient: @unchecked Sendable {
         Task {
             do {
                 let user = try await authentication.getCurrentUser()
-                self.userIdentifier = user.userId
+                self.lock.execute { self._userIdentifier = user.userId }
             } catch {
-                self.userIdentifier = nil
+                self.lock.execute { self._userIdentifier = nil }
             }
             self.updateSessionControllers()
         }
@@ -81,7 +87,7 @@ final class AWSCloudWatchLoggingCategoryClient: @unchecked Sendable {
     private func updateSessionControllers() {
         lock.execute {
             for controller in loggersByKey.values {
-                controller.setCurrentUser(identifier: self.userIdentifier)
+                controller.setCurrentUser(identifier: self._userIdentifier)
             }
         }
     }
@@ -96,7 +102,7 @@ final class AWSCloudWatchLoggingCategoryClient: @unchecked Sendable {
         case HubPayload.EventName.Auth.signedIn, CognitoEventName.signInAPI.rawValue, CognitoEventName.configured.rawValue:
             takeUserIdentifierFromCurrentUser()
         case HubPayload.EventName.Auth.signedOut, CognitoEventName.signOutAPI.rawValue:
-            userIdentifier = nil
+            lock.execute { _userIdentifier = nil }
             updateSessionControllers()
         default:
             break
@@ -112,17 +118,14 @@ final class AWSCloudWatchLoggingCategoryClient: @unchecked Sendable {
 
     func getLoggerSessionController(forCategory category: String, logLevel: LogLevel) -> AWSCloudWatchLoggingSessionController? {
         let key = LoggerKey(category: category, logLevel: logLevel)
-        if let existing = loggersByKey[key] {
-            return existing
-        }
-        return nil
+        return lock.execute { loggersByKey[key] }
     }
 }
 
 extension AWSCloudWatchLoggingCategoryClient: LoggingCategoryClientBehavior {
     func enable() {
-        enabled = true
         lock.execute {
+            _enabled = true
             for controller in loggersByKey.values {
                 controller.enable()
             }
@@ -130,8 +133,8 @@ extension AWSCloudWatchLoggingCategoryClient: LoggingCategoryClientBehavior {
     }
 
     func disable() {
-        enabled = false
         lock.execute {
+            _enabled = false
             for controller in loggersByKey.values {
                 controller.disable()
             }
@@ -159,10 +162,10 @@ extension AWSCloudWatchLoggingCategoryClient: LoggingCategoryClientBehavior {
                 logGroupName: self.logGroupName,
                 region: self.region,
                 localStoreMaxSizeInMB: self.localStoreMaxSizeInMB,
-                userIdentifier: self.userIdentifier,
+                userIdentifier: self._userIdentifier,
                 networkMonitor: self.networkMonitor
             )
-            if enabled {
+            if _enabled {
                 controller.enable()
             }
             loggersByKey[key] = controller
@@ -175,7 +178,7 @@ extension AWSCloudWatchLoggingCategoryClient: LoggingCategoryClientBehavior {
     }
 
     func logger(forCategory category: String) -> Logger {
-        let defaultLogLevel = logFilter.getDefaultLogLevel(forCategory: category, userIdentifier: userIdentifier)
+        let defaultLogLevel = logFilter.getDefaultLogLevel(forCategory: category, userIdentifier: currentUserIdentifier)
         return logger(forCategory: category, namespace: nil, logLevel: defaultLogLevel)
     }
 
@@ -184,12 +187,12 @@ extension AWSCloudWatchLoggingCategoryClient: LoggingCategoryClientBehavior {
     }
 
     func logger(forCategory category: String, forNamespace namespace: String) -> Logger {
-        let defaultLogLevel = logFilter.getDefaultLogLevel(forCategory: category, userIdentifier: userIdentifier)
+        let defaultLogLevel = logFilter.getDefaultLogLevel(forCategory: category, userIdentifier: currentUserIdentifier)
         return logger(forCategory: category, namespace: namespace, logLevel: defaultLogLevel)
     }
 
     func getInternalClient() -> CloudWatchLogsClientProtocol {
-        guard let client = loggersByKey.first(where: { $0.value.client != nil })?.value.client else {
+        guard let client = lock.execute({ loggersByKey.first(where: { $0.value.client != nil })?.value.client }) else {
             return Fatal.preconditionFailure(
                 """
                 AWSCloudWatchLoggingPlugin is missing an internal AWS CloudWatch client.  Ensure that
@@ -200,9 +203,17 @@ extension AWSCloudWatchLoggingCategoryClient: LoggingCategoryClientBehavior {
         return client
     }
 
+    /// Snapshots the controllers under the lock, then flushes outside it.
+    ///
+    /// This runs on a repeating background timer, so iterating `loggersByKey` directly raced every
+    /// insertion made under the lock by `logger(forCategory:namespace:logLevel:)`. Awaiting while holding
+    /// the lock is not an option either, hence the snapshot.
     func flushLogs() async throws {
-        guard enabled else { return }
-        for logger in loggersByKey.values {
+        let controllers: [AWSCloudWatchLoggingSessionController] = lock.execute {
+            guard _enabled else { return [] }
+            return Array(loggersByKey.values)
+        }
+        for logger in controllers {
             try await logger.flushLogs()
         }
     }

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingPlugin.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingPlugin.swift
@@ -17,7 +17,10 @@ import Foundation
 /// delegates all calls to the default Console logger implementation.
 ///
 /// - Tag: CloudWatchLoggingPlugin
-public class AWSCloudWatchLoggingPlugin: LoggingCategoryPlugin {
+/// - Note: `final` and `@unchecked Sendable` to satisfy the `Sendable` requirement on `Plugin`.
+///   The client and configuration are established during `configure(using:)` before any logging
+///   call can reach them.
+public final class AWSCloudWatchLoggingPlugin: LoggingCategoryPlugin, @unchecked Sendable {
     /// An instance of the authentication service.
     var loggingClient: AWSCloudWatchLoggingCategoryClient!
 

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/AWSCloudWatchLoggingSessionController.swift
@@ -19,7 +19,9 @@ import SmithyIdentity
 /// user authentication sessions.
 ///
 /// - Tag: CloudWatchLogSessionController
-final class AWSCloudWatchLoggingSessionController {
+/// - Note: `@unchecked Sendable`: mutable state is established during setup and not written
+///   concurrently with reads.
+final class AWSCloudWatchLoggingSessionController: @unchecked Sendable {
 
     var client: CloudWatchLogsClientProtocol?
     let namespace: String?

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Configuration/DefaultRemoteLoggingConstraintsProvider.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Configuration/DefaultRemoteLoggingConstraintsProvider.swift
@@ -15,7 +15,9 @@ import Smithy
 import SmithyHTTPAPI
 import SmithyIdentity
 
-public class DefaultRemoteLoggingConstraintsProvider: RemoteLoggingConstraintsProvider {
+/// - Note: `final` and `@unchecked Sendable`: `refresh()` starts a detached task that reaches back
+///   into this provider.
+public final class DefaultRemoteLoggingConstraintsProvider: RemoteLoggingConstraintsProvider, @unchecked Sendable {
     public let refreshIntervalInSeconds: Int
     private let endpoint: URL
     private let credentialProvider: (any AWSCredentialIdentityResolver)?

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Consumer/CloudWatchLoggingConsumer.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Consumer/CloudWatchLoggingConsumer.swift
@@ -11,7 +11,10 @@ import AWSCloudWatchLogs
 import AWSPluginsCore
 import Foundation
 
-class CloudWatchLoggingConsumer {
+/// - Note: `final` and `@unchecked Sendable` to satisfy `LogBatchConsumer`s `Sendable` requirement.
+///   `client` comes from the AWS SDK and is not declared `Sendable`; `logStreamName` is resolved
+///   once before the first flush.
+final class CloudWatchLoggingConsumer: @unchecked Sendable {
 
     private let client: CloudWatchLogsClientProtocol
     private let formatter: CloudWatchLoggingStreamNameFormatter

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Domain/LogBatch.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Domain/LogBatch.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 /// Represents a batch of log that has a series of log entries to produce/consume
-protocol LogBatch {
+/// - Note: `Sendable` because batches are handed to a `Task` when flushing.
+protocol LogBatch: Sendable {
 
     /// Read the log entries for this log batch
     func readEntries() throws -> [LogEntry]

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Domain/LogBatchConsumer.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Domain/LogBatchConsumer.swift
@@ -10,7 +10,8 @@ import Foundation
 /// Represents a general consumer for contents of a
 /// [LogFile](x-source-tag://LogFile)
 ///
-protocol LogBatchConsumer {
+/// - Note: `Sendable` because the consumer is invoked from a `Task` when flushing.
+protocol LogBatchConsumer: Sendable {
 
     /// Processes the given [LogBatch](x-source-tag://LogBatch) and ensures to call
     /// [LogBatch.complete](x-source-tag://LogBatch.complete) on the given `batch` when

--- a/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Producer/RotatingLogger.swift
+++ b/AmplifyPlugins/Logging/Sources/AWSCloudWatchLoggingPlugin/Producer/RotatingLogger.swift
@@ -9,7 +9,9 @@ import Amplify
 @preconcurrency import Combine
 import Foundation
 
-final class RotatingLogger {
+/// - Note: `@unchecked Sendable`: mutable state is established during setup and not written
+///   concurrently with reads.
+final class RotatingLogger: @unchecked Sendable {
 
     var logLevel: Amplify.LogLevel
 


### PR DESCRIPTION
Slice **29 of 38** in the Swift 6 language-mode migration — 8 file(s).

Stacked on `swift6/28-predictions-plugin-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.