### PR TITLE
test(datastore): migrate the DataStore test targets

### DIFF
--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/AWSDataStoreLocalStoreTests.swift
@@ -16,7 +16,9 @@ import AWSPluginsCore
 
 // swfitlint:disable file_length
 // swiftlint:disable type_body_length
-class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStoreLocalStoreTests: LocalStoreIntegrationTestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginAmplifyVersionableTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AmplifyTestCommon
 
 // swiftlint:disable:next type_name
-class AWSDataStorePluginAmplifyVersionableTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStorePluginAmplifyVersionableTests: XCTestCase, @unchecked Sendable {
 
     func testVersionExists() {
         #if os(watchOS)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/AWSDataStorePluginTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 
 // swiftlint:disable type_body_length
-class AWSDataStorePluginTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStorePluginTests: XCTestCase, @unchecked Sendable {
 
     /// Ensure that DataStore configures successfully, regardless of what configuration is passed to `configure(using:)`
     func testConfigureWithAmplifyOutputs() throws {
@@ -125,7 +127,8 @@ class AWSDataStorePluginTests: XCTestCase {
         let stopExpectation = expectation(description: "Stop plugin should be called")
         stopExpectation.isInverted = true
         let startExpectation = expectation(description: "Start Sync should be called")
-        var currCount = 0
+        // Counted from a `@Sendable` closure, so it cannot be a captured `var`.
+        let currCount = AtomicValue(initialValue: 0)
         let storageEngine = MockStorageEngineBehavior()
 
         storageEngine.responders[.stopSync] = StopSyncResponder { _ in
@@ -133,7 +136,7 @@ class AWSDataStorePluginTests: XCTestCase {
         }
 
         storageEngine.responders[.startSync] = StartSyncResponder { _ in
-            currCount = self.expect(startExpectation, currCount, 1)
+            currCount.set(self.expect(startExpectation, currCount.get(), 1))
         }
 
         let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
@@ -164,15 +167,16 @@ class AWSDataStorePluginTests: XCTestCase {
     func testStorageEngineStartsOnPluginClearStart() async throws {
         let clearExpectation = expectation(description: "Clear should be called")
         let startExpectation = expectation(description: "Start Sync should be called")
-        var currCount = 0
+        // Counted from a `@Sendable` closure, so it cannot be a captured `var`.
+        let currCount = AtomicValue(initialValue: 0)
 
         let storageEngine = MockStorageEngineBehavior()
         storageEngine.responders[.clear] = ClearResponder { _ in
-            currCount = self.expect(clearExpectation, currCount, 1)
+            currCount.set(self.expect(clearExpectation, currCount.get(), 1))
         }
 
         storageEngine.responders[.startSync] = StartSyncResponder { _ in
-            currCount = self.expect(startExpectation, currCount, 2)
+            currCount.set(self.expect(startExpectation, currCount.get(), 2))
         }
 
         let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
@@ -360,14 +364,15 @@ class AWSDataStorePluginTests: XCTestCase {
         let startExpectation = expectation(description: "Start Sync should be called with Query")
         let clearExpectation = expectation(description: "Clear should be called")
         let startExpectationOnQuery = expectation(description: "Start Sync should be called again with Query")
-        var count = 0
+        // Counted from a `@Sendable` closure, so it cannot be a captured `var`.
+        let count = AtomicValue(initialValue: 0)
         let storageEngine = MockStorageEngineBehavior()
         storageEngine.responders[.query] = QueryResponder<ExampleWithEveryType> { _ in
-            count = self.expect(startExpectation, count, 1)
+            count.set(self.expect(startExpectation, count.get(), 1))
             return .success([])
         }
         storageEngine.responders[.clear] = ClearResponder { _ in
-            count = self.expect(clearExpectation, count, 2)
+            count.set(self.expect(clearExpectation, count.get(), 2))
         }
 
         let dataStorePublisher = DataStorePublisher()
@@ -415,7 +420,7 @@ class AWSDataStorePluginTests: XCTestCase {
             })
             await fulfillment(of: [clearCompleted], timeout: 1.0)
             storageEngine.responders[.query] = QueryResponder<ExampleWithEveryType> {_ in
-                count = self.expect(startExpectationOnQuery, count, 3)
+                count.set(self.expect(startExpectationOnQuery, count.get(), 3))
                 return .success([])
             }
 
@@ -454,13 +459,15 @@ class AWSDataStorePluginTests: XCTestCase {
         let startExpectation = expectation(description: "Start Sync should be called with start")
         let clearExpectation = expectation(description: "Clear should be called")
 
-        var count = 0
+        // Counted from a `@Sendable` closure, so it cannot be a captured `var`.
+
+        let count = AtomicValue(initialValue: 0)
         let storageEngine = MockStorageEngineBehavior()
         storageEngine.responders[.startSync] = StartSyncResponder { _ in
-            count = self.expect(startExpectation, count, 1)
+            count.set(self.expect(startExpectation, count.get(), 1))
         }
         storageEngine.responders[.clear] = ClearResponder { _ in
-            count = self.expect(clearExpectation, count, 2)
+            count.set(self.expect(clearExpectation, count.get(), 2))
         }
 
         let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
@@ -687,9 +694,10 @@ class AWSDataStorePluginTests: XCTestCase {
     func testStopStorageEngineOnTerminalFailureEvent() async {
         let storageEngine = MockStorageEngineBehavior()
         let stopExpectation = expectation(description: "stop should be called")
-        var count = 0
+        // Counted from a `@Sendable` closure, so it cannot be a captured `var`.
+        let count = AtomicValue(initialValue: 0)
         storageEngine.responders[.stopSync] = StopSyncResponder { _ in
-            count = self.expect(stopExpectation, count, 1)
+            count.set(self.expect(stopExpectation, count.get(), 1))
         }
         let storageEngineBehaviorFactory: StorageEngineBehaviorFactory = {_, _, _, _, _, _  throws in
             return storageEngine

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/ConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/ConfigurationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSDataStorePlugin
 
-class AWSAPICategoryPluginConfigureTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAPICategoryPluginConfigureTests: XCTestCase, @unchecked Sendable {
 
     func testConfigureSuccessForNilConfiguration() throws {
         let dataStorePublisher = DataStorePublisher()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreCategoryConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreCategoryConfigurationTests.swift
@@ -9,7 +9,9 @@ import AWSDataStorePlugin
 import XCTest
 @testable import Amplify
 
-class AWSDataStorePluginConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStorePluginConfigurationTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         await Amplify.reset()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreListProviderTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/DataStoreListProviderTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-class DataStoreListProviderTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreListProviderTests: XCTestCase, @unchecked Sendable {
 
     var mockDataStorePlugin: MockDataStoreCategoryPlugin!
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/QueryPaginationInputTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/QueryPaginationInputTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSDataStorePlugin
 
-class QueryPaginationInputTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class QueryPaginationInputTests: XCTestCase, @unchecked Sendable {
 
     /// - Given: a `QueryPaginationInput`
     /// - When:

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/QueryPredicateTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/QueryPredicateTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-class QueryPredicateTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class QueryPredicateTests: XCTestCase, @unchecked Sendable {
 
     private lazy var _encoder: JSONEncoder = {
         var encoder = JSONEncoder()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/QuerySortDescriptorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/QuerySortDescriptorTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-class QuerySortDescriptorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class QuerySortDescriptorTests: XCTestCase, @unchecked Sendable {
 
     func testAscendingSort() {
         let fieldName = "fieldName"

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLStatementTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLStatementTests.swift
@@ -15,7 +15,9 @@ import XCTest
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
 // TODO: Refactor this into separate test suites
-class SQLStatementTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SQLStatementTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         // one-to-many/many-to-one association

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLiteStorageEngineAdapterJsonTests.swift
@@ -15,7 +15,9 @@ import Foundation
 import SQLite
 
 // swiftlint:disable type_body_length
-class SQLiteStorageEngineAdapterJsonTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SQLiteStorageEngineAdapterJsonTests: XCTestCase, @unchecked Sendable {
 
     var connection: Connection!
     var storageEngine: StorageEngine!
@@ -199,7 +201,7 @@ class SQLiteStorageEngineAdapterJsonTests: XCTestCase {
         ] as [String: JSONValue]
         let model = DynamicModel(values: post)
 
-        func checkSavedPost(id: String) {
+        @Sendable func checkSavedPost(id: String) {
             storageAdapter.query(DynamicModel.self, modelSchema: ModelRegistry.modelSchema(from: "Post")!) {
                 switch $0 {
                 case .success(let posts):
@@ -302,7 +304,7 @@ class SQLiteStorageEngineAdapterJsonTests: XCTestCase {
     func testInsertPostAndThenUpdateItWithCondition() {
         let expectation = expectation(description: "it should insert and update a Post")
         let schema = ModelRegistry.modelSchema(from: "Post")!
-        func checkSavedPost(id: String) {
+        @Sendable func checkSavedPost(id: String) {
             storageAdapter.query(DynamicModel.self, modelSchema: schema) {
                 switch $0 {
                 case .success(let posts):
@@ -513,7 +515,8 @@ class SQLiteStorageEngineAdapterJsonTests: XCTestCase {
         var counter = 0
         let maxCount = 10
         let schema = ModelRegistry.modelSchema(from: "Post")!
-        var postsAdded: [String] = []
+        // Appended from a `@Sendable` completion and read from a nested one.
+        let postsAdded = AtomicValue<[String]>(initialValue: [])
         while counter < maxCount {
             let title = "\(titleX)\(counter)"
             let content = "\(contentX)\(counter)"
@@ -524,12 +527,14 @@ class SQLiteStorageEngineAdapterJsonTests: XCTestCase {
                 "createdAt": .string(createdAt)
             ] as [String: JSONValue]
             let model = DynamicModel(values: post)
+            // Snapshotted so the completion captures an immutable value rather than the loop variable.
+            let currentIndex = counter
 
             storageAdapter.save(model, modelSchema: schema) { insertResult in
                 switch insertResult {
                 case .success:
-                    postsAdded.append(model.id)
-                    if counter == maxCount - 1 {
+                    postsAdded.with { $0.append(model.id) }
+                    if currentIndex == maxCount - 1 {
                         saveExpectation.fulfill()
                         self.storageAdapter.delete(
                             DynamicModel.self,
@@ -539,7 +544,7 @@ class SQLiteStorageEngineAdapterJsonTests: XCTestCase {
                             switch result {
                             case .success:
                                 deleteExpectation.fulfill()
-                                for postId in postsAdded {
+                                for postId in postsAdded.get() {
                                     self.checkIfPostIsDeleted(id: postId)
                                 }
                                 queryExpectation.fulfill()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLiteStorageEngineAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SQLiteStorageEngineAdapterTests.swift
@@ -148,7 +148,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
         let expectation = expectation(
             description: "it should insert and update a Post")
 
-        func checkSavedPost(id: String) {
+        @Sendable func checkSavedPost(id: String) {
             storageAdapter.query(Post.self) {
                 switch $0 {
                 case .success(let posts):
@@ -165,15 +165,19 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             }
         }
 
-        var post = Post(title: "title", content: "content", createdAt: .now())
+        let post = Post(title: "title", content: "content", createdAt: .now())
         storageAdapter.save(post) { insertResult in
             switch insertResult {
             case .success:
-                post.title = "title updated"
-                self.storageAdapter.save(post) { updateResult in
+                let updatedPost: Post = {
+                    var post = post
+                    post.title = "title updated"
+                    return post
+                }()
+                self.storageAdapter.save(updatedPost) { updateResult in
                     switch updateResult {
                     case .success:
-                        checkSavedPost(id: post.id)
+                        checkSavedPost(id: updatedPost.id)
                     case .failure(let error):
                         XCTFail(error.errorDescription)
                     }
@@ -198,7 +202,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
         let expectation = expectation(
             description: "it should insert and update a Post")
 
-        func checkSavedPost(id: String) {
+        @Sendable func checkSavedPost(id: String) {
             storageAdapter.query(Post.self) {
                 switch $0 {
                 case .success(let posts):
@@ -215,16 +219,20 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             }
         }
 
-        var post = Post(title: "title", content: "content", createdAt: .now())
+        let post = Post(title: "title", content: "content", createdAt: .now())
         storageAdapter.save(post) { insertResult in
             switch insertResult {
             case .success:
-                post.title = "title updated"
+                let updatedPost: Post = {
+                    var post = post
+                    post.title = "title updated"
+                    return post
+                }()
                 let condition = Post.keys.content == post.content
-                self.storageAdapter.save(post, condition: condition) { updateResult in
+                self.storageAdapter.save(updatedPost, condition: condition) { updateResult in
                     switch updateResult {
                     case .success:
-                        checkSavedPost(id: post.id)
+                        checkSavedPost(id: updatedPost.id)
                     case .failure(let error):
                         XCTFail(error.errorDescription)
                     }
@@ -248,7 +256,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
         let expectation = expectation(
             description: "it should insert and update a Post")
 
-        func checkSavedPost(id: String) {
+        @Sendable func checkSavedPost(id: String) {
             storageAdapter.query(Post.self) {
                 switch $0 {
                 case .success(let posts):
@@ -265,15 +273,19 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
             }
         }
 
-        var post = Post(title: "title", content: "content", createdAt: .now())
+        let post = Post(title: "title", content: "content", createdAt: .now())
         storageAdapter.save(post) { insertResult in
             switch insertResult {
             case .success:
-                post.title = "title updated"
-                self.storageAdapter.save(post, condition: QueryPredicateConstant.all) { updateResult in
+                let updatedPost: Post = {
+                    var post = post
+                    post.title = "title updated"
+                    return post
+                }()
+                self.storageAdapter.save(updatedPost, condition: QueryPredicateConstant.all) { updateResult in
                     switch updateResult {
                     case .success:
-                        checkSavedPost(id: post.id)
+                        checkSavedPost(id: updatedPost.id)
                     case .failure(let error):
                         XCTFail(error.errorDescription)
                     }
@@ -324,13 +336,17 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
         let expectation = expectation(
             description: "it should insert and then fail to update the Post, given bad condition")
 
-        var post = Post(title: "title not updated", content: "content", createdAt: .now())
+        let post = Post(title: "title not updated", content: "content", createdAt: .now())
         storageAdapter.save(post) { insertResult in
             switch insertResult {
             case .success:
-                post.title = "title updated"
+                let updatedPost: Post = {
+                    var post = post
+                    post.title = "title updated"
+                    return post
+                }()
                 let condition = Post.keys.content == "content 2 does not match previous content"
-                self.storageAdapter.save(post, condition: condition) { updateResult in
+                self.storageAdapter.save(updatedPost, condition: condition) { updateResult in
                     switch updateResult {
                     case .success:
                         XCTFail("Update should not be successful")
@@ -504,17 +520,20 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
         let contentX = "content"
         var counter = 0
         let maxCount = 10
-        var postsAdded: [String] = []
+        // Appended from a `@Sendable` completion and read from a nested one.
+        let postsAdded = AtomicValue<[String]>(initialValue: [])
         while counter < maxCount {
             let title = "\(titleX)\(counter)"
             let content = "\(contentX)\(counter)"
 
             let post = Post(title: title, content: content, createdAt: .now())
+            // Snapshotted so the completion captures an immutable value rather than the loop variable.
+            let currentIndex = counter
             storageAdapter.save(post) { insertResult in
                 switch insertResult {
                 case .success:
-                    postsAdded.append(post.id)
-                    if counter == maxCount - 1 {
+                    postsAdded.with { $0.append(post.id) }
+                    if currentIndex == maxCount - 1 {
                         saveExpectation.fulfill()
                         self.storageAdapter.delete(
                             Post.self,
@@ -524,7 +543,7 @@ class SQLiteStorageEngineAdapterTests: BaseDataStoreTests {
                             switch result {
                             case .success:
                                 deleteExpectation.fulfill()
-                                for postId in postsAdded {
+                                for postId in postsAdded.get() {
                                     self.checkIfPostIsDeleted(id: postId)
                                 }
                                 queryExpectation.fulfill()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SortByDependencyOrderTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/SortByDependencyOrderTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-class SortByDependencyOrderTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SortByDependencyOrderTests: XCTestCase, @unchecked Sendable {
 
     var modelList = [Model.Type]()
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/StateMachineTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Core/StateMachineTests.swift
@@ -11,7 +11,9 @@ import XCTest
 // Testable import b/c StateMachine is an internal type
 @testable @preconcurrency import AWSDataStorePlugin
 
-class StateMachineTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StateMachineTests: XCTestCase, @unchecked Sendable {
 
     /// - Given: A simple state machine
     /// - When:

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Migration/MockMutationSyncMigrationDelegate.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Migration/MockMutationSyncMigrationDelegate.swift
@@ -10,7 +10,11 @@ import XCTest
 @testable import Amplify
 @testable import AWSDataStorePlugin
 
-class MockMutationSyncMetadataMigrationDelegate: MutationSyncMetadataMigrationDelegate {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockMutationSyncMetadataMigrationDelegate: MutationSyncMetadataMigrationDelegate, @unchecked Sendable {
 
     var preconditionCheckError: DataStoreError?
     var transactionError: DataStoreError?

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Migration/ModelSyncMutationMigrationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Migration/ModelSyncMutationMigrationTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-final class ModelSyncMetadataMigrationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class ModelSyncMetadataMigrationTests: XCTestCase, @unchecked Sendable {
 
     var connection: Connection!
     var storageEngine: StorageEngine!

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Migration/MutationSyncMetadataMigrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Migration/MutationSyncMetadataMigrationTestBase.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class MutationSyncMetadataMigrationTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class MutationSyncMetadataMigrationTestBase: XCTestCase, @unchecked Sendable {
     var storageAdapter: SQLiteStorageEngineAdapter!
     var modelSchemas: [ModelSchema]!
 
@@ -69,31 +71,33 @@ class MutationSyncMetadataMigrationTestBase: XCTestCase {
 
     func queryMutationSyncMetadata() -> [MutationSyncMetadata]? {
         let firstQueryModelSyncMetadata = expectation(description: "query successful")
-        var result: [MutationSyncMetadata]?
+        // Assigned from a `@Sendable` completion, so it cannot be a captured `var`.
+        let result = AtomicValue<[MutationSyncMetadata]?>(initialValue: nil)
         storageAdapter.query(MutationSyncMetadata.self) {
             switch $0 {
             case .success(let mutationSyncMetadatas):
-                result = mutationSyncMetadatas
+                result.set(mutationSyncMetadatas)
                 firstQueryModelSyncMetadata.fulfill()
             case .failure(let error): XCTFail("\(error.errorDescription)")
             }
         }
         wait(for: [firstQueryModelSyncMetadata], timeout: 1)
-        return result
+        return result.get()
     }
 
     func queryModelSyncMetadata() -> [ModelSyncMetadata]? {
         let queryModelSyncMetadata = expectation(description: "query model sync metadata successful")
-        var result: [ModelSyncMetadata]?
+        // Assigned from a `@Sendable` completion, so it cannot be a captured `var`.
+        let result = AtomicValue<[ModelSyncMetadata]?>(initialValue: nil)
         storageAdapter.query(ModelSyncMetadata.self) {
             switch $0 {
             case .success(let modelSyncMetadatas):
-                result = modelSyncMetadatas
+                result.set(modelSyncMetadatas)
                 queryModelSyncMetadata.fulfill()
             case .failure(let error): XCTFail("\(error.errorDescription)")
             }
         }
         wait(for: [queryModelSyncMetadata], timeout: 1)
-        return result
+        return result.get()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Migration/MutationSyncMetadataMigrationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Migration/MutationSyncMetadataMigrationTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class MutationSyncMetadataMigrationTests: MutationSyncMetadataMigrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class MutationSyncMetadataMigrationTests: MutationSyncMetadataMigrationTestBase, @unchecked Sendable {
 
     func testApply_MissingDelegate() {
         let delegate = MockMutationSyncMetadataMigrationDelegate()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Migration/SQLiteMutationSyncMetadataMigrationDelegateTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Migration/SQLiteMutationSyncMetadataMigrationDelegateTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class SQLiteMutationSyncMetadataMigrationDelegateTests: MutationSyncMetadataMigrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SQLiteMutationSyncMetadataMigrationDelegateTests: MutationSyncMetadataMigrationTestBase, @unchecked Sendable {
 
     // MARK: - Clear tests
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Migration/SQLiteMutationSyncMetadataMigrationValidationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Migration/SQLiteMutationSyncMetadataMigrationValidationTests.swift
@@ -14,7 +14,9 @@ import SQLite3
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class SQLiteMutationSyncMetadataMigrationValidationTests: MutationSyncMetadataMigrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SQLiteMutationSyncMetadataMigrationValidationTests: MutationSyncMetadataMigrationTestBase, @unchecked Sendable {
 
     // MARK: - Precondition tests
     func testPreconditionSuccess() throws {

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Models/ExampleWithEveryType.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Models/ExampleWithEveryType.swift
@@ -13,7 +13,7 @@ public enum ExampleEnum: String, EnumPersistable {
     case bar
 }
 
-public struct ExampleNonModelType: Codable {
+public struct ExampleNonModelType: Codable, Sendable {
 
     public let someString: String
     public let someEnum: ExampleEnum

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/SQLite/StatementModelTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/SQLite/StatementModelTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-class StatementModelTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StatementModelTests: XCTestCase, @unchecked Sendable {
 
     func testDropLastPath_invalidString() throws {
         let path = "post."

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsBase.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import Amplify
 import Foundation
 import SQLite
 import XCTest
@@ -13,7 +14,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-class StorageEngineTestsBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageEngineTestsBase: XCTestCase, @unchecked Sendable {
     let defaultTimeout = 0.3
     var connection: Connection!
     var storageEngine: StorageEngine!
@@ -26,14 +29,15 @@ class StorageEngineTestsBase: XCTestCase {
      */
     func saveModelSynchronous<M: Model>(model: M) -> DataStoreResult<M> {
         let saveFinished = expectation(description: "Save finished")
-        var result: DataStoreResult<M>?
+        // Assigned from a `@Sendable` completion, so it cannot be a captured `var`.
+        let result = AtomicValue<DataStoreResult<M>?>(initialValue: nil)
 
         storageEngine.save(model) { sResult in
-            result = sResult
+            result.set(sResult)
             saveFinished.fulfill()
         }
         wait(for: [saveFinished], timeout: defaultTimeout)
-        guard let saveResult = result else {
+        guard let saveResult = result.get() else {
             return .failure(causedBy: "Save operation timed out")
         }
         return saveResult
@@ -41,14 +45,15 @@ class StorageEngineTestsBase: XCTestCase {
 
     func saveModelSynchronous<M: Model>(model: M) async -> DataStoreResult<M> {
         let saveFinished = expectation(description: "Save finished")
-        var result: DataStoreResult<M>?
+        // Assigned from a `@Sendable` completion, so it cannot be a captured `var`.
+        let result = AtomicValue<DataStoreResult<M>?>(initialValue: nil)
 
         storageEngine.save(model) { sResult in
-            result = sResult
+            result.set(sResult)
             saveFinished.fulfill()
         }
         await fulfillment(of: [saveFinished], timeout: defaultTimeout)
-        guard let saveResult = result else {
+        guard let saveResult = result.get() else {
             return .failure(causedBy: "Save operation timed out")
         }
         return saveResult
@@ -82,15 +87,16 @@ class StorageEngineTestsBase: XCTestCase {
 
     func queryModelSynchronous<M: Model>(modelType: M.Type, predicate: QueryPredicate) -> DataStoreResult<[M]> {
         let queryFinished = expectation(description: "Query Finished")
-        var result: DataStoreResult<[M]>?
+        // Assigned from a `@Sendable` completion, so it cannot be a captured `var`.
+        let result = AtomicValue<DataStoreResult<[M]>?>(initialValue: nil)
 
         storageEngine.query(modelType, predicate: predicate) { qResult in
-            result = qResult
+            result.set(qResult)
             queryFinished.fulfill()
         }
 
         wait(for: [queryFinished], timeout: defaultTimeout)
-        guard let queryResult = result else {
+        guard let queryResult = result.get() else {
             return .failure(causedBy: "Query operation timed out")
         }
         return queryResult
@@ -98,15 +104,16 @@ class StorageEngineTestsBase: XCTestCase {
 
     func queryModelSynchronous<M: Model>(modelType: M.Type, predicate: QueryPredicate) async -> DataStoreResult<[M]> {
         let queryFinished = expectation(description: "Query Finished")
-        var result: DataStoreResult<[M]>?
+        // Assigned from a `@Sendable` completion, so it cannot be a captured `var`.
+        let result = AtomicValue<DataStoreResult<[M]>?>(initialValue: nil)
 
         storageEngine.query(modelType, predicate: predicate) { qResult in
-            result = qResult
+            result.set(qResult)
             queryFinished.fulfill()
         }
 
         await fulfillment(of: [queryFinished], timeout: defaultTimeout)
-        guard let queryResult = result else {
+        guard let queryResult = result.get() else {
             return .failure(causedBy: "Query operation timed out")
         }
         return queryResult
@@ -173,7 +180,8 @@ class StorageEngineTestsBase: XCTestCase {
         timeout: TimeInterval = 10
     ) -> DataStoreResult<M?> {
         let deleteFinished = expectation(description: "Delete Finished")
-        var result: DataStoreResult<M?>?
+        // Assigned from a `@Sendable` completion, so it cannot be a captured `var`.
+        let result = AtomicValue<DataStoreResult<M?>?>(initialValue: nil)
 
         storageEngine.delete(
             modelType,
@@ -181,13 +189,13 @@ class StorageEngineTestsBase: XCTestCase {
             withId: id,
             condition: predicate,
             completion: { dResult in
-            result = dResult
+            result.set(dResult)
             deleteFinished.fulfill()
         }
         )
 
         wait(for: [deleteFinished], timeout: timeout)
-        guard let deleteResult = result else {
+        guard let deleteResult = result.get() else {
             return .failure(causedBy: "Delete operation timed out")
         }
         return deleteResult

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsHasOne.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsHasOne.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import Amplify
 import Foundation
 import SQLite
 import XCTest
@@ -53,14 +54,15 @@ class StorageEngineTestsHasOne: StorageEngineTestsBase {
     func testSaveModelWithPredicateAll() {
         let team = Team(name: "Team")
         let saveFinished = expectation(description: "Save finished")
-        var result: DataStoreResult<Team>?
+        // Assigned from a `@Sendable` completion, so it cannot be a captured `var`.
+        let result = AtomicValue<DataStoreResult<Team>?>(initialValue: nil)
         storageEngine.save(team, condition: QueryPredicateConstant.all) { sResult in
-            result = sResult
+            result.set(sResult)
             saveFinished.fulfill()
         }
         wait(for: [saveFinished], timeout: defaultTimeout)
 
-        guard result != nil else {
+        guard result.get() != nil else {
             XCTFail("Save operation timed out")
             return
         }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsSQLiteIndex.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Storage/StorageEngineTestsSQLiteIndex.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import Amplify
 import Foundation
 import SQLite
 import XCTest
@@ -330,14 +331,15 @@ class StorageEngineTestsSQLiteIndex: StorageEngineTestsBase {
 
     func saveModelSynchronous<M: Model>(model: M, storageEngine: StorageEngine) -> DataStoreResult<M> {
         let saveFinished = expectation(description: "Save finished")
-        var result: DataStoreResult<M>?
+        // Assigned from a `@Sendable` completion, so it cannot be a captured `var`.
+        let result = AtomicValue<DataStoreResult<M>?>(initialValue: nil)
 
         storageEngine.save(model) { sResult in
-            result = sResult
+            result.set(sResult)
             saveFinished.fulfill()
         }
         wait(for: [saveFinished], timeout: defaultTimeout)
-        guard let saveResult = result else {
+        guard let saveResult = result.get() else {
             return .failure(causedBy: "Save operation timed out")
         }
         return saveResult
@@ -349,15 +351,16 @@ class StorageEngineTestsSQLiteIndex: StorageEngineTestsBase {
         storageEngine: StorageEngine
     ) -> DataStoreResult<[M]> {
         let queryFinished = expectation(description: "Query Finished")
-        var result: DataStoreResult<[M]>?
+        // Assigned from a `@Sendable` completion, so it cannot be a captured `var`.
+        let result = AtomicValue<DataStoreResult<[M]>?>(initialValue: nil)
 
         storageEngine.query(modelType, predicate: predicate) { qResult in
-            result = qResult
+            result.set(qResult)
             queryFinished.fulfill()
         }
 
         wait(for: [queryFinished], timeout: defaultTimeout)
-        guard let queryResult = result else {
+        guard let queryResult = result.get() else {
             return .failure(causedBy: "Query operation timed out")
         }
         return queryResult

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/ObserveQueryTaskRunnerTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/ObserveQueryTaskRunnerTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class ObserveQueryTaskRunnerTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ObserveQueryTaskRunnerTests: XCTestCase, @unchecked Sendable {
     var storageEngine: MockStorageEngineBehavior!
     var dataStorePublisher: ModelSubcriptionBehavior!
     var dataStoreStateSubject = PassthroughSubject<DataStoreState, DataStoreError>()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/ObserveTaskRunnerTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/ObserveTaskRunnerTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSDataStorePlugin
 
-final class ObserveTaskRunnerTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class ObserveTaskRunnerTests: XCTestCase, @unchecked Sendable {
 
     func testSuccess() async throws {
         let dataStorePublisher = DataStorePublisher()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/Support/ModelSortTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/Support/ModelSortTests.swift
@@ -15,7 +15,9 @@ import XCTest
 @testable import AWSPluginsCore
 
 // swiftlint:disable type_body_length
-class ModelSortTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ModelSortTests: XCTestCase, @unchecked Sendable {
 
     func testSortModelString() throws {
         var posts = [

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/Support/SortedListTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Subscribe/Support/SortedListTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class SortedListTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SortedListTests: XCTestCase, @unchecked Sendable {
 
     func testSortedListSetAndReset() {
         let posts = [

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/APICategoryDependencyTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/APICategoryDependencyTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 
 /// Tests Amplify behavior around DataStore's dependency on the API category
-class APICategoryDependencyTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class APICategoryDependencyTests: XCTestCase, @unchecked Sendable {
 
     // Tests in this class will directly access the database to validate persistent queue behavior
     var storageAdapter: SQLiteStorageEngineAdapter!

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/DataStoreHubTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/DataStoreHubTests.swift
@@ -7,7 +7,9 @@
 
 import XCTest
 
-class DataStoreHubTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreHubTests: XCTestCase, @unchecked Sendable {
 
     /// - Given: An API-enabled DataStore
     /// - When:

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOperationSyncExpressionTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOperationSyncExpressionTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable @preconcurrency import AWSPluginsCore
 
-class InitialSyncOperationSyncExpressionTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class InitialSyncOperationSyncExpressionTests: XCTestCase, @unchecked Sendable {
     typealias APIPluginQueryResponder = QueryRequestResponder<PaginatedList<AnyModel>>
 
     var storageAdapter: StorageEngineAdapter!

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOperationTests.swift
@@ -15,7 +15,9 @@ import XCTest
 @testable import AWSPluginsCore
 
 // swiftlint:disable type_body_length
-class InitialSyncOperationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class InitialSyncOperationTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         continueAfterFailure = false

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/InitialSyncOrchestratorTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable @preconcurrency import AWSPluginsCore
 
-class InitialSyncOrchestratorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class InitialSyncOrchestratorTests: XCTestCase, @unchecked Sendable {
 
     override class func setUp() {
         Amplify.Logging.logLevel = .info

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/ReadyEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/ReadyEventEmitterTests.swift
@@ -15,7 +15,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class ReadyEventEmitterTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ReadyEventEmitterTests: XCTestCase, @unchecked Sendable {
     var stateMachine: MockStateMachine<RemoteSyncEngine.State, RemoteSyncEngine.Action>!
     var readyEventEmitter: ReadyEventEmitter?
     var readyEventSink: AnyCancellable?

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/SyncEngineStartupTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/SyncEngineStartupTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 
 /// Test order of startup operations to ensure SyncEngine is properly following the delta sync merge algorithm
-class SyncEngineStartupTests: SyncEngineTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SyncEngineStartupTests: SyncEngineTestBase, @unchecked Sendable {
 
     func testShouldPauseSubscriptions() throws {
         throw XCTSkip("Not yet implemented")

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/InitialSync/SyncEventEmitterTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class SyncEventEmitterTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SyncEventEmitterTests: XCTestCase, @unchecked Sendable {
     var initialSyncOrchestrator: MockAWSInitialSyncOrchestrator?
     var reconciliationQueue: MockAWSIncomingEventReconciliationQueue?
     var syncEventEmitter: SyncEventEmitter?

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionTests.swift
@@ -15,7 +15,9 @@ import Combine
 @testable import AWSPluginsCore
 
 /// Tests behavior of local DataStore subscriptions (as opposed to remote API subscription behaviors)
-class LocalSubscriptionTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class LocalSubscriptionTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         try await super.setUp()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionWithJSONModelTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/LocalSubscriptionWithJSONModelTests.swift
@@ -16,7 +16,9 @@ import Combine
 
 /// Tests behavior of local DataStore subscriptions (as opposed to remote API subscription behaviors)
 /// using serialized JSON models
-class LocalSubscriptionWithJSONModelTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class LocalSubscriptionWithJSONModelTests: XCTestCase, @unchecked Sendable {
     var dataStorePlugin: AWSDataStorePlugin!
 
     override func setUp() async throws {

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/AWSMutationDatabaseAdapterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/AWSMutationDatabaseAdapterTests.swift
@@ -14,7 +14,9 @@ import AWSPluginsCore
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-class AWSMutationDatabaseAdapterTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSMutationDatabaseAdapterTests: XCTestCase, @unchecked Sendable {
     var databaseAdapter: AWSMutationDatabaseAdapter!
     var storageAdapter: MockSQLiteStorageEngineAdapter!
     let model1 = Post(title: "model1", content: "content1", createdAt: .now())

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/AWSMutationEventIngesterTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-class AWSMutationEventIngesterTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSMutationEventIngesterTests: XCTestCase, @unchecked Sendable {
     // Used by tests to assert that the MutationEvent table is being updated
     var storageAdapter: SQLiteStorageEngineAdapter!
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationEventClearStateTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationEventClearStateTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class MutationEventClearStateTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class MutationEventClearStateTests: XCTestCase, @unchecked Sendable {
     var mockStorageAdapter: MockSQLiteStorageEngineAdapter!
     var mutationEventClearState: MutationEventClearState!
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/MutationIngesterConflictResolutionTests.swift
@@ -19,7 +19,9 @@ import XCTest
 /// Tests in this class have a naming convention of `test_<existing>_<candidate>`, which is to say: given that the
 /// mutation queue has an existing record of type `<existing>`, assert the behavior when candidate a mutation of
 /// type `<candidate>`.
-class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class MutationIngesterConflictResolutionTests: SyncEngineTestBase, @unchecked Sendable {
 
     // MARK: - Existing == .create
 
@@ -102,8 +104,11 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             try await startAmplifyAndWaitForSync()
         }
 
-        var mutatedPost = post
-        mutatedPost.content = "UPDATED CONTENT"
+        let mutatedPost: Post = {
+            var post = post
+            post.content = "UPDATED CONTENT"
+            return post
+        }()
         let savedPost = try await Amplify.DataStore.save(mutatedPost)
         XCTAssertEqual(savedPost.content, mutatedPost.content)
 
@@ -261,8 +266,11 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             try await startAmplifyAndWaitForSync()
         }
 
-        var mutatedPost = post
-        mutatedPost.content = "UPDATED CONTENT"
+        let mutatedPost: Post = {
+            var post = post
+            post.content = "UPDATED CONTENT"
+            return post
+        }()
         let savedPost = try await Amplify.DataStore.save(mutatedPost)
         XCTAssertEqual(savedPost.content, mutatedPost.content)
 
@@ -414,8 +422,11 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             try await startAmplifyAndWaitForSync()
         }
 
-        var mutatedPost = post
-        mutatedPost.content = "UPDATED CONTENT"
+        let mutatedPost: Post = {
+            var post = post
+            post.content = "UPDATED CONTENT"
+            return post
+        }()
         do {
             _ = try await Amplify.DataStore.save(mutatedPost)
             XCTFail("Should have caught error")
@@ -647,8 +658,11 @@ class MutationIngesterConflictResolutionTests: SyncEngineTestBase {
             try saveMutationEvent(of: .create, for: post, inProcess: true)
         }
 
-        var mutatedPost = post
-        mutatedPost.content = "UPDATED CONTENT"
+        let mutatedPost: Post = {
+            var post = post
+            post.content = "UPDATED CONTENT"
+            return post
+        }()
         let savedPost = try await Amplify.DataStore.save(mutatedPost)
         XCTAssertEqual(savedPost.content, mutatedPost.content)
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueNetworkTests.swift
@@ -16,7 +16,9 @@ import XCTest
 @testable @preconcurrency import AWSPluginsCore
 @testable import AWSPluginsCore
 
-class OutgoingMutationQueueNetworkTests: SyncEngineTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class OutgoingMutationQueueNetworkTests: SyncEngineTestBase, @unchecked Sendable {
 
     var cancellables: Set<AnyCancellable>!
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable @preconcurrency import AWSPluginsCore
 @testable import AWSPluginsCore
 
-class OutgoingMutationQueueTests: SyncEngineTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class OutgoingMutationQueueTests: SyncEngineTestBase, @unchecked Sendable {
 
     /// - Given: A sync-configured DataStore
     /// - When:
@@ -199,19 +201,21 @@ class OutgoingMutationQueueTests: SyncEngineTestBase {
 
         await fulfillment(of: [mutationEventSaved], timeout: 1.0)
 
-        var outboxStatusReceivedCurrentCount = 0
+        // Counted from a `@Sendable` closure, so it cannot be a captured `var`.
+
+        let outboxStatusReceivedCurrentCount = AtomicValue(initialValue: 0)
         let outboxStatusOnStart = expectation(description: "On DataStore start, outboxStatus received")
         let outboxStatusOnMutationEnqueued = expectation(description: "Mutation enqueued, outboxStatus received")
 
         let filter = HubFilters.forEventName(HubPayload.EventName.DataStore.outboxStatus)
         let hubListener = Amplify.Hub.listen(to: .dataStore, isIncluded: filter) { payload in
-            outboxStatusReceivedCurrentCount += 1
+            _ = outboxStatusReceivedCurrentCount.increment()
             guard let outboxStatusEvent = payload.data as? OutboxStatusEvent else {
                 XCTFail("Failed to cast payload data as OutboxStatusEvent")
                 return
             }
 
-            switch outboxStatusReceivedCurrentCount {
+            switch outboxStatusReceivedCurrentCount.get() {
             case 1:
                 XCTAssertFalse(outboxStatusEvent.isEmpty)
                 outboxStatusOnStart.fulfill()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/OutgoingMutationQueueTestsWithMockStateMachine.swift
@@ -15,7 +15,9 @@ import XCTest
 @testable @preconcurrency import AWSPluginsCore
 @testable import AWSPluginsCore
 
-class OutgoingMutationQueueMockStateTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class OutgoingMutationQueueMockStateTest: XCTestCase, @unchecked Sendable {
     var mutationQueue: OutgoingMutationQueue!
     var stateMachine: MockStateMachine<OutgoingMutationQueue.State, OutgoingMutationQueue.Action>!
     var publisher: AWSMutationEventPublisher!
@@ -279,7 +281,11 @@ extension OutgoingMutationQueue.Action: Equatable {
     }
 }
 
-class MockMutationEventSource: MutationEventSource {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockMutationEventSource: MutationEventSource, @unchecked Sendable {
     var resultQueue = [DataStoreResult<MutationEvent>]()
 
     func pushMutationEvent(futureResult: DataStoreResult<MutationEvent>) {

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/ProcessMutationErrorFromCloudOperationTests.swift
@@ -18,7 +18,9 @@ import XCTest
 // swiftlint:disable type_body_length
 // swiftlint:disable type_name
 // swiftlint:disable file_length
-class ProcessMutationErrorFromCloudOperationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ProcessMutationErrorFromCloudOperationTests: XCTestCase, @unchecked Sendable {
     // swiftlint:enable type_name
     let defaultAsyncWaitTimeout = 10.0
     var mockAPIPlugin: MockAPICategoryPlugin!

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/MutationQueue/SyncMutationToCloudOperationTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class SyncMutationToCloudOperationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SyncMutationToCloudOperationTests: XCTestCase, @unchecked Sendable {
     let defaultAsyncWaitTimeout = 2.0
     let secondsInADay = 60 * 60 * 24
     var mockAPIPlugin: MockAPICategoryPlugin!
@@ -42,16 +44,18 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         let post1 = Post(title: "post1", content: "content1", createdAt: .now())
         let mutationEvent = try MutationEvent(model: post1, modelSchema: post1.schema, mutationType: .create)
 
-        var numberOfTimesEntered = 0
+        // Incremented from a `@Sendable` request interceptor, so it cannot be a captured `var`.
+
+        let numberOfTimesEntered = AtomicValue(initialValue: 0)
         let responder = MutateRequestResponder<MutationSync<AnyModel>> { request in
-            defer { numberOfTimesEntered += 1 }
-            if numberOfTimesEntered == 0 {
+            defer { _ = numberOfTimesEntered.increment() }
+            if numberOfTimesEntered.get() == 0 {
                 let requestInputVersion = request.variables.flatMap { $0["input"] as? [String: Any] }.flatMap { $0["_version"] as? Int }
                 XCTAssertEqual(requestInputVersion, 10)
                 expectFirstCallToAPIMutate.fulfill()
                 let urlError = URLError(URLError.notConnectedToInternet)
                 return .failure(.unknown("", "", APIError.networkError("mock NotConnectedToInternetError", nil, urlError)))
-            } else if numberOfTimesEntered == 1, let anyModel = try? model.eraseToAnyModel() {
+            } else if numberOfTimesEntered.get() == 1, let anyModel = try? model.eraseToAnyModel() {
                 expectSecondCallToAPIMutate.fulfill()
                 let remoteSyncMetadata = MutationSyncMetadata(
                     modelId: model.id,
@@ -110,14 +114,16 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         let mutationEvent = try MutationEvent(model: post1, modelSchema: post1.schema, mutationType: .create)
         let model = MockSynced(id: "id-1")
 
-        var numberOfTimesEntered = 0
+        // Incremented from a `@Sendable` request interceptor, so it cannot be a captured `var`.
+
+        let numberOfTimesEntered = AtomicValue(initialValue: 0)
         let responder = MutateRequestResponder<MutationSync<AnyModel>> { request in
-            defer { numberOfTimesEntered += 1 }
-            if numberOfTimesEntered == 0 {
+            defer { _ = numberOfTimesEntered.increment() }
+            if numberOfTimesEntered.get() == 0 {
                 expectFirstCallToAPIMutate.fulfill()
                 let urlError = URLError(URLError.notConnectedToInternet)
                 return .failure(.unknown("", "", APIError.networkError("mock NotConnectedToInternetError", nil, urlError)))
-            } else if numberOfTimesEntered == 1, let anyModel = try? model.eraseToAnyModel() {
+            } else if numberOfTimesEntered.get() == 1, let anyModel = try? model.eraseToAnyModel() {
                 expectSecondCallToAPIMutate.fulfill()
                 let remoteSyncMetadata = MutationSyncMetadata(
                     modelId: model.id,
@@ -168,10 +174,12 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         let post1 = Post(title: "post1", content: "content1", createdAt: .now())
         let mutationEvent = try MutationEvent(model: post1, modelSchema: post1.schema, mutationType: .create)
 
-        var numberOfTimesEntered = 0
+        // Incremented from a `@Sendable` request interceptor, so it cannot be a captured `var`.
+
+        let numberOfTimesEntered = AtomicValue(initialValue: 0)
         let responder = MutateRequestResponder<MutationSync<AnyModel>> { _ in
-            defer { numberOfTimesEntered += 1 }
-            if numberOfTimesEntered == 0 {
+            defer { _ = numberOfTimesEntered.increment() }
+            if numberOfTimesEntered.get() == 0 {
                 expectFirstCallToAPIMutate.fulfill()
                 let urlError = URLError(URLError.notConnectedToInternet)
                 return .failure(.unknown("", "", APIError.networkError("mock NotConnectedToInternetError", nil, urlError)))
@@ -253,7 +261,8 @@ class SyncMutationToCloudOperationTests: XCTestCase {
     /// When: Mutating model fails with 401
     /// Then: DataStore will try again with each auth type and eventually fails
     func testGetRetryAdviceForEachModelAuthTypeThenFail_HTTPStatusError401() async throws {
-        var numberOfTimesEntered = 0
+        // Incremented from a `@Sendable` request interceptor, so it cannot be a captured `var`.
+        let numberOfTimesEntered = AtomicValue(initialValue: 0)
         let mutationEvent = try createMutationEvent()
         let authStrategy = MockMultiAuthModeStrategy()
         let expectedNumberOfTimesEntered = authStrategy.authTypesFor(schema: mutationEvent.schema, operation: .create).count
@@ -276,7 +285,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
             networkReachabilityPublisher: publisher,
             currentAttemptNumber: 1,
             completion: { result in
-                if numberOfTimesEntered == expectedNumberOfTimesEntered {
+                if numberOfTimesEntered.get() == expectedNumberOfTimesEntered {
                     expectCalllToApiMutateNTimesAndFail.fulfill()
 
                 } else {
@@ -286,7 +295,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         )
 
         let responder = MutateRequestResponder<MutationSync<AnyModel>> { request in
-            defer { numberOfTimesEntered += 1 }
+            defer { _ = numberOfTimesEntered.increment() }
             return .failure(.unknown("", "", error))
         }
 
@@ -317,8 +326,10 @@ class SyncMutationToCloudOperationTests: XCTestCase {
 
     func testGetRetryAdvice_OperationErrorAuthErrorWithSingleAuth_RetryFalse() async throws {
         let expectation = expectation(description: "operation completed")
-        var numberOfTimesEntered = 0
-        var error: APIError?
+        // Incremented from a `@Sendable` request interceptor, so it cannot be a captured `var`.
+        let numberOfTimesEntered = AtomicValue(initialValue: 0)
+        // Assigned from the `@Sendable` completion, so it cannot be a captured `var`.
+        let error = AtomicValue<APIError?>(initialValue: nil)
         let operation = try await SyncMutationToCloudOperation(
             mutationEvent: createMutationEvent(),
             getLatestSyncMetadata: { nil },
@@ -327,10 +338,10 @@ class SyncMutationToCloudOperationTests: XCTestCase {
             networkReachabilityPublisher: publisher,
             currentAttemptNumber: 1,
             completion: { result in
-                XCTAssertEqual(numberOfTimesEntered, 1)
+                XCTAssertEqual(numberOfTimesEntered.get(), 1)
                 switch result {
                 case .failure(let apiError):
-                    error = apiError
+                    error.set(apiError)
                 default:
                     XCTFail("Wrong result")
                 }
@@ -339,7 +350,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         )
 
         let responder = MutateRequestResponder<MutationSync<AnyModel>> { request in
-            defer { numberOfTimesEntered += 1 }
+            defer { _ = numberOfTimesEntered.increment() }
             let authError = AuthError.notAuthorized("", "", nil)
             return .failure(.unknown("", "", APIError.operationError("", "", authError)))
         }
@@ -349,7 +360,7 @@ class SyncMutationToCloudOperationTests: XCTestCase {
         let queue = OperationQueue()
         queue.addOperation(operation)
         await fulfillment(of: [expectation])
-        XCTAssertEqual(false, operation.getRetryAdviceIfRetryable(error: error!).shouldRetry)
+        XCTAssertEqual(false, operation.getRetryAdviceIfRetryable(error: try XCTUnwrap(error.get())).shouldRetry)
     }
 
     func testGetRetryAdvice_OperationErrorAuthErrorSessionExpired_RetryTrue() async throws {
@@ -393,7 +404,11 @@ class SyncMutationToCloudOperationTests: XCTestCase {
 
 }
 
-public class MockMultiAuthModeStrategy: AuthModeStrategy {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+public class MockMultiAuthModeStrategy: AuthModeStrategy, @unchecked Sendable {
     public weak var authDelegate: AuthModeStrategyDelegate?
     public required init() {}
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSync/RemoteSyncAPIInvocationTests.swift
@@ -15,7 +15,9 @@ import Combine
 @testable import AWSDataStorePlugin
 
 /// Tests that DataStore invokes proper API methods to fulfill remote sync
-class RemoteSyncAPIInvocationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RemoteSyncAPIInvocationTests: XCTestCase, @unchecked Sendable {
 
     /// Convenience property to get easy access to the mock API plugin
     var apiPlugin: MockAPICategoryPlugin!

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RemoteSyncEngineTests.swift
@@ -13,7 +13,9 @@ import Combine
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-class RemoteSyncEngineTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RemoteSyncEngineTests: XCTestCase, @unchecked Sendable {
     var apiPlugin: MockAPICategoryPlugin!
 
     var amplifyConfig: AmplifyConfiguration!
@@ -78,7 +80,8 @@ class RemoteSyncEngineTests: XCTestCase {
         let cleanedup = expectation(description: "cleanedup")
         let failureOnInitialSync = expectation(description: "failureOnInitialSync")
         let retryAdviceReceivedNetworkError = expectation(description: "retry advice received network error")
-        var currCount = 1
+        // Threaded through `@Sendable` completions, so it cannot be a captured `var`.
+        let currCount = AtomicValue(initialValue: 1)
 
         let advice = RequestRetryAdvice.init(shouldRetry: false)
         mockRequestRetryablePolicy.pushOnRetryRequestAdvice(response: advice)
@@ -101,26 +104,26 @@ class RemoteSyncEngineTests: XCTestCase {
         let remoteSyncEngineSink = remoteSyncEngine
             .publisher
             .sink(receiveCompletion: { _ in
-                currCount = self.checkAndFulfill(currCount, 7, expectation: failureOnInitialSync)
+                currCount.set(self.checkAndFulfill(currCount.get(), 7, expectation: failureOnInitialSync))
             }, receiveValue: { (event: RemoteSyncEngineEvent) in
                 switch event {
                 case .storageAdapterAvailable:
-                    currCount = self.checkAndFulfill(currCount, 1, expectation: storageAdapterAvailable)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 1, expectation: storageAdapterAvailable))
                 case .subscriptionsPaused:
-                    currCount = self.checkAndFulfill(currCount, 2, expectation: subscriptionsPaused)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 2, expectation: subscriptionsPaused))
                 case .mutationsPaused:
-                    currCount = self.checkAndFulfill(currCount, 3, expectation: mutationsPaused)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 3, expectation: mutationsPaused))
                     DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
                         MockAWSIncomingEventReconciliationQueue.mockSend(event: .initialized)
                     }
                 case .clearedStateOutgoingMutations:
-                    currCount = self.checkAndFulfill(currCount, 4, expectation: stateMutationsCleared)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 4, expectation: stateMutationsCleared))
                 case .subscriptionsInitialized:
-                    currCount = self.checkAndFulfill(currCount, 5, expectation: subscriptionsInitialized)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 5, expectation: subscriptionsInitialized))
                 case .performedInitialSync:
                     XCTFail("performedInitialQueries should not be successful")
                 case .cleanedUp:
-                    currCount = self.checkAndFulfill(currCount, 6, expectation: cleanedup)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 6, expectation: cleanedup))
                 default:
                     XCTFail("Unexpected case gets hit")
                 }
@@ -159,7 +162,9 @@ class RemoteSyncEngineTests: XCTestCase {
         let mutationQueueStarted = expectation(description: "mutationQueueStarted")
         let syncStarted = expectation(description: "sync started")
 
-        var currCount = 1
+        // Threaded through `@Sendable` completions, so it cannot be a captured `var`.
+
+        let currCount = AtomicValue(initialValue: 1)
 
         let remoteSyncEngineSink = remoteSyncEngine
             .publisher
@@ -168,26 +173,26 @@ class RemoteSyncEngineTests: XCTestCase {
             }, receiveValue: { (event: RemoteSyncEngineEvent) in
                 switch event {
                 case .storageAdapterAvailable:
-                    currCount = self.checkAndFulfill(currCount, 1, expectation: storageAdapterAvailable)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 1, expectation: storageAdapterAvailable))
                 case .subscriptionsPaused:
-                    currCount = self.checkAndFulfill(currCount, 2, expectation: subscriptionsPaused)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 2, expectation: subscriptionsPaused))
                 case .mutationsPaused:
-                    currCount = self.checkAndFulfill(currCount, 3, expectation: mutationsPaused)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 3, expectation: mutationsPaused))
                     DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
                         MockAWSIncomingEventReconciliationQueue.mockSend(event: .initialized)
                     }
                 case .clearedStateOutgoingMutations:
-                    currCount = self.checkAndFulfill(currCount, 4, expectation: stateMutationsCleared)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 4, expectation: stateMutationsCleared))
                 case .subscriptionsInitialized:
-                    currCount = self.checkAndFulfill(currCount, 5, expectation: subscriptionsInitialized)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 5, expectation: subscriptionsInitialized))
                 case .performedInitialSync:
-                    currCount = self.checkAndFulfill(currCount, 6, expectation: performedInitialSync)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 6, expectation: performedInitialSync))
                 case .subscriptionsActivated:
-                    currCount = self.checkAndFulfill(currCount, 7, expectation: subscriptionActivation)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 7, expectation: subscriptionActivation))
                 case .mutationQueueStarted:
-                    currCount = self.checkAndFulfill(currCount, 8, expectation: mutationQueueStarted)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 8, expectation: mutationQueueStarted))
                 case .syncStarted:
-                    currCount = self.checkAndFulfill(currCount, 9, expectation: syncStarted)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 9, expectation: syncStarted))
                 default:
                     XCTFail("unexpected call")
                 }
@@ -226,7 +231,9 @@ class RemoteSyncEngineTests: XCTestCase {
         let cleanedUp = expectation(description: "cleanedUp")
         let forceFailToNotRestartSyncEngine = expectation(description: "forceFailToNotRestartSyncEngine")
 
-        var currCount = 1
+        // Threaded through `@Sendable` completions, so it cannot be a captured `var`.
+
+        let currCount = AtomicValue(initialValue: 1)
 
         let advice = RequestRetryAdvice.init(shouldRetry: false)
         mockRequestRetryablePolicy.pushOnRetryRequestAdvice(response: advice)
@@ -234,36 +241,36 @@ class RemoteSyncEngineTests: XCTestCase {
         let remoteSyncEngineSink = remoteSyncEngine
             .publisher
             .sink(receiveCompletion: { _ in
-                currCount = self.checkAndFulfill(currCount, 11, expectation: forceFailToNotRestartSyncEngine)
+                currCount.set(self.checkAndFulfill(currCount.get(), 11, expectation: forceFailToNotRestartSyncEngine))
             }, receiveValue: { (event: RemoteSyncEngineEvent) in
                 switch event {
                 case .storageAdapterAvailable:
-                    currCount = self.checkAndFulfill(currCount, 1, expectation: storageAdapterAvailable)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 1, expectation: storageAdapterAvailable))
                 case .subscriptionsPaused:
-                    currCount = self.checkAndFulfill(currCount, 2, expectation: subscriptionsPaused)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 2, expectation: subscriptionsPaused))
                 case .mutationsPaused:
-                    currCount = self.checkAndFulfill(currCount, 3, expectation: mutationsPaused)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 3, expectation: mutationsPaused))
                     DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
                         MockAWSIncomingEventReconciliationQueue.mockSend(event: .initialized)
                     }
                 case .clearedStateOutgoingMutations:
-                    currCount = self.checkAndFulfill(currCount, 4, expectation: stateMutationsCleared)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 4, expectation: stateMutationsCleared))
                 case .subscriptionsInitialized:
-                    currCount = self.checkAndFulfill(currCount, 5, expectation: subscriptionsInitialized)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 5, expectation: subscriptionsInitialized))
                 case .performedInitialSync:
-                    currCount = self.checkAndFulfill(currCount, 6, expectation: performedInitialSync)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 6, expectation: performedInitialSync))
                 case .subscriptionsActivated:
-                    currCount = self.checkAndFulfill(currCount, 7, expectation: subscriptionActivation)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 7, expectation: subscriptionActivation))
                 case .mutationQueueStarted:
-                    currCount = self.checkAndFulfill(currCount, 8, expectation: mutationQueueStarted)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 8, expectation: mutationQueueStarted))
                 case .syncStarted:
-                    currCount = self.checkAndFulfill(currCount, 9, expectation: syncStarted)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 9, expectation: syncStarted))
                     DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
                         MockAWSIncomingEventReconciliationQueue
                             .mockSendCompletion(completion: .failure(DataStoreError.unknown("", "", nil)))
                     }
                 case .cleanedUp:
-                    currCount = self.checkAndFulfill(currCount, 10, expectation: cleanedUp)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 10, expectation: cleanedUp))
                 default:
                     XCTFail("unexpected call")
                 }
@@ -305,7 +312,9 @@ class RemoteSyncEngineTests: XCTestCase {
         let forceFailToNotRestartSyncEngine = expectation(description: "forceFailToNotRestartSyncEngine")
         let completionBlockCalled = expectation(description: "Completion block is called")
 
-        var currCount = 1
+        // Threaded through `@Sendable` completions, so it cannot be a captured `var`.
+
+        let currCount = AtomicValue(initialValue: 1)
 
         let advice = RequestRetryAdvice.init(shouldRetry: false)
         mockRequestRetryablePolicy.pushOnRetryRequestAdvice(response: advice)
@@ -313,39 +322,39 @@ class RemoteSyncEngineTests: XCTestCase {
         let remoteSyncEngineSink = remoteSyncEngine
             .publisher
             .sink(receiveCompletion: { _ in
-                currCount = self.checkAndFulfill(currCount, 11, expectation: forceFailToNotRestartSyncEngine)
+                currCount.set(self.checkAndFulfill(currCount.get(), 11, expectation: forceFailToNotRestartSyncEngine))
             }, receiveValue: { (event: RemoteSyncEngineEvent) in
                 switch event {
                 case .storageAdapterAvailable:
-                    currCount = self.checkAndFulfill(currCount, 1, expectation: storageAdapterAvailable)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 1, expectation: storageAdapterAvailable))
                 case .subscriptionsPaused:
-                    currCount = self.checkAndFulfill(currCount, 2, expectation: subscriptionsPaused)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 2, expectation: subscriptionsPaused))
                 case .mutationsPaused:
-                    currCount = self.checkAndFulfill(currCount, 3, expectation: mutationsPaused)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 3, expectation: mutationsPaused))
                     DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
                         MockAWSIncomingEventReconciliationQueue.mockSend(event: .initialized)
                     }
                 case .clearedStateOutgoingMutations:
-                    currCount = self.checkAndFulfill(currCount, 4, expectation: stateMutationsCleared)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 4, expectation: stateMutationsCleared))
                 case .subscriptionsInitialized:
-                    currCount = self.checkAndFulfill(currCount, 5, expectation: subscriptionsInitialized)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 5, expectation: subscriptionsInitialized))
                 case .performedInitialSync:
-                    currCount = self.checkAndFulfill(currCount, 6, expectation: performedInitialSync)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 6, expectation: performedInitialSync))
                 case .subscriptionsActivated:
-                    currCount = self.checkAndFulfill(currCount, 7, expectation: subscriptionActivation)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 7, expectation: subscriptionActivation))
                 case .mutationQueueStarted:
-                    currCount = self.checkAndFulfill(currCount, 8, expectation: mutationQueueStarted)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 8, expectation: mutationQueueStarted))
                 case .syncStarted:
-                    currCount = self.checkAndFulfill(currCount, 9, expectation: syncStarted)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 9, expectation: syncStarted))
                     DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .milliseconds(500)) {
                         self.remoteSyncEngine.stop(completion: { result in
                             if case .success = result {
-                                currCount = self.checkAndFulfill(currCount, 12, expectation: completionBlockCalled)
+                                currCount.set(self.checkAndFulfill(currCount.get(), 12, expectation: completionBlockCalled))
                             }
                         })
                     }
                 case .cleanedUpForTermination:
-                    currCount = self.checkAndFulfill(currCount, 10, expectation: cleanedUpForTermination)
+                    currCount.set(self.checkAndFulfill(currCount.get(), 10, expectation: cleanedUpForTermination))
                 default:
                     XCTFail("unexpected call")
                 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RequestRetryablePolicyTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/RequestRetryablePolicyTests.swift
@@ -9,7 +9,9 @@ import Foundation
 import XCTest
 @testable import AWSDataStorePlugin
 
-class RequestRetryablePolicyTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RequestRetryablePolicyTests: XCTestCase, @unchecked Sendable {
     var retryPolicy: RequestRetryablePolicy!
     let defaultTimeout = DispatchTimeInterval.seconds(60)
     override func setUp() {

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/StorageEngineSyncRequirementsTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/StorageEngineSyncRequirementsTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class StorageEngineSyncRequirementsTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageEngineSyncRequirementsTests: XCTestCase, @unchecked Sendable {
 
     // MARK: - RequiresAuthPlugin tests
 
@@ -245,7 +247,11 @@ class StorageEngineSyncRequirementsTests: XCTestCase {
 
     // MARK: - Helpers
 
-    class MockAPIAuthInformationPlugin: MockAPICategoryPlugin, AWSAPIAuthInformation {
+    // `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+    // by a single test at a time.
+
+    class MockAPIAuthInformationPlugin: MockAPICategoryPlugin, AWSAPIAuthInformation, @unchecked Sendable {
 
         var authType: AWSAuthorizationType?
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/AWSIncomingEventReconciliationQueueTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class AWSIncomingEventReconciliationQueueTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSIncomingEventReconciliationQueueTests: XCTestCase, @unchecked Sendable {
     var storageAdapter: MockSQLiteStorageEngineAdapter!
     var apiPlugin: MockAPICategoryPlugin!
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisherTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/IncomingAsyncSubscriptionEventPublisherTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable @preconcurrency import AWSDataStorePlugin
 @testable @preconcurrency import AWSPluginsCore
 
-final class IncomingAsyncSubscriptionEventPublisherTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class IncomingAsyncSubscriptionEventPublisherTests: XCTestCase, @unchecked Sendable {
     var apiPlugin: MockAPICategoryPlugin!
     override func setUp() {
         apiPlugin = MockAPICategoryPlugin()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationDeleteTests.swift
@@ -17,7 +17,9 @@ import XCTest
 typealias MutationSyncInProcessListener = GraphQLSubscriptionOperation<MutationSync<AnyModel>>.InProcessListener
 
 /// Tests system behavior at a higher level than the reconciler tests--ensures data is appropriately applied and deleted
-class ModelReconciliationDeleteTests: SyncEngineTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ModelReconciliationDeleteTests: SyncEngineTestBase, @unchecked Sendable {
 
     /// - Given:
     ///   - A sync-enabled DataStore

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ModelReconciliationQueueBehaviorTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable @preconcurrency import AWSPluginsCore
 
-class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ModelReconciliationQueueBehaviorTests: ReconciliationQueueTestBase, @unchecked Sendable {
 
     /// - Given: A new AWSModelReconciliationQueue
     /// - When:

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ReconcileAndLocalSaveOperationTests.swift
@@ -16,7 +16,9 @@ import XCTest
 
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
-class ReconcileAndLocalSaveOperationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ReconcileAndLocalSaveOperationTests: XCTestCase, @unchecked Sendable {
     var storageAdapter: MockSQLiteStorageEngineAdapter!
     var anyPostMetadata: MutationSyncMetadata!
     var anyPostMutationSync: MutationSync<AnyModel>!

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ReconcileAndSaveQueueTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/ReconcileAndSaveQueueTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class ReconcileAndSaveQueueTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ReconcileAndSaveQueueTests: XCTestCase, @unchecked Sendable {
     var storageAdapter: MockSQLiteStorageEngineAdapter!
     var anyPostMetadata: MutationSyncMetadata!
     var anyPostMutationSync: MutationSync<AnyModel>!

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/RemoteSyncReconcilerTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/RemoteSyncReconcilerTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class RemoteSyncReconcilerTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RemoteSyncReconcilerTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         continueAfterFailure = false

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/Support/MockModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/Support/MockModelReconciliationQueue.swift
@@ -13,9 +13,15 @@ import Foundation
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class MockModelReconciliationQueue: ModelReconciliationQueue {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
 
-    static var mockModelReconciliationQueues: [String: MockModelReconciliationQueue] = [:]
+// by a single test at a time.
+
+class MockModelReconciliationQueue: ModelReconciliationQueue, @unchecked Sendable {
+
+    // `nonisolated(unsafe)`: populated during a test's setup and read within that test; XCTest runs
+    // one test at a time.
+    nonisolated(unsafe) static var mockModelReconciliationQueues: [String: MockModelReconciliationQueue] = [:]
 
     private let modelSchema: ModelSchema
     let modelReconciliationQueueSubject: PassthroughSubject<ModelReconciliationQueueEvent, DataStoreError>

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/Support/MockModelReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/Support/MockModelReconciliationQueue.swift
@@ -13,15 +13,16 @@ import Foundation
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
-
-// by a single test at a time.
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. The only shared mutable
+// state is the static registry below, which is an `AtomicDictionary`.
 
 class MockModelReconciliationQueue: ModelReconciliationQueue, @unchecked Sendable {
 
-    // `nonisolated(unsafe)`: populated during a test's setup and read within that test; XCTest runs
-    // one test at a time.
-    nonisolated(unsafe) static var mockModelReconciliationQueues: [String: MockModelReconciliationQueue] = [:]
+    /// `AtomicDictionary` rather than `nonisolated(unsafe) static var`: `init` registers each instance
+    /// here, and the reconciliation-queue factory builds one per model schema, so several inits can run
+    /// concurrently and mutate the same `Dictionary`. "XCTest runs one test at a time" does not cover
+    /// that, because the concurrency is within a single test.
+    static let mockModelReconciliationQueues = AtomicDictionary<String, MockModelReconciliationQueue>()
 
     private let modelSchema: ModelSchema
     let modelReconciliationQueueSubject: PassthroughSubject<ModelReconciliationQueueEvent, DataStoreError>
@@ -60,6 +61,6 @@ class MockModelReconciliationQueue: ModelReconciliationQueue, @unchecked Sendabl
     }
 
     static func reset() {
-        MockModelReconciliationQueue.mockModelReconciliationQueues = [:]
+        MockModelReconciliationQueue.mockModelReconciliationQueues.removeAll()
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/Support/MockSQLiteStorageEngineAdapter.swift
@@ -12,7 +12,11 @@ import XCTest
 @testable import Amplify
 @testable import AWSDataStorePlugin
 
-class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockSQLiteStorageEngineAdapter: StorageEngineAdapter, @unchecked Sendable {
 
     static let maxNumberOfPredicates: Int = 950
 
@@ -310,7 +314,11 @@ class MockSQLiteStorageEngineAdapter: StorageEngineAdapter {
     }
 }
 
-class MockStorageEngineBehavior: StorageEngineBehavior {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockStorageEngineBehavior: StorageEngineBehavior, @unchecked Sendable {
 
     static let mockStorageEngineBehaviorFactory =
         MockStorageEngineBehavior.init(isSyncEnabled:dataStoreConfiguration:validAPIPluginKey:validAuthPluginKey:modelRegistryVersion:userDefault:)

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/Support/ReconciliationQueueTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/SubscriptionSync/Support/ReconciliationQueueTestBase.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class ReconciliationQueueTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ReconciliationQueueTestBase: XCTestCase, @unchecked Sendable {
 
     var apiPlugin: MockAPICategoryPlugin!
     var authPlugin: MockAuthCategoryPlugin!

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/AWSAuthorizationTypeIteratorTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/AWSAuthorizationTypeIteratorTests.swift
@@ -8,7 +8,9 @@
 import AWSPluginsCore
 import XCTest
 
-class AWSAuthorizationTypeIteratorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAuthorizationTypeIteratorTests: XCTestCase, @unchecked Sendable {
 
     func testEmptyIterator_hasNextValue_false() throws {
         var iterator = AWSAuthorizationTypeIterator(withValues: [])

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/MutationEventQueryTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/MutationEventQueryTests.swift
@@ -14,7 +14,11 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class MutationEventQueryTests: BaseDataStoreTests {
+/// - Note: `@unchecked Sendable` so the test body can be captured by the `@Sendable` completion
+
+///   closures the production API now takes. `XCTestCase` is not `Sendable`, and each test runs alone.
+
+final class MutationEventQueryTests: BaseDataStoreTests, @unchecked Sendable {
 
     func testQueryPendingMutation_EmptyResult() {
         let querySuccess = expectation(description: "query mutation events success")

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/StopwatchTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/Sync/Support/StopwatchTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable @preconcurrency import AWSDataStorePlugin
 
-class StopwatchTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StopwatchTests: XCTestCase, @unchecked Sendable {
 
     func testStartLapStop() throws {
         let stopwatch = Stopwatch()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/BaseDataStoreTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/BaseDataStoreTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 
 /// Base class for Local data store tests
-class BaseDataStoreTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class BaseDataStoreTests: XCTestCase, @unchecked Sendable {
 
     var connection: Connection!
     var storageEngine: StorageEngine!
@@ -89,7 +91,8 @@ class BaseDataStoreTests: XCTestCase {
     func populateData<M: Model>(_ models: [M]) {
         let saveComplete = expectation(description: "save completed")
 
-        func save(model: M, index: Int) {
+        // `@Sendable` because it recurses from inside the storage adapter's `@Sendable` completion.
+        @Sendable func save(model: M, index: Int) {
             storageAdapter.save(model) {
                 switch $0 {
                 case .success:

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/LocalStoreIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/LocalStoreIntegrationTestBase.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSDataStorePlugin
 
-class LocalStoreIntegrationTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class LocalStoreIntegrationTestBase: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         await Amplify.reset()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockAWSIncomingEventReconciliationQueue.swift
@@ -12,7 +12,11 @@ import Combine
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue, @unchecked Sendable {
     static let factory: IncomingEventReconciliationQueueFactory = { modelSchemas, api, storageAdapter, syncExpressions, auth, _, _, _ in
         MockAWSIncomingEventReconciliationQueue(
             modelSchemas: modelSchemas,
@@ -27,7 +31,7 @@ class MockAWSIncomingEventReconciliationQueue: IncomingEventReconciliationQueue 
         return incomingEventSubject.eraseToAnyPublisher()
     }
 
-    static var lastInstance = AtomicValue<MockAWSIncomingEventReconciliationQueue?>(initialValue: nil)
+    static let lastInstance = AtomicValue<MockAWSIncomingEventReconciliationQueue?>(initialValue: nil)
     init(
         modelSchemas: [ModelSchema],
         api: APICategoryGraphQLBehavior?,

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockAWSInitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockAWSInitialSyncOrchestrator.swift
@@ -13,7 +13,11 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-class MockAWSInitialSyncOrchestrator: InitialSyncOrchestrator {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockAWSInitialSyncOrchestrator: InitialSyncOrchestrator, @unchecked Sendable {
     static let factory: InitialSyncOrchestratorFactory = {
         dataStoreConfiguration, _, api, reconciliationQueue, storageAdapter  in
         MockAWSInitialSyncOrchestrator(
@@ -27,8 +31,10 @@ class MockAWSInitialSyncOrchestrator: InitialSyncOrchestrator {
     typealias SyncOperationResult = Result<Void, DataStoreError>
     typealias SyncOperationResultHandler = (SyncOperationResult) -> Void
 
-    private static var instance: MockAWSInitialSyncOrchestrator?
-    private static var mockedResponse: SyncOperationResult?
+    // `nonisolated(unsafe)`: set by a test's `setUpWithError` before use and read after; XCTest runs
+    // one test at a time.
+    private nonisolated(unsafe) static var instance: MockAWSInitialSyncOrchestrator?
+    private nonisolated(unsafe) static var mockedResponse: SyncOperationResult?
 
     let initialSyncOrchestratorTopic: PassthroughSubject<InitialSyncOperationEvent, DataStoreError>
     var publisher: AnyPublisher<InitialSyncOperationEvent, DataStoreError> {

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockAWSInitialSyncOrchestrator.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockAWSInitialSyncOrchestrator.swift
@@ -31,10 +31,13 @@ class MockAWSInitialSyncOrchestrator: InitialSyncOrchestrator, @unchecked Sendab
     typealias SyncOperationResult = Result<Void, DataStoreError>
     typealias SyncOperationResultHandler = (SyncOperationResult) -> Void
 
-    // `nonisolated(unsafe)`: set by a test's `setUpWithError` before use and read after; XCTest runs
-    // one test at a time.
-    private nonisolated(unsafe) static var instance: MockAWSInitialSyncOrchestrator?
-    private nonisolated(unsafe) static var mockedResponse: SyncOperationResult?
+    /// `AtomicValue` rather than `nonisolated(unsafe) static var`: this outlives an individual test, and
+    /// the sync engine keeps a strong reference that can fire `sync(completion:)` during teardown — so a
+    /// `reset()` from the next test's `setUp` can overlap a read from the previous test's engine. XCTest
+    /// running one test at a time does not cover that, which is what the previous annotation assumed.
+    ///
+    /// The unused `instance` static that sat here was dead and has been removed.
+    private static let mockedResponse = AtomicValue<SyncOperationResult?>(initialValue: nil)
 
     let initialSyncOrchestratorTopic: PassthroughSubject<InitialSyncOperationEvent, DataStoreError>
     var publisher: AnyPublisher<InitialSyncOperationEvent, DataStoreError> {
@@ -51,15 +54,15 @@ class MockAWSInitialSyncOrchestrator: InitialSyncOrchestrator, @unchecked Sendab
     }
 
     static func reset() {
-        mockedResponse = nil
+        mockedResponse.set(nil)
     }
 
     static func setResponseOnSync(result: SyncOperationResult) {
-        mockedResponse = result
+        mockedResponse.set(result)
     }
 
     func sync(completion: @escaping SyncOperationResultHandler) {
-        let response = MockAWSInitialSyncOrchestrator.mockedResponse ?? .successfulVoid
+        let response = MockAWSInitialSyncOrchestrator.mockedResponse.get() ?? .successfulVoid
         completion(response)
     }
 }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockFileManager.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockFileManager.swift
@@ -11,7 +11,11 @@ enum MockFileManagerError: Error {
     case removeItemError
 }
 
-class MockFileManager: FileManager {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockFileManager: FileManager, @unchecked Sendable {
 
     var removeItem: ((URL) -> Void)?
 

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockOutgoingMutationQueue.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockOutgoingMutationQueue.swift
@@ -12,7 +12,11 @@ import Combine
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-class MockOutgoingMutationQueue: OutgoingMutationQueueBehavior {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockOutgoingMutationQueue: OutgoingMutationQueueBehavior, @unchecked Sendable {
     func stopSyncingToCloud(_ completion: @escaping BasicClosure = {}) {
         completion()
     }

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockReconciliationQueue.swift
@@ -11,7 +11,11 @@ import Combine
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-final class MockReconciliationQueue: MessageReporter, IncomingEventReconciliationQueue {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockReconciliationQueue: MessageReporter, IncomingEventReconciliationQueue, @unchecked Sendable {
 
     func start() {
         notify()

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockRemoteSyncEngine.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockRemoteSyncEngine.swift
@@ -15,7 +15,11 @@ import Foundation
 
 typealias OnSubmitCallBack = (MutationEvent, @escaping (Result<MutationEvent, DataStoreError>) -> Void) -> Void
 
-class MockRemoteSyncEngine: RemoteSyncEngineBehavior {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockRemoteSyncEngine: RemoteSyncEngineBehavior, @unchecked Sendable {
     var syncing = false
 
     func submit(_ mutationEvent: MutationEvent, completion: @escaping (Result<MutationEvent, DataStoreError>) -> Void) {

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockRequestRetryablePolicy.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/Mocks/MockRequestRetryablePolicy.swift
@@ -12,7 +12,11 @@ import Foundation
 @testable import AWSDataStorePlugin
 @testable import AWSPluginsCore
 
-class MockRequestRetryablePolicy: RequestRetryablePolicy {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockRequestRetryablePolicy: RequestRetryablePolicy, @unchecked Sendable {
 
     var responseQueue: [RequestRetryAdvice] = []
     var onRetryRequestAdvice: ((URLError?, HTTPURLResponse?, Int) -> Void)?

--- a/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/SyncEngineTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/AWSDataStorePluginTests/TestSupport/SyncEngineTestBase.swift
@@ -15,7 +15,9 @@ import XCTest
 @testable import AWSPluginsCore
 
 /// Base class for SyncEngine and sync-enabled DataStore tests
-class SyncEngineTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SyncEngineTestBase: XCTestCase, @unchecked Sendable {
 
     /// Populated during setUp, used in each test during `Amplify.configure()`
     var amplifyConfig: AmplifyConfiguration!
@@ -190,7 +192,7 @@ class SyncEngineTestBase: XCTestCase {
 
     /// Starts amplify by invoking `Amplify.configure(amplifyConfig)`, and waits to receive a `syncStarted` Hub message
     /// before returning.
-    private func startAmplifyAndWaitForSync(completion: @escaping (Swift.Result<Void, Error>) -> Void) {
+    private func startAmplifyAndWaitForSync(completion: @escaping @Sendable (Swift.Result<Void, Error>) -> Void) {
         token = Amplify.Hub.listen(to: .dataStore) { [weak self] payload in
             if payload.eventName == "DataStore.syncStarted" {
                 if let token = self?.token {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthCognitoTests/AWSDataStoreAuthBaseTest.swift
@@ -65,7 +65,9 @@ class AuthRecorderInterceptor: URLRequestInterceptor {
     }
 }
 
-class AWSDataStoreAuthBaseTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStoreAuthBaseTest: XCTestCase, @unchecked Sendable {
     var amplifyConfig: AmplifyConfiguration!
     var user1: TestUser?
     var user2: TestUser?

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthIAMTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginAuthIAMTests/AWSDataStoreAuthBaseTest.swift
@@ -98,7 +98,9 @@ class DataStoreAuthBaseTestURLSessionFactory: URLSessionBehaviorFactory {
 
 }
 
-class AWSDataStoreAuthBaseTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStoreAuthBaseTest: XCTestCase, @unchecked Sendable {
     var requests: Set<AnyCancellable> = []
 
     var amplifyConfig: AmplifyConfiguration!

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/11/AWSDataStoreIntSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/11/AWSDataStoreIntSortKeyTest.swift
@@ -31,7 +31,9 @@ private struct TestModels: AmplifyModelRegistration {
     var version: String = "test"
 }
 
-class AWSDataStoreIntSortKeyTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStoreIntSortKeyTest: XCTestCase, @unchecked Sendable {
     let configFile = "testconfiguration/AWSDataStoreCategoryPluginPrimaryKeyIntegrationTests-amplifyconfiguration"
 
     override func setUp() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/12/AWSDataStoreFloatSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/12/AWSDataStoreFloatSortKeyTest.swift
@@ -31,7 +31,9 @@ private struct TestModels: AmplifyModelRegistration {
     var version: String = "test"
 }
 
-class AWSDataStoreFloatSortKeyTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStoreFloatSortKeyTest: XCTestCase, @unchecked Sendable {
     let configFile = "testconfiguration/AWSDataStoreCategoryPluginPrimaryKeyIntegrationTests-amplifyconfiguration"
 
     override func setUp() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/13/AWSDataStoreDateTimeSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/13/AWSDataStoreDateTimeSortKeyTest.swift
@@ -31,7 +31,9 @@ private struct TestModels: AmplifyModelRegistration {
     var version: String = "test"
 }
 
-class AWSDataStoreDateTimeSortKeyTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStoreDateTimeSortKeyTest: XCTestCase, @unchecked Sendable {
     let configFile = "testconfiguration/AWSDataStoreCategoryPluginPrimaryKeyIntegrationTests-amplifyconfiguration"
 
     override func setUp() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/14/AWSDataStoreDateSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/14/AWSDataStoreDateSortKeyTest.swift
@@ -31,7 +31,9 @@ private struct TestModels: AmplifyModelRegistration {
     var version: String = "test"
 }
 
-class AWSDataStoreDateSortKeyTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStoreDateSortKeyTest: XCTestCase, @unchecked Sendable {
     let configFile = "testconfiguration/AWSDataStoreCategoryPluginPrimaryKeyIntegrationTests-amplifyconfiguration"
 
     override func setUp() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/15/AWSDataStoreTimeSortKeyTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/15/AWSDataStoreTimeSortKeyTest.swift
@@ -31,7 +31,9 @@ private struct TestModels: AmplifyModelRegistration {
     var version: String = "test"
 }
 
-class AWSDataStoreTimeSortKeyTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStoreTimeSortKeyTest: XCTestCase, @unchecked Sendable {
     let configFile = "testconfiguration/AWSDataStoreCategoryPluginPrimaryKeyIntegrationTests-amplifyconfiguration"
 
     override func setUp() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/9/AWSDataStoreCompositeSortKeyIdentifierTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/9/AWSDataStoreCompositeSortKeyIdentifierTest.swift
@@ -24,7 +24,9 @@ private struct TestModels: AmplifyModelRegistration {
     let version: String = "test"
 }
 
-class AWSDataStoreCompositeSortKeyIdentifierTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStoreCompositeSortKeyIdentifierTest: XCTestCase, @unchecked Sendable {
     let configFile = "testconfiguration/AWSDataStoreCategoryPluginPrimaryKeyIntegrationTests-amplifyconfiguration"
 
     override func setUp() async throws {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStorePrimaryKeyBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStorePrimaryKeyBaseTest.swift
@@ -16,7 +16,9 @@ import XCTest
 
 @testable import Amplify
 
-class AWSDataStorePrimaryKeyBaseTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStorePrimaryKeyBaseTest: XCTestCase, @unchecked Sendable {
     var requests: Set<AnyCancellable> = []
 
     var amplifyConfig: AmplifyConfiguration!

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStoreSortKeyBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginCPKTests/PrimaryKey/AWSDataStoreSortKeyBaseTest.swift
@@ -17,7 +17,9 @@ import AWSDataStorePlugin
 @testable import DataStoreHostApp
 #endif
 
-class AWSDataStoreSortKeyBaseTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStoreSortKeyBaseTest: XCTestCase, @unchecked Sendable {
     static let defaultConfigFile = "AWSDataStoreCategoryPluginPrimaryKeyIntegrationTests-amplifyconfiguration"
     override func setUp() async throws {
         continueAfterFailure = false

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/AWSDataStoreCategoryPluginFlutterIntegrationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/AWSDataStoreCategoryPluginFlutterIntegrationTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import AWSDataStorePlugin
 import XCTest
 
-class AWSDataStorePluginFlutterConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStorePluginFlutterConfigurationTests: XCTestCase, @unchecked Sendable {
 
     // Note this test requires the ability to write a new database in the Documents directory, so it must be embedded
     // in a host app

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario1FlutterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario1FlutterTests.swift
@@ -26,7 +26,9 @@ import XCTest
  See https://docs.amplify.aws/cli/graphql-transformer/connection for more details
  */
 
-class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario1FlutterTests: SyncEngineFlutterIntegrationTestBase, @unchecked Sendable {
 
     func testSaveTeamAndProjectSyncToCloud() throws {
         try startAmplifyAndWaitForSync()

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario2FlutterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario2FlutterTests.swift
@@ -28,7 +28,9 @@ import XCTest
  See https://docs.amplify.aws/cli/graphql-transformer/connection for more details
  */
 
-class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario2FlutterTests: SyncEngineFlutterIntegrationTestBase, @unchecked Sendable {
 
     func testSaveTeamAndProjectSyncToCloud() throws {
         try startAmplifyAndWaitForSync()

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario3FlutterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario3FlutterTests.swift
@@ -28,7 +28,9 @@ type Comment3 @model
 See https://docs.amplify.aws/cli/graphql-transformer/connection for more details
 */
 
-class DataStoreConnectionScenario3FlutterTests: SyncEngineFlutterIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario3FlutterTests: SyncEngineFlutterIntegrationTestBase, @unchecked Sendable {
 
     func testSavePostAndCommentSyncToCloud() throws {
         try startAmplifyAndWaitForSync()

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario4FlutterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario4FlutterTests.swift
@@ -29,7 +29,9 @@ import XCTest
  See https://docs.amplify.aws/cli/graphql-transformer/connection for more details
  */
 
-class DataStoreConnectionScenario4FlutterTests: SyncEngineFlutterIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario4FlutterTests: SyncEngineFlutterIntegrationTestBase, @unchecked Sendable {
 
     func testCreateCommentAndGetCommentWithPost() throws {
         try startAmplifyAndWaitForSync()

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario5FlutterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario5FlutterTests.swift
@@ -39,7 +39,9 @@ import XCTest
  See https://docs.amplify.aws/cli/graphql-transformer/connection for more details.
  */
 
-class DataStoreConnectionScenario5FlutterTests: SyncEngineFlutterIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario5FlutterTests: SyncEngineFlutterIntegrationTestBase, @unchecked Sendable {
 
     func testListPostEditorByPost() throws {
         try startAmplifyAndWaitForSync()

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario6FlutterTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/Connection/DataStoreConnectionScenario6FlutterTests.swift
@@ -34,7 +34,9 @@ import XCTest
  ```
  */
 
-class DataStoreConnectionScenario6FlutterTests: SyncEngineFlutterIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario6FlutterTests: SyncEngineFlutterIntegrationTestBase, @unchecked Sendable {
     /// TODO: Implement testGetBlogThenFetchPostsThenFetchComments
     func testGetCommentThenFetchPostThenFetchBlog() throws {
         try startAmplifyAndWaitForSync()

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/DataStoreFlutterConsecutiveUpdatesTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/DataStoreFlutterConsecutiveUpdatesTests.swift
@@ -14,7 +14,9 @@ import XCTest
 
 // swiftlint:disable cyclomatic_complexity
 // swiftlint:disable type_body_length
-class DataStoreFlutterConsecutiveUpdatesTests: SyncEngineFlutterIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreFlutterConsecutiveUpdatesTests: SyncEngineFlutterIntegrationTestBase, @unchecked Sendable {
     /// - Given: API has been setup with `Post` model registered
     /// - When: A Post is saved and then immediately updated
     /// - Then: The post should be updated with new fields immediately and in the eventual consistent state

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/DataStoreFlutterEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/DataStoreFlutterEndToEndTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSDataStorePlugin
 
-class DataStoreEndToEndTests: SyncEngineFlutterIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreEndToEndTests: SyncEngineFlutterIntegrationTestBase, @unchecked Sendable {
 
     func testCreateMutateDelete() throws {
         let plugin: AWSDataStorePlugin = try Amplify.DataStore.getPlugin(for: "awsDataStorePlugin") as! AWSDataStorePlugin

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SyncEngineFlutterIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginFlutterTests/TestSupport/SyncEngineFlutterIntegrationTestBase.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSDataStorePlugin
 @testable import DataStoreHostApp
 
-class SyncEngineFlutterIntegrationTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SyncEngineFlutterIntegrationTestBase: XCTestCase, @unchecked Sendable {
 
     static let amplifyConfigurationFile = "testconfiguration/AWSDataStoreCategoryPluginIntegrationTests-amplifyconfiguration"
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/AWSDataStorePluginConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/AWSDataStorePluginConfigurationTests.swift
@@ -9,7 +9,9 @@ import AWSDataStorePlugin
 import XCTest
 @testable import Amplify
 
-class AWSDataStorePluginConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStorePluginConfigurationTests: XCTestCase, @unchecked Sendable {
 
     override func tearDown() async throws {
         await Amplify.reset()

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario1Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario1Tests.swift
@@ -31,7 +31,9 @@ import XCTest
 
  */
 
-class DataStoreConnectionScenario1Tests: SyncEngineIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario1Tests: SyncEngineIntegrationTestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario2Tests.swift
@@ -32,7 +32,9 @@ import XCTest
  See https://docs.amplify.aws/cli/graphql-transformer/connection for more details
  */
 
-class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario2Tests: SyncEngineIntegrationTestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario3Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario3Tests.swift
@@ -32,7 +32,9 @@ type Comment3 @model
 See https://docs.amplify.aws/cli/graphql-transformer/connection for more details
 */
 
-class DataStoreConnectionScenario3Tests: SyncEngineIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario3Tests: SyncEngineIntegrationTestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario4Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario4Tests.swift
@@ -30,7 +30,9 @@ import XCTest
  See https://docs.amplify.aws/cli/graphql-transformer/connection for more details
  */
 
-class DataStoreConnectionScenario4Tests: SyncEngineIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario4Tests: SyncEngineIntegrationTestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario5Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario5Tests.swift
@@ -41,7 +41,9 @@ import XCTest
  See https://docs.amplify.aws/cli/graphql-transformer/connection for more details.
  */
 
-class DataStoreConnectionScenario5Tests: SyncEngineIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario5Tests: SyncEngineIntegrationTestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/Connection/DataStoreConnectionScenario6Tests.swift
@@ -40,7 +40,9 @@ import XCTest
  */
 
 @available(iOS 13.0, *)
-class DataStoreConnectionScenario6Tests: SyncEngineIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario6Tests: SyncEngineIntegrationTestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreConfigurationTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreConfigurationTests.swift
@@ -12,7 +12,9 @@ import AWSPluginsCore
 @testable import Amplify
 @testable import AWSDataStorePlugin
 
-class DataStoreConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConfigurationTests: XCTestCase, @unchecked Sendable {
 
     override func tearDown() async throws {
         try await Amplify.DataStore.clear()

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreConsecutiveUpdatesTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreConsecutiveUpdatesTests.swift
@@ -17,7 +17,9 @@ import AWSPluginsCore
 
 // swiftlint:disable cyclomatic_complexity
 // swiftlint:disable type_body_length
-class DataStoreConsecutiveUpdatesTests: SyncEngineIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConsecutiveUpdatesTests: SyncEngineIntegrationTestBase, @unchecked Sendable {
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {
             registry.register(modelType: Post.self)

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreCustomPrimaryKeyTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreCustomPrimaryKeyTests.swift
@@ -16,7 +16,9 @@ import AWSPluginsCore
 #endif
 
 // swiftlint:disable cyclomatic_complexity
-class DataStoreCustomPrimaryKeyTests: SyncEngineIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreCustomPrimaryKeyTests: SyncEngineIntegrationTestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreEndToEndTests.swift
@@ -16,7 +16,9 @@ import Combine
 @testable import DataStoreHostApp
 #endif
 
-class DataStoreEndToEndTests: SyncEngineIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreEndToEndTests: SyncEngineIntegrationTestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreHubEventsTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreHubEventsTests.swift
@@ -12,7 +12,9 @@ import AWSPluginsCore
 @testable import Amplify
 @testable import AWSDataStorePlugin
 
-class DataStoreHubEventTests: HubEventsIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreHubEventTests: HubEventsIntegrationTestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreLargeNumberModelsSubscriptionTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreLargeNumberModelsSubscriptionTests.swift
@@ -10,7 +10,9 @@ import Combine
 import XCTest
 @testable import AWSAPIPlugin
 
-class DataStoreLargeNumberModelsSubscriptionTests: SyncEngineIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreLargeNumberModelsSubscriptionTests: SyncEngineIntegrationTestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreObserveQueryTests.swift
@@ -15,7 +15,9 @@ import Combine
 
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
-class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreObserveQueryTests: SyncEngineIntegrationTestBase, @unchecked Sendable {
 
     var cancellables = Set<AnyCancellable>()
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreScalarTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/DataStoreScalarTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSDataStorePlugin
 
-class DataStoreScalarTests: SyncEngineIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreScalarTests: SyncEngineIntegrationTestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/SubscriptionEndToEndTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/SubscriptionEndToEndTests.swift
@@ -15,7 +15,9 @@ import XCTest
 @testable import DataStoreHostApp
 #endif
 
-class SubscriptionEndToEndTests: SyncEngineIntegrationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SubscriptionEndToEndTests: SyncEngineIntegrationTestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/DataStoreTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/DataStoreTestBase.swift
@@ -9,6 +9,8 @@ import Amplify
 import Foundation
 import XCTest
 
-class DataStoreTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreTestBase: XCTestCase, @unchecked Sendable {
 
 }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/HubEventsIntegrationTestBase.swift
@@ -15,7 +15,9 @@ import AWSPluginsCore
 @testable import Amplify
 @testable import AWSDataStorePlugin
 
-class HubEventsIntegrationTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class HubEventsIntegrationTestBase: XCTestCase, @unchecked Sendable {
 
     static let amplifyConfigurationFile = "testconfiguration/AWSDataStoreCategoryPluginIntegrationTests-amplifyconfiguration"
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginIntegrationTests/TestSupport/SyncEngineIntegrationTestBase.swift
@@ -15,7 +15,9 @@ import XCTest
 @testable import DataStoreHostApp
 #endif
 
-class SyncEngineIntegrationTestBase: DataStoreTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SyncEngineIntegrationTestBase: DataStoreTestBase, @unchecked Sendable {
 
     static let amplifyConfigurationFile = "testconfiguration/AWSDataStoreCategoryPluginIntegrationTests-amplifyconfiguration"
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/AWSDataStoreLazyLoadBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginLazyLoadTests/LazyLoadBase/AWSDataStoreLazyLoadBaseTest.swift
@@ -17,7 +17,9 @@ import XCTest
 #endif
 @testable import Amplify
 
-class AWSDataStoreLazyLoadBaseTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStoreLazyLoadBaseTest: XCTestCase, @unchecked Sendable {
     var amplifyConfig: AmplifyConfiguration!
 
     var apiOnly: Bool = false

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreAuthBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginMultiAuthTests/AWSDataStoreAuthBaseTest.swift
@@ -101,7 +101,9 @@ class DataStoreAuthBaseTestURLSessionFactory: URLSessionBehaviorFactory {
 }
 
 
-class AWSDataStoreAuthBaseTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSDataStoreAuthBaseTest: XCTestCase, @unchecked Sendable {
     var requests: Set<AnyCancellable> = []
 
     var amplifyConfig: AmplifyConfiguration!

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TestSupport/DataStoreTestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TestSupport/DataStoreTestBase.swift
@@ -9,7 +9,9 @@ import Amplify
 import Foundation
 import XCTest
 
-class DataStoreTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreTestBase: XCTestCase, @unchecked Sendable {
     func saveModel<M: Model>(_ model: M) async throws -> M {
         return try await Amplify.DataStore.save(model)
     }

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TestSupport/SyncEngineIntegrationV2TestBase.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TestSupport/SyncEngineIntegrationV2TestBase.swift
@@ -13,7 +13,9 @@ import XCTest
 #endif
 import AWSAPIPlugin
 
-class SyncEngineIntegrationV2TestBase: DataStoreTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SyncEngineIntegrationV2TestBase: DataStoreTestBase, @unchecked Sendable {
 
     static let amplifyConfigurationFile = "testconfiguration/AWSDataStoreCategoryPluginIntegrationV2Tests-amplifyconfiguration"
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionOptionalAssociations.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionOptionalAssociations.swift
@@ -55,7 +55,9 @@ import XCTest
  }
  */
 
-class DataStoreConnectionOptionalAssociations: SyncEngineIntegrationV2TestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionOptionalAssociations: SyncEngineIntegrationV2TestBase, @unchecked Sendable {
 
     var token: UnsubscribeToken?
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario1V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario1V2Tests.swift
@@ -30,7 +30,9 @@ import XCTest
 
  */
 
-class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario1V2Tests: SyncEngineIntegrationV2TestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario2V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario2V2Tests.swift
@@ -32,7 +32,9 @@ import XCTest
  */
 
 // swiftlint:disable type_body_length
-class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario2V2Tests: SyncEngineIntegrationV2TestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario3V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario3V2Tests.swift
@@ -30,7 +30,9 @@ import XCTest
 See https://docs.amplify.aws/cli/graphql-transformer/connection for more details
 */
 
-class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario3V2Tests: SyncEngineIntegrationV2TestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario3aV2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario3aV2Tests.swift
@@ -29,7 +29,9 @@ import XCTest
 See https://docs.amplify.aws/cli/graphql-transformer/connection for more details
 */
 
-class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario3aV2Tests: SyncEngineIntegrationV2TestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario4V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario4V2Tests.swift
@@ -31,7 +31,9 @@ import XCTest
  See https://docs.amplify.aws/cli/graphql-transformer/connection for more details
  */
 
-class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario4V2Tests: SyncEngineIntegrationV2TestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario5V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario5V2Tests.swift
@@ -30,7 +30,9 @@ import XCTest
  See https://docs.amplify.aws/cli/graphql-transformer/connection for more details.
  */
 
-class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario5V2Tests: SyncEngineIntegrationV2TestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario6V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario6V2Tests.swift
@@ -39,7 +39,9 @@ import XCTest
  */
 
 // swiftlint:disable type_body_length
-class DataStoreConnectionScenario6V2Tests: SyncEngineIntegrationV2TestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario6V2Tests: SyncEngineIntegrationV2TestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario7V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario7V2Tests.swift
@@ -34,7 +34,9 @@ import XCTest
  ```
  */
 // swiftlint:disable type_body_length
-class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario7V2Tests: SyncEngineIntegrationV2TestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario8V2Tests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreConnectionScenario8V2Tests.swift
@@ -38,7 +38,9 @@ import XCTest
  ```
  */
 // swiftlint:disable type_body_length
-class DataStoreConnectionScenario8V2Tests: SyncEngineIntegrationV2TestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreConnectionScenario8V2Tests: SyncEngineIntegrationV2TestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreModelWithCustomTimestampTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreModelWithCustomTimestampTests.swift
@@ -18,7 +18,9 @@ import XCTest
 
  */
 
-class DataStoreModelWithCustomTimestampTests: SyncEngineIntegrationV2TestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreModelWithCustomTimestampTests: SyncEngineIntegrationV2TestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreModelWithDefaultValueTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreModelWithDefaultValueTests.swift
@@ -17,7 +17,9 @@ import XCTest
  }
  */
 
-class DataStoreModelWithDefaultValueTests: SyncEngineIntegrationV2TestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreModelWithDefaultValueTests: SyncEngineIntegrationV2TestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreModelWithSecondaryIndexTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreModelWithSecondaryIndexTests.swift
@@ -20,7 +20,9 @@ import XCTest
  }
  */
 
-class DataStoreModelWithSecondaryIndexTests: SyncEngineIntegrationV2TestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreModelWithSecondaryIndexTests: SyncEngineIntegrationV2TestBase, @unchecked Sendable {
 
     struct TestModelRegistration: AmplifyModelRegistration {
         func registerModels(registry: ModelRegistry.Type) {

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreSchemaDriftTests.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/AWSDataStorePluginV2Tests/TransformerV2/DataStoreSchemaDriftTests.swift
@@ -29,7 +29,9 @@ import XCTest
  */
 
 @available(iOS 13.0, *)
-class DataStoreSchemaDriftTests: SyncEngineIntegrationV2TestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreSchemaDriftTests: SyncEngineIntegrationV2TestBase, @unchecked Sendable {
 
     var subscriptions: Set<AnyCancellable> = []
 

--- a/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressBaseTest.swift
+++ b/AmplifyPlugins/DataStore/Tests/DataStoreHostApp/DataStoreStressTests/DataStoreStressBaseTest.swift
@@ -15,7 +15,9 @@ import Combine
 @testable import AWSDataStorePlugin
 @testable import DataStoreHostApp
 
-class DataStoreStressBaseTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DataStoreStressBaseTest: XCTestCase, @unchecked Sendable {
 
     static let amplifyConfigurationFile = "testconfiguration/AWSAmplifyStressTests-amplifyconfiguration"
     let concurrencyLimit = 50


### PR DESCRIPTION
Slice **33 of 38** in the Swift 6 language-mode migration — 133 file(s).

Stacked on `swift6/32-tests-auth`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.