### PR TITLE
feat(analytics): Sendable across Pinpoint, Analytics, Geo and Push

### DIFF
--- a/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin.swift
+++ b/AmplifyPlugins/Analytics/Sources/AWSPinpointAnalyticsPlugin/AWSPinpointAnalyticsPlugin.swift
@@ -12,7 +12,10 @@ import Foundation
 import Network
 
 /// The AWSPinpointAnalyticsPlugin implements the Analytics APIs for Pinpoint
-public final class AWSPinpointAnalyticsPlugin: AnalyticsCategoryPlugin {
+/// - Note: `@unchecked Sendable` to satisfy the `Sendable` requirement on `Plugin`. The Pinpoint
+///   client and configuration are populated during `configure(using:)` before any client call can
+///   reach them.
+public final class AWSPinpointAnalyticsPlugin: AnalyticsCategoryPlugin, @unchecked Sendable {
     /// An instance of the AWS Pinpoint service
     var pinpoint: AWSPinpointBehavior!
 

--- a/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/AWSLocationGeoPlugin.swift
+++ b/AmplifyPlugins/Geo/Sources/AWSLocationGeoPlugin/AWSLocationGeoPlugin.swift
@@ -12,7 +12,10 @@ import Foundation
 import AWSLocation
 
 /// The AWSLocationPlugin implements the Geo APIs for Amazon Location
-public final class AWSLocationGeoPlugin: GeoCategoryPlugin {
+/// - Note: `@unchecked Sendable` to satisfy the `Sendable` requirement on `Plugin`. The service,
+///   auth, and configuration properties are implicitly-unwrapped and populated during
+///   `configure(using:)` before any client call can reach them.
+public final class AWSLocationGeoPlugin: GeoCategoryPlugin, @unchecked Sendable {
     /// An instance of the AWS Location service
     var locationService: AWSLocationBehavior!
 

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/AWSPinpointBehavior.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/AWSPinpointBehavior.swift
@@ -76,7 +76,7 @@ public protocol AWSPinpointBehavior {
 }
 
 @_spi(InternalAWSPinpoint)
-public enum AWSPinpointSource: String {
+public enum AWSPinpointSource: String, Sendable {
     case analytics
     case pushNotifications
 }

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/AnalyticsClient.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/AnalyticsClient.swift
@@ -12,7 +12,8 @@ import StoreKit
 
 @_spi(InternalAWSPinpoint)
 public protocol AnalyticsClientBehaviour: Actor {
-    typealias SubmitResult = (Result<[PinpointEvent], Error>) -> Void
+    // `@Sendable` because the auto-flush timer invokes it from a `Task`.
+    typealias SubmitResult = @Sendable (Result<[PinpointEvent], Error>) -> Void
     nonisolated var pinpointClient: PinpointClientProtocol { get }
 
     func addGlobalAttribute(_ attribute: String, forKey key: String)
@@ -55,7 +56,8 @@ extension AnalyticsClientBehaviour {
     }
 }
 
-typealias SessionProvider = () -> PinpointSession
+// `@Sendable` because the provider is held by the analytics actor and called from its tasks.
+typealias SessionProvider = @Sendable () -> PinpointSession
 
 actor AnalyticsClient: AnalyticsClientBehaviour {
     private var automaticSubmitEventsInterval: TimeInterval = .zero

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/LocalStorage/PinpointEvent+Bindings.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/LocalStorage/PinpointEvent+Bindings.swift
@@ -9,7 +9,8 @@ import Foundation
 import SQLite
 
 extension PinpointEvent {
-    private static let archiver: AmplifyArchiverBehaviour = AmplifyArchiver()
+    // `nonisolated(unsafe)`: the archiver is stateless; `AmplifyArchiverBehaviour` is not `Sendable`.
+    private nonisolated(unsafe) static let archiver: AmplifyArchiverBehaviour = AmplifyArchiver()
 
     /// Converts a Pinpoint Event to a collection of SQL Bindings for SQL insert statements
     /// - Parameters:

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/PinpointEvent.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/PinpointEvent.swift
@@ -10,8 +10,11 @@ import Foundation
 
 private typealias Constants = AWSPinpointAnalytics.Constants.Event
 
+/// - Note: `final` and `@unchecked Sendable`: the identity and session fields are `let`; the lazy
+///   attribute/metric dictionaries are populated while the event is being built, before it is handed
+///   to the recorder.
 @_spi(InternalAWSPinpoint)
-public class PinpointEvent: AnalyticsPropertiesModel {
+public final class PinpointEvent: AnalyticsPropertiesModel, @unchecked Sendable {
     let id: String
     public let eventType: String
     let eventDate: Date

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/PinpointEvent.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Analytics/PinpointEvent.swift
@@ -10,9 +10,17 @@ import Foundation
 
 private typealias Constants = AWSPinpointAnalytics.Constants.Event
 
-/// - Note: `final` and `@unchecked Sendable`: the identity and session fields are `let`; the lazy
-///   attribute/metric dictionaries are populated while the event is being built, before it is handed
-///   to the recorder.
+/// - Note: `final` and `@unchecked Sendable`. The identity and session fields are `let`, so those are
+///   genuinely immutable. `attributes` and `metrics` are not: they are `lazy var` with `public` mutators
+///   (`addAttribute(_:forKey:)`, `addMetric(_:forKey:)`), and they are unsynchronized.
+///
+///   The intended lifecycle is build-then-submit — attributes are added while composing the event, and it
+///   is immutable in practice once handed to the recorder. But that is a caller contract, not something
+///   this type enforces: nothing stops a caller retaining the event and adding an attribute after it is
+///   enqueued, and because events are queued for a later flush the two can genuinely overlap. `lazy`
+///   makes it slightly worse, since even a first *read* mutates the storage.
+///
+///   The exposure predates this annotation, which only stops the compiler from asking about it.
 @_spi(InternalAWSPinpoint)
 public final class PinpointEvent: AnalyticsPropertiesModel, @unchecked Sendable {
     let id: String

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Context/AWSPinpointFactory.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Context/AWSPinpointFactory.swift
@@ -16,13 +16,14 @@ public class AWSPinpointFactory {
         let region: String
     }
 
-    private static var instances: AtomicDictionary<PinpointContextKey, PinpointContext> = [:]
+    private static let instances: AtomicDictionary<PinpointContextKey, PinpointContext> = [:]
 
     private init() {}
 
-    static var credentialIdentityResolver = AWSAuthService().getCredentialIdentityResolver()
+    // `nonisolated(unsafe)`: these two are overridden by tests before use and otherwise read-only.
+    nonisolated(unsafe) static var credentialIdentityResolver = AWSAuthService().getCredentialIdentityResolver()
 
-    static var provisioningProfileReader: ProvisioningProfileReader = .default
+    nonisolated(unsafe) static var provisioningProfileReader: ProvisioningProfileReader = .default
 
     public static func sharedPinpoint(
         appId: String,

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Context/PinpointContext.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Context/PinpointContext.swift
@@ -13,7 +13,8 @@ import Foundation
 import SmithyIdentity
 
 // MARK: - UserDefaultsBehaviour
-protocol UserDefaultsBehaviour {
+/// - Note: `Sendable` because the endpoint client holds this and reads it from its async setup.
+protocol UserDefaultsBehaviour: Sendable {
     func save(_ value: UserDefaultsBehaviourValue?, forKey key: String)
     func removeObject(forKey key: String)
     func string(forKey key: String) -> String?
@@ -105,7 +106,9 @@ private struct PinpointContextStorage {
     let archiver: AmplifyArchiverBehaviour
 }
 
-class PinpointContext {
+/// - Note: `final` and `@unchecked Sendable`: the context is a long-lived container created once per
+///   app id, and it forwards work to the analytics/endpoint clients from detached tasks.
+final class PinpointContext: @unchecked Sendable {
     let endpointClient: EndpointClientBehaviour
     let sessionClient: SessionClientBehaviour
     let analyticsClient: AnalyticsClientBehaviour
@@ -160,7 +163,7 @@ class PinpointContext {
             userDefaults: userDefaults
         )
 
-        let sessionProvider: () -> PinpointSession = { [weak sessionClient] in
+        let sessionProvider: @Sendable () -> PinpointSession = { [weak sessionClient] in
             guard let sessionClient else {
                 fatalError("SessionClient was deallocated")
             }

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Endpoint/EndpointClient.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Endpoint/EndpointClient.swift
@@ -38,7 +38,9 @@ actor EndpointClient: EndpointClientBehaviour {
     private let remoteNotificationsHelper: RemoteNotificationsBehaviour
 
     private var endpointProfile: PinpointEndpointProfile?
-    private static let defaultDateFormatter = ISO8601DateFormatter()
+    // `nonisolated(unsafe)`: `ISO8601DateFormatter` is documented as thread-safe for formatting but
+    // is not declared `Sendable`.
+    private nonisolated(unsafe) static let defaultDateFormatter = ISO8601DateFormatter()
 
     init(
         configuration: EndpointClient.Configuration,

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Endpoint/EndpointInformation.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Endpoint/EndpointInformation.swift
@@ -8,7 +8,7 @@
 import Amplify
 import Foundation
 
-struct EndpointInformation {
+struct EndpointInformation: Sendable {
     typealias Platform = (name: String, version: String)
 
     let model: String
@@ -16,7 +16,8 @@ struct EndpointInformation {
     let platform: Platform
 }
 
-protocol EndpointInformationProvider {
+/// - Note: `Sendable` because the endpoint client awaits this from its own async setup path.
+protocol EndpointInformationProvider: Sendable {
     func endpointInfo() async -> EndpointInformation
 }
 

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Endpoint/PinpointEndpointProfile.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Endpoint/PinpointEndpointProfile.swift
@@ -10,7 +10,7 @@ import AWSPinpoint
 import Foundation
 
 @_spi(InternalAWSPinpoint)
-public struct PinpointEndpointProfile: Codable, Equatable {
+public struct PinpointEndpointProfile: Codable, Equatable, Sendable {
     typealias DeviceToken = String
 
     var applicationId: String

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Service/PinpointClientProtocol.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Service/PinpointClientProtocol.swift
@@ -10,7 +10,8 @@ import AWSPinpoint
 import Foundation
 
 // swiftlint:disable file_length
-public protocol PinpointClientProtocol {
+/// - Note: `Sendable` because the client is held by the analytics actor and used from its tasks.
+public protocol PinpointClientProtocol: Sendable {
     /// Performs the `CreateApp` operation on the `Pinpoint` service.
     ///
     /// Creates an application.

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Session/PinpointSession.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Session/PinpointSession.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @_spi(InternalAWSPinpoint)
-public struct PinpointSession: Codable {
+public struct PinpointSession: Codable, Sendable {
     private enum State: Codable {
         case active
         case paused(date: Date)

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Session/SessionClient.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Session/SessionClient.swift
@@ -9,8 +9,10 @@ import Amplify
 import AWSPluginsCore
 import Foundation
 
+/// - Note: `Sendable` because the session client is held across task boundaries by the analytics
+///   client and the app-lifecycle observers.
 @_spi(InternalAWSPinpoint)
-public protocol SessionClientBehaviour: AnyObject {
+public protocol SessionClientBehaviour: AnyObject, Sendable {
     var currentSession: PinpointSession { get }
     var analyticsClient: AnalyticsClientBehaviour? { get set }
 
@@ -23,7 +25,9 @@ struct SessionClientConfiguration {
     let uniqueDeviceId: String
 }
 
-class SessionClient: SessionClientBehaviour {
+/// - Note: `final` and `@unchecked Sendable` to satisfy `SessionClientBehaviour`'s `Sendable`
+///   requirement. Session state transitions run on the client's own serial queue.
+final class SessionClient: SessionClientBehaviour, @unchecked Sendable {
     private var session: PinpointSession
 
     weak var analyticsClient: AnalyticsClientBehaviour?
@@ -272,5 +276,7 @@ extension SessionClient {
 }
 
 extension PinpointSession {
-    static var none = PinpointSession(sessionId: "InvalidId", startTime: Date(), stopTime: nil)
+    // `let` rather than `var`: nothing reassigns this sentinel, and a mutable static is not
+    // concurrency-safe in the Swift 6 language mode.
+    static let none = PinpointSession(sessionId: "InvalidId", startTime: Date(), stopTime: nil)
 }

--- a/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Support/Utils/RemoteNotificationsHelper.swift
+++ b/AmplifyPlugins/Internal/Sources/InternalAWSPinpoint/Support/Utils/RemoteNotificationsHelper.swift
@@ -10,8 +10,9 @@ import AmplifyUtilsNotifications
 import Foundation
 import UserNotifications
 
+/// - Note: `Sendable` because `shared` is a global and the endpoint client reads it from tasks.
 @_spi(InternalAWSPinpoint)
-public protocol RemoteNotificationsBehaviour {
+public protocol RemoteNotificationsBehaviour: Sendable {
     var isRegisteredForRemoteNotifications: Bool { get async }
     func requestAuthorization(_ options: UNAuthorizationOptions) async throws -> Bool
     func registerForRemoteNotifications() async
@@ -28,7 +29,8 @@ public extension RemoteNotificationsBehaviour where Self == AmplifyRemoteNotific
 public struct AmplifyRemoteNotificationsHelper: RemoteNotificationsBehaviour {
     private init() {}
 
-    static var shared: RemoteNotificationsBehaviour = AmplifyRemoteNotificationsHelper()
+    // `nonisolated(unsafe)`: overridden by tests before use, otherwise read-only.
+    nonisolated(unsafe) static var shared: RemoteNotificationsBehaviour = AmplifyRemoteNotificationsHelper()
 
     public var isRegisteredForRemoteNotifications: Bool {
         get async {

--- a/AmplifyPlugins/Notifications/Push/Sources/AWSPinpointPushNotificationsPlugin/AWSPinpointPushNotificationsPlugin.swift
+++ b/AmplifyPlugins/Notifications/Push/Sources/AWSPinpointPushNotificationsPlugin/AWSPinpointPushNotificationsPlugin.swift
@@ -11,7 +11,10 @@ import Foundation
 import UserNotifications
 
 /// The AWSPinpointPushNotificationsPlugin implements the Push Notifications support for Pinpoint
-public final class AWSPinpointPushNotificationsPlugin: PushNotificationsCategoryPlugin {
+/// - Note: `@unchecked Sendable` to satisfy the `Sendable` requirement on `Plugin`. The Pinpoint
+///   client and configuration are populated during `configure(using:)` before any client call can
+///   reach them.
+public final class AWSPinpointPushNotificationsPlugin: PushNotificationsCategoryPlugin, @unchecked Sendable {
     /// An instance of the AWS Pinpoint service
     var pinpoint: AWSPinpointBehavior!
 


### PR DESCRIPTION
Slice **30 of 38** in the Swift 6 language-mode migration — 16 file(s).

Stacked on `swift6/29-logging-plugin-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.