### PR TITLE
test(api): migrate the API test targets

### DIFF
--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/AnyModelIntegrationTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/AnyModelIntegrationTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import Amplify
 @testable import APIHostApp
 
-class AnyModelIntegrationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AnyModelIntegrationTests: XCTestCase, @unchecked Sendable {
     let networkTimeout: TimeInterval = 180.0
 
     override func setUp() async throws {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/AppSyncRealTimeClientTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/AppSyncRealTimeClientTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable @_spi(WebSocket) import AWSPluginsCore
 @testable import InternalAmplifyCredentials
 
-class AppSyncRealTimeClientTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AppSyncRealTimeClientTests: XCTestCase, @unchecked Sendable {
     let subscriptionRequest = """
     subscription MySubscription {
       onCreatePost {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario1Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario1Tests.swift
@@ -31,7 +31,9 @@ import XCTest
  See https://docs.amplify.aws/cli/graphql-transformer/connection for more details
 
  */
-class GraphQLConnectionScenario1Tests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLConnectionScenario1Tests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         do {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario2Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario2Tests.swift
@@ -32,7 +32,9 @@ import XCTest
  ```
  See https://docs.amplify.aws/cli/graphql-transformer/connection for more details
  */
-class GraphQLConnectionScenario2Tests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLConnectionScenario2Tests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         do {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario3Tests.swift
@@ -32,7 +32,9 @@ import XCTest
  ```
  See https://docs.amplify.aws/cli/graphql-transformer/connection for more details
  */
-class GraphQLConnectionScenario3Tests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLConnectionScenario3Tests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         do {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario4Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario4Tests.swift
@@ -33,7 +33,9 @@ import XCTest
  ```
  See https://docs.amplify.aws/cli/graphql-transformer/connection for more details
  */
-class GraphQLConnectionScenario4Tests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLConnectionScenario4Tests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         do {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario5Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario5Tests.swift
@@ -44,7 +44,9 @@ import XCTest
  ```
  See https://docs.amplify.aws/cli/graphql-transformer/connection for more details.
  */
-class GraphQLConnectionScenario5Tests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLConnectionScenario5Tests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         do {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario6Tests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLConnectionScenario6Tests.swift
@@ -39,7 +39,9 @@ import XCTest
  }
  ```
  */
-class GraphQLConnectionScenario6Tests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLConnectionScenario6Tests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         do {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLModelBasedTests.swift
@@ -15,7 +15,9 @@ import XCTest
 #endif
 
 // swiftlint:disable type_body_length
-class GraphQLModelBasedTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLModelBasedTests: XCTestCase, @unchecked Sendable {
 
     static let amplifyConfiguration = "testconfiguration/GraphQLModelBasedTests-amplifyconfiguration"
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLScalarTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLScalarTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import APIHostApp
 #endif
 
-class GraphQLScalarTests: GraphQLTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLScalarTests: GraphQLTestBase, @unchecked Sendable {
 
     override func setUp() {
         do {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncBasedTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncBasedTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSAPIPlugin
 
 // swiftlint:disable type_body_length
-class GraphQLSyncBasedTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLSyncBasedTests: XCTestCase, @unchecked Sendable {
 
     static let amplifyConfiguration = "testconfiguration/GraphQLSyncBasedTests-amplifyconfiguration"
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncCustomPrimaryKeyTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLSyncBased/GraphQLSyncCustomPrimaryKeyTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import APIHostApp
 @testable import AWSAPIPlugin
 
-class GraphQLSyncCustomPrimaryKeyTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLSyncCustomPrimaryKeyTests: XCTestCase, @unchecked Sendable {
 
     static let amplifyConfiguration = "testconfiguration/GraphQLSyncBasedTests-amplifyconfiguration"
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLTestBase.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginFunctionalTests/GraphQLTestBase.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import APIHostApp
 #endif
 
-class GraphQLTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLTestBase: XCTestCase, @unchecked Sendable {
     func mutateModel<M: Decodable>(request: GraphQLRequest<M>) async throws -> M {
         let result = try await Amplify.API.mutate(request: request)
         switch result {

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGen2GraphQLTests/AWSAPIPluginGen2GraphQLBaseTest.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGen2GraphQLTests/AWSAPIPluginGen2GraphQLBaseTest.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import APIHostApp
 @testable import AWSPluginsCore
 
-class AWSAPIPluginGen2GraphQLBaseTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAPIPluginGen2GraphQLBaseTest: XCTestCase, @unchecked Sendable {
 
     var defaultTestEmail = "test-\(UUID().uuidString)@amazon.com"
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLIAMTests/GraphQLWithIAMIntegrationTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLIAMTests/GraphQLWithIAMIntegrationTests.swift
@@ -16,7 +16,9 @@ import XCTest
 @testable import APIHostApp
 #endif
 
-class GraphQLWithIAMIntegrationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLWithIAMIntegrationTests: XCTestCase, @unchecked Sendable {
 
     let amplifyConfigurationFile = "testconfiguration/GraphQLWithIAMIntegrationTests-amplifyconfiguration"
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLLambdaAuthTests/GraphQLWithLambdaAuthIntegrationTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLLambdaAuthTests/GraphQLWithLambdaAuthIntegrationTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import APIHostApp
 #endif
 
-class GraphQLWithLambdaAuthIntegrationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLWithLambdaAuthIntegrationTests: XCTestCase, @unchecked Sendable {
 
     let amplifyConfigurationFile = "testconfiguration/GraphQLWithLambdaAuthIntegrationTests-amplifyconfiguration"
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLUserPoolTests/Base/AsyncExpectation.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLUserPoolTests/Base/AsyncExpectation.swift
@@ -179,13 +179,14 @@ public enum AsyncTesting {
         guard !expectations.isEmpty else { return }
 
         // check if all expectations are already satisfied and skip sleeping
-        var count = 0
+        // Counted from a `@Sendable` closure, so it cannot be a captured `var`.
+        let count = AtomicValue(initialValue: 0)
         for exp in expectations {
             if await exp.isFulfilled {
-                count += 1
+                _ = count.increment()
             }
         }
-        if count == expectations.count {
+        if count.get() == expectations.count {
             return
         }
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLUserPoolTests/GraphQLWithUserPoolIntegrationTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginGraphQLUserPoolTests/GraphQLWithUserPoolIntegrationTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import APIHostApp
 
 // swiftlint:disable type_body_length
-class GraphQLWithUserPoolIntegrationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLWithUserPoolIntegrationTests: XCTestCase, @unchecked Sendable {
     let amplifyConfigurationFile = "testconfiguration/GraphQLWithUserPoolIntegrationTests-amplifyconfiguration"
 
     let username = "integTest\(UUID().uuidString)"

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginIGraphQLAuthDirectiveTests/GraphQLAuthDirectiveIntegrationTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginIGraphQLAuthDirectiveTests/GraphQLAuthDirectiveIntegrationTests.swift
@@ -17,7 +17,9 @@ import XCTest
 @testable import APIHostApp
 #endif
 
-class GraphQLAuthDirectiveIntegrationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLAuthDirectiveIntegrationTests: XCTestCase, @unchecked Sendable {
     struct User {
         let username: String
         let password: String

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/GraphQLLazyLoadBaseTest.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginLazyLoadTests/GraphQLLazyLoadBaseTest.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSAPIPlugin
 @testable import AWSPluginsCore
 
-class GraphQLLazyLoadBaseTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLLazyLoadBaseTest: XCTestCase, @unchecked Sendable {
 
     var amplifyConfig: AmplifyConfiguration!
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginRESTIAMTests/RESTWithIAMIntegrationTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginRESTIAMTests/RESTWithIAMIntegrationTests.swift
@@ -16,7 +16,9 @@ import XCTest
 @testable import APIHostApp
 #endif
 
-class RESTWithIAMIntegrationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RESTWithIAMIntegrationTests: XCTestCase, @unchecked Sendable {
 
     static let amplifyConfiguration = "testconfiguration/RESTWithIAMIntegrationTests-amplifyconfiguration"
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginRESTUserPoolTests/RESTWithUserPoolIntegrationTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/AWSAPIPluginRESTUserPoolTests/RESTWithUserPoolIntegrationTests.swift
@@ -17,7 +17,9 @@ import XCTest
 @testable import APIHostApp
 #endif
 
-class RESTWithUserPoolIntegrationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RESTWithUserPoolIntegrationTests: XCTestCase, @unchecked Sendable {
 
     static let amplifyConfigurationFile = "testconfiguration/RESTWithUserPoolIntegrationTests-amplifyconfiguration"
 

--- a/AmplifyPlugins/API/Tests/APIHostApp/GraphQLAPIStressTests/GraphQLAPIStressTests.swift
+++ b/AmplifyPlugins/API/Tests/APIHostApp/GraphQLAPIStressTests/GraphQLAPIStressTests.swift
@@ -27,7 +27,9 @@ import XCTest
 
  */
 
-final class APIStressTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class APIStressTests: XCTestCase, @unchecked Sendable {
 
     static let amplifyConfiguration = "testconfiguration/AWSGraphQLAPIStressTests-amplifyconfiguration"
     let concurrencyLimit = 50

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/APIError+UnauthorizedTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/APIError+UnauthorizedTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSAPIPlugin
 
-class APIErrorUnauthorizedTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class APIErrorUnauthorizedTests: XCTestCase, @unchecked Sendable {
 
     func testAPIErrorUnauthorized() throws {
         let apiError = APIError.operationError("Unauthorized", "", nil)

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/APISwiftCompatibility/APISwiftTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/APISwiftCompatibility/APISwiftTests.swift
@@ -8,7 +8,9 @@
 import Amplify
 import XCTest
 
-final class APISwiftTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class APISwiftTests: XCTestCase, @unchecked Sendable {
 
     func testCreateBlogMutation() {
         let file = S3ObjectInput(bucket: "bucket", key: "let", region: "region")

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+AuthInformationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+AuthInformationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSAPIPlugin
 
-class AWSAPICategoryPluginAuthInformationTests: AWSAPICategoryPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAPICategoryPluginAuthInformationTests: AWSAPICategoryPluginTestBase, @unchecked Sendable {
 
     func testDefaultAuthTypeForApiName() throws {
         let apiPlugin = AWSAPIPlugin()

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+ConfigureTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+ConfigureTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSAPIPlugin
 
-class AWSAPICategoryPluginConfigureTests: AWSAPICategoryPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAPICategoryPluginConfigureTests: AWSAPICategoryPluginTestBase, @unchecked Sendable {
 
     func testPluginKey() {
         XCTAssertEqual(apiPlugin.key, "awsAPIPlugin")

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+GraphQLBehaviorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+GraphQLBehaviorTests.swift
@@ -10,7 +10,9 @@ import AWSPluginsCore
 import XCTest
 @testable import AWSAPIPlugin
 
-class AWSAPICategoryPluginGraphQLBehaviorTests: AWSAPICategoryPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAPICategoryPluginGraphQLBehaviorTests: AWSAPICategoryPluginTestBase, @unchecked Sendable {
 
     // MARK: Query API Tests
 

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+InterceptorBehaviorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+InterceptorBehaviorTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSAPIPlugin
 
 // swiftlint:disable:next type_name
-class AWSAPICategoryPluginInterceptorBehaviorTests: AWSAPICategoryPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAPICategoryPluginInterceptorBehaviorTests: AWSAPICategoryPluginTestBase, @unchecked Sendable {
 
     func testAddInterceptor() throws {
         XCTAssertNotNil(apiPlugin.pluginConfig.endpoints[apiName])

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+RESTClientBehaviorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+RESTClientBehaviorTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSAPIPlugin
 
 // swiftlint:disable:next type_name
-class AWSAPICategoryPluginRESTClientBehaviorTests: AWSAPICategoryPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAPICategoryPluginRESTClientBehaviorTests: AWSAPICategoryPluginTestBase, @unchecked Sendable {
 
     // MARK: Get API tests
 

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+ResetTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+ResetTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSAPIPlugin
 
-class AWSAPICategoryPluginResetTests: AWSAPICategoryPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAPICategoryPluginResetTests: AWSAPICategoryPluginTestBase, @unchecked Sendable {
 
     func testReset() async {
         let resettable = apiPlugin as Resettable

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+URLSessionBehaviorDelegateTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+URLSessionBehaviorDelegateTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 
 // swiftlint:disable:next type_name
-class AWSAPICategoryPluginURLSessionBehaviorDelegateTests: AWSAPICategoryPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAPICategoryPluginURLSessionBehaviorDelegateTests: AWSAPICategoryPluginTestBase, @unchecked Sendable {
     func testClassMustNotBeEmptyOrSwiftFormatWillCrash() {
         // TODO implement code
     }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+URLSessionDelegateTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPlugin+URLSessionDelegateTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 
 // swiftlint:disable:next type_name
-class AWSAPICategoryPluginURLSessionDelegateTests: AWSAPICategoryPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAPICategoryPluginURLSessionDelegateTests: AWSAPICategoryPluginTestBase, @unchecked Sendable {
     func testClassMustNotBeEmptyOrSwiftFormatWillCrash() {
         // TODO implement code
     }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPluginAmplifyVersionableTests.swift
@@ -9,7 +9,9 @@ import AWSAPIPlugin
 import XCTest
 
 // swiftlint:disable:next type_name
-class AWSAPICategoryPluginAmplifyVersionableTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAPICategoryPluginAmplifyVersionableTests: XCTestCase, @unchecked Sendable {
 
     func testVersionExists() {
         let plugin = AWSAPIPlugin()

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPluginTestBase.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AWSAPICategoryPluginTestBase.swift
@@ -14,7 +14,9 @@ import XCTest
 
 import AWSPluginsCore
 
-class AWSAPICategoryPluginTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAPICategoryPluginTestBase: XCTestCase, @unchecked Sendable {
 
     var apiPlugin: AWSAPIPlugin!
     var authService: MockAWSAuthService!

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AppSyncRealTimeClient/AppSyncRealTimeClientReconnectTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AppSyncRealTimeClient/AppSyncRealTimeClientReconnectTests.swift
@@ -15,7 +15,9 @@ import XCTest
 // session-expiry connection_error was swallowed, so connectionInit timed out and
 // connect() retried, opening a new connection on every retry.
 // https://github.com/aws-amplify/amplify-swift/issues/4007
-class AppSyncRealTimeClientReconnectTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test bodies are captured by the
+// `@Sendable` closures Combine's `sink` takes. XCTest runs one test at a time.
+class AppSyncRealTimeClientReconnectTests: XCTestCase, @unchecked Sendable {
 
     private func makeClient(
         _ webSocketClient: MockWebSocketClient
@@ -79,16 +81,13 @@ class AppSyncRealTimeClientReconnectTests: XCTestCase {
         let webSocketClient = MockWebSocketClient()
         let client = makeClient(webSocketClient)
 
-        let lock = NSLock()
-        var connectionInitCount = 0
+        let connectionInitCount = AtomicValue(initialValue: 0)
         var cancellables = Set<AnyCancellable>()
         await webSocketClient.actionSubject
             .sink { action in
                 guard case .write(let message) = action,
                       message.contains("connection_init") else { return }
-                lock.lock()
-                connectionInitCount += 1
-                lock.unlock()
+                connectionInitCount.increment()
                 client.subject.send(.success(self.unauthorizedConnectionError))
             }
             .store(in: &cancellables)
@@ -105,9 +104,7 @@ class AppSyncRealTimeClientReconnectTests: XCTestCase {
         }
         await fulfillment(of: [failed], timeout: 3)
 
-        lock.lock()
-        let count = connectionInitCount
-        lock.unlock()
+        let count = connectionInitCount.get()
         XCTAssertEqual(count, 1, "connect() must not retry a non-recoverable auth error")
     }
 
@@ -183,16 +180,13 @@ class AppSyncRealTimeClientReconnectTests: XCTestCase {
             appSyncRealTimeClient: client
         )
 
-        let lock = NSLock()
-        var startCount = 0
+        let startCount = AtomicValue(initialValue: 0)
         var cancellables = Set<AnyCancellable>()
         await webSocketClient.actionSubject
             .sink { action in
                 guard case .write(let message) = action,
                       message.contains("sub-4007") else { return }
-                lock.lock()
-                startCount += 1
-                lock.unlock()
+                startCount.increment()
                 client.subject.send(.success(.init(
                     id: "sub-4007",
                     payload: .object([
@@ -219,9 +213,7 @@ class AppSyncRealTimeClientReconnectTests: XCTestCase {
         // Simulate resume-on-reconnect: it must NOT send another start.
         try? await subscription.subscribe()
 
-        lock.lock()
-        let count = startCount
-        lock.unlock()
+        let count = startCount.get()
         XCTAssertEqual(count, 1, "a non-recoverable subscription failure must not be resubscribed")
     }
 
@@ -232,15 +224,12 @@ class AppSyncRealTimeClientReconnectTests: XCTestCase {
         let webSocketClient = MockWebSocketClient()
         let client = makeClient(webSocketClient)
 
-        let lock = NSLock()
-        var connectCount = 0
+        let connectCount = AtomicValue(initialValue: 0)
         var cancellables = Set<AnyCancellable>()
         await webSocketClient.actionSubject
             .sink { action in
                 guard case .connect = action else { return }
-                lock.lock()
-                connectCount += 1
-                lock.unlock()
+                connectCount.increment()
             }
             .store(in: &cancellables)
 
@@ -260,9 +249,7 @@ class AppSyncRealTimeClientReconnectTests: XCTestCase {
         await webSocketClient.subject.send(.connected)
         try await Task.sleep(nanoseconds: 300 * 1_000_000)
 
-        lock.lock()
-        let count = connectCount
-        lock.unlock()
+        let count = connectCount.get()
         XCTAssertEqual(count, 1, "overlapping reconnects must collapse to a single connect()")
     }
 
@@ -277,16 +264,13 @@ class AppSyncRealTimeClientReconnectTests: XCTestCase {
             appSyncRealTimeClient: client
         )
 
-        let lock = NSLock()
-        var startCount = 0
+        let startCount = AtomicValue(initialValue: 0)
         var cancellables = Set<AnyCancellable>()
         await webSocketClient.actionSubject
             .sink { action in
                 guard case .write(let message) = action,
                       message.contains("sub-limit") else { return }
-                lock.lock()
-                startCount += 1
-                lock.unlock()
+                startCount.increment()
                 client.subject.send(.success(.init(
                     id: "sub-limit",
                     payload: .object([
@@ -313,9 +297,7 @@ class AppSyncRealTimeClientReconnectTests: XCTestCase {
         // Resume-on-reconnect must send another start (not permanently terminated).
         try? await subscription.subscribe()
 
-        lock.lock()
-        let count = startCount
-        lock.unlock()
+        let count = startCount.get()
         XCTAssertEqual(count, 2, "a transient limitExceeded must be retried on resubscribe, not terminated")
     }
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AppSyncRealTimeClient/AppSyncRealTimeClientTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AppSyncRealTimeClient/AppSyncRealTimeClientTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @_spi(WebSocket) import AWSPluginsCore
 @testable import AWSAPIPlugin
 
-class AppSyncRealTimeClientTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AppSyncRealTimeClientTests: XCTestCase, @unchecked Sendable {
 
     func testSendRequestWithTimeout_withNoResponse_failedWithTimeOutError() async {
         let timeout = 1.0

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AppSyncRealTimeClient/AppSyncRealTimeRequestAuthTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/AppSyncRealTimeClient/AppSyncRealTimeRequestAuthTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSAPIPlugin
 
-class AppSyncRealTimeRequestAuthTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AppSyncRealTimeRequestAuthTests: XCTestCase, @unchecked Sendable {
     let host = UUID().uuidString
     let apiKey = UUID().uuidString
     let date = UUID().uuidString

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationEndpointConfigTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationEndpointConfigTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSAPIPlugin
 
 // swiftlint:disable:next type_name
-class AWSAPICategoryPluginConfigurationEndpointConfigTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAPICategoryPluginConfigurationEndpointConfigTests: XCTestCase, @unchecked Sendable {
 
     let graphQLAPI = "graphQLAPI"
     let graphQLAPI2 = "graphQLAPI2"

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPICategoryPluginConfigurationTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import AWSAPIPlugin
 @testable import AWSPluginsTestCommon
 
-class AWSAPICategoryPluginConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAPICategoryPluginConfigurationTests: XCTestCase, @unchecked Sendable {
     let graphQLAPI = "graphQLAPI"
     let apiKey = "apiKey-123"
 

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPIEndpointInterceptorsTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Configuration/AWSAPIEndpointInterceptorsTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSAPIPlugin
 @testable import AWSPluginsTestCommon
 
-class AWSAPIEndpointInterceptorsTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAPIEndpointInterceptorsTests: XCTestCase, @unchecked Sendable {
     let endpointName = "endpointName"
     let apiKey = "apiKey-123456789"
     var config: AWSAuthorizationConfiguration?

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListDecoderTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListDecoderTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSAPIPlugin
 
-class AppSyncListDecoderTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AppSyncListDecoderTests: XCTestCase, @unchecked Sendable {
 
     let encoder = JSONEncoder()
     let decoder = JSONDecoder()

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListPayloadTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListPayloadTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSAPIPlugin
 
-class AppSyncListPayloadTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AppSyncListPayloadTests: XCTestCase, @unchecked Sendable {
 
     func testRetrieveFilterAndLimit() {
         let variables: [String: JSONValue] = [

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListProviderTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListProviderTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSAPIPlugin
 @testable import AWSPluginsCore
 
-class AppSyncListProviderTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AppSyncListProviderTests: XCTestCase, @unchecked Sendable {
     var mockAPIPlugin: MockAPICategoryPlugin!
 
     override func setUp() async throws {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListResponseTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncListResponseTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSAPIPlugin
 
-class AppSyncListResponseTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AppSyncListResponseTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: Comment4.self)

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncModelMetadataTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/AppSyncModelMetadataTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSAPIPlugin
 
-class ModelMetadataTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ModelMetadataTests: XCTestCase, @unchecked Sendable {
     override func setUp() {
         ModelRegistry.register(modelType: Comment4.self)
         ModelRegistry.register(modelType: Post4.self)

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/ListTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Core/ListTests.swift
@@ -11,7 +11,9 @@ import XCTest
 import XCTest
 @testable import AWSAPIPlugin
 
-class ListTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ListTests: XCTestCase, @unchecked Sendable {
 
     override class func setUp() {
         ModelListDecoderRegistry.registerDecoder(AppSyncListDecoder.self)

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/APIKeyURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/APIKeyURLRequestInterceptorTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSAPIPlugin
 
-class APIKeyURLRequestInterceptorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class APIKeyURLRequestInterceptorTests: XCTestCase, @unchecked Sendable {
     func testAPIKeyInterceptor() {
         let mockAPIKeyProvider = MockAPIKeyProvider()
         let interceptor = APIKeyURLRequestInterceptor(apiKeyProvider: mockAPIKeyProvider)

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/AuthTokenURLRequestInterceptorTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSAPIPlugin
 
-class AuthTokenURLRequestInterceptorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AuthTokenURLRequestInterceptorTests: XCTestCase, @unchecked Sendable {
     func testAuthTokenInterceptor() async throws {
         let mockTokenProvider = MockTokenProvider()
         let interceptor = AuthTokenURLRequestInterceptor(authTokenProvider: mockTokenProvider)

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/IAMURLRequestInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/IAMURLRequestInterceptorTests.swift
@@ -7,7 +7,9 @@
 
 import XCTest
 
-class IAMURLRequestInterceptorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class IAMURLRequestInterceptorTests: XCTestCase, @unchecked Sendable {
     func testClassMustNotBeEmptyOrSwiftFormatWillCrash() {
         // TODO implement code
     }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/APIKeyAuthInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/APIKeyAuthInterceptorTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSAPIPlugin
 
-class APIKeyAuthInterceptorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class APIKeyAuthInterceptorTests: XCTestCase, @unchecked Sendable {
 
     func testInterceptConnection_addApiKeyInRequestHeader() async {
         let apiKey = UUID().uuidString

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/CognitoAuthInterceptorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Interceptor/SubscriptionInterceptor/CognitoAuthInterceptorTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AWSAPIPlugin
 @testable @_spi(WebSocket) import AWSPluginsCore
 
-class CognitoAuthInterceptorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class CognitoAuthInterceptorTests: XCTestCase, @unchecked Sendable {
 
     func testInterceptConnection_withAuthTokenProvider_appendCorrectAuthHeader() async {
         let authTokenProvider = MockAuthTokenProvider()
@@ -77,14 +79,22 @@ class CognitoAuthInterceptorTests: XCTestCase {
     }
 }
 
-private class MockAuthTokenProvider: AmplifyAuthTokenProvider {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+private class MockAuthTokenProvider: AmplifyAuthTokenProvider, @unchecked Sendable {
     let authToken = UUID().uuidString
     func getLatestAuthToken() async throws -> String {
         return authToken
     }
 }
 
-private class MockAuthTokenProviderFailed: AmplifyAuthTokenProvider {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+private class MockAuthTokenProviderFailed: AmplifyAuthTokenProvider, @unchecked Sendable {
     let authToken = UUID().uuidString
     func getLatestAuthToken() async throws -> String {
         throw "Intended"

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Mocks/MockSubscription.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Mocks/MockSubscription.swift
@@ -40,7 +40,11 @@ struct MockSubscriptionConnectionFactory: AppSyncRealTimeClientFactoryProtocol {
     }
 }
 
-class MockAppSyncRealTimeClient: AppSyncRealTimeClientProtocol  {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockAppSyncRealTimeClient: AppSyncRealTimeClientProtocol, @unchecked Sendable {
 
 
     private let subject = PassthroughSubject<AppSyncSubscriptionEvent, Never>()
@@ -86,7 +90,11 @@ class MockAppSyncRealTimeClient: AppSyncRealTimeClientProtocol  {
     }
 }
 
-class MockAppSyncRequestInterceptor: AppSyncRequestInterceptor {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockAppSyncRequestInterceptor: AppSyncRequestInterceptor, @unchecked Sendable {
     func interceptRequest(event: AppSyncRealTimeRequest, url: URL) async -> AppSyncRealTimeRequest {
         return event
     }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLOperationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLOperationTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSAPIPlugin
 @testable import AWSPluginsTestCommon
 
-class AWSGraphQLOperationTests: AWSAPICategoryPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSGraphQLOperationTests: AWSAPICategoryPluginTestBase, @unchecked Sendable {
 
     /// Tests that upon completion, the operation is removed from the task mapper.
     func testOperationCleanup() async {
@@ -52,7 +54,7 @@ class AWSGraphQLOperationTests: AWSAPICategoryPluginTestBase {
             responseType: JSONValue.self,
             authMode: AWSAuthorizationType.amazonCognitoUserPools
         )
-        let task = try OperationTestBase.makeSingleValueErrorMockTask()
+        let task = OperationTestBase.makeSingleValueErrorMockTask()
         let mockSession = MockURLSession(onTaskForRequest: { _ in task })
         let pluginConfig = try AWSAPICategoryPluginConfiguration(
             endpoints: [

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionOperationCancelTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import AWSPluginsTestCommon
 
 // swiftlint:disable:next type_name
-class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSGraphQLSubscriptionOperationCancelTests: XCTestCase, @unchecked Sendable {
     var apiPlugin: AWSAPIPlugin!
     var authService: MockAWSAuthService!
     var pluginConfig: AWSAPICategoryPluginConfiguration!

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionTaskRunnerCancelTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSGraphQLSubscriptionTaskRunnerCancelTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import AWSPluginsTestCommon
 
 // swiftlint:disable:next type_name
-class AWSGraphQLSubscriptionTaskRunnerCancelTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSGraphQLSubscriptionTaskRunnerCancelTests: XCTestCase, @unchecked Sendable {
     var apiPlugin: AWSAPIPlugin!
     var authService: MockAWSAuthService!
     var pluginConfig: AWSAPICategoryPluginConfiguration!

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSHTTPURLResponseTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSHTTPURLResponseTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSAPIPlugin
 
-class AWSHTTPURLResponseTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSHTTPURLResponseTests: XCTestCase, @unchecked Sendable {
 
     func testAWSHTTPURLResponse() throws {
         let body = Data("responseBody".utf8)

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSRESTOperationTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/AWSRESTOperationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSAPIPlugin
 
-class AWSRESTOperationTests: OperationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSRESTOperationTests: OperationTestBase, @unchecked Sendable {
 
     func testRESTOperationSuccess() throws {
         throw XCTSkip("Not yet implemented")

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLMutateCombineTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLMutateCombineTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSAPIPlugin
 @testable import AWSAPIPlugin
 
-class GraphQLMutateCombineTests: OperationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLMutateCombineTests: OperationTestBase, @unchecked Sendable {
     let testDocument = "mutate { updateTodo { id name description }}"
 
     func testMutateSucceeds() async throws {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLQueryCombineTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLQueryCombineTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSAPIPlugin
 @testable import AWSAPIPlugin
 
-class GraphQLQueryCombineTests: OperationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLQueryCombineTests: OperationTestBase, @unchecked Sendable {
     let testDocument = "query { getTodo { id name description }}"
 
     func testQuerySucceeds() async throws {

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeCombineTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeCombineTests.swift
@@ -13,7 +13,9 @@ import Amplify
 @testable import AmplifyTestCommon
 @testable import AWSAPIPlugin
 
-class GraphQLSubscribeCombineTests: OperationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLSubscribeCombineTests: OperationTestBase, @unchecked Sendable {
 
     var sink: AnyCancellable?
 

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTaskTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTaskTests.swift
@@ -13,7 +13,9 @@ import Amplify
 @testable import AmplifyTestCommon
 @testable import AWSAPIPlugin
 
-class GraphQLSubscribeTasksTests: OperationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLSubscribeTasksTests: OperationTestBase, @unchecked Sendable {
 
     // Setup expectations
     var onSubscribeInvoked: XCTestExpectation!

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/GraphQLSubscribeTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSAPIPlugin
 
-class GraphQLSubscribeTests: OperationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLSubscribeTests: OperationTestBase, @unchecked Sendable {
 
     // Setup expectations
     var onSubscribeInvoked: XCTestExpectation!

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/OperationTestBase.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/OperationTestBase.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSAPIPlugin
 @testable import AWSPluginsTestCommon
 
-class OperationTestBase: XCTestCase {
+/// - Note: `@unchecked Sendable` so subclass test bodies can be captured by the `@Sendable` closures
+///   `Amplify.Publisher.create` takes. `XCTestCase` is not `Sendable`, and each test runs alone.
+class OperationTestBase: XCTestCase, @unchecked Sendable {
 
     var apiPlugin: AWSAPIPlugin!
 
@@ -52,14 +54,14 @@ class OperationTestBase: XCTestCase {
         sending data: Data,
         for endpointType: AWSAPICategoryPluginEndpointType
     ) throws {
-        let task = try makeSingleValueSuccessMockTask(sending: data)
+        let task = makeSingleValueSuccessMockTask(sending: data)
         let mockSession = MockURLSession(onTaskForRequest: { _ in task })
         let sessionFactory = MockSessionFactory(returning: mockSession)
         try setUpPlugin(sessionFactory: sessionFactory, endpointType: endpointType)
     }
 
     func setUpPluginForSingleError(for endpointType: AWSAPICategoryPluginEndpointType) throws {
-        let task = try Self.makeSingleValueErrorMockTask()
+        let task = Self.makeSingleValueErrorMockTask()
         let mockSession = MockURLSession(onTaskForRequest: { _ in task })
         let sessionFactory = MockSessionFactory(returning: mockSession)
         try setUpPlugin(sessionFactory: sessionFactory, endpointType: endpointType)
@@ -77,9 +79,13 @@ class OperationTestBase: XCTestCase {
         )
     }
 
-    func makeSingleValueSuccessMockTask(sending data: Data) throws -> MockURLSessionTask {
-        var mockTask: MockURLSessionTask!
-        mockTask = MockURLSessionTask(onResume: {
+    func makeSingleValueSuccessMockTask(sending data: Data) -> MockURLSessionTask {
+        // The `onResume` closure has to reference the task it is being assigned to, so the task is
+        // held in an `AtomicValue`: capturing the `var` directly is a reference to a mutable variable
+        // from concurrently-executing code, which the Swift 6 language mode rejects.
+        let mockTaskBox = AtomicValue<MockURLSessionTask?>(initialValue: nil)
+        let mockTask = MockURLSessionTask(onResume: {
+            guard let mockTask = mockTaskBox.get() else { return }
             guard let mockSession = mockTask.mockSession,
                 let delegate = mockSession.sessionBehaviorDelegate
                 else {
@@ -99,16 +105,17 @@ class OperationTestBase: XCTestCase {
             )
         })
 
-        guard let task = mockTask else {
-            throw "mockTask unexpectedly nil"
-        }
-
-        return task
+        mockTaskBox.set(mockTask)
+        return mockTask
     }
 
-    static func makeSingleValueErrorMockTask() throws -> MockURLSessionTask {
-        var mockTask: MockURLSessionTask!
-        mockTask = MockURLSessionTask(onResume: {
+    static func makeSingleValueErrorMockTask() -> MockURLSessionTask {
+        // The `onResume` closure has to reference the task it is being assigned to, so the task is
+        // held in an `AtomicValue`: capturing the `var` directly is a reference to a mutable variable
+        // from concurrently-executing code, which the Swift 6 language mode rejects.
+        let mockTaskBox = AtomicValue<MockURLSessionTask?>(initialValue: nil)
+        let mockTask = MockURLSessionTask(onResume: {
+            guard let mockTask = mockTaskBox.get() else { return }
             guard let mockSession = mockTask.mockSession,
                 let delegate = mockSession.sessionBehaviorDelegate
                 else {
@@ -122,11 +129,8 @@ class OperationTestBase: XCTestCase {
             )
         })
 
-        guard let task = mockTask else {
-            throw "mockTask unexpectedly nil"
-        }
-
-        return task
+        mockTaskBox.set(mockTask)
+        return mockTask
     }
 
 }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/RESTCombineTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Operation/RESTCombineTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSAPIPlugin
 @testable import AWSAPIPlugin
 
-class RESTCombineTests: OperationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RESTCombineTests: OperationTestBase, @unchecked Sendable {
 
     func testGetSucceeds() async throws {
         let sentData = Data([0x00, 0x01, 0x02, 0x03])

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Reachability/NetworkReachabilityNotifierTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Reachability/NetworkReachabilityNotifierTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSAPIPlugin
 
-class NetworkReachabilityNotifierTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class NetworkReachabilityNotifierTests: XCTestCase, @unchecked Sendable {
     var notification: Notification!
     var notifier: NetworkReachabilityNotifier!
 

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Request/GraphQLOperationRequestUtilsTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Request/GraphQLOperationRequestUtilsTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSAPIPlugin
 
-class GraphQLOperationRequestUtilsTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLOperationRequestUtilsTests: XCTestCase, @unchecked Sendable {
 
     let baseURL = URL(string: "https://someurl")!
     let testDocument = "testDocument"

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Request/GraphQLOperationRequestValidateTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Request/GraphQLOperationRequestValidateTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSAPIPlugin
 
-class GraphQLOperationRequestValidateTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLOperationRequestValidateTests: XCTestCase, @unchecked Sendable {
 
     let testApiName = "testApiName"
     let testDocument = "testDocument"

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Request/RESTOperationRequestValidateTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Request/RESTOperationRequestValidateTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSAPIPlugin
 
-class RESTOperationRequestValidateTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RESTOperationRequestValidateTests: XCTestCase, @unchecked Sendable {
 
     let testApiName = "testApiName"
 

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/SubscriptionFactory/AppSyncRealTimeClientFactoryTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/SubscriptionFactory/AppSyncRealTimeClientFactoryTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSAPIPlugin
 
-class AppSyncRealTimeClientFactoryTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AppSyncRealTimeClientFactoryTests: XCTestCase, @unchecked Sendable {
 
     func testAppSyncRealTimeEndpoint_withAWSAppSyncDomain_returnCorrectRealtimeDomain() {
         let appSyncEndpoint = URL(string: "https://abc.appsync-api.amazonaws.com/graphql")!

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLErrorDecoderTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLErrorDecoderTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSAPIPlugin
 
-class GraphQLErrorDecoderTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLErrorDecoderTests: XCTestCase, @unchecked Sendable {
 
     func testDecodeErrors() throws {
         let graphQLErrorJSON: JSONValue = [

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLResponseDecoderLazyPostComment4V2Tests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLResponseDecoderLazyPostComment4V2Tests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSAPIPlugin
 
 // Decoder tests for ParentPost4V2 and ChildComment4V2
-class GraphQLResponseDecoderLazyPostComment4V2Tests: XCTestCase, SharedTestCasesPostComment4V2 {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLResponseDecoderLazyPostComment4V2Tests: XCTestCase, SharedTestCasesPostComment4V2, @unchecked Sendable {
 
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLResponseDecoderPostComment4V2Tests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLResponseDecoderPostComment4V2Tests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSAPIPlugin
 
 // Decoder tests for ParentPost4V2 and ChildComment4V2
-class GraphQLResponseDecoderPostComment4V2Tests: XCTestCase, SharedTestCasesPostComment4V2 {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLResponseDecoderPostComment4V2Tests: XCTestCase, SharedTestCasesPostComment4V2, @unchecked Sendable {
 
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLResponseDecoderTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Decode/GraphQLResponseDecoderTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSAPIPlugin
 
-class GraphQLResponseDecoderTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLResponseDecoderTests: XCTestCase, @unchecked Sendable {
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
 

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Internal/AWSAppSyncGrpahQLResponseTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Internal/AWSAppSyncGrpahQLResponseTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSAPIPlugin
 
-class AWSAppSyncGrpahQLResponseTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAppSyncGrpahQLResponseTests: XCTestCase, @unchecked Sendable {
 
     static let decoder = JSONDecoder()
     static let encoder = JSONEncoder()

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/Array+Error+TypeCastTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/Array+Error+TypeCastTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable @_spi(AmplifyAPI) import AWSAPIPlugin
 
-class ArrayWithErrorElementExtensionTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ArrayWithErrorElementExtensionTests: XCTestCase, @unchecked Sendable {
 
     /**
      Given: errors with generic protocol type

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/GraphQLRequestToListQueryTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/GraphQLRequestToListQueryTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSAPIPlugin
 
-class GraphQLRequestToListQueryTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLRequestToListQueryTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: Comment4.self)

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/GraphQLRequestUtils+ValidatorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/GraphQLRequestUtils+ValidatorTests.swift
@@ -7,7 +7,9 @@
 
 import XCTest
 
-class GraphQLRequestUtilsValidatorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLRequestUtilsValidatorTests: XCTestCase, @unchecked Sendable {
     func testClassMustNotBeEmptyOrSwiftFormatWillCrash() {
         // TODO implement code
     }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/GraphQLRequestUtilsTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/GraphQLRequestUtilsTests.swift
@@ -7,7 +7,9 @@
 
 import XCTest
 
-class GraphQLRequestUtilsTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLRequestUtilsTests: XCTestCase, @unchecked Sendable {
     func testClassMustNotBeEmptyOrSwiftFormatWillCrash() {
         // TODO implement code
     }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/RESTRequestUtils+ValidatorTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/RESTRequestUtils+ValidatorTests.swift
@@ -7,7 +7,9 @@
 
 import XCTest
 
-class RESTRequestUtilsValidatorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RESTRequestUtilsValidatorTests: XCTestCase, @unchecked Sendable {
     func testClassMustNotBeEmptyOrSwiftFormatWillCrash() {
         // TODO implement code
     }

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/RESTRequestUtilsTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/RESTRequestUtilsTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSAPIPlugin
 
-class RESTRequestUtilsTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RESTRequestUtilsTests: XCTestCase, @unchecked Sendable {
     private func assertQueryParameters(
         testCase: Int,
         withURL url: URL,

--- a/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/Result+AsyncTests.swift
+++ b/AmplifyPlugins/API/Tests/AWSAPIPluginTests/Support/Utils/Result+AsyncTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSAPIPlugin
 
-class ResultAsyncTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ResultAsyncTests: XCTestCase, @unchecked Sendable {
 
     func testFlatMapAsync_withSuccess_applyFunction() async {
         func plus1(_ number: Int) async -> Int {


### PR DESCRIPTION
Slice **34 of 38** in the Swift 6 language-mode migration — 82 file(s).

Stacked on `swift6/33-tests-datastore`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.