### PR TITLE
test(core): migrate Amplify core and shared test targets

### DIFF
--- a/AmplifyAsyncTesting/Sources/AsyncTesting/AsyncTesting.swift
+++ b/AmplifyAsyncTesting/Sources/AsyncTesting/AsyncTesting.swift
@@ -22,7 +22,10 @@ public enum AsyncTesting {
         )
     }
 
-    @MainActor
+    // Deliberately not `@MainActor`: every expectation access below is an awaited
+    // call into the `AsyncExpectation` actor, so this needs no main-actor isolation.
+    // Requiring it would force callers to send a non-Sendable `XCTestCase` across an
+    // isolation boundary, which is an error in the Swift 6 language mode.
     public static func waitForExpectations(
         _ expectations: [AsyncExpectation],
         timeout: Double = 1.0,

--- a/AmplifyAsyncTesting/Sources/AsyncTesting/XCTestCase+AsyncTesting.swift
+++ b/AmplifyAsyncTesting/Sources/AsyncTesting/XCTestCase+AsyncTesting.swift
@@ -41,7 +41,9 @@ public extension XCTestCase {
     /// - Parameters:
     ///   - expectations: An array of async expectations that must be fulfilled.
     ///   - timeout: The number of seconds within which all expectations must be fulfilled.
-    @MainActor
+    // Not `@MainActor` for the same reason as `AsyncTesting.waitForExpectations`: this
+    // body never touches `self`, so main-actor isolation would only serve to push a
+    // non-Sendable `XCTestCase` across an isolation boundary.
     func waitForExpectations(
         _ expectations: [AsyncExpectation],
         timeout: Double = 1.0,
@@ -62,7 +64,7 @@ public extension XCTestCase {
     ///   - operation: operation to run
     /// - Returns: result of closure
     @discardableResult
-    func testTask<Success>(
+    func testTask<Success: Sendable>(
         timeout: Double = defaultTimeoutForAsyncExpectations,
         file: StaticString = #filePath,
         line: UInt = #line,
@@ -94,10 +96,10 @@ public extension XCTestCase {
     ///
     /// - Returns:The result of successfuly running `action`, or `nil` if it threw an error.
     @discardableResult
-    internal func wait<T>(
+    internal func wait<T: Sendable>(
         with expectation: AsyncExpectation,
         timeout: TimeInterval = defaultNetworkTimeoutForAsyncExpectations,
-        action: @escaping () async throws -> T
+        action: @escaping @Sendable () async throws -> T
     ) async -> T? {
         let task = Task { () -> T? in
             defer {
@@ -128,10 +130,10 @@ public extension XCTestCase {
     ///
     /// - Returns:The result of successfuly running `action`, or `nil` if it threw an error.
     @discardableResult
-    internal func wait<T>(
+    internal func wait<T: Sendable>(
         name: String,
         timeout: TimeInterval = defaultNetworkTimeoutForAsyncExpectations,
-        action: @escaping () async throws -> T
+        action: @escaping @Sendable () async throws -> T
     ) async -> T? {
         let expectation = asyncExpectation(description: name)
         return await wait(with: expectation, timeout: timeout, action: action)
@@ -153,7 +155,7 @@ public extension XCTestCase {
     internal func waitError(
         with expectation: AsyncExpectation,
         timeout: TimeInterval = defaultNetworkTimeoutForAsyncExpectations,
-        action: @escaping () async throws -> some Any
+        action: @escaping @Sendable () async throws -> some Any
     ) async -> Error? {
         let task = Task { () -> Error? in
             defer {
@@ -189,7 +191,7 @@ public extension XCTestCase {
     internal func waitError(
         name: String,
         timeout: TimeInterval = defaultNetworkTimeoutForAsyncExpectations,
-        action: @escaping () async throws -> some Any
+        action: @escaping @Sendable () async throws -> some Any
     ) async -> Error? {
         let expectation = asyncExpectation(description: name)
         return await waitError(with: expectation, timeout: timeout, action: action)

--- a/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAPICategoryPlugin.swift
@@ -10,10 +10,14 @@ import AWSPluginsCore
 import Combine
 import Foundation
 
+// `@unchecked Sendable` because the category plugin protocols now require `Sendable` (see
+// `Plugin`), and a `Sendable` class may not inherit from a non-`NSObject` superclass. These are
+// test doubles driven from a single test at a time.
 class MockAPICategoryPlugin: MessageReporter,
                              APICategoryPlugin,
                              APICategoryReachabilityBehavior,
-                             APICategoryGraphQLBehavior {
+                             APICategoryGraphQLBehavior,
+                             @unchecked Sendable {
 
     var authProviderFactory: APIAuthProviderFactory?
 
@@ -292,7 +296,9 @@ class MockAPICategoryPlugin: MessageReporter,
     }
 }
 
-class MockSecondAPICategoryPlugin: MockAPICategoryPlugin {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double.
+
+class MockSecondAPICategoryPlugin: MockAPICategoryPlugin, @unchecked Sendable {
     override var key: String {
         return "MockSecondAPICategoryPlugin"
     }
@@ -374,7 +380,8 @@ class MockAPIAuthProviderFactory: APIAuthProviderFactory {
     }
 }
 
-class MockOIDCAuthProvider: AmplifyOIDCAuthProvider {
+// `@unchecked Sendable`: test double whose `result` is set up before use.
+final class MockOIDCAuthProvider: AmplifyOIDCAuthProvider, @unchecked Sendable {
     var result: Result<AuthToken, Error>?
 
     func getLatestAuthToken() async throws -> String {
@@ -386,7 +393,8 @@ class MockOIDCAuthProvider: AmplifyOIDCAuthProvider {
     }
 }
 
-class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
+// `@unchecked Sendable`: test double whose `result` is set up before use.
+final class MockFunctionAuthProvider: AmplifyFunctionAuthProvider, @unchecked Sendable {
     var result: Result<AuthToken, Error>?
 
     func getLatestAuthToken() async throws -> String {
@@ -398,7 +406,9 @@ class MockFunctionAuthProvider: AmplifyFunctionAuthProvider {
     }
 }
 
-class MockAWSGraphQLSubscriptionTaskRunner<R: Decodable>: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double.
+
+class MockAWSGraphQLSubscriptionTaskRunner<R: Decodable & Sendable>: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel, @unchecked Sendable {
 
     typealias Request = GraphQLOperationRequest<R>
     typealias InProcess = GraphQLSubscriptionEvent<R>

--- a/AmplifyTestCommon/Mocks/MockAnalyticsCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAnalyticsCategoryPlugin.swift
@@ -7,7 +7,10 @@
 
 import Amplify
 
-class MockAnalyticsCategoryPlugin: MessageReporter, AnalyticsCategoryPlugin {
+// `@unchecked Sendable` because the category plugin protocols now require `Sendable` (see
+// `Plugin`), and a `Sendable` class may not inherit from a non-`NSObject` superclass. These are
+// test doubles driven from a single test at a time.
+class MockAnalyticsCategoryPlugin: MessageReporter, AnalyticsCategoryPlugin, @unchecked Sendable {
     var key: String {
         return "MockAnalyticsCategoryPlugin"
     }
@@ -53,7 +56,9 @@ class MockAnalyticsCategoryPlugin: MessageReporter, AnalyticsCategoryPlugin {
     }
 }
 
-class MockSecondAnalyticsCategoryPlugin: MockAnalyticsCategoryPlugin {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double.
+
+class MockSecondAnalyticsCategoryPlugin: MockAnalyticsCategoryPlugin, @unchecked Sendable {
     override var key: String {
         return "MockSecondAnalyticsCategoryPlugin"
     }

--- a/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockAuthCategoryPlugin.swift
@@ -8,7 +8,10 @@
 import Amplify
 import Foundation
 
-class MockAuthCategoryPlugin: MessageReporter, AuthCategoryPlugin {
+// `@unchecked Sendable` because the category plugin protocols now require `Sendable` (see
+// `Plugin`), and a `Sendable` class may not inherit from a non-`NSObject` superclass. These are
+// test doubles driven from a single test at a time.
+class MockAuthCategoryPlugin: MessageReporter, AuthCategoryPlugin, @unchecked Sendable {
 
     func getCurrentUser() async throws -> any AuthUser {
         fatalError()
@@ -195,13 +198,17 @@ class MockAuthCategoryPlugin: MessageReporter, AuthCategoryPlugin {
     }
 }
 
-class MockSecondAuthCategoryPlugin: MockAuthCategoryPlugin {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double.
+
+class MockSecondAuthCategoryPlugin: MockAuthCategoryPlugin, @unchecked Sendable {
     override var key: String {
         return "MockSecondAuthCategoryPlugin"
     }
 }
 
-class MockAuthCategoryPluginWithoutKey: MockAuthCategoryPlugin {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double.
+
+class MockAuthCategoryPluginWithoutKey: MockAuthCategoryPlugin, @unchecked Sendable {
     override var key: String {
         return ""
     }

--- a/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockDataStoreCategoryPlugin.swift
@@ -8,7 +8,10 @@
 import Amplify
 import Combine
 
-class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
+// `@unchecked Sendable` because the category plugin protocols now require `Sendable` (see
+// `Plugin`), and a `Sendable` class may not inherit from a non-`NSObject` superclass. These are
+// test doubles driven from a single test at a time.
+class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin, @unchecked Sendable {
 
     var responders = [ResponderKeys: Any]()
 
@@ -27,7 +30,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
     func save<M: Model>(
         _ model: M,
         where condition: QueryPredicate? = nil,
-        completion: @escaping (DataStoreResult<M>) -> Void
+        completion: @escaping @Sendable (DataStoreResult<M>) -> Void
     ) {
         notify("save")
 
@@ -54,7 +57,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
     func query<M: Model>(
         _ modelType: M.Type,
         byId id: String,
-        completion: @escaping (DataStoreResult<M?>) -> Void
+        completion: @escaping @Sendable (DataStoreResult<M?>) -> Void
     ) {
         notify("queryById")
 
@@ -78,7 +81,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
     func query<M: Model>(
         _ modelType: M.Type,
         byIdentifier id: String,
-        completion: @escaping (DataStoreResult<M?>) -> Void
+        completion: @escaping @Sendable (DataStoreResult<M?>) -> Void
     ) where M: ModelIdentifiable,
                                                                           M.IdentifierFormat == ModelIdentifierFormat.Default {
         notify("queryByIdentifier")
@@ -106,7 +109,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         where predicate: QueryPredicate?,
         sort sortInput: QuerySortInput?,
         paginate paginationInput: QueryPaginationInput?,
-        completion: @escaping (DataStoreResult<[M]>) -> Void
+        completion: @escaping @Sendable (DataStoreResult<[M]>) -> Void
     ) {
         notify("queryByPredicate")
 
@@ -154,13 +157,15 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
     func query<M>(
         _ modelType: M.Type,
         byIdentifier id: ModelIdentifier<M, M.IdentifierFormat>,
-        completion: @escaping (DataStoreResult<M?>) -> Void
+        completion: @escaping @Sendable (DataStoreResult<M?>) -> Void
     ) where M: Model, M: ModelIdentifiable {
         notify("queryWithIdentifier")
 
+       // Hoisted so the task captures a `String` rather than the identifier value.
+       let identifierValue = id.stringValue
        if let responder = responders[.queryByIdListener] as? QueryByIdResponder<M> {
            Task {
-               if let callback = responder.callback((modelType: modelType, id: id.stringValue)) {
+               if let callback = responder.callback((modelType: modelType, id: identifierValue)) {
                    completion(callback)
                }
            }
@@ -180,7 +185,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         _ modelType: M.Type,
         withId id: String,
         where predicate: QueryPredicate? = nil,
-        completion: @escaping (DataStoreResult<Void>) -> Void
+        completion: @escaping @Sendable (DataStoreResult<Void>) -> Void
     ) {
         notify("deleteById")
 
@@ -205,7 +210,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         _ modelType: M.Type,
         withIdentifier id: String,
         where predicate: QueryPredicate? = nil,
-        completion: @escaping (DataStoreResult<Void>) -> Void
+        completion: @escaping @Sendable (DataStoreResult<Void>) -> Void
     ) where M: ModelIdentifiable,
                                                                              M.IdentifierFormat == ModelIdentifierFormat.Default {
         notify("deleteByIdentifier")
@@ -236,9 +241,11 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
     ) where M: Model, M: ModelIdentifiable {
         notify("deleteByIdentifier")
 
+        // Hoisted so the task captures a `String` rather than the identifier value.
+        let identifierValue = id.stringValue
         if let responder = responders[.deleteByIdListener] as? DeleteByIdResponder<M> {
             Task {
-                if let callback = responder.callback((modelType: modelType, id: id.stringValue)) {
+                if let callback = responder.callback((modelType: modelType, id: identifierValue)) {
                     completion(callback)
                 }
             }
@@ -256,7 +263,7 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
     func delete<M: Model>(
         _ modelType: M.Type,
         where predicate: QueryPredicate,
-        completion: @escaping (DataStoreResult<Void>) -> Void
+        completion: @escaping @Sendable (DataStoreResult<Void>) -> Void
     ) {
         notify("deleteModelTypeByPredicate")
 
@@ -385,31 +392,38 @@ class MockDataStoreCategoryPlugin: MessageReporter, DataStoreCategoryPlugin {
         sort sortInput: QuerySortInput?
     ) -> AmplifyAsyncThrowingSequence<DataStoreQuerySnapshot<M>> {
 
-        let request = ObserveQueryRequest(options: [])
+        let request = ObserveQueryRequest()
         let taskRunner = MockObserveQueryTaskRunner<M>(request: request)
         return taskRunner.sequence
     }
 }
 
-class MockSecondDataStoreCategoryPlugin: MockDataStoreCategoryPlugin {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double.
+
+class MockSecondDataStoreCategoryPlugin: MockDataStoreCategoryPlugin, @unchecked Sendable {
     override var key: String {
         return "MockSecondDataStoreCategoryPlugin"
     }
 }
 
 
-class ObserveQueryRequest: AmplifyOperationRequest {
-    var options: Any
+// Mirrors the plugin's `ObserveQueryRequest`: `Options` must be `Sendable`, and options are unused.
+final class ObserveQueryRequest: AmplifyOperationRequest, Sendable {
+    struct Options: Sendable {
+        init() {}
+    }
 
-    typealias Options = Any
+    let options: Options
 
-    init(options: Any) {
+    init(options: Options = .init()) {
         self.options = options
     }
 
 }
 
-class MockObserveQueryTaskRunner<M: Model>: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double.
+
+class MockObserveQueryTaskRunner<M: Model>: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel, @unchecked Sendable {
 
     typealias Request = ObserveQueryRequest
     typealias InProcess = DataStoreQuerySnapshot<M>

--- a/AmplifyTestCommon/Mocks/MockGeoCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockGeoCategoryPlugin.swift
@@ -8,7 +8,10 @@
 import Amplify
 import Foundation
 
-class MockGeoCategoryPlugin: MessageReporter, GeoCategoryPlugin {
+// `@unchecked Sendable` because the category plugin protocols now require `Sendable` (see
+// `Plugin`), and a `Sendable` class may not inherit from a non-`NSObject` superclass. These are
+// test doubles driven from a single test at a time.
+class MockGeoCategoryPlugin: MessageReporter, GeoCategoryPlugin, @unchecked Sendable {
     var key: String {
         return "MockGeoCategoryPlugin"
     }
@@ -65,7 +68,9 @@ class MockGeoCategoryPlugin: MessageReporter, GeoCategoryPlugin {
     }
 }
 
-class MockSecondGeoCategoryPlugin: MockGeoCategoryPlugin {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double.
+
+class MockSecondGeoCategoryPlugin: MockGeoCategoryPlugin, @unchecked Sendable {
     override var key: String {
         return "MockSecondGeoCategoryPlugin"
     }

--- a/AmplifyTestCommon/Mocks/MockHubCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockHubCategoryPlugin.swift
@@ -9,7 +9,10 @@ import Foundation
 
 import Amplify
 
-class MockHubCategoryPlugin: MessageReporter, HubCategoryPlugin {
+// `@unchecked Sendable` because the category plugin protocols now require `Sendable` (see
+// `Plugin`), and a `Sendable` class may not inherit from a non-`NSObject` superclass. These are
+// test doubles driven from a single test at a time.
+class MockHubCategoryPlugin: MessageReporter, HubCategoryPlugin, @unchecked Sendable {
     var key: String {
         return "MockHubCategoryPlugin"
     }
@@ -49,7 +52,9 @@ class MockHubCategoryPlugin: MessageReporter, HubCategoryPlugin {
     }
 }
 
-class MockSecondHubCategoryPlugin: MockHubCategoryPlugin {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double.
+
+class MockSecondHubCategoryPlugin: MockHubCategoryPlugin, @unchecked Sendable {
     override var key: String {
         return "MockSecondHubCategoryPlugin"
     }

--- a/AmplifyTestCommon/Mocks/MockLoggingCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockLoggingCategoryPlugin.swift
@@ -7,7 +7,10 @@
 
 import Amplify
 
-class MockLoggingCategoryPlugin: MessageReporter, LoggingCategoryPlugin, Logger {
+// `@unchecked Sendable` because the category plugin protocols now require `Sendable` (see
+// `Plugin`), and a `Sendable` class may not inherit from a non-`NSObject` superclass. These are
+// test doubles driven from a single test at a time.
+class MockLoggingCategoryPlugin: MessageReporter, LoggingCategoryPlugin, Logger, @unchecked Sendable {
     var logLevel = LogLevel.verbose
 
     var `default`: Logger {
@@ -75,7 +78,9 @@ class MockLoggingCategoryPlugin: MessageReporter, LoggingCategoryPlugin, Logger 
     }
 }
 
-class MockSecondLoggingCategoryPlugin: MockLoggingCategoryPlugin {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double.
+
+class MockSecondLoggingCategoryPlugin: MockLoggingCategoryPlugin, @unchecked Sendable {
     override var key: String {
         return "MockSecondLoggingCategoryPlugin"
     }

--- a/AmplifyTestCommon/Mocks/MockPredictionsCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockPredictionsCategoryPlugin.swift
@@ -8,7 +8,10 @@
 import Amplify
 import Foundation
 
-class MockPredictionsCategoryPlugin: MessageReporter, PredictionsCategoryPlugin {
+// `@unchecked Sendable` because the category plugin protocols now require `Sendable` (see
+// `Plugin`), and a `Sendable` class may not inherit from a non-`NSObject` superclass. These are
+// test doubles driven from a single test at a time.
+class MockPredictionsCategoryPlugin: MessageReporter, PredictionsCategoryPlugin, @unchecked Sendable {
     func identify<Output>(_ request: Predictions.Identify.Request<Output>, in image: URL, options: Predictions.Identify.Options?) async throws -> Output {
         fatalError()
     }
@@ -34,7 +37,9 @@ class MockPredictionsCategoryPlugin: MessageReporter, PredictionsCategoryPlugin 
     }
 }
 
-class MockSecondPredictionsCategoryPlugin: MockPredictionsCategoryPlugin {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double.
+
+class MockSecondPredictionsCategoryPlugin: MockPredictionsCategoryPlugin, @unchecked Sendable {
     override var key: String {
         return "MockSecondPredictionsCategoryPlugin"
     }

--- a/AmplifyTestCommon/Mocks/MockPushNotificationsCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockPushNotificationsCategoryPlugin.swift
@@ -9,7 +9,10 @@ import Amplify
 import Foundation
 import UserNotifications
 
-class MockPushNotificationsCategoryPlugin: MessageReporter, PushNotificationsCategoryPlugin {
+// `@unchecked Sendable` because the category plugin protocols now require `Sendable` (see
+// `Plugin`), and a `Sendable` class may not inherit from a non-`NSObject` superclass. These are
+// test doubles driven from a single test at a time.
+class MockPushNotificationsCategoryPlugin: MessageReporter, PushNotificationsCategoryPlugin, @unchecked Sendable {
     var key: String {
         "MockPushNotificationsCategoryPlugin"
     }
@@ -41,7 +44,9 @@ class MockPushNotificationsCategoryPlugin: MessageReporter, PushNotificationsCat
 #endif
 }
 
-class MockSecondPushNotificationsCategoryPlugin: MockPushNotificationsCategoryPlugin {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double.
+
+class MockSecondPushNotificationsCategoryPlugin: MockPushNotificationsCategoryPlugin, @unchecked Sendable {
     override var key: String {
         "MockSecondPushNotificationsCategoryPlugin"
     }

--- a/AmplifyTestCommon/Mocks/MockStorageCategoryPlugin.swift
+++ b/AmplifyTestCommon/Mocks/MockStorageCategoryPlugin.swift
@@ -8,7 +8,10 @@
 import Amplify
 import Foundation
 
-class MockStorageCategoryPlugin: MessageReporter, StorageCategoryPlugin {
+// `@unchecked Sendable` because the category plugin protocols now require `Sendable` (see
+// `Plugin`), and a `Sendable` class may not inherit from a non-`NSObject` superclass. These are
+// test doubles driven from a single test at a time.
+class MockStorageCategoryPlugin: MessageReporter, StorageCategoryPlugin, @unchecked Sendable {
 
     func getURL(
         key: String,
@@ -266,7 +269,9 @@ class MockStorageCategoryPlugin: MessageReporter, StorageCategoryPlugin {
     }
 }
 
-class MockSecondStorageCategoryPlugin: MockStorageCategoryPlugin {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double.
+
+class MockSecondStorageCategoryPlugin: MockStorageCategoryPlugin, @unchecked Sendable {
     override var key: String {
         return "MockSecondStorageCategoryPlugin"
     }

--- a/AmplifyTestCommon/Models/Associations/UserAccount.swift
+++ b/AmplifyTestCommon/Models/Associations/UserAccount.swift
@@ -13,7 +13,9 @@ import Foundation
 // circular reference issues with structs and a
 // hasOne+belongsTo relationship
 // TODO: replace this with a struct when the above issue is solved.
-public class UserAccount: Model {
+// `@unchecked Sendable`: `Model` is `Sendable`, and this test fixture is a class with `var`
+// properties. Driven from a single test at a time.
+public class UserAccount: Model, @unchecked Sendable {
 
     public let id: String
 

--- a/AmplifyTestCommon/Models/Associations/UserProfile.swift
+++ b/AmplifyTestCommon/Models/Associations/UserProfile.swift
@@ -13,7 +13,8 @@ import Foundation
 // circular reference issues with structs and a
 // hasOne+belongsTo relationship
 // TODO: replace this with a struct when the above issue is solved.
-public class UserProfile: Model {
+// `@unchecked Sendable`: see `UserAccount`.
+public class UserProfile: Model, @unchecked Sendable {
 
     public let id: String
 

--- a/AmplifyTestCommon/Models/Deprecated/DeprecatedTodo.swift
+++ b/AmplifyTestCommon/Models/Deprecated/DeprecatedTodo.swift
@@ -66,7 +66,7 @@ public extension DeprecatedTodo {
     }
 }
 
-public struct Note: Codable {
+public struct Note: Codable, Sendable {
     var name: String
     var color: String
 }

--- a/AmplifyTestCommon/Models/TransformerV2/4aV2/Project4aV2.swift
+++ b/AmplifyTestCommon/Models/TransformerV2/4aV2/Project4aV2.swift
@@ -13,7 +13,9 @@ import Foundation
 // which will fail with error:
 // <>
 
-public class Project4aV2: Model {
+// `@unchecked Sendable`: `Model` is `Sendable` and this test fixture is a class with `var`
+// properties. Driven from a single test at a time.
+public class Project4aV2: Model, @unchecked Sendable {
   public let id: String
   public var name: String?
   public var team: Team4aV2?

--- a/AmplifyTestCommon/Models/TransformerV2/4aV2/Team4aV2.swift
+++ b/AmplifyTestCommon/Models/TransformerV2/4aV2/Team4aV2.swift
@@ -9,7 +9,9 @@
 import Amplify
 import Foundation
 
-public class Team4aV2: Model {
+// `@unchecked Sendable`: `Model` is `Sendable` and this test fixture is a class with `var`
+// properties. Driven from a single test at a time.
+public class Team4aV2: Model, @unchecked Sendable {
   public let id: String
   public var name: String
   public var project: Project4aV2?

--- a/AmplifyTestCommon/Models/TransformerV2/4bV2/Project4bV2.swift
+++ b/AmplifyTestCommon/Models/TransformerV2/4bV2/Project4bV2.swift
@@ -9,7 +9,9 @@
 import Amplify
 import Foundation
 
-public class Project4bV2: Model {
+// `@unchecked Sendable`: `Model` is `Sendable` and this test fixture is a class with `var`
+// properties. Driven from a single test at a time.
+public class Project4bV2: Model, @unchecked Sendable {
   public let id: String
   public var name: String?
   public var team: Team4bV2?

--- a/AmplifyTestCommon/Models/TransformerV2/4bV2/Team4bV2.swift
+++ b/AmplifyTestCommon/Models/TransformerV2/4bV2/Team4bV2.swift
@@ -9,7 +9,9 @@
 import Amplify
 import Foundation
 
-public class Team4bV2: Model {
+// `@unchecked Sendable`: `Model` is `Sendable` and this test fixture is a class with `var`
+// properties. Driven from a single test at a time.
+public class Team4bV2: Model, @unchecked Sendable {
   public let id: String
   public var name: String
   public var project: Project4bV2?

--- a/AmplifyTests/CategoryTests/API/APICategoryClientGraphQLTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryClientGraphQLTests.swift
@@ -12,7 +12,9 @@ import XCTest
 
 @testable import AmplifyTestCommon
 
-class APICategoryClientGraphQLTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class APICategoryClientGraphQLTests: XCTestCase, @unchecked Sendable {
     var mockAmplifyConfig: AmplifyConfiguration!
 
     override func setUp() async throws {

--- a/AmplifyTests/CategoryTests/API/APICategoryClientInterceptorTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryClientInterceptorTests.swift
@@ -12,7 +12,9 @@ import XCTest
 
 @testable import AmplifyTestCommon
 
-class APICategoryClientInterceptorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class APICategoryClientInterceptorTests: XCTestCase, @unchecked Sendable {
     var mockAmplifyConfig: AmplifyConfiguration!
 
     override func setUp() async throws {

--- a/AmplifyTests/CategoryTests/API/APICategoryClientRESTTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryClientRESTTests.swift
@@ -12,7 +12,9 @@ import XCTest
 
 @testable import AmplifyTestCommon
 
-class APICategoryClientRESTTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class APICategoryClientRESTTests: XCTestCase, @unchecked Sendable {
     var mockAmplifyConfig: AmplifyConfiguration!
 
     override func setUp() async throws {

--- a/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/API/APICategoryConfigurationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class APICategoryConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class APICategoryConfigurationTests: XCTestCase, @unchecked Sendable {
     override func setUp() async throws {
         await Amplify.reset()
     }

--- a/AmplifyTests/CategoryTests/API/APIPluginSelectorFactoryTests.swift
+++ b/AmplifyTests/CategoryTests/API/APIPluginSelectorFactoryTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class APIPluginSelectorFactoryTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class APIPluginSelectorFactoryTests: XCTestCase, @unchecked Sendable {
 
 //    override func setUp() {
 //        await Amplify.reset()

--- a/AmplifyTests/CategoryTests/API/NondeterminsticOperationTests.swift
+++ b/AmplifyTests/CategoryTests/API/NondeterminsticOperationTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import Amplify
 
-class NondeterminsticOperationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class NondeterminsticOperationTests: XCTestCase, @unchecked Sendable {
     enum TestError: Error {
         case error
     }
@@ -19,17 +21,17 @@ class NondeterminsticOperationTests: XCTestCase {
      */
     func test_withAllSucceedOperations_onlyFirstOneExecuted() async throws {
         let expectation1 = expectation(description: "opeartion 1 executed")
-        let operation1: () async throws -> Void  =  {
+        let operation1: @Sendable () async throws -> Void = {
             expectation1.fulfill()
         }
         let expectation2 = expectation(description: "opeartion 2 executed")
         expectation2.isInverted = true
-        let operation2: () async throws -> Void  =  {
+        let operation2: @Sendable () async throws -> Void = {
             expectation2.fulfill()
         }
         let expectation3 = expectation(description: "opeartion 3 executed")
         expectation3.isInverted = true
-        let operation3: () async throws -> Void  =  {
+        let operation3: @Sendable () async throws -> Void = {
             expectation3.fulfill()
         }
 
@@ -51,17 +53,17 @@ class NondeterminsticOperationTests: XCTestCase {
      */
     func test_withAllFailedOperations_throwsTotoalFailureAndAllOperationsAreExecuted() async throws {
         let expectation1 = expectation(description: "opeartion 1 executed")
-        let operation1: () async throws -> Void  =  {
+        let operation1: @Sendable () async throws -> Void = {
             expectation1.fulfill()
             throw TestError.error
         }
         let expectation2 = expectation(description: "opeartion 2 executed")
-        let operation2: () async throws -> Void  =  {
+        let operation2: @Sendable () async throws -> Void = {
             expectation2.fulfill()
             throw TestError.error
         }
         let expectation3 = expectation(description: "opeartion 3 executed")
-        let operation3: () async throws -> Void  =  {
+        let operation3: @Sendable () async throws -> Void = {
             expectation3.fulfill()
             throw TestError.error
         }
@@ -88,22 +90,22 @@ class NondeterminsticOperationTests: XCTestCase {
      */
     func test_withSomeSuccessOperations_AllOperationsUntilSuccessOperationAreExecuted() async throws {
         let expectation1 = expectation(description: "opeartion 1 executed")
-        let operation1: () async throws -> Void  =  {
+        let operation1: @Sendable () async throws -> Void = {
             expectation1.fulfill()
             throw TestError.error
         }
         let expectation2 = expectation(description: "opeartion 2 executed")
-        let operation2: () async throws -> Void  =  {
+        let operation2: @Sendable () async throws -> Void = {
             expectation2.fulfill()
             throw TestError.error
         }
         let expectation3 = expectation(description: "opeartion 3 executed")
-        let operation3: () async throws -> Void  =  {
+        let operation3: @Sendable () async throws -> Void = {
             expectation3.fulfill()
         }
         let expectation4 = expectation(description: "opeartion  executed")
         expectation4.isInverted = true
-        let operation4: () async throws -> Void  =  {
+        let operation4: @Sendable () async throws -> Void = {
             expectation4.fulfill()
             throw TestError.error
         }

--- a/AmplifyTests/CategoryTests/API/RetryableGraphQLOperationTests.swift
+++ b/AmplifyTests/CategoryTests/API/RetryableGraphQLOperationTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class RetryableGraphQLOperationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RetryableGraphQLOperationTests: XCTestCase, @unchecked Sendable {
     let testApiName = "apiName"
 
     /// Given: a RetryableGraphQLOperation with 2 operations
@@ -19,13 +21,13 @@ class RetryableGraphQLOperationTests: XCTestCase {
     /// Then: return the success response
     func testShouldRetryOperationWithNotAuthorizedAuthError() async throws {
         let expectation1 = expectation(description: "Operation 1 throws signed out auth error")
-        let operation1: () async throws -> GraphQLResponse<String> = {
+        let operation1: @Sendable () async throws -> GraphQLResponse<String> = {
             expectation1.fulfill()
             throw APIError.operationError("", "", AuthError.notAuthorized("", ""))
         }
 
         let expectation2 = expectation(description: "Operation 2 successfully finished")
-        let operation2: () async throws -> GraphQLResponse<String> = {
+        let operation2: @Sendable () async throws -> GraphQLResponse<String> = {
             expectation2.fulfill()
             return .success("operation 2")
         }
@@ -49,14 +51,14 @@ class RetryableGraphQLOperationTests: XCTestCase {
     /// Then: return the success response
     func testShouldNotRetryOperationWithUnknownError() async throws {
         let expectation1 = expectation(description: "Operation 1 throws signed out auth error")
-        let operation1: () async throws -> GraphQLResponse<String> = {
+        let operation1: @Sendable () async throws -> GraphQLResponse<String> = {
             expectation1.fulfill()
             throw APIError.unknown("~Unknown~", "")
         }
 
         let expectation2 = expectation(description: "Operation 2 successfully finished")
         expectation2.isInverted = true
-        let operation2: () async throws -> GraphQLResponse<String> = {
+        let operation2: @Sendable () async throws -> GraphQLResponse<String> = {
             expectation2.fulfill()
             return .success("operation 2")
         }

--- a/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryClientAPITests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AmplifyTestCommon
 
 // Tests that the client behavior API calls pass through from Category to CategoryPlugin
-class AnalyticsCategoryClientAPITests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AnalyticsCategoryClientAPITests: XCTestCase, @unchecked Sendable {
     var analytics: AnalyticsCategory!
     var plugin: MockAnalyticsCategoryPlugin!
 

--- a/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Analytics/AnalyticsCategoryConfigurationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class AnalyticsCategoryConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AnalyticsCategoryConfigurationTests: XCTestCase, @unchecked Sendable {
     override func setUp() async throws {
         await Amplify.reset()
     }

--- a/AmplifyTests/CategoryTests/Analytics/AnalyticsPluginSelectorFactoryTests.swift
+++ b/AmplifyTests/CategoryTests/Analytics/AnalyticsPluginSelectorFactoryTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class AnalyticsPluginSelectorFactoryTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AnalyticsPluginSelectorFactoryTests: XCTestCase, @unchecked Sendable {
 
 //    override func setUp() {
 //        await Amplify.reset()

--- a/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Auth/AuthCategoryConfigurationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class AuthCategoryConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AuthCategoryConfigurationTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         await Amplify.reset()

--- a/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryClientAPITests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class DataStoreCategoryClientAPITests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreCategoryClientAPITests: XCTestCase, @unchecked Sendable {
     var mockAmplifyConfig: AmplifyConfiguration!
 
     override func setUp() async throws {
@@ -49,7 +51,9 @@ class DataStoreCategoryClientAPITests: XCTestCase {
 
 }
 
-class TestModel: Model {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+class TestModel: Model, @unchecked Sendable {
     static func make() -> TestModel {
         return TestModel(id: UUID().uuidString)
     }

--- a/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/DataStoreCategoryConfigurationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class DataStoreCategoryConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreCategoryConfigurationTests: XCTestCase, @unchecked Sendable {
     override func setUp() async throws {
         await Amplify.reset()
     }

--- a/AmplifyTests/CategoryTests/DataStore/JSONValueHolderTest.swift
+++ b/AmplifyTests/CategoryTests/DataStore/JSONValueHolderTest.swift
@@ -8,7 +8,9 @@
 import Amplify
 import XCTest
 
-class JSONValueHolderTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class JSONValueHolderTest: XCTestCase, @unchecked Sendable {
 
     var jsonValueHodler = DynamicModel(values: [
         "id": 123,

--- a/AmplifyTests/CategoryTests/DataStore/Model/Collection/ArrayLiteralListProviderTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/Model/Collection/ArrayLiteralListProviderTests.swift
@@ -8,7 +8,9 @@
 import Amplify
 import XCTest
 
-class ArrayLiteralListProviderTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ArrayLiteralListProviderTests: XCTestCase, @unchecked Sendable {
     struct BasicModel: Model {
         var id: String
     }

--- a/AmplifyTests/CategoryTests/DataStore/Model/LazyReferenceTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/Model/LazyReferenceTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-final class LazyReferenceTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class LazyReferenceTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: LazyParentPost4V2.self)

--- a/AmplifyTests/CategoryTests/DataStore/Model/ListTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/Model/ListTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class ListTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ListTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelListDecoderRegistry.reset()

--- a/AmplifyTests/CategoryTests/DataStore/ModelFieldAssociationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/ModelFieldAssociationTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class ModelFieldAssociationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ModelFieldAssociationTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: Post.self)

--- a/AmplifyTests/CategoryTests/DataStore/ModelIdentifierTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/ModelIdentifierTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import AmplifyTestCommon
 import XCTest
 
-class ModelIdentifierTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ModelIdentifierTests: XCTestCase, @unchecked Sendable {
     override func setUp() {
 
         // default primary keys models

--- a/AmplifyTests/CategoryTests/DataStore/ModelPrimaryKeyTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/ModelPrimaryKeyTests.swift
@@ -12,7 +12,9 @@ import AmplifyTestCommon
 import AWSPluginsCore
 @testable import Amplify
 
-class ModelPrimaryKeyTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ModelPrimaryKeyTests: XCTestCase, @unchecked Sendable {
     override func setUp() {
 
         // default primary keys models

--- a/AmplifyTests/CategoryTests/DataStore/ModelRegistryTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/ModelRegistryTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AmplifyTestCommon
 
-class ModelRegistryTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ModelRegistryTests: XCTestCase, @unchecked Sendable {
 
     let postJSON =
     #"{"id":"1","title":"title","content":"content","comments":[],"createdAt":"2019-12-31T01:23:45.678Z"}"#

--- a/AmplifyTests/CategoryTests/DataStore/TemporalComparableTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/TemporalComparableTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 @testable import Amplify
 
-class TemporalComparableTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class TemporalComparableTests: XCTestCase, @unchecked Sendable {
 
     // MARK: - Date
 

--- a/AmplifyTests/CategoryTests/DataStore/TemporalOperationTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/TemporalOperationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 @testable import Amplify
 
-class TemporalOperationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class TemporalOperationTests: XCTestCase, @unchecked Sendable {
 
     // MARK: - Date
 

--- a/AmplifyTests/CategoryTests/DataStore/TemporalTests.swift
+++ b/AmplifyTests/CategoryTests/DataStore/TemporalTests.swift
@@ -12,7 +12,9 @@ import XCTest
 
 let pst = TimeZone(secondsFromGMT: -28_800)!
 
-class TemporalTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class TemporalTests: XCTestCase, @unchecked Sendable {
 
     // MARK: - DateTime
 

--- a/AmplifyTests/CategoryTests/Geo/GeoCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Geo/GeoCategoryClientAPITests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AmplifyTestCommon
 
 // Tests that the client behavior API calls pass through from Category to CategoryPlugin
-class GeoCategoryClientAPITests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GeoCategoryClientAPITests: XCTestCase, @unchecked Sendable {
     var geo: GeoCategory!
     var plugin: MockGeoCategoryPlugin!
 

--- a/AmplifyTests/CategoryTests/Geo/GeoCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Geo/GeoCategoryConfigurationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class GeoCategoryConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GeoCategoryConfigurationTests: XCTestCase, @unchecked Sendable {
     override func setUp() async throws {
         await Amplify.reset()
     }

--- a/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/AmplifyOperationHubTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class AmplifyOperationHubTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyOperationHubTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         await Amplify.reset()
@@ -111,7 +113,9 @@ class AmplifyOperationHubTests: XCTestCase {
 
 }
 
-class MockDispatchingStoragePlugin: StorageCategoryPlugin {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+class MockDispatchingStoragePlugin: StorageCategoryPlugin, @unchecked Sendable {
 
     var key: PluginKey = "MockDispatchingStoragePlugin"
 

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AWSHubPluginAmplifyVersionableTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AWSHubPluginAmplifyVersionableTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import Amplify
 
-class AWSHubPluginAmplifyVersionableTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSHubPluginAmplifyVersionableTests: XCTestCase, @unchecked Sendable {
 
     func testVersionExists() {
         let plugin = AWSHubPlugin()

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeHubListenToOperationTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeHubListenToOperationTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class AutoUnsubscribeHubListenToOperationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AutoUnsubscribeHubListenToOperationTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         await Amplify.reset()

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeOperationTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/AutoUnsubscribeOperationTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class AutoUnsubscribeOperationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AutoUnsubscribeOperationTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         await Amplify.reset()

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginCustomChannelTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginCustomChannelTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class DefaultHubPluginCustomChannelTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DefaultHubPluginCustomChannelTests: XCTestCase, @unchecked Sendable {
 
     var plugin: HubCategoryPlugin {
         guard let plugin = try? Amplify.Hub.getPlugin(for: "awsHubPlugin"),

--- a/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/DefaultPluginTests/DefaultHubPluginTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class DefaultHubPluginTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DefaultHubPluginTests: XCTestCase, @unchecked Sendable {
 
     var plugin: HubCategoryPlugin {
         guard let plugin = try? Amplify.Hub.getPlugin(for: "awsHubPlugin"),
@@ -100,8 +102,9 @@ class DefaultHubPluginTests: XCTestCase {
     /// Then: My listener is removed, and I receive no more events
     func testDefaultPluginRemoveListener() async throws {
         let isStillRegistered = AtomicValue(initialValue: true)
-        var isStillRegisteredExpected = true
-        var currentExpectation: XCTestExpectation?
+        // Read from the `@Sendable` Hub listener below, so neither can be a captured `var`.
+        let isStillRegisteredExpected = AtomicValue(initialValue: true)
+        let currentExpectation = AtomicValue<XCTestExpectation?>(initialValue: nil)
         let unsubscribeToken = plugin.listen(to: .storage, isIncluded: nil) { hubPayload in
             if isStillRegistered.get() {
                 // Ignore system-generated notifications (e.g., "configuration finished"). After we `removeListener`
@@ -110,17 +113,17 @@ class DefaultHubPluginTests: XCTestCase {
                 guard hubPayload.eventName == "TEST_EVENT" else {
                     return
                 }
-                if isStillRegisteredExpected {
-                    currentExpectation?.fulfill()
+                if isStillRegisteredExpected.get() {
+                    currentExpectation.get()?.fulfill()
                 }
             } else {
-                if !isStillRegisteredExpected {
-                    currentExpectation?.fulfill()
+                if !isStillRegisteredExpected.get() {
+                    currentExpectation.get()?.fulfill()
                 }
             }
         }
 
-        currentExpectation = expectation(description: "Message was received as expected")
+        currentExpectation.set(expectation(description: "Message was received as expected"))
         guard try await HubListenerTestUtilities.waitForListener(
             with: unsubscribeToken,
             plugin: plugin,
@@ -131,17 +134,17 @@ class DefaultHubPluginTests: XCTestCase {
         }
 
         plugin.dispatch(to: .storage, payload: HubPayload(eventName: "TEST_EVENT"))
-        try await fulfillment(of: [XCTUnwrap(currentExpectation)], timeout: 0.5)
+        try await fulfillment(of: [XCTUnwrap(currentExpectation.get())], timeout: 0.5)
 
         plugin.removeListener(unsubscribeToken)
         try? await Task.sleep(seconds: 0.01)
 
-        isStillRegisteredExpected = false
-        currentExpectation = expectation(description: "Message was received after removing listener")
-        currentExpectation?.isInverted = true
+        isStillRegisteredExpected.set(false)
+        currentExpectation.set(expectation(description: "Message was received after removing listener"))
+        currentExpectation.get()?.isInverted = true
 
-        try await isStillRegistered.set(
-            HubListenerTestUtilities.waitForListener(
+        isStillRegistered.set(
+            try await HubListenerTestUtilities.waitForListener(
                 with: unsubscribeToken,
                 plugin: plugin,
                 timeout: 0.5
@@ -151,7 +154,7 @@ class DefaultHubPluginTests: XCTestCase {
         XCTAssertFalse(isStillRegistered.get(), "Should not be registered after removeListener")
 
         plugin.dispatch(to: .storage, payload: HubPayload(eventName: "TEST_EVENT"))
-        try await fulfillment(of: [XCTUnwrap(currentExpectation)], timeout: 0.5)
+        try await fulfillment(of: [XCTUnwrap(currentExpectation.get())], timeout: 0.5)
     }
 
     /// Given: The default Hub plugin

--- a/AmplifyTests/CategoryTests/Hub/HubCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubCategoryConfigurationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class HubCategoryConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class HubCategoryConfigurationTests: XCTestCase, @unchecked Sendable {
     override func setUp() async throws {
         await Amplify.reset()
     }

--- a/AmplifyTests/CategoryTests/Hub/HubClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubClientAPITests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 @testable import AmplifyTestCommon
 
-class HubClientAPITests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class HubClientAPITests: XCTestCase, @unchecked Sendable {
     var mockAmplifyConfig: AmplifyConfiguration!
 
     override func setUp() async throws {

--- a/AmplifyTests/CategoryTests/Hub/HubCombineTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubCombineTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class HubCombineTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class HubCombineTests: XCTestCase, @unchecked Sendable {
 
     func testValue() async {
         let receivedValue = expectation(description: "Received value")

--- a/AmplifyTests/CategoryTests/Hub/HubListenerTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubListenerTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 @testable import AmplifyTestCommon
 
-class HubListenerTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class HubListenerTests: XCTestCase, @unchecked Sendable {
 
     /// Given: A configured hub, and a category API that takes a listener callback
     /// When: I invoke the API with a callback

--- a/AmplifyTests/CategoryTests/Hub/HubPluginSelectorFactoryTests.swift
+++ b/AmplifyTests/CategoryTests/Hub/HubPluginSelectorFactoryTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class HubPluginSelectorFactoryTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class HubPluginSelectorFactoryTests: XCTestCase, @unchecked Sendable {
 
 //    override func setUp() {
 //        await Amplify.reset()

--- a/AmplifyTests/CategoryTests/Logging/DefaultLoggingPluginAmplifyVersionableTests.swift
+++ b/AmplifyTests/CategoryTests/Logging/DefaultLoggingPluginAmplifyVersionableTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 
 // swiftlint:disable:next type_name
-class DefaultLoggingPluginAmplifyVersionableTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DefaultLoggingPluginAmplifyVersionableTests: XCTestCase, @unchecked Sendable {
 
     func testVersionExists() {
         let plugin = AWSUnifiedLoggingPlugin()

--- a/AmplifyTests/CategoryTests/Logging/DefaultLoggingPluginTests.swift
+++ b/AmplifyTests/CategoryTests/Logging/DefaultLoggingPluginTests.swift
@@ -16,7 +16,9 @@ import XCTest
 /// important. The `message` arguments are auto-closures, and we're relying on that fact to determine whether a message
 /// is being evaluated or not. In other words, don't assign the message to a variable, and then pass it to the logging
 /// method.
-class DefaultLoggingPluginTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DefaultLoggingPluginTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         await Amplify.reset()

--- a/AmplifyTests/CategoryTests/Logging/LoggingCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Logging/LoggingCategoryClientAPITests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class LoggingCategoryClientAPITests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class LoggingCategoryClientAPITests: XCTestCase, @unchecked Sendable {
     var mockAmplifyConfig: AmplifyConfiguration!
 
     override func setUp() async throws {
@@ -152,7 +154,9 @@ class LoggingCategoryClientAPITests: XCTestCase {
 
 // A bare class that does not forward or evaluate message autoclosure. Used to test that Amplify, as
 // a framework, does not evaluate the autoclosure
-class NonEvaluatingLoggingPlugin: LoggingCategoryPlugin, Logger {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+class NonEvaluatingLoggingPlugin: LoggingCategoryPlugin, Logger, @unchecked Sendable {
     var logLevel = LogLevel.error
 
     let key = "NonEvaluatingLoggingPlugin"

--- a/AmplifyTests/CategoryTests/Logging/LoggingCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Logging/LoggingCategoryConfigurationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class LoggingCategoryConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class LoggingCategoryConfigurationTests: XCTestCase, @unchecked Sendable {
     override func setUp() async throws {
         await Amplify.reset()
     }

--- a/AmplifyTests/CategoryTests/Logging/LoggingPluginSelectorFactoryTests.swift
+++ b/AmplifyTests/CategoryTests/Logging/LoggingPluginSelectorFactoryTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class LoggingPluginSelectorFactoryTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class LoggingPluginSelectorFactoryTests: XCTestCase, @unchecked Sendable {
 //
 //    override func setUp() {
 //        await Amplify.reset()

--- a/AmplifyTests/CategoryTests/Notifications/NotificationsCategoryTests.swift
+++ b/AmplifyTests/CategoryTests/Notifications/NotificationsCategoryTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-final class NotificationsCategoryTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class NotificationsCategoryTests: XCTestCase, @unchecked Sendable {
     private var category: NotificationsCategory!
 
     override func setUp() async throws {

--- a/AmplifyTests/CategoryTests/Notifications/Push/PushNotificationsCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Notifications/Push/PushNotificationsCategoryClientAPITests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class PushNotificationsCategoryClientAPITests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class PushNotificationsCategoryClientAPITests: XCTestCase, @unchecked Sendable {
     private var category: PushNotificationsCategory!
     private var plugin: MockPushNotificationsCategoryPlugin!
 

--- a/AmplifyTests/CategoryTests/Notifications/Push/PushNotificationsCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Notifications/Push/PushNotificationsCategoryConfigurationTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class PushNotificationsCategoryConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class PushNotificationsCategoryConfigurationTests: XCTestCase, @unchecked Sendable {
     // MARK: - Setup methods
 
     override func setUp() async throws {

--- a/AmplifyTests/CategoryTests/Predictions/ModelsTest/LanguageTypeTest.swift
+++ b/AmplifyTests/CategoryTests/Predictions/ModelsTest/LanguageTypeTest.swift
@@ -8,7 +8,9 @@
 import Amplify
 import XCTest
 
-class LanguageTypeTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class LanguageTypeTest: XCTestCase, @unchecked Sendable {
 
     func testInitialization() {
         let language = Predictions.Language(code: "en")

--- a/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryClientAPITests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import Amplify
 
-class PredictionsCategoryClientAPITests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class PredictionsCategoryClientAPITests: XCTestCase, @unchecked Sendable {
     override func setUp() async throws {
         await Amplify.reset()
     }

--- a/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Predictions/PredictionsCategoryConfigurationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class PredictionsCategoryConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class PredictionsCategoryConfigurationTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         await Amplify.reset()

--- a/AmplifyTests/CategoryTests/Storage/StorageCategoryClientAPITests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StorageCategoryClientAPITests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import Amplify
 
-class StorageCategoryClientAPITests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageCategoryClientAPITests: XCTestCase, @unchecked Sendable {
     override func setUp() async throws {
         await Amplify.reset()
     }

--- a/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StorageCategoryConfigurationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class StorageCategoryConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageCategoryConfigurationTests: XCTestCase, @unchecked Sendable {
     override func setUp() async throws {
         await Amplify.reset()
     }

--- a/AmplifyTests/CategoryTests/Storage/StoragePathTests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StoragePathTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class StoragePathTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StoragePathTests: XCTestCase, @unchecked Sendable {
 
     /// Given: StringStoragePath object
     /// When: resolve is called

--- a/AmplifyTests/CategoryTests/Storage/StoragePluginSelectorFactoryTests.swift
+++ b/AmplifyTests/CategoryTests/Storage/StoragePluginSelectorFactoryTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class StoragePluginSelectorFactoryTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StoragePluginSelectorFactoryTests: XCTestCase, @unchecked Sendable {
 
 //    override func setUp() {
 //        await Amplify.reset()

--- a/AmplifyTests/CoreTests/AmplifyConfigurationInitializationTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyConfigurationInitializationTests.swift
@@ -11,7 +11,9 @@ import XCTest
 
 /// Uses internal methods of the Amplify configuration system to ensure we are throwing expected errors in exceptional
 /// circumstances
-class AmplifyConfigurationInitializationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyConfigurationInitializationTests: XCTestCase, @unchecked Sendable {
 
     static let tempDir: URL = {
         let fileManager = FileManager.default

--- a/AmplifyTests/CoreTests/AmplifyInProcessReportingOperationChainedTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyInProcessReportingOperationChainedTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AmplifyTestCommon
 
 // swiftlint:disable:next type_name
-class AmplifyInProcessReportingOperationChainedTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyInProcessReportingOperationChainedTests: XCTestCase, @unchecked Sendable {
 
     func testChainedResultPublishersSucceed() async {
         let makeSuccessResponder: (Int) -> MockPublisherInProcessOperation.Responder = { value in

--- a/AmplifyTests/CoreTests/AmplifyInProcessReportingOperationCombineTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyInProcessReportingOperationCombineTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AmplifyTestCommon
 
 // swiftlint:disable:next type_name
-class AmplifyInProcessReportingOperationCombineTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyInProcessReportingOperationCombineTests: XCTestCase, @unchecked Sendable {
 
     var receivedResultValue: XCTestExpectation!
     var receivedResultFinished: XCTestExpectation!

--- a/AmplifyTests/CoreTests/AmplifyOperationCombineTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyOperationCombineTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class AmplifyOperationCombineTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyOperationCombineTests: XCTestCase, @unchecked Sendable {
 
     func testResultPublisherSucceeds() async {
         let responder: MockPublisherOperation.Responder = { operation in

--- a/AmplifyTests/CoreTests/AmplifyOutputsDataPublicAPITests.swift
+++ b/AmplifyTests/CoreTests/AmplifyOutputsDataPublicAPITests.swift
@@ -13,7 +13,9 @@ import XCTest
 
 /// Tests that verify `AmplifyOutputsData` and all nested types are accessible
 /// without `@_spi(InternalAmplifyConfiguration)` — only standard `import Amplify` is needed.
-class AmplifyOutputsDataPublicAPITests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyOutputsDataPublicAPITests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         await Amplify.reset()

--- a/AmplifyTests/CoreTests/AmplifyOutputsInitializationTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyOutputsInitializationTests.swift
@@ -11,7 +11,9 @@ import XCTest
 
 /// Uses internal methods of the Amplify configuration system to ensure we are throwing expected errors in exceptional
 /// circumstances
-class AmplifyOutputsInitializationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyOutputsInitializationTests: XCTestCase, @unchecked Sendable {
 
     static let tempDir: URL = {
         let fileManager = FileManager.default

--- a/AmplifyTests/CoreTests/AmplifyPublisherTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyPublisherTests.swift
@@ -12,7 +12,11 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class AmplifyPublisherTests: XCTestCase {
+/// - Note: `@unchecked Sendable` so the test body can be captured by the `@Sendable` completion
+
+///   closures the production API now takes. `XCTestCase` is not `Sendable`, and each test runs alone.
+
+final class AmplifyPublisherTests: XCTestCase, @unchecked Sendable {
     enum Failure: Error {
         case unluckyNumber
     }

--- a/AmplifyTests/CoreTests/AmplifyTaskQueueTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyTaskQueueTests.swift
@@ -29,7 +29,9 @@ import XCTest
 // does not guarantee order of execution. TaskQueue is intended to serialize execution to guarantee
 // that the in-process task completes before the new one is executed.
 
-final class AmplifyTaskQueueTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AmplifyTaskQueueTests: XCTestCase, @unchecked Sendable {
 
     /// Test basic TaskQueue.sync behavior
     ///

--- a/AmplifyTests/CoreTests/AmplifyTaskTests.swift
+++ b/AmplifyTests/CoreTests/AmplifyTaskTests.swift
@@ -13,7 +13,9 @@ import Combine
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class AmplifyTaskTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyTaskTests: XCTestCase, @unchecked Sendable {
     let queue = OperationQueue()
 
     func testFastOperation() async throws {

--- a/AmplifyTests/CoreTests/AnyEncodableTests.swift
+++ b/AmplifyTests/CoreTests/AnyEncodableTests.swift
@@ -14,7 +14,9 @@ private struct EncodableStruct: Codable, Equatable {
     let number: Int
 }
 
-class AnyEncodableTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AnyEncodableTests: XCTestCase, @unchecked Sendable {
 
     /// - Given: a struct that comforms to `Encodable`
     /// - When:

--- a/AmplifyTests/CoreTests/AtomicValue+BoolTests.swift
+++ b/AmplifyTests/CoreTests/AtomicValue+BoolTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 
 // These tests must be run with ThreadSanitizer enabled
-class AtomicValueBoolTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AtomicValueBoolTests: XCTestCase, @unchecked Sendable {
 
     func testGetAndToggleStartingWithTrue() {
         let atomicBool = AtomicValue(initialValue: true)

--- a/AmplifyTests/CoreTests/AtomicValue+NumericTests.swift
+++ b/AmplifyTests/CoreTests/AtomicValue+NumericTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 
 // These tests must be run with ThreadSanitizer enabled
-class AtomicValueNumericTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AtomicValueNumericTests: XCTestCase, @unchecked Sendable {
 
     func testIncrement() {
         let atomicInt = AtomicValue(initialValue: 0)

--- a/AmplifyTests/CoreTests/AtomicValue+RangeReplaceableCollectionTests.swift
+++ b/AmplifyTests/CoreTests/AtomicValue+RangeReplaceableCollectionTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 
 // These tests must be run with ThreadSanitizer enabled
-class AtomicValueRangeReplaceableTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AtomicValueRangeReplaceableTests: XCTestCase, @unchecked Sendable {
 
     func testAppend() {
         let atomicArray = AtomicValue(initialValue: [Int]())

--- a/AmplifyTests/CoreTests/AtomicValueTests.swift
+++ b/AmplifyTests/CoreTests/AtomicValueTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 
 // These tests must be run with ThreadSanitizer enabled
-class AtomicValueTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AtomicValueTests: XCTestCase, @unchecked Sendable {
 
     func testPerformance() {
         let atomicInt = AtomicValue(initialValue: 0)

--- a/AmplifyTests/CoreTests/ChildTaskTests.swift
+++ b/AmplifyTests/CoreTests/ChildTaskTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable @preconcurrency import Amplify
 
 // These tests must be run with ThreadSanitizer enabled
-class ChildTaskTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ChildTaskTests: XCTestCase, @unchecked Sendable {
     class Worker: Cancellable {
         var cancelCount = 0
         func cancel() {

--- a/AmplifyTests/CoreTests/ConfigurationTests.swift
+++ b/AmplifyTests/CoreTests/ConfigurationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class ConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ConfigurationTests: XCTestCase, @unchecked Sendable {
     override func setUp() async throws {
         await Amplify.reset()
     }

--- a/AmplifyTests/CoreTests/FoundationUtilsTests.swift
+++ b/AmplifyTests/CoreTests/FoundationUtilsTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import Amplify
 
-class FoundationUtilsTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class FoundationUtilsTests: XCTestCase, @unchecked Sendable {
 
     func test_isEmpty_extensionPlaysNicelyWithStandardLib_Array() {
         let notEmpty = ["Foo"]

--- a/AmplifyTests/CoreTests/InternalTaskTests.swift
+++ b/AmplifyTests/CoreTests/InternalTaskTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class InternalTaskTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class InternalTaskTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         await Amplify.reset()
@@ -30,10 +32,11 @@ class InternalTaskTests: XCTestCase {
         let task = Task<[String], Never> {
             let hubDone = expectation(description: "hub done")
             var emojis = [String]()
-            var hubValues = [String]()
+            // Appended from a `@Sendable` Hub listener, so it cannot be a captured `var`.
+            let hubValues = AtomicValue<[String]>(initialValue: [])
             let token = runner.subscribe { emoji in
-                hubValues.append(emoji)
-                if hubValues.count == total {
+                hubValues.with { $0.append(emoji) }
+                if hubValues.get().count == total {
                     hubDone.fulfill()
                 }
             }
@@ -42,7 +45,7 @@ class InternalTaskTests: XCTestCase {
             }
             await fulfillment(of: [hubDone])
             done.fulfill()
-            XCTAssertEqual(total, hubValues.count)
+            XCTAssertEqual(total, hubValues.get().count)
             XCTAssertEqual(total, emojis.count)
             runner.unsubscribe(token)
             return emojis

--- a/AmplifyTests/CoreTests/JSONValue+KeyPathTests.swift
+++ b/AmplifyTests/CoreTests/JSONValue+KeyPathTests.swift
@@ -8,7 +8,9 @@
 import Amplify
 import XCTest
 
-class JSONValueKeyPathTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class JSONValueKeyPathTests: XCTestCase, @unchecked Sendable {
 
     func testKeyPathForInt() {
         let intVal: JSONValue = 1

--- a/AmplifyTests/CoreTests/JSONValue+SubscriptTests.swift
+++ b/AmplifyTests/CoreTests/JSONValue+SubscriptTests.swift
@@ -8,7 +8,9 @@
 import Amplify
 import XCTest
 
-class JSONValueSubscriptTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class JSONValueSubscriptTests: XCTestCase, @unchecked Sendable {
 
     func testSubscriptForInt() {
         let intVal: JSONValue = 1

--- a/AmplifyTests/CoreTests/JSONValueTests.swift
+++ b/AmplifyTests/CoreTests/JSONValueTests.swift
@@ -8,7 +8,9 @@
 import Amplify
 import XCTest
 
-class JSONValueTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class JSONValueTests: XCTestCase, @unchecked Sendable {
 
     func testDecode() throws {
         let decoder = JSONDecoder()

--- a/AmplifyTests/CoreTests/Model+CodableTests.swift
+++ b/AmplifyTests/CoreTests/Model+CodableTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import AmplifyTestCommon
 import XCTest
 
-class ModelCodableTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ModelCodableTests: XCTestCase, @unchecked Sendable {
     let postJSONWithFractionalSeconds = """
     {"comments":[],"content":"content","createdAt":"1970-01-12T13:46:40.123Z","id":"post-1","title":"title"}
     """

--- a/AmplifyTests/CoreTests/NotificationListeningAnalyticsPlugin.swift
+++ b/AmplifyTests/CoreTests/NotificationListeningAnalyticsPlugin.swift
@@ -8,7 +8,9 @@
 import Amplify
 import XCTest
 
-class NotificationListeningAnalyticsPlugin: AnalyticsCategoryPlugin {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+class NotificationListeningAnalyticsPlugin: AnalyticsCategoryPlugin, @unchecked Sendable {
     let key = "NotificationListeningAnalyticsPlugin"
     let notificationReceived: XCTestExpectation
 
@@ -19,13 +21,16 @@ class NotificationListeningAnalyticsPlugin: AnalyticsCategoryPlugin {
     func configure(using configuration: Any?) throws {
         let isConfigured = HubFilters.forEventName(HubPayload.EventName.Amplify.configured)
 
-        var token: UnsubscribeToken?
-        token = Amplify.Hub.listen(to: .analytics, isIncluded: isConfigured) { _ in
+        // The listener removes itself, so the token is held in a box rather than a `var` captured
+        // before assignment.
+        let tokenBox = AtomicValue<UnsubscribeToken?>(initialValue: nil)
+        let token = Amplify.Hub.listen(to: .analytics, isIncluded: isConfigured) { _ in
             self.notificationReceived.fulfill()
-            if let token {
+            if let token = tokenBox.get() {
                 Amplify.Hub.removeListener(token)
             }
         }
+        tokenBox.set(token)
     }
 
     func identifyUser(userId identityId: String, userProfile: AnalyticsUserProfile?) {

--- a/AmplifyTests/CoreTests/Operations/FastOperation.swift
+++ b/AmplifyTests/CoreTests/Operations/FastOperation.swift
@@ -11,17 +11,24 @@ import Combine
 #endif
 import Amplify
 
-public class FastOperationRequest: AmplifyOperationRequest {
-    public let options: [AnyHashable: Any]
+/// `Options` must be `Sendable` (see `AmplifyOperationRequest`), and `[AnyHashable: Any]` cannot be:
+/// `AnyHashable`'s `Sendable` conformance is explicitly unavailable. No call site passes options, so
+/// this uses a dedicated empty type instead.
+public final class FastOperationRequest: AmplifyOperationRequest, Sendable {
+    public struct Options: Sendable {
+        public init() {}
+    }
+
+    public let options: Options
     public let numbers: [Int]
 
-    public init(options: [AnyHashable: Any] = [:], numbers: [Int]) {
+    public init(options: Options = .init(), numbers: [Int]) {
         self.options = options
         self.numbers = numbers
     }
 }
 
-public struct FastOperationSuccess {
+public struct FastOperationSuccess: Sendable {
     public let value: Int
 
     public init(value: Int) {
@@ -67,7 +74,7 @@ public enum FastOperationError: AmplifyError {
 }
 
 public typealias FastOperationResult = Result<FastOperationSuccess, FastOperationError>
-public typealias FastOperationResultListener = (FastOperationResult) -> Void
+public typealias FastOperationResultListener = @Sendable (FastOperationResult) -> Void
 
 public class FastOperation: AmplifyOperation<FastOperationRequest, FastOperationSuccess, FastOperationError>, @unchecked Sendable {
     public typealias TaskAdapter = AmplifyOperationTaskAdapter<Request, Success, Failure>

--- a/AmplifyTests/CoreTests/Operations/LongOperation.swift
+++ b/AmplifyTests/CoreTests/Operations/LongOperation.swift
@@ -11,13 +11,20 @@ import Combine
 #endif
 import Amplify
 
-public class LongOperationRequest: AmplifyOperationRequest, RequestIdentifier {
-    public let options: [AnyHashable: Any]
+/// `Options` must be `Sendable` (see `AmplifyOperationRequest`), and `[AnyHashable: Any]` cannot be:
+/// `AnyHashable`'s `Sendable` conformance is explicitly unavailable. No call site passes options, so
+/// this uses a dedicated empty type instead.
+public final class LongOperationRequest: AmplifyOperationRequest, RequestIdentifier, Sendable {
+    public struct Options: Sendable {
+        public init() {}
+    }
+
+    public let options: Options
     public let steps: Int
     public let delay: Double
     public let requestID: String
 
-    public init(options: [AnyHashable: Any] = [:], steps: Int, delay: Double) {
+    public init(options: Options = .init(), steps: Int, delay: Double) {
         self.options = options
         self.steps = steps
         self.delay = delay
@@ -25,7 +32,7 @@ public class LongOperationRequest: AmplifyOperationRequest, RequestIdentifier {
     }
 }
 
-public struct LongOperationSuccess {
+public struct LongOperationSuccess: Sendable {
     let id = UUID().uuidString
 }
 
@@ -67,8 +74,8 @@ public enum LongOperationError: AmplifyError {
 }
 
 public typealias LongOperationResult = Result<LongOperationSuccess, LongOperationError>
-public typealias LongOperationProgressListener = (Progress) -> Void
-public typealias LongOperationResultListener = (LongOperationResult) -> Void
+public typealias LongOperationProgressListener = @Sendable (Progress) -> Void
+public typealias LongOperationResultListener = @Sendable (LongOperationResult) -> Void
 
 public class LongOperation: AmplifyInProcessReportingOperation<LongOperationRequest, Progress, LongOperationSuccess, LongOperationError>, @unchecked Sendable {
     public typealias TaskAdapter = AmplifyInProcessReportingOperationTaskAdapter<Request, InProcess, Success, Failure>
@@ -77,7 +84,9 @@ public class LongOperation: AmplifyInProcessReportingOperation<LongOperationRequ
     public typealias ProgressPublisher = AnyPublisher<InProcess, Failure>
 #endif
 
-    var count = 0
+    // Counted from a `@Sendable` closure, so it cannot be a captured `var`.
+
+    let count = AtomicValue(initialValue: 0)
     var currentProgress: Progress!
 
     public init(
@@ -113,7 +122,7 @@ public class LongOperation: AmplifyInProcessReportingOperation<LongOperationRequ
 
         reportProgress()
 
-        if count < request.steps {
+        if count.get() < request.steps {
             DispatchQueue.global().asyncAfter(deadline: .now() + request.delay, execute: advance)
         } else {
             dispatch(result: .success(LongOperationSuccess()))
@@ -122,12 +131,12 @@ public class LongOperation: AmplifyInProcessReportingOperation<LongOperationRequ
     }
 
     private func advance() {
-        count += 1
+        _ = count.increment()
         work()
     }
 
     private func reportProgress() {
-        currentProgress.completedUnitCount = Int64(count)
+        currentProgress.completedUnitCount = Int64(count.get())
         dispatchInProcess(data: currentProgress)
     }
 }

--- a/AmplifyTests/CoreTests/Optional+ExtentionTests.swift
+++ b/AmplifyTests/CoreTests/Optional+ExtentionTests.swift
@@ -8,7 +8,9 @@
 @_spi(OptionalExtension) import Amplify
 import XCTest
 
-class OptionalExtensionTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class OptionalExtensionTests: XCTestCase, @unchecked Sendable {
 
     /// - Given:
     ///     Optional of integer with none

--- a/AmplifyTests/CoreTests/RequestIdentifierTests.swift
+++ b/AmplifyTests/CoreTests/RequestIdentifierTests.swift
@@ -10,10 +10,12 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class RequestIdentiferTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RequestIdentiferTests: XCTestCase, @unchecked Sendable {
 
     func testLongOperationRequest() {
-        let request = LongOperationRequest(options: [:], steps: 10, delay: 0.25)
+        let request = LongOperationRequest(steps: 10, delay: 0.25)
         XCTAssertFalse(request.requestID.isEmpty)
     }
 

--- a/AmplifyTests/CoreTests/Tasks/InternalTasks.swift
+++ b/AmplifyTests/CoreTests/Tasks/InternalTasks.swift
@@ -8,19 +8,28 @@
 import Amplify
 import Foundation
 
-public class MagicEightBallRequest: AmplifyOperationRequest {
-    public let options: [AnyHashable: Any]
+/// `Options` must be `Sendable` (see `AmplifyOperationRequest`), and `[AnyHashable: Any]` cannot be:
+/// `AnyHashable`'s `Sendable` conformance is explicitly unavailable. No call site passes options, so
+/// this uses a dedicated empty type instead.
+public final class MagicEightBallRequest: AmplifyOperationRequest, Sendable {
+    public struct Options: Sendable {
+        public init() {}
+    }
+
+    public let options: Options
     public let total: Int
     public let delay: Double
 
-    public init(options: [AnyHashable: Any] = [:], total: Int, delay: Double) {
+    public init(options: Options = .init(), total: Int, delay: Double) {
         self.options = options
         self.total = total
         self.delay = delay
     }
 }
 
-public class MagicEightBallTaskRunner: InternalTaskRunner, InternalTaskAsyncSequence, InternalTaskChannel, InternalTaskIdentifiable, InternalTaskHubInProcess {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+public class MagicEightBallTaskRunner: InternalTaskRunner, InternalTaskAsyncSequence, InternalTaskChannel, InternalTaskIdentifiable, InternalTaskHubInProcess, @unchecked Sendable {
     public typealias Request = MagicEightBallRequest
     public typealias InProcess = String
 
@@ -92,19 +101,28 @@ public struct MagicEightBallPlugin {
 
 }
 
-public class RandomEmojiRequest: AmplifyOperationRequest {
-    public let options: [AnyHashable: Any]
+/// `Options` must be `Sendable` (see `AmplifyOperationRequest`), and `[AnyHashable: Any]` cannot be:
+/// `AnyHashable`'s `Sendable` conformance is explicitly unavailable. No call site passes options, so
+/// this uses a dedicated empty type instead.
+public final class RandomEmojiRequest: AmplifyOperationRequest, Sendable {
+    public struct Options: Sendable {
+        public init() {}
+    }
+
+    public let options: Options
     public let total: Int
     public let delay: Double
 
-    public init(options: [AnyHashable: Any] = [:], total: Int, delay: Double) {
+    public init(options: Options = .init(), total: Int, delay: Double) {
         self.options = options
         self.total = total
         self.delay = delay
     }
 }
 
-public class RandomEmojiTaskRunner: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+public class RandomEmojiTaskRunner: InternalTaskRunner, InternalTaskAsyncThrowingSequence, InternalTaskThrowingChannel, @unchecked Sendable {
     public typealias Request = RandomEmojiRequest
     public typealias InProcess = String
 

--- a/AmplifyTests/CoreTests/TreeTests.swift
+++ b/AmplifyTests/CoreTests/TreeTests.swift
@@ -8,7 +8,9 @@
 import Amplify
 import XCTest
 
-class TreeTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class TreeTests: XCTestCase, @unchecked Sendable {
 
     func testTreeWithChildren() {
         let tree = Tree<Int>(value: 0)

--- a/AmplifyTests/DevMenuTests/DevMenuExtensionTests.swift
+++ b/AmplifyTests/DevMenuTests/DevMenuExtensionTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 
 @MainActor
-class DevMenuExtensionTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DevMenuExtensionTests: XCTestCase, @unchecked Sendable {
     let provider = MockDevMenuContextProvider()
     override func setUp() async throws {
         do {

--- a/AmplifyTests/DevMenuTests/GestureRecognizerTests.swift
+++ b/AmplifyTests/DevMenuTests/GestureRecognizerTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 
 @available(iOS 13.0.0, *)
-class GestureRecognizerTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GestureRecognizerTests: XCTestCase, @unchecked Sendable {
 
     /// Test if long press gesture recognizer is added to UIWindow
     ///

--- a/AmplifyTests/DevMenuTests/PersistentLogWrapperTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLogWrapperTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 
 @MainActor
-class PersistentLogWrapperTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class PersistentLogWrapperTests: XCTestCase, @unchecked Sendable {
 
     let provider = MockDevMenuContextProvider()
 

--- a/AmplifyTests/DevMenuTests/PersistentLoggingPluginAmplifyVersionableTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLoggingPluginAmplifyVersionableTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 #if os(iOS) && !os(visionOS)
 // swiftlint:disable:next type_name
-class PersistentLoggingPluginAmplifyVersionableTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class PersistentLoggingPluginAmplifyVersionableTests: XCTestCase, @unchecked Sendable {
 
     func testVersionExists() {
         let plugin = PersistentLoggingPlugin(plugin: AWSUnifiedLoggingPlugin())

--- a/AmplifyTests/DevMenuTests/PersistentLoggingPluginTests.swift
+++ b/AmplifyTests/DevMenuTests/PersistentLoggingPluginTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 
 @MainActor
-class PersistentLoggingPluginTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class PersistentLoggingPluginTests: XCTestCase, @unchecked Sendable {
 
     let provider = MockDevMenuContextProvider()
 


### PR DESCRIPTION
Slice **31 of 38** in the Swift 6 language-mode migration — 105 file(s).

Stacked on `swift6/30-pinpoint-analytics-push-sendable`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.