### PR TITLE
test(auth): migrate the Auth test targets

### DIFF
--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/AWSCognitoAuthPluginAppSyncSignerTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/AWSCognitoAuthPluginAppSyncSignerTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 
-class AWSCognitoAuthPluginAppSyncSignerTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSCognitoAuthPluginAppSyncSignerTests: XCTestCase, @unchecked Sendable {
 
     /// Tests translating the URLRequest to the SDKRequest
     /// The translation should account for expected fields, as asserted in the test.

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/ClearCredentialsTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/ClearCredentialsTests.swift
@@ -10,7 +10,9 @@ import AWSPluginsCore
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class ClearCredentialsTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ClearCredentialsTests: XCTestCase, @unchecked Sendable {
 
     /// Test is responsible to check if the clear credentials action invokes the store correctly
     ///

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/LoadCredentialsTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/LoadCredentialsTests.swift
@@ -11,7 +11,9 @@ import Amplify
 import AWSPluginsCore
 @testable import AWSCognitoAuthPlugin
 
-class LoadCredentialsTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class LoadCredentialsTests: XCTestCase, @unchecked Sendable {
 
     /// Test is responsible to check the happy path of retrieving credentials from the store
     ///

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MigrateLegacyCredentialStoreTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MigrateLegacyCredentialStoreTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class MigrateLegacyCredentialStoreTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class MigrateLegacyCredentialStoreTests: XCTestCase, @unchecked Sendable {
 
     typealias AmplifyStoreFactory = BasicCredentialStoreEnvironment.AmplifyAuthCredentialStoreFactory
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MockAmplifyCredentialStoreBehavior.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MockAmplifyCredentialStoreBehavior.swift
@@ -10,7 +10,11 @@ import Foundation
 import AWSPluginsCore
 @testable import AWSCognitoAuthPlugin
 
-class MockAmplifyCredentialStoreBehavior: AmplifyAuthCredentialStoreBehavior {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockAmplifyCredentialStoreBehavior: AmplifyAuthCredentialStoreBehavior, @unchecked Sendable {
 
     typealias Migrationhandler = () -> Void
     typealias SaveCredentialHandler = (Codable) throws -> Void

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MockCredentialStoreBehavior.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/MockCredentialStoreBehavior.swift
@@ -10,7 +10,11 @@ import Foundation
 import AWSPluginsCore
 @testable import AWSCognitoAuthPlugin
 
-class MockKeychainStoreBehavior: KeychainStoreBehavior {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockKeychainStoreBehavior: KeychainStoreBehavior, @unchecked Sendable {
 
     typealias VoidHandler = () -> Void
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/StoreCredentialTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/CredentialStore/StoreCredentialTests.swift
@@ -9,7 +9,9 @@ import XCTest
 
 @testable import AWSCognitoAuthPlugin
 
-class StoreCredentialTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StoreCredentialTests: XCTestCase, @unchecked Sendable {
 
 //    /// Test is responsible to check the happy path of storing credentials into the store
 //    ///

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/DeviceKeyPersistence/InputUsernameDeviceKeyTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/DeviceKeyPersistence/InputUsernameDeviceKeyTests.swift
@@ -9,7 +9,9 @@ import AWSCognitoIdentityProvider
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class InputUsernameDeviceKeyTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class InputUsernameDeviceKeyTests: XCTestCase, @unchecked Sendable {
 
     // MARK: - SignedInData Codable backwards compatibility
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchAWSCredentials/FetchAuthAWSCredentialsTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchAWSCredentials/FetchAuthAWSCredentialsTests.swift
@@ -12,7 +12,9 @@ import AWSCognitoIdentity
 
 @testable import AWSCognitoAuthPlugin
 
-class FetchAuthAWSCredentialsTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class FetchAuthAWSCredentialsTests: XCTestCase, @unchecked Sendable {
 
     func testNoEnvironment() async {
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchUserPoolTokens/RefreshUserPoolTokensTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/FetchUserPoolTokens/RefreshUserPoolTokensTests.swift
@@ -12,7 +12,9 @@ import XCTest
 
 @testable import AWSCognitoAuthPlugin
 
-class RefreshUserPoolTokensTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RefreshUserPoolTokensTests: XCTestCase, @unchecked Sendable {
 
     func testNoUserPoolEnvironment() async {
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/InitializeFetchAuthSessionTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/FetchAuthSession/InitializeFetchAuthSessionTests.swift
@@ -9,7 +9,9 @@ import XCTest
 
 @testable import AWSCognitoAuthPlugin
 
-class InitializeFetchAuthSessionTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class InitializeFetchAuthSessionTests: XCTestCase, @unchecked Sendable {
 
     func testInitializeUserPoolTokens()  async {
         let expectation = expectation(description: "initializeUserPool")

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/InitiateAuthSRPTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/InitiateAuthSRPTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 @testable import AWSCognitoAuthPlugin
 
-class InitiateAuthSRPTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class InitiateAuthSRPTests: XCTestCase, @unchecked Sendable {
 
     func testInitiate() async {
         let initiateAuthInvoked = expectation(description: "initiateAuthInvoked")

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyDevicePasswordSRPSignatureTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyDevicePasswordSRPSignatureTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AWSCognitoAuthPlugin
 @testable import AWSPluginsTestCommon
 
-class VerifyDevicePasswordSRPSignatureTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class VerifyDevicePasswordSRPSignatureTests: XCTestCase, @unchecked Sendable {
     private var srpClient: MockSRPClientBehavior!
 
     override func setUp() async throws {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyPasswordSRPTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/InitiateAuthSRP/VerifyPasswordSRPTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSCognitoAuthPlugin
 @testable import AWSPluginsTestCommon
 
-class VerifyPasswordSRPTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class VerifyPasswordSRPTests: XCTestCase, @unchecked Sendable {
 
     typealias CognitoFactory = BasicSRPAuthEnvironment.CognitoUserPoolFactory
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/RevokeTokenTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/RevokeTokenTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AWSCognitoAuthPlugin
 @testable import AWSPluginsTestCommon
 
-class RevokeTokenTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RevokeTokenTests: XCTestCase, @unchecked Sendable {
 
     func testRevokeTokenInvoked() async {
         let revokeTokenInvoked = expectation(description: "revokeTokenInvoked")

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/ShowHostedUISignOutTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/ShowHostedUISignOutTests.swift
@@ -10,7 +10,9 @@ import AWSPluginsCore
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class ShowHostedUISignOutTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ShowHostedUISignOutTests: XCTestCase, @unchecked Sendable {
     private var mockHostedUIResult: Result<[URLQueryItem], HostedUIError>!
     private var signOutRedirectURI: String!
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/SignOutGloballyTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/SignOut/SignOutGloballyTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AWSCognitoAuthPlugin
 @testable import AWSPluginsTestCommon
 
-class SignOutGloballyTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SignOutGloballyTests: XCTestCase, @unchecked Sendable {
 
     func testGlobalSignOutInvoked() async {
         let globalSignOutInvoked = expectation(description: "globalSignOutInvoked")

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/VerifySignInChallenge/VerifySignInChallengeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ActionTests/VerifySignInChallenge/VerifySignInChallengeTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSCognitoAuthPlugin
 @testable import AWSPluginsTestCommon
 
-class VerifySignInChallengeTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class VerifySignInChallengeTests: XCTestCase, @unchecked Sendable {
 
     typealias CognitoFactory = BasicSRPAuthEnvironment.CognitoUserPoolFactory
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ClientBehaviorTests/AuthGetCurrentUserTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ClientBehaviorTests/AuthGetCurrentUserTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 
-class AuthGetCurrentUserTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AuthGetCurrentUserTests: XCTestCase, @unchecked Sendable {
 
     func testGetCurrentUserWhileSignedIn() async throws {
         let userId = "xyz987"

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/CognitoASFTests/ASFCognitoTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/CognitoASFTests/ASFCognitoTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class ASFCognitoTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ASFCognitoTests: XCTestCase, @unchecked Sendable {
 
     func testTimeZoneOffetNegative() {
         let asf = CognitoUserPoolASF()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/CognitoASFTests/ASFDeviceInfoTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/CognitoASFTests/ASFDeviceInfoTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class ASFDeviceInfoTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ASFDeviceInfoTests: XCTestCase, @unchecked Sendable {
 
     func testdeviceInfo() async {
         let asf = ASFDeviceInfo(id: "mockID")

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/CognitoASFTests/CognitoUserPoolASFTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/CognitoASFTests/CognitoUserPoolASFTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class CognitoUserPoolASFTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class CognitoUserPoolASFTests: XCTestCase, @unchecked Sendable {
     private var userPool: CognitoUserPoolASF!
 
     override func setUp() {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/AWSCognitoAuthPluginAmplifyOutputsConfigTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/AWSCognitoAuthPluginAmplifyOutputsConfigTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 
-class AWSCognitoAuthPluginAmplifyOutputsConfigTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSCognitoAuthPluginAmplifyOutputsConfigTests: XCTestCase, @unchecked Sendable {
 
     override func tearDown() async throws {
         await Amplify.reset()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/AWSCognitoAuthPluginConfigTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 
-class AWSCognitoAuthPluginConfigTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSCognitoAuthPluginConfigTests: XCTestCase, @unchecked Sendable {
 
     override func tearDown() async throws {
         await Amplify.reset()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/AuthFlowTypeTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/AuthFlowTypeTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class AuthFlowTypeTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AuthFlowTypeTests: XCTestCase, @unchecked Sendable {
 
     func testRawValue() {
         XCTAssertEqual(AuthFlowType.userSRP.rawValue, "USER_SRP_AUTH")

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/ClientSecretConfigurationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/ClientSecretConfigurationTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import AWSCognitoAuthPlugin
 @testable import AWSPluginsTestCommon
 
-class ClientSecretConfigurationTests: XCTestCase {
+/// - Note: `@unchecked Sendable` so the test body can be captured by the `@Sendable` closures the
+///   production API now takes. `XCTestCase` is not `Sendable`, and each test runs alone.
+class ClientSecretConfigurationTests: XCTestCase, @unchecked Sendable {
 
     let networkTimeout = TimeInterval(2)
     var mockIdentityProvider: CognitoUserPoolBehavior!

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/EscapeHatchTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ConfigurationTests/EscapeHatchTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSCognitoAuthPlugin
 
 
-class EscapeHatchTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class EscapeHatchTests: XCTestCase, @unchecked Sendable {
     /// Test escape hatch with valid config for user pool and identity pool
     ///
     /// - Given: A AWSCognitoAuthPlugin configured with User Pool and Identity Pool

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/CredentialStore/CredentialStoreOperationClientTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/CredentialStore/CredentialStoreOperationClientTests.swift
@@ -10,7 +10,9 @@ import Foundation
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class CredentialStoreOperationClientTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class CredentialStoreOperationClientTests: XCTestCase, @unchecked Sendable {
 
     var credentialClient: CredentialStoreStateBehavior!
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/HubEventTests/AuthHubEventHandlerTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/HubEventTests/AuthHubEventHandlerTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 
-class AuthHubEventHandlerTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AuthHubEventHandlerTests: XCTestCase, @unchecked Sendable {
 
     let networkTimeout = TimeInterval(2)
     var plugin: AWSCognitoAuthPlugin!
@@ -445,7 +447,7 @@ class AuthHubEventHandlerTests: XCTestCase {
         configurePlugin(initialState: initialState, userPoolFactory: mockIdentityProvider)
     }
 
-    private func urlSessionMock() -> URLSession {
+    @Sendable private func urlSessionMock() -> URLSession {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [MockURLProtocol.self]
         return URLSession(configuration: configuration)
@@ -477,11 +479,11 @@ class AuthHubEventHandlerTests: XCTestCase {
             return (HTTPURLResponse(), mockJson)
         }
 
-        func sessionFactory() -> HostedUISessionBehavior {
+        @Sendable func sessionFactory() -> HostedUISessionBehavior {
             MockHostedUISession(result: mockHostedUIResult)
         }
 
-        func mockRandomString() -> RandomStringBehavior {
+        @Sendable func mockRandomString() -> RandomStringBehavior {
             return MockRandomStringGenerator(mockString: mockState, mockUUID: mockState)
         }
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockAuthHubEventBehavior.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockAuthHubEventBehavior.swift
@@ -8,7 +8,11 @@
 import Amplify
 @testable import AWSCognitoAuthPlugin
 
-class MockAuthHubEventBehavior: AuthHubEventBehavior {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockAuthHubEventBehavior: AuthHubEventBehavior, @unchecked Sendable {
     func sendUserSignedInEvent() {
         // Incomplete implementation
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockCredentialRegistrant.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockCredentialRegistrant.swift
@@ -12,13 +12,16 @@ import Foundation
 @testable import AWSCognitoAuthPlugin
 
 @available(iOS 17.4, macOS 13.5, *)
-class MockCredentialRegistrant: CredentialRegistrantProtocol {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+class MockCredentialRegistrant: CredentialRegistrantProtocol, @unchecked Sendable {
     var presentationAnchor: AuthUIPresentationAnchor?
 
     var mockedCreateResponse: Result<CredentialRegistrationPayload, Error>?
-    var createCallCount = 0
+    // Counted from a `@Sendable` mock closure, so it cannot be a captured `var`.
+    let createCallCount = TestCounter()
     func create(with options: CredentialCreationOptions) async throws -> CredentialRegistrationPayload {
-        createCallCount += 1
+        createCallCount.increment()
         if let mockedCreateResponse {
             return try mockedCreateResponse.get()
         }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockHostedUISession.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockHostedUISession.swift
@@ -9,7 +9,8 @@ import Foundation
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 
-class MockHostedUISession: HostedUISessionBehavior {
+// `@unchecked Sendable`: `HostedUISessionBehavior` is `Sendable` now. Test double with `let` state.
+final class MockHostedUISession: HostedUISessionBehavior, @unchecked Sendable {
 
     let result: Result<[URLQueryItem], HostedUIError>
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockURLProtocol.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Mocks/MockURLProtocol.swift
@@ -9,7 +9,8 @@ import Foundation
 
 class MockURLProtocol: URLProtocol {
 
-    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data) )?
+    // `nonisolated(unsafe)`: a test sets this before exercising the protocol and clears it after.
+    nonisolated(unsafe) static var requestHandler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
 
     override class func canInit(with request: URLRequest) -> Bool {
         return true

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/AuthState/AuthStateConfiguringAuthentication.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/AuthState/AuthStateConfiguringAuthentication.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class AuthStateConfiguringAuthentication: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AuthStateConfiguringAuthentication: XCTestCase, @unchecked Sendable {
     var resolver: AnyResolver<AuthState> {
         AuthState.Resolver().logging().eraseToAnyResolver()
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/AuthState/AuthStateConfiguringAuthorization.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/AuthState/AuthStateConfiguringAuthorization.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class AuthStateConfiguringAuthorization: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AuthStateConfiguringAuthorization: XCTestCase, @unchecked Sendable {
     var resolver: AnyResolver<AuthState> {
         AuthState.Resolver().logging().eraseToAnyResolver()
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/AuthState/AuthStateConfiguringTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/AuthState/AuthStateConfiguringTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class AuthStateConfiguringTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AuthStateConfiguringTests: XCTestCase, @unchecked Sendable {
     var resolver: AnyResolver<AuthState> {
         AuthState.Resolver().logging().eraseToAnyResolver()
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/AuthState/AuthStateNotConfiguredTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/AuthState/AuthStateNotConfiguredTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class AuthStateNotConfiguredTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AuthStateNotConfiguredTests: XCTestCase, @unchecked Sendable {
     var resolver: AnyResolver<AuthState> {
         AuthState.Resolver().logging().eraseToAnyResolver()
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/AuthenticationStateResolverTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/AuthenticationStateResolverTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class AuthenticationStateResolverTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AuthenticationStateResolverTests: XCTestCase, @unchecked Sendable {
 
     var resolver: AuthenticationState.Resolver {
         AuthenticationState.Resolver()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/AuthorizationState/AuthorizationStateResolverTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/AuthorizationState/AuthorizationStateResolverTests.swift
@@ -23,7 +23,9 @@ extension AuthorizationStateSequence {
         self.expected = expected
     }
 }
-class AuthorizationStateResolverTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AuthorizationStateResolverTests: XCTestCase, @unchecked Sendable {
 
     func testValidAuthorizationStateSequences() throws {
         let authorizationError = AuthorizationError.configuration(message: "someError")

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/AuthorizationState/FetchAuthSessionStateResolverTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/AuthorizationState/FetchAuthSessionStateResolverTests.swift
@@ -25,7 +25,9 @@ extension FetchAuthSessionStateSequence {
     }
 }
 
-class FetchAuthSessionStateResolverTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class FetchAuthSessionStateResolverTests: XCTestCase, @unchecked Sendable {
 
     func testValidFetchAuthSessionStateSequences() throws {
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/CredentialStoreState/CredentialStoreStateResolverTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/CredentialStoreState/CredentialStoreStateResolverTests.swift
@@ -24,7 +24,9 @@ extension CredentialStoreStateSequence {
     }
 }
 
-class CredentialStoreStateResolverTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class CredentialStoreStateResolverTests: XCTestCase, @unchecked Sendable {
     func testValidCredentialStoreStateSequences() throws {
         let credentialStoreError = KeychainStoreError.configuration(message: "someError")
         let testData = AmplifyCredentials.testData

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/InitiatingAuthTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/InitiatingAuthTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 import AWSCognitoIdentityProvider
 
-class InitiatingAuthTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class InitiatingAuthTests: XCTestCase, @unchecked Sendable {
     var resolver: AnyResolver<SRPSignInState> {
         SRPSignInState.Resolver().logging().eraseToAnyResolver()
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/NotStartedTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/NotStartedTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class NotStartedTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class NotStartedTests: XCTestCase, @unchecked Sendable {
     var resolver: AnyResolver<SRPSignInState> {
         SRPSignInState.Resolver().logging().eraseToAnyResolver()
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/SRPSignInStateTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SRPSignInState/SRPSignInStateTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class SRPSignInStateTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SRPSignInStateTests: XCTestCase, @unchecked Sendable {
     var resolver: AnyResolver<SRPSignInState> {
         SRPSignInState.Resolver().logging().eraseToAnyResolver()
     }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignOutState/SignOutStateNotStartedTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignOutState/SignOutStateNotStartedTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class SignOutStateNotStartedTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SignOutStateNotStartedTests: XCTestCase, @unchecked Sendable {
 
     var resolver: AnyResolver<SignOutState> {
         SignOutState.Resolver().logging().eraseToAnyResolver()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignOutState/SignOutStateResolverTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignOutState/SignOutStateResolverTests.swift
@@ -24,7 +24,9 @@ extension SignOutStateSequence {
     }
 }
 
-class SignOutStateResolverTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SignOutStateResolverTests: XCTestCase, @unchecked Sendable {
     func testValidSignOutStateSequences() throws {
         let validSequences: [SignOutStateSequence] = [
             SignOutStateSequence(

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignOutState/SignOutStateRevokingTokenTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignOutState/SignOutStateRevokingTokenTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class SignOutStateRevokingTokenTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SignOutStateRevokingTokenTests: XCTestCase, @unchecked Sendable {
 
     var resolver: AnyResolver<SignOutState> {
         SignOutState.Resolver().logging().eraseToAnyResolver()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignOutState/SignOutStateSigningOutGloballyTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignOutState/SignOutStateSigningOutGloballyTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class SignOutStateSigningOutGloballyTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SignOutStateSigningOutGloballyTests: XCTestCase, @unchecked Sendable {
 
     var resolver: AnyResolver<SignOutState> {
         SignOutState.Resolver().logging().eraseToAnyResolver()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignOutState/SignOutStateSigningOutLocallyTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignOutState/SignOutStateSigningOutLocallyTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class SignOutStateSigningOutLocallyTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SignOutStateSigningOutLocallyTests: XCTestCase, @unchecked Sendable {
 
     var resolver: AnyResolver<SignOutState> {
         SignOutState.Resolver().logging().eraseToAnyResolver()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignUpState/ConfirmSignUpInputTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignUpState/ConfirmSignUpInputTests.swift
@@ -11,7 +11,9 @@ import XCTest
 
 import AWSCognitoIdentityProvider
 
-class ConfirmSignUpInputTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ConfirmSignUpInputTests: XCTestCase, @unchecked Sendable {
 
     func testConfirmSignUpInputWithClientSecretAndAsfDeviceId() async throws {
         let username = "jeff"

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignUpState/RespondToAuthInputTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignUpState/RespondToAuthInputTests.swift
@@ -11,7 +11,9 @@ import XCTest
 
 import AWSCognitoIdentityProvider
 
-class RespondToAuthInputTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RespondToAuthInputTests: XCTestCase, @unchecked Sendable {
 
     func testDevicePasswordVerifierInput() async throws {
         let username = "jeff"

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignUpState/SignUpInputTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/ResolverTests/SignUpState/SignUpInputTests.swift
@@ -11,7 +11,9 @@ import XCTest
 
 import AWSCognitoIdentityProvider
 
-class SignUpInputTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SignUpInputTests: XCTestCase, @unchecked Sendable {
 
     func testSignUpInputWithClientSecret() async throws {
         let username = "jeff"

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/SRPTests/HKDFTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/SRPTests/HKDFTests.swift
@@ -12,7 +12,9 @@ import AWSCognitoIdentityProvider
 
 @testable import AWSCognitoAuthPlugin
 
-class HKDFTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class HKDFTests: XCTestCase, @unchecked Sendable {
 
     func testHKDF() {
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/SRPTests/SRPClientTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/SRPTests/SRPClientTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 @testable import AWSCognitoAuthPlugin
 
-class SRPClientTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SRPClientTests: XCTestCase, @unchecked Sendable {
 
     func srpClient(NHexValue N: String, gHexValue g: String) throws -> SRPClientBehavior {
         return try AmplifySRPClient(NHexValue: N, gHexValue: g)

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/AWSAuthCognitoSessionTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/AWSAuthCognitoSessionTests.swift
@@ -10,7 +10,9 @@ import AWSPluginsCore
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class AWSAuthCognitoSessionTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAuthCognitoSessionTests: XCTestCase, @unchecked Sendable {
 
     /// Given: a JWT token
     /// When: expiring in 2 mins

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/ConfigurationHelperTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/ConfigurationHelperTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 
-final class ConfigurationHelperTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class ConfigurationHelperTests: XCTestCase, @unchecked Sendable {
 
     /// Test parsing the config and verifying the defaults that are set.
     func testParseUserPoolData_Defaults() throws {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/CustomEndpoint/CustomEndpoint+AuthConfigurationJSONTestCase.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/CustomEndpoint/CustomEndpoint+AuthConfigurationJSONTestCase.swift
@@ -10,7 +10,9 @@ import Foundation
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class CustomEndpoint_AuthConfigurationJSONTestCase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class CustomEndpoint_AuthConfigurationJSONTestCase: XCTestCase, @unchecked Sendable {
     /// Given: The `awsCognitoAuthPlugin` portion of an `amplifyconfiguration.json`
     /// When: The `Endpoint` value is present and valid.
     /// Then: The configuration should succeed with the expected `UserPoolConfigurationData().endpoint` output.

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/CustomEndpoint/EndpointResolving+ValidationStepTestCase.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/CustomEndpoint/EndpointResolving+ValidationStepTestCase.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class EndpointResolving_ValidationStepTestCase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class EndpointResolving_ValidationStepTestCase: XCTestCase, @unchecked Sendable {
     // MARK: EndpointResolving.ValidationStep.schemeIsEmpty()
     /// Given: A String representation of a URL.
     /// When: That String doesn't contain a scheme.

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/CustomEndpoint/EndpointResolvingTestCase.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/CustomEndpoint/EndpointResolvingTestCase.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class EndpointResolvingTestCase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class EndpointResolvingTestCase: XCTestCase, @unchecked Sendable {
     /// Given: A String representation of a URL.
     /// When: That String satisfies the ValidationSteps `.schemeIsEmpty()`,
     /// `.validURL()`, and `.pathIsEmpty()` (in this order)

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/DefaultConfig.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/DefaultConfig.swift
@@ -124,8 +124,8 @@ enum Defaults {
     }
 
     static func makeDefaultCredentialStoreEnvironment(
-        amplifyStoreFactory: @escaping () -> AmplifyAuthCredentialStoreBehavior = makeAmplifyStore,
-        legacyStoreFactory: @escaping (String) -> KeychainStoreBehavior = makeLegacyStore(service: )
+        amplifyStoreFactory: @escaping @Sendable () -> AmplifyAuthCredentialStoreBehavior = makeAmplifyStore,
+        legacyStoreFactory: @escaping @Sendable (String) -> KeychainStoreBehavior = makeLegacyStore(service: )
     ) -> CredentialEnvironment {
         CredentialEnvironment(
             authConfiguration: makeDefaultAuthConfigData(),
@@ -139,8 +139,8 @@ enum Defaults {
 
     static func makeDefaultAuthEnvironment(
         authZEnvironment: BasicAuthorizationEnvironment? = nil,
-        identityPoolFactory: @escaping () throws -> CognitoIdentityBehavior = makeIdentity,
-        userPoolFactory: @escaping () throws -> CognitoUserPoolBehavior = makeDefaultUserPool,
+        identityPoolFactory: @escaping @Sendable () throws -> CognitoIdentityBehavior = makeIdentity,
+        userPoolFactory: @escaping @Sendable () throws -> CognitoUserPoolBehavior = makeDefaultUserPool,
         hostedUIEnvironment: HostedUIEnvironment? = nil
     ) -> AuthEnvironment {
         let userPoolConfigData = makeDefaultUserPoolConfigData()
@@ -180,8 +180,8 @@ enum Defaults {
 
     static func makeDefaultAuthStateMachine(
         initialState: AuthState? = nil,
-        identityPoolFactory: @escaping () throws -> CognitoIdentityBehavior = makeIdentity,
-        userPoolFactory: @escaping () throws -> CognitoUserPoolBehavior = makeDefaultUserPool,
+        identityPoolFactory: @escaping @Sendable () throws -> CognitoIdentityBehavior = makeIdentity,
+        userPoolFactory: @escaping @Sendable () throws -> CognitoUserPoolBehavior = makeDefaultUserPool,
         hostedUIEnvironment: HostedUIEnvironment? = nil
     ) ->
     AuthStateMachine {
@@ -307,9 +307,10 @@ struct MockCredentialStoreOperationClient: CredentialStoreStateBehavior {
     }
 }
 
-class MockAmplifyStore: AmplifyAuthCredentialStoreBehavior {
+// `@unchecked Sendable`: test double driven by a single test at a time.
+final class MockAmplifyStore: AmplifyAuthCredentialStoreBehavior, @unchecked Sendable {
     let credentialsKey = "amplifyCredentials"
-    static var dict = AtomicDictionary<String, Data>()
+    static let dict = AtomicDictionary<String, Data>()
 
     func saveCredential(_ credential: AmplifyCredentials) throws {
         let value = (try? JSONEncoder().encode(credential)) ?? Data()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/HostedUIASWebAuthenticationSessionTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/HostedUIASWebAuthenticationSessionTests.swift
@@ -11,7 +11,9 @@ import AuthenticationServices
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class HostedUIASWebAuthenticationSessionTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class HostedUIASWebAuthenticationSessionTests: XCTestCase, @unchecked Sendable {
     private var session: HostedUIASWebAuthenticationSession!
     private var factory: ASWebAuthenticationSessionFactory!
 
@@ -134,7 +136,9 @@ class HostedUIASWebAuthenticationSessionTests: XCTestCase {
     }
 }
 
-class ASWebAuthenticationSessionFactory {
+// `@unchecked Sendable` so `createSession` can be used as the `@Sendable` factory the production
+// type now expects. The mocked fields are set by a single test before use.
+final class ASWebAuthenticationSessionFactory: @unchecked Sendable {
     var mockedURL: URL?
     var mockedError: Error?
     var mockCanStart: Bool?
@@ -156,7 +160,9 @@ class ASWebAuthenticationSessionFactory {
     }
 }
 
-class MockASWebAuthenticationSession: ASWebAuthenticationSession {
+// `@unchecked Sendable`: returned from the `@Sendable` session factory. `ASWebAuthenticationSession`
+// is an NSObject subclass driven on the main thread by the system.
+final class MockASWebAuthenticationSession: ASWebAuthenticationSession, @unchecked Sendable {
     private var callback: ASWebAuthenticationSession.CompletionHandler
     override init(
         url URL: URL,
@@ -199,7 +205,9 @@ extension HostedUIASWebAuthenticationSession {
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class HostedUIASWebAuthenticationSessionTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class HostedUIASWebAuthenticationSessionTests: XCTestCase, @unchecked Sendable {
     func testShowHostedUI_shouldThrowServiceError() async {
         let session = HostedUIASWebAuthenticationSession()
         do {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/HostedUIOptionsTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/HostedUIOptionsTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class HostedUIOptionsTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class HostedUIOptionsTests: XCTestCase, @unchecked Sendable {
 
     // MARK: - Decoding
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/HostedUIRequestHelperTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/HostedUIRequestHelperTests.swift
@@ -11,7 +11,9 @@ import Amplify
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class HostedUIRequestHelperTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class HostedUIRequestHelperTests: XCTestCase, @unchecked Sendable {
     private var configuration: HostedUIConfigurationData!
     private let result = HostedUIResult(
         code: "code",

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockDispatcher.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockDispatcher.swift
@@ -8,7 +8,8 @@
 @testable import AWSCognitoAuthPlugin
 
 struct MockDispatcher: EventDispatcher {
-    typealias SendCallback = (StateMachineEvent) -> Void
+    // `@Sendable` because `EventDispatcher` is `Sendable` and dispatch happens from detached tasks.
+    typealias SendCallback = @Sendable (StateMachineEvent) -> Void
     let sendCallback: SendCallback
 
     init(_ sendCallback: @escaping SendCallback) {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockIdentity.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockIdentity.swift
@@ -11,9 +11,9 @@ import ClientRuntime
 
 struct MockIdentity: CognitoIdentityBehavior {
 
-    typealias MockGetIdResponse = (GetIdInput) async throws -> GetIdOutput
+    typealias MockGetIdResponse = @Sendable (GetIdInput) async throws -> GetIdOutput
 
-    typealias MockGetCredentialsResponse = (GetCredentialsForIdentityInput) async throws
+    typealias MockGetCredentialsResponse = @Sendable (GetCredentialsForIdentityInput) async throws
     -> GetCredentialsForIdentityOutput
 
     let mockGetIdResponse: MockGetIdResponse?

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockIdentityProvider.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/Support/MockIdentityProvider.swift
@@ -11,82 +11,82 @@ import ClientRuntime
 
 struct MockIdentityProvider: CognitoUserPoolBehavior {
 
-    typealias MockSignUpResponse = (SignUpInput) async throws
+    typealias MockSignUpResponse = @Sendable (SignUpInput) async throws
     -> SignUpOutput
 
-    typealias MockRevokeTokenResponse = (RevokeTokenInput) async throws
+    typealias MockRevokeTokenResponse = @Sendable (RevokeTokenInput) async throws
     -> RevokeTokenOutput
 
-    typealias MockInitiateAuthResponse = (InitiateAuthInput) async throws
+    typealias MockInitiateAuthResponse = @Sendable (InitiateAuthInput) async throws
     -> InitiateAuthOutput
 
-    typealias MockGetTokensFromRefreshTokenResponse = (GetTokensFromRefreshTokenInput) async throws
+    typealias MockGetTokensFromRefreshTokenResponse = @Sendable (GetTokensFromRefreshTokenInput) async throws
     -> GetTokensFromRefreshTokenOutput
 
-    typealias MockConfirmSignUpResponse = (ConfirmSignUpInput) async throws
+    typealias MockConfirmSignUpResponse = @Sendable (ConfirmSignUpInput) async throws
     -> ConfirmSignUpOutput
 
-    typealias MockGlobalSignOutResponse = (GlobalSignOutInput) async throws
+    typealias MockGlobalSignOutResponse = @Sendable (GlobalSignOutInput) async throws
     -> GlobalSignOutOutput
 
-    typealias MockRespondToAuthChallengeResponse = (RespondToAuthChallengeInput) async throws
+    typealias MockRespondToAuthChallengeResponse = @Sendable (RespondToAuthChallengeInput) async throws
     -> RespondToAuthChallengeOutput
 
-    typealias MockGetUserAttributeVerificationCodeOutput = (GetUserAttributeVerificationCodeInput) async throws
+    typealias MockGetUserAttributeVerificationCodeOutput = @Sendable (GetUserAttributeVerificationCodeInput) async throws
     -> GetUserAttributeVerificationCodeOutput
 
-    typealias MockGetUserAttributesOutput = (GetUserInput) async throws
+    typealias MockGetUserAttributesOutput = @Sendable (GetUserInput) async throws
     -> GetUserOutput
 
-    typealias MockUpdateUserAttributesOutput = (UpdateUserAttributesInput) async throws
+    typealias MockUpdateUserAttributesOutput = @Sendable (UpdateUserAttributesInput) async throws
     -> UpdateUserAttributesOutput
 
-    typealias MockConfirmUserAttributeOutput = (VerifyUserAttributeInput) async throws
+    typealias MockConfirmUserAttributeOutput = @Sendable (VerifyUserAttributeInput) async throws
     -> VerifyUserAttributeOutput
 
-    typealias MockChangePasswordOutput = (ChangePasswordInput) async throws
+    typealias MockChangePasswordOutput = @Sendable (ChangePasswordInput) async throws
     -> ChangePasswordOutput
 
-    typealias MockResendConfirmationCodeOutput = (ResendConfirmationCodeInput) async throws
+    typealias MockResendConfirmationCodeOutput = @Sendable (ResendConfirmationCodeInput) async throws
     -> ResendConfirmationCodeOutput
 
-    typealias MockForgotPasswordOutput = (ForgotPasswordInput) async throws
+    typealias MockForgotPasswordOutput = @Sendable (ForgotPasswordInput) async throws
     -> ForgotPasswordOutput
 
-    typealias MockDeleteUserOutput = (DeleteUserInput) async throws
+    typealias MockDeleteUserOutput = @Sendable (DeleteUserInput) async throws
     -> DeleteUserOutput
 
-    typealias MockConfirmForgotPasswordOutput = (ConfirmForgotPasswordInput) async throws
+    typealias MockConfirmForgotPasswordOutput = @Sendable (ConfirmForgotPasswordInput) async throws
     -> ConfirmForgotPasswordOutput
 
-    typealias MockListDevicesOutput = (ListDevicesInput) async throws
+    typealias MockListDevicesOutput = @Sendable (ListDevicesInput) async throws
     -> ListDevicesOutput
 
-    typealias MockRememberDeviceResponse = (UpdateDeviceStatusInput) async throws
+    typealias MockRememberDeviceResponse = @Sendable (UpdateDeviceStatusInput) async throws
     -> UpdateDeviceStatusOutput
 
-    typealias MockForgetDeviceResponse = (ForgetDeviceInput) async throws
+    typealias MockForgetDeviceResponse = @Sendable (ForgetDeviceInput) async throws
     -> ForgetDeviceOutput
 
-    typealias MockConfirmDeviceResponse = (ConfirmDeviceInput) async throws
+    typealias MockConfirmDeviceResponse = @Sendable (ConfirmDeviceInput) async throws
     -> ConfirmDeviceOutput
 
-    typealias MockSetUserMFAPreferenceResponse = (SetUserMFAPreferenceInput) async throws
+    typealias MockSetUserMFAPreferenceResponse = @Sendable (SetUserMFAPreferenceInput) async throws
     -> SetUserMFAPreferenceOutput
 
-    typealias MockAssociateSoftwareTokenResponse = (AssociateSoftwareTokenInput) async throws
+    typealias MockAssociateSoftwareTokenResponse = @Sendable (AssociateSoftwareTokenInput) async throws
     -> AssociateSoftwareTokenOutput
 
-    typealias MockVerifySoftwareTokenResponse = (VerifySoftwareTokenInput) async throws
+    typealias MockVerifySoftwareTokenResponse = @Sendable (VerifySoftwareTokenInput) async throws
     -> VerifySoftwareTokenOutput
 
-    typealias MockListWebAuthnCredentialsResponse = (ListWebAuthnCredentialsInput) async throws -> ListWebAuthnCredentialsOutput
+    typealias MockListWebAuthnCredentialsResponse = @Sendable (ListWebAuthnCredentialsInput) async throws -> ListWebAuthnCredentialsOutput
 
-    typealias MockDeleteWebAuthnCredentialResponse = (DeleteWebAuthnCredentialInput) async throws -> DeleteWebAuthnCredentialOutput
+    typealias MockDeleteWebAuthnCredentialResponse = @Sendable (DeleteWebAuthnCredentialInput) async throws -> DeleteWebAuthnCredentialOutput
 
-    typealias MockStartWebAuthnRegistrationResponse = (StartWebAuthnRegistrationInput) async throws -> StartWebAuthnRegistrationOutput
+    typealias MockStartWebAuthnRegistrationResponse = @Sendable (StartWebAuthnRegistrationInput) async throws -> StartWebAuthnRegistrationOutput
 
-    typealias MockCompletetWebAuthnRegistrationResponse = (CompleteWebAuthnRegistrationInput) async throws -> CompleteWebAuthnRegistrationOutput
+    typealias MockCompletetWebAuthnRegistrationResponse = @Sendable (CompleteWebAuthnRegistrationInput) async throws -> CompleteWebAuthnRegistrationOutput
 
     let mockSignUpResponse: MockSignUpResponse?
     let mockRevokeTokenResponse: MockRevokeTokenResponse?

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFederationToIdentityPoolTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFederationToIdentityPoolTests.swift
@@ -282,7 +282,8 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
     ///
     func testClearFederationToIdentityPoolWithInitialErrorState() async throws {
 
-        var shouldThrowError = false
+        // Read from a `@Sendable` mock closure, so it cannot be a captured `var`.
+        let shouldThrowError = TestBox(false)
         let credentials = CognitoIdentityClientTypes.Credentials(
             accessKeyId: "accessKey",
             expiration: Date(),
@@ -291,7 +292,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
         )
 
         let getId: MockIdentity.MockGetIdResponse = { _ in
-            if shouldThrowError {
+            if shouldThrowError.get() {
                 throw AWSCognitoIdentity.InternalErrorException()
             } else {
                 return .init(identityId: "mockIdentityId")
@@ -317,14 +318,14 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
         )
         do {
             // Should setup the plugin with a token
-            shouldThrowError = false
+            shouldThrowError.set(false)
             _ = try await plugin.federateToIdentityPool(
                 withProviderToken: "someToken",
                 for: .facebook
             )
 
             // Push the AuthState to an error state
-            shouldThrowError = true
+            shouldThrowError.set(true)
             _ = try? await plugin.federateToIdentityPool(
                 withProviderToken: "someToken",
                 for: .facebook
@@ -840,7 +841,9 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
     ///
     func testFederateToIdentityPoolWhenGetIdErrorsOut() async throws {
 
-        var shouldThrowError = false
+        // Read from a `@Sendable` mock closure, so it cannot be a captured `var`.
+
+        let shouldThrowError = TestBox(false)
 
         let provider = AuthProvider.facebook
         let authenticationToken = "authenticationToken"
@@ -858,7 +861,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
         }
 
         let getCredentials: MockIdentity.MockGetCredentialsResponse = { input in
-            if shouldThrowError {
+            if shouldThrowError.get() {
                 throw AWSCognitoIdentity.InvalidParameterException()
             } else {
                 return .init(credentials: credentials, identityId: mockIdentityId)
@@ -882,7 +885,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
             initialState: initialState
         )
 
-        shouldThrowError = true
+        shouldThrowError.set(true)
         do {
             _ = try await plugin.federateToIdentityPool(withProviderToken: authenticationToken, for: provider)
         } catch let error as AuthError {
@@ -894,7 +897,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
             XCTFail("Test should throw Auth Error")
         }
 
-        shouldThrowError = false
+        shouldThrowError.set(false)
         do {
             let federatedResult = try await plugin.federateToIdentityPool(withProviderToken: authenticationToken, for: provider)
             XCTAssertNotNil(federatedResult)
@@ -924,7 +927,9 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
 
         let mockIdentityId = "mockIdentityId"
 
-        var shouldThrowError = false
+        // Read from a `@Sendable` mock closure, so it cannot be a captured `var`.
+
+        let shouldThrowError = TestBox(false)
 
         let federatedToken: FederatedToken = .testData
         let credentials = CognitoIdentityClientTypes.Credentials(
@@ -940,7 +945,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
         }
 
         let getCredentials: MockIdentity.MockGetCredentialsResponse = { _ in
-            if shouldThrowError {
+            if shouldThrowError.get() {
                 throw AWSCognitoIdentity.InternalErrorException()
             } else {
                 return .init(credentials: credentials, identityId: mockIdentityId)
@@ -969,7 +974,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
         )
 
 
-        shouldThrowError = true
+        shouldThrowError.set(true)
         do {
             let session = try await plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options())
             XCTAssertFalse(session.isSignedIn)
@@ -986,7 +991,7 @@ class AWSAuthFederationToIdentityPoolTests: BaseAuthorizationTests {
             XCTFail("Received failure with error \(error)")
         }
 
-        shouldThrowError = false
+        shouldThrowError.set(false)
         do {
             let session = try await plugin.fetchAuthSession(options: AuthFetchSessionRequest.Options())
             XCTAssertTrue(session.isSignedIn)

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFetchSessionTaskKeychainSharingTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/AWSAuthFetchSessionTaskKeychainSharingTests.swift
@@ -14,7 +14,9 @@ import XCTest
 /// fetchAuthSession reconcile path does not destroy locally-originated
 /// in-flight sign-in/sign-out work, and only reconfigures when the
 /// shared keychain genuinely diverges from the in-memory state machine.
-class AWSAuthFetchSessionTaskKeychainSharingTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAuthFetchSessionTaskKeychainSharingTests: XCTestCase, @unchecked Sendable {
 
     private actor StateRecorder {
         private(set) var seenStateTypes: Set<String> = []

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/BaseAuthorizationTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/AuthorizationTests/BaseAuthorizationTests.swift
@@ -10,14 +10,16 @@ import Foundation
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class BaseAuthorizationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class BaseAuthorizationTests: XCTestCase, @unchecked Sendable {
 
     let apiTimeout = 2.0
 
     func configurePluginWith(
         authConfiguration: AuthConfiguration = Defaults.makeDefaultAuthConfigData(),
-        userPool: @escaping () throws -> CognitoUserPoolBehavior = Defaults.makeDefaultUserPool,
-        identityPool: @escaping () throws -> CognitoIdentityBehavior = Defaults.makeIdentity,
+        userPool: @escaping @Sendable () throws -> CognitoUserPoolBehavior = Defaults.makeDefaultUserPool,
+        identityPool: @escaping @Sendable () throws -> CognitoIdentityBehavior = Defaults.makeIdentity,
         initialState: AuthState
     ) -> AWSCognitoAuthPlugin {
         let plugin = AWSCognitoAuthPlugin()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSCognitoAuthClientBehaviorTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/AWSCognitoAuthClientBehaviorTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 
-class AWSCognitoAuthClientBehaviorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSCognitoAuthClientBehaviorTests: XCTestCase, @unchecked Sendable {
     let networkTimeout = TimeInterval(10)
     var mockIdentityProvider: CognitoUserPoolBehavior!
     var plugin: AWSCognitoAuthPlugin!

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthMigrationSignInTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/AWSAuthMigrationSignInTaskTests.swift
@@ -14,7 +14,9 @@ import XCTest
 import AWSCognitoIdentity
 import AWSCognitoIdentityProvider
 
-class AWSAuthMigrationSignInTaskTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAuthMigrationSignInTaskTests: XCTestCase, @unchecked Sendable {
 
     let networkTimeout = TimeInterval(5)
     var mockIdentityProvider: CognitoUserPoolBehavior!

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/EmailMFATests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/ClientBehaviorTests/SignIn/EmailMFATests.swift
@@ -113,7 +113,8 @@ class EmailMFATests: BasePluginTest {
     ///    - I should get a .confirmSignInWithOTP response
     ///
     func testSuccessfulEmailMFACodeStep() async {
-        var signInStepIterator = 0
+        // Read from a `@Sendable` mock closure, so it cannot be a captured `var`.
+        let signInStepIterator = TestCounter()
         mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
             return InitiateAuthOutput(
                 authenticationResult: .none,
@@ -122,7 +123,7 @@ class EmailMFATests: BasePluginTest {
                 session: "someSession"
             )
         }, mockRespondToAuthChallengeResponse: { input in
-            if signInStepIterator == 0 {
+            if signInStepIterator.get() == 0 {
                 return .testData(
                     challenge: .emailOtp,
                     challengeParameters: [
@@ -130,7 +131,7 @@ class EmailMFATests: BasePluginTest {
                         "CODE_DELIVERY_DESTINATION": "test@test.com"
                     ]
                 )
-            } else if signInStepIterator == 1 {
+            } else if signInStepIterator.get() == 1 {
                 XCTAssertEqual(input.challengeResponses?["EMAIL_OTP_CODE"], "123456")
                 XCTAssertEqual(input.session, "session")
                 return .testData()
@@ -156,7 +157,7 @@ class EmailMFATests: BasePluginTest {
             XCTAssertFalse(result.isSignedIn, "Signin result should be complete")
 
             // step 2: confirm sign in
-            signInStepIterator = 1
+            signInStepIterator.set(1)
             let confirmSignInResult = try await plugin.confirmSignIn(
                 challengeResponse: "123456",
                 options: .init()
@@ -183,7 +184,8 @@ class EmailMFATests: BasePluginTest {
     ///    - I should get a .continueSignInWithMFASetupSelection response
     ///
     func testConfirmSignInForEmailMFASetupSelectionStep() async {
-        var signInStepIterator = 0
+        // Read from a `@Sendable` mock closure, so it cannot be a captured `var`.
+        let signInStepIterator = TestCounter()
         mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
             return InitiateAuthOutput(
                 authenticationResult: .none,
@@ -192,7 +194,7 @@ class EmailMFATests: BasePluginTest {
                 session: "session0"
             )
         }, mockRespondToAuthChallengeResponse: { input in
-            switch signInStepIterator {
+            switch signInStepIterator.get() {
             case 0:
                 XCTAssertEqual(input.session, "session0")
                 return .testData(
@@ -245,7 +247,7 @@ class EmailMFATests: BasePluginTest {
             }
 
             // Step 3: pass an email to setup
-            signInStepIterator = 1
+            signInStepIterator.set(1)
             confirmSignInResult = try await plugin.confirmSignIn(
                 challengeResponse: "test@test.com")
             guard case .confirmSignInWithOTP(let deliveryDetails) = confirmSignInResult.nextStep else {
@@ -261,7 +263,7 @@ class EmailMFATests: BasePluginTest {
             XCTAssertFalse(result.isSignedIn, "Signin result should be complete")
 
             // step 4: confirm sign in
-            signInStepIterator = 2
+            signInStepIterator.set(2)
             confirmSignInResult = try await plugin.confirmSignIn(
                 challengeResponse: "123456",
                 options: .init()
@@ -287,7 +289,8 @@ class EmailMFATests: BasePluginTest {
     ///    - I should get a .continueSignInWithMFASetupSelection response
     ///
     func testConfirmSignInForTOTPMFASetupSelectionStep() async {
-        var completeSignIn = false
+        // Read from a `@Sendable` mock closure, so it cannot be a captured `var`.
+        let completeSignIn = TestBox(false)
         mockIdentityProvider = MockIdentityProvider(mockInitiateAuthResponse: { input in
             return InitiateAuthOutput(
                 authenticationResult: .none,
@@ -296,7 +299,7 @@ class EmailMFATests: BasePluginTest {
                 session: "someSession"
             )
         }, mockRespondToAuthChallengeResponse: { input in
-            if completeSignIn {
+            if completeSignIn.get() {
                 XCTAssertEqual(input.session, "verifiedSession")
                 return .testData()
             }
@@ -344,7 +347,7 @@ class EmailMFATests: BasePluginTest {
             XCTAssertFalse(result.isSignedIn, "Signin result should be complete")
 
             // Step 3: complete sign in by verifying TOTP set up
-            completeSignIn = true
+            completeSignIn.set(true)
             let pluginOptions = AWSAuthConfirmSignInOptions(friendlyDeviceName: "device")
             confirmSignInResult = try await plugin.confirmSignIn(
                 challengeResponse: "123456",

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/HostedUITests/AWSAuthHostedUISignInTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 
-class AWSAuthHostedUISignInTests: XCTestCase {
+/// - Note: `@unchecked Sendable` so the test body can be captured by the `@Sendable` closures the
+///   production API now takes. `XCTestCase` is not `Sendable`, and each test runs alone.
+class AWSAuthHostedUISignInTests: XCTestCase, @unchecked Sendable {
 
     var plugin: AWSCognitoAuthPlugin!
     let networkTimeout = TimeInterval(5)
@@ -38,7 +40,7 @@ class AWSAuthHostedUISignInTests: XCTestCase {
     ))
     let initialState = AuthState.configured(.signedOut(.init(lastKnownUserName: nil)), .configured, .notStarted)
 
-    func urlSessionMock() -> URLSession {
+    @Sendable func urlSessionMock() -> URLSession {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [MockURLProtocol.self]
         return URLSession(configuration: configuration)
@@ -51,11 +53,11 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             return (HTTPURLResponse(), self.mockJson)
         }
 
-        func sessionFactory() -> HostedUISessionBehavior {
+        @Sendable func sessionFactory() -> HostedUISessionBehavior {
             MockHostedUISession(result: mockHostedUIResult)
         }
 
-        func mockRandomString() -> RandomStringBehavior {
+        @Sendable func mockRandomString() -> RandomStringBehavior {
             return MockRandomStringGenerator(mockString: mockState, mockUUID: mockState)
         }
 
@@ -92,11 +94,11 @@ class AWSAuthHostedUISignInTests: XCTestCase {
             return (HTTPURLResponse(), self.mockJson)
         }
 
-        func sessionFactory() -> HostedUISessionBehavior {
+        @Sendable func sessionFactory() -> HostedUISessionBehavior {
             MockHostedUISession(result: mockHostedUIResult)
         }
 
-        func mockRandomString() -> RandomStringBehavior {
+        @Sendable func mockRandomString() -> RandomStringBehavior {
             return MockRandomStringGenerator(mockString: mockState, mockUUID: mockState)
         }
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/BasePluginTest.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/UserBehaviourTests/BasePluginTest.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 
-class BasePluginTest: XCTestCase {
+/// - Note: `@unchecked Sendable` so the test body can be captured by the `@Sendable` closures the
+///   production API now takes. `XCTestCase` is not `Sendable`, and each test runs alone.
+class BasePluginTest: XCTestCase, @unchecked Sendable {
 
     let apiTimeout = 2.0
     var mockIdentityProvider: CognitoUserPoolBehavior!
@@ -73,8 +75,8 @@ class BasePluginTest: XCTestCase {
 
     func configureCustomPluginWith(
         authConfiguration: AuthConfiguration = Defaults.makeDefaultAuthConfigData(),
-        userPool: @escaping () throws -> CognitoUserPoolBehavior = Defaults.makeDefaultUserPool,
-        identityPool: @escaping () throws -> CognitoIdentityBehavior = Defaults.makeIdentity,
+        userPool: @escaping @Sendable () throws -> CognitoUserPoolBehavior = Defaults.makeDefaultUserPool,
+        identityPool: @escaping @Sendable () throws -> CognitoIdentityBehavior = Defaults.makeIdentity,
         initialState: AuthState
     ) -> AWSCognitoAuthPlugin {
             let plugin = AWSCognitoAuthPlugin()

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/WebAuthnBehaviourTests/AssociateWebAuthnCredentialTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/WebAuthnBehaviourTests/AssociateWebAuthnCredentialTaskTests.swift
@@ -10,11 +10,14 @@ import enum Amplify.AuthError
 import enum AWSCognitoIdentity.CognitoIdentityClientTypes
 import struct AWSCognitoIdentityProvider.StartWebAuthnRegistrationOutput
 import struct AWSCognitoIdentityProvider.WebAuthnNotEnabledException
+import Amplify
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
 @available(iOS 17.4, macOS 13.5, *)
-class AssociateWebAuthnCredentialTaskTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AssociateWebAuthnCredentialTaskTests: XCTestCase, @unchecked Sendable {
     private var task: AssociateWebAuthnCredentialTask!
     private var identityProvider: MockIdentityProvider!
     private var credentialRegistrant: MockCredentialRegistrant!
@@ -88,34 +91,38 @@ class AssociateWebAuthnCredentialTaskTests: XCTestCase {
     }
 
     func testExecute_withSuccess_shouldSucceed() async throws {
-        var startWebAuthnRegistrationCallCount = 0
+        // Counted from a `@Sendable` mock closure, so it cannot be a captured `var`.
+        let startWebAuthnRegistrationCallCount = TestCounter()
         identityProvider.mockStartWebAuthnRegistrationResponse = { _ in
-            startWebAuthnRegistrationCallCount += 1
+            startWebAuthnRegistrationCallCount.increment()
             return self.startWebAuthnRegistrationResponse()
         }
 
-        var completeWebAuthnRegistrationCallCount = 0
+        // Counted from a `@Sendable` mock closure, so it cannot be a captured `var`.
+        let completeWebAuthnRegistrationCallCount = TestCounter()
         identityProvider.mockCompleteWebAuthnRegistrationResponse = { _ in
-            completeWebAuthnRegistrationCallCount += 1
+            completeWebAuthnRegistrationCallCount.increment()
             return .init()
         }
 
         try await task.execute()
-        XCTAssertEqual(startWebAuthnRegistrationCallCount, 1)
-        XCTAssertEqual(credentialRegistrant.createCallCount, 1)
-        XCTAssertEqual(completeWebAuthnRegistrationCallCount, 1)
+        XCTAssertEqual(startWebAuthnRegistrationCallCount.get(), 1)
+        XCTAssertEqual(credentialRegistrant.createCallCount.get(), 1)
+        XCTAssertEqual(completeWebAuthnRegistrationCallCount.get(), 1)
     }
 
     func testExecute_withRegistrationFailed_shouldFail() async {
-        var startWebAuthnRegistrationCallCount = 0
+        // Counted from a `@Sendable` mock closure, so it cannot be a captured `var`.
+        let startWebAuthnRegistrationCallCount = TestCounter()
         identityProvider.mockStartWebAuthnRegistrationResponse = { _ in
-            startWebAuthnRegistrationCallCount += 1
+            startWebAuthnRegistrationCallCount.increment()
             return self.startWebAuthnRegistrationResponse()
         }
 
-        var completeWebAuthnRegistrationCallCount = 0
+        // Counted from a `@Sendable` mock closure, so it cannot be a captured `var`.
+        let completeWebAuthnRegistrationCallCount = TestCounter()
         identityProvider.mockCompleteWebAuthnRegistrationResponse = { _ in
-            completeWebAuthnRegistrationCallCount += 1
+            completeWebAuthnRegistrationCallCount.increment()
             return .init()
         }
 
@@ -132,9 +139,9 @@ class AssociateWebAuthnCredentialTaskTests: XCTestCase {
                 return
             }
 
-            XCTAssertEqual(startWebAuthnRegistrationCallCount, 1)
-            XCTAssertEqual(credentialRegistrant.createCallCount, 1)
-            XCTAssertEqual(completeWebAuthnRegistrationCallCount, 0)
+            XCTAssertEqual(startWebAuthnRegistrationCallCount.get(), 1)
+            XCTAssertEqual(credentialRegistrant.createCallCount.get(), 1)
+            XCTAssertEqual(completeWebAuthnRegistrationCallCount.get(), 0)
         } catch {
             XCTFail("Expected AuthError error, got \(error)")
         }
@@ -145,9 +152,10 @@ class AssociateWebAuthnCredentialTaskTests: XCTestCase {
             throw WebAuthnNotEnabledException(message: "WebAuthn is not enabled")
         }
 
-        var completeWebAuthnRegistrationCallCount = 0
+        // Counted from a `@Sendable` mock closure, so it cannot be a captured `var`.
+        let completeWebAuthnRegistrationCallCount = TestCounter()
         identityProvider.mockCompleteWebAuthnRegistrationResponse = { _ in
-            completeWebAuthnRegistrationCallCount += 1
+            completeWebAuthnRegistrationCallCount.increment()
             return .init()
         }
 
@@ -161,8 +169,8 @@ class AssociateWebAuthnCredentialTaskTests: XCTestCase {
             }
 
             XCTAssertEqual(underlyingError as? AWSCognitoAuthError, AWSCognitoAuthError.webAuthnNotEnabled)
-            XCTAssertEqual(credentialRegistrant.createCallCount, 0)
-            XCTAssertEqual(completeWebAuthnRegistrationCallCount, 0)
+            XCTAssertEqual(credentialRegistrant.createCallCount.get(), 0)
+            XCTAssertEqual(completeWebAuthnRegistrationCallCount.get(), 0)
         } catch {
             XCTFail("Expected AuthError error, got \(error)")
         }
@@ -173,9 +181,10 @@ class AssociateWebAuthnCredentialTaskTests: XCTestCase {
             throw CancellationError()
         }
 
-        var completeWebAuthnRegistrationCallCount = 0
+        // Counted from a `@Sendable` mock closure, so it cannot be a captured `var`.
+        let completeWebAuthnRegistrationCallCount = TestCounter()
         identityProvider.mockCompleteWebAuthnRegistrationResponse = { _ in
-            completeWebAuthnRegistrationCallCount += 1
+            completeWebAuthnRegistrationCallCount.increment()
             return .init()
         }
 
@@ -189,17 +198,18 @@ class AssociateWebAuthnCredentialTaskTests: XCTestCase {
             }
 
             XCTAssertEqual(description, "An unknown error type was thrown by the service. Unable to associate WebAuthn credential.")
-            XCTAssertEqual(credentialRegistrant.createCallCount, 0)
-            XCTAssertEqual(completeWebAuthnRegistrationCallCount, 0)
+            XCTAssertEqual(credentialRegistrant.createCallCount.get(), 0)
+            XCTAssertEqual(completeWebAuthnRegistrationCallCount.get(), 0)
         } catch {
             XCTFail("Expected AuthError error, got \(error)")
         }
     }
 
     func testExecute_withServiceErrorOnComplete_shouldFailWithServiceError() async {
-        var startWebAuthnRegistrationCallCount = 0
+        // Counted from a `@Sendable` mock closure, so it cannot be a captured `var`.
+        let startWebAuthnRegistrationCallCount = TestCounter()
         identityProvider.mockStartWebAuthnRegistrationResponse = { _ in
-            startWebAuthnRegistrationCallCount += 1
+            startWebAuthnRegistrationCallCount.increment()
             return self.startWebAuthnRegistrationResponse()
         }
 
@@ -217,17 +227,18 @@ class AssociateWebAuthnCredentialTaskTests: XCTestCase {
             }
 
             XCTAssertEqual(underlyingError as? AWSCognitoAuthError, AWSCognitoAuthError.webAuthnNotEnabled)
-            XCTAssertEqual(startWebAuthnRegistrationCallCount, 1)
-            XCTAssertEqual(credentialRegistrant.createCallCount, 1)
+            XCTAssertEqual(startWebAuthnRegistrationCallCount.get(), 1)
+            XCTAssertEqual(credentialRegistrant.createCallCount.get(), 1)
         } catch {
             XCTFail("Expected AuthError error, got \(error)")
         }
     }
 
     func testExecute_withOtherErrorOnComplete_shouldFailWithUnknownServiceError() async {
-        var startWebAuthnRegistrationCallCount = 0
+        // Counted from a `@Sendable` mock closure, so it cannot be a captured `var`.
+        let startWebAuthnRegistrationCallCount = TestCounter()
         identityProvider.mockStartWebAuthnRegistrationResponse = { _ in
-            startWebAuthnRegistrationCallCount += 1
+            startWebAuthnRegistrationCallCount.increment()
             return self.startWebAuthnRegistrationResponse()
         }
 
@@ -245,8 +256,8 @@ class AssociateWebAuthnCredentialTaskTests: XCTestCase {
             }
 
             XCTAssertEqual(description, "An unknown error type was thrown by the service. Unable to associate WebAuthn credential.")
-            XCTAssertEqual(startWebAuthnRegistrationCallCount, 1)
-            XCTAssertEqual(credentialRegistrant.createCallCount, 1)
+            XCTAssertEqual(startWebAuthnRegistrationCallCount.get(), 1)
+            XCTAssertEqual(credentialRegistrant.createCallCount.get(), 1)
         } catch {
             XCTFail("Expected AuthError error, got \(error)")
         }

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/WebAuthnBehaviourTests/DeleteWebAuthnCredentialTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/WebAuthnBehaviourTests/DeleteWebAuthnCredentialTaskTests.swift
@@ -8,10 +8,13 @@
 import enum Amplify.AuthError
 import enum AWSCognitoIdentity.CognitoIdentityClientTypes
 import struct AWSCognitoIdentityProvider.WebAuthnClientMismatchException
+import Amplify
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class DeleteWebAuthnCredentialTaskTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DeleteWebAuthnCredentialTaskTests: XCTestCase, @unchecked Sendable {
     private var task: DeleteWebAuthnCredentialTask!
     private var identityProvider: MockIdentityProvider!
 
@@ -71,14 +74,15 @@ class DeleteWebAuthnCredentialTaskTests: XCTestCase {
     }
 
     func testExecute_withSuccess_shouldSucceed() async throws {
-        var deleteWebAuthnCredentialCallCount = 0
+        // Counted from a `@Sendable` mock closure, so it cannot be a captured `var`.
+        let deleteWebAuthnCredentialCallCount = TestCounter()
         identityProvider.mockDeleteWebAuthnCredentialResponse = { _ in
-            deleteWebAuthnCredentialCallCount += 1
+            deleteWebAuthnCredentialCallCount.increment()
             return .init()
         }
 
         try await task.execute()
-        XCTAssertEqual(deleteWebAuthnCredentialCallCount, 1)
+        XCTAssertEqual(deleteWebAuthnCredentialCallCount.get(), 1)
     }
 
     func testExecute_withServiceError_shouldFailWithServiceError() async {

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/WebAuthnBehaviourTests/ListWebAuthnCredentialsTaskTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TaskTests/WebAuthnBehaviourTests/ListWebAuthnCredentialsTaskTests.swift
@@ -8,10 +8,13 @@
 import enum Amplify.AuthError
 import enum AWSCognitoIdentity.CognitoIdentityClientTypes
 import struct AWSCognitoIdentityProvider.WebAuthnRelyingPartyMismatchException
+import Amplify
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class ListWebAuthnCredentialsTaskTests: XCTestCase {
+/// - Note: `@unchecked Sendable` so the test body can be captured by the `@Sendable` closures the
+///   production API now takes. `XCTestCase` is not `Sendable`, and each test runs alone.
+class ListWebAuthnCredentialsTaskTests: XCTestCase, @unchecked Sendable {
     private var task: ListWebAuthnCredentialsTask!
     private var identityProvider: MockIdentityProvider!
 
@@ -71,9 +74,10 @@ class ListWebAuthnCredentialsTaskTests: XCTestCase {
     }
 
     func testExecute_withSuccess_shouldSucceed() async throws {
-        var listWebAuthnCredentialsCallCount = 0
+        // Counted from a `@Sendable` mock closure, so it cannot be a captured `var`.
+        let listWebAuthnCredentialsCallCount = TestCounter()
         identityProvider.mockListWebAuthnCredentialsResponse = { _ in
-            listWebAuthnCredentialsCallCount += 1
+            listWebAuthnCredentialsCallCount.increment()
             return .init(
                 credentials: [
                     .init(
@@ -100,7 +104,7 @@ class ListWebAuthnCredentialsTaskTests: XCTestCase {
         let result = try await task.execute()
         let credentials = try XCTUnwrap(result.credentials)
         let nextToken = try XCTUnwrap(result.nextToken)
-        XCTAssertEqual(listWebAuthnCredentialsCallCount, 1)
+        XCTAssertEqual(listWebAuthnCredentialsCallCount.get(), 1)
         XCTAssertEqual(credentials.count, 2)
         XCTAssertEqual(nextToken, "nextToken")
         XCTAssertTrue(credentials.contains(where: { $0.credentialId == "credentialId1" }))

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AmplifyAuthCognitoPluginTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AmplifyAuthCognitoPluginTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 
-class AmplifyAuthCognitoPluginTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyAuthCognitoPluginTests: XCTestCase, @unchecked Sendable {
 
     let apiTimeout = 1.0
 

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthTestHarnessInput.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/TestHarness/AuthTestHarnessInput.swift
@@ -14,7 +14,9 @@ import Foundation
 @testable import Amplify
 @testable import AWSCognitoAuthPlugin
 
-struct AuthTestHarnessInput {
+// `@unchecked Sendable`: captured by the `@Sendable` mock closures the harness installs. Test
+// fixture built once per case.
+struct AuthTestHarnessInput: @unchecked Sendable {
     let initialAuthState: AuthState
     let expectedAuthState: AuthState?
     let amplifyAPI: AmplifyAPI

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/hierarchical-state-machine-swiftTests/CombinedStateTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/hierarchical-state-machine-swiftTests/CombinedStateTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class CombinedStateTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class CombinedStateTests: XCTestCase, @unchecked Sendable {
 
     func testSimpleCombinedState() {
         let starting = ColorCounter(

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/hierarchical-state-machine-swiftTests/StateMachineListenerTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/hierarchical-state-machine-swiftTests/StateMachineListenerTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable @preconcurrency import AWSCognitoAuthPlugin
 
-class StateMachineListenerTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StateMachineListenerTests: XCTestCase, @unchecked Sendable {
 
     var stateMachine: CounterStateMachine!
 
@@ -99,13 +101,14 @@ class StateMachineListenerTests: XCTestCase {
             let seq = await stateMachine.listen()
             await stateMachine.send(Counter.Event(id: "set2", eventType: .set(11)))
             Task {
-                var count = 0
+                // Counted from a `@Sendable` closure, so it cannot be a captured `var`.
+                let count = TestCounter()
                 for await state in seq {
-                    if count == 0 {
-                        count += 1
+                    if count.get() == 0 {
+                        count.increment()
                         XCTAssertEqual(state.value, 10)
-                    } else if count == 1 {
-                        count += 1
+                    } else if count.get() == 1 {
+                        count.increment()
                         XCTAssertEqual(state.value, 11)
                     } else {
                         XCTAssertEqual(state.value, 12)

--- a/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/hierarchical-state-machine-swiftTests/StateMachineTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AWSCognitoAuthPluginUnitTests/hierarchical-state-machine-swiftTests/StateMachineTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSCognitoAuthPlugin
 
-class StateMachineTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StateMachineTests: XCTestCase, @unchecked Sendable {
 
     func testDefaultState() async {
         let testMachine = CounterStateMachine.logging()
@@ -127,7 +129,7 @@ class StateMachineTests: XCTestCase {
         let action1WasExecuted = expectation(description: "action1WasExecuted")
         let action2WasExecuted = expectation(description: "action2WasExecuted")
 
-        let executionCount = AtomicValue(initialValue: 0)
+        let executionCount = TestCounter()
         let action1 = BasicAction(identifier: "basic") { dispatcher, _ in
 
             action1WasExecuted.fulfill()

--- a/AmplifyPlugins/Auth/Tests/AmplifyBigIntegerUnitTests/AmplifyBigIntDecimalTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AmplifyBigIntegerUnitTests/AmplifyBigIntDecimalTests.swift
@@ -8,7 +8,9 @@
 import AmplifyBigInteger
 import XCTest
 
-final class AmplifyBigIntDecimalTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AmplifyBigIntDecimalTests: XCTestCase, @unchecked Sendable {
 
     func testConversionDecimal() throws {
         guard let firstInt = AmplifyBigInt("2", radix: 10) else {

--- a/AmplifyPlugins/Auth/Tests/AmplifyBigIntegerUnitTests/AmplifyBigIntegerHelperTests.swift
+++ b/AmplifyPlugins/Auth/Tests/AmplifyBigIntegerUnitTests/AmplifyBigIntegerHelperTests.swift
@@ -8,7 +8,9 @@
 import AmplifyBigInteger
 import XCTest
 
-final class AmplifyBigIntegerHelperTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AmplifyBigIntegerHelperTests: XCTestCase, @unchecked Sendable {
 
     func testHex236() {
         let num = AmplifyBigInt(236)

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AWSAuthBaseTest.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthIntegrationTests/AWSAuthBaseTest.swift
@@ -11,7 +11,9 @@ import XCTest
 
 private let internalTestDomain = "@amplify-swift-gamma.awsapps.com"
 
-class AWSAuthBaseTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAuthBaseTest: XCTestCase, @unchecked Sendable {
 
     let networkTimeout = TimeInterval(5)
 

--- a/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthStressTests/AuthStressBaseTest.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostApp/AuthStressTests/AuthStressBaseTest.swift
@@ -9,7 +9,9 @@ import AWSCognitoAuthPlugin
 import XCTest
 @testable import Amplify
 
-class AuthStressBaseTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AuthStressBaseTest: XCTestCase, @unchecked Sendable {
 
     let networkTimeout = TimeInterval(5)
 

--- a/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIAppUITests/UITestCase.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthHostedUIApp/AuthHostedUIAppUITests/UITestCase.swift
@@ -11,7 +11,9 @@ protocol Screen {
     var app: XCUIApplication { get }
 }
 
-class UITestCase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class UITestCase: XCTestCase, @unchecked Sendable {
     var app: XCUIApplication!
 
     override func setUp() {

--- a/AmplifyPlugins/Auth/Tests/AuthWebAuthnApp/AuthWebAuthnAppUITests/AuthWebAuthnAppUITests.swift
+++ b/AmplifyPlugins/Auth/Tests/AuthWebAuthnApp/AuthWebAuthnAppUITests/AuthWebAuthnAppUITests.swift
@@ -7,7 +7,9 @@
 
 import XCTest
 
-final class AuthWebAuthnAppUITests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AuthWebAuthnAppUITests: XCTestCase, @unchecked Sendable {
     private let timeout = TimeInterval(30)
     private let app = XCUIApplication()
     private var username: String!


### PR DESCRIPTION
Slice **32 of 38** in the Swift 6 language-mode migration — 88 file(s).

Stacked on `swift6/31-tests-core`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.