### PR TITLE
test(storage): migrate the Storage test targets

### DIFF
--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginAmplifyVersionableTests.swift
@@ -9,7 +9,9 @@ import AWSS3StoragePlugin
 import XCTest
 
 // swiftlint:disable:next type_name
-class AWSS3StoragePluginAmplifyVersionableTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginAmplifyVersionableTests: XCTestCase, @unchecked Sendable {
 
     func testVersionExists() {
         let plugin = AWSS3StoragePlugin()

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginAsyncBehaviorTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginAsyncBehaviorTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSPluginsTestCommon
 @testable import AWSS3StoragePlugin
 
-class AWSS3StoragePluginAsyncBehaviorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginAsyncBehaviorTests: XCTestCase, @unchecked Sendable {
 
     var storagePlugin: AWSS3StoragePlugin!
     var storageService: MockAWSS3StorageService!

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginBaseConfigTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginBaseConfigTests.swift
@@ -9,7 +9,9 @@ import AWSS3StoragePlugin
 import XCTest
 @testable import Amplify
 
-class AWSS3StoragePluginBaseConfigTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginBaseConfigTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         // Operation unit tests may leave Amplify configured; this suite expects a clean framework before `add`.

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginGetPresignedUrlTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginGetPresignedUrlTests.swift
@@ -12,7 +12,9 @@
 import Amplify
 import XCTest
 
-final class AWSS3StoragePluginGetPresignedUrlTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AWSS3StoragePluginGetPresignedUrlTests: XCTestCase, @unchecked Sendable {
 
     var systemUnderTest: AWSS3StoragePlugin!
     var storageService: MockAWSS3StorageService!

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginStorageBucketTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginStorageBucketTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AWSPluginsTestCommon
 @testable import AWSS3StoragePlugin
 
-class AWSS3StoragePluginStorageBucketTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginStorageBucketTests: XCTestCase, @unchecked Sendable {
     private var storagePlugin: AWSS3StoragePlugin!
     private var defaultService: MockAWSS3StorageService!
     private var authService: MockAWSAuthService!

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginTestBase.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/AWSS3StoragePluginTestBase.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSPluginsTestCommon
 @testable import AWSS3StoragePlugin
 
-class AWSS3StoragePluginTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginTests: XCTestCase, @unchecked Sendable {
     var storagePlugin: AWSS3StoragePlugin!
     var storageService: MockAWSS3StorageService!
     var authService: MockAWSAuthService!

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Configuration/AWSS3PluginPrefixResolverTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Configuration/AWSS3PluginPrefixResolverTests.swift
@@ -22,7 +22,7 @@ extension Sequence<PrefixTestData> {
     }
 }
 
-struct PrefixTestData {
+struct PrefixTestData: Sendable {
     let accessLevel: StorageAccessLevel
     let targetIdentityId: String?
     let expectedPrefix: String
@@ -49,7 +49,9 @@ struct PrefixTestData {
     }
 }
 
-class AWSS3PluginPrefixResolverTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3PluginPrefixResolverTests: XCTestCase, @unchecked Sendable {
 
     func testPassthroughPrefixResolver() async throws {
         let prefixResolver = PassThroughPrefixResolver()

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Configuration/AWSS3StoragePluginConfigurationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Configuration/AWSS3StoragePluginConfigurationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSS3StoragePlugin
 
-class AWSS3StoragePluginConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginConfigurationTests: XCTestCase, @unchecked Sendable {
 
     func testConfiguration() {
         let storagePlugin = AWSS3StoragePlugin(configuration: .prefixResolver(MockPrefixResolver()))

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Configuration/S3ClientConfigurationProxyTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Configuration/S3ClientConfigurationProxyTests.swift
@@ -13,7 +13,9 @@ import XCTest
 
 @testable import AWSS3StoragePlugin
 
-final class S3ClientConfigurationAccelerateTestCase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class S3ClientConfigurationAccelerateTestCase: XCTestCase, @unchecked Sendable {
 
     /// Given: A base configuration that has a value for a property such as `accelerate`.
     /// When: An override is set through `withAccelerate(_:)`

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Dependency/AWSS3AdapterTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Dependency/AWSS3AdapterTests.swift
@@ -10,7 +10,11 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class AWSS3AdapterTests: XCTestCase {
+/// - Note: `@unchecked Sendable` so the test body can be captured by the `@Sendable` completion
+
+///   closures the production API now takes. `XCTestCase` is not `Sendable`, and each test runs alone.
+
+final class AWSS3AdapterTests: XCTestCase, @unchecked Sendable {
     private var adapter: AWSS3Adapter!
     private var awsS3: S3ClientMock!
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageDownloadFileOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageDownloadFileOperationTests.swift
@@ -14,7 +14,9 @@ import XCTest
 
 import AWSS3
 
-class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StorageDownloadFileOperationTests: AWSS3StorageOperationTestBase, @unchecked Sendable {
 
     private let livenessServiceDispatchQueue = DispatchQueue(
         label: "com.amazon.aws.amplify.liveness.service",

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageGetDataOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageGetDataOperationTests.swift
@@ -14,7 +14,9 @@ import XCTest
 
 import AWSS3
 
-class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase, @unchecked Sendable {
 
     func testDownloadDataOperationValidationError() async {
         let request = StorageDownloadDataRequest(key: "", options: StorageDownloadDataRequest.Options())
@@ -391,5 +393,5 @@ class AWSS3StorageDownloadDataOperationTests: AWSS3StorageOperationTestBase {
 }
 
 struct InvalidCustomStoragePath: StoragePath {
-    var resolve: (String) -> String
+    var resolve: @Sendable (String) -> String
 }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageOperationTestBase.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageOperationTestBase.swift
@@ -27,7 +27,9 @@ private actor AmplifyOperationTestsGlobalConfig {
 
 private let amplifyOperationTestsGlobalConfig = AmplifyOperationTestsGlobalConfig()
 
-class AWSS3StorageOperationTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StorageOperationTestBase: XCTestCase, @unchecked Sendable {
 
     var hubPlugin: MockHubCategoryPlugin!
     var mockStorageService: MockAWSS3StorageService!

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StoragePutDataOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StoragePutDataOperationTests.swift
@@ -14,7 +14,9 @@ import XCTest
 
 import AWSS3
 
-class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StorageUploadDataOperationTests: AWSS3StorageOperationTestBase, @unchecked Sendable {
 
     func testUploadDataOperationValidationError() async {
         let options = StorageUploadDataRequest.Options(accessLevel: .protected)

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageRemoveOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageRemoveOperationTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSPluginsTestCommon
 @testable import AWSS3StoragePlugin
 
-class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StorageRemoveOperationTests: AWSS3StorageOperationTestBase, @unchecked Sendable {
 
     func testRemoveOperationValidationError() async {
         let options = StorageRemoveRequest.Options()

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests.swift
@@ -14,7 +14,9 @@ import XCTest
 
 import AWSS3
 
-class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StorageUploadFileOperationTests: AWSS3StorageOperationTestBase, @unchecked Sendable {
 
     func testUploadFileOperationValidationError() async {
         let options = StorageUploadFileRequest.Options(accessLevel: .protected)

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests2.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Operation/AWSS3StorageUploadFileOperationTests2.swift
@@ -14,7 +14,9 @@
 import AWSS3
 import XCTest
 
-final class AWSS3StorageUploadFileOperationTests2: AWSS3StorageOperationTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AWSS3StorageUploadFileOperationTests2: AWSS3StorageOperationTestBase, @unchecked Sendable {
 
     override func setUp() async throws {
         try await super.setUp()

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSS3StorageDownloadFileRequestTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSS3StorageDownloadFileRequestTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class StorageDownloadFileRequestTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageDownloadFileRequestTests: XCTestCase, @unchecked Sendable {
 
     let testTargetIdentityId = "TestTargetIdentityId"
     let testKey = "TestKey"

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSS3StorageGetDataRequestTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSS3StorageGetDataRequestTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class StorageDownloadDataRequestTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageDownloadDataRequestTests: XCTestCase, @unchecked Sendable {
 
     let testTargetIdentityId = "TestTargetIdentityId"
     let testKey = "TestKey"

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSS3StorageGetURLRequestTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSS3StorageGetURLRequestTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSS3StoragePlugin
 
-class StorageGetURLRequestTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageGetURLRequestTests: XCTestCase, @unchecked Sendable {
 
     let testTargetIdentityId = "TestTargetIdentityId"
     let testKey = "TestKey"

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSS3StorageListRequestTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSS3StorageListRequestTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSS3StoragePlugin
 
-class StorageListRequestTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageListRequestTests: XCTestCase, @unchecked Sendable {
 
     let testTargetIdentityId = "TestTargetIdentityId"
     let testPath = "TestPath"

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSS3StoragePutDataRequestTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSS3StoragePutDataRequestTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class AWSS3StorageUploadDataRequestTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StorageUploadDataRequestTests: XCTestCase, @unchecked Sendable {
 
     let testTargetIdentityId = "TestTargetIdentityId"
     let testKey = "TestKey"

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSS3StorageRemoveRequestTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSS3StorageRemoveRequestTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSS3StoragePlugin
 
-class AWSS3StorageRemoveRequestTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StorageRemoveRequestTests: XCTestCase, @unchecked Sendable {
 
     let testTargetIdentityId = "TestTargetIdentityId"
     let testKey = "TestKey"

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSS3StorageUploadFileRequestTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSS3StorageUploadFileRequestTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class AWSS3StorageUploadFileRequestTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StorageUploadFileRequestTests: XCTestCase, @unchecked Sendable {
 
     let testTargetIdentityId = "TestTargetIdentityId"
     let testKey = "TestKey"

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSStorageGetURLOptionsTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Request/AWSStorageGetURLOptionsTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSS3StoragePlugin
 
-class AWSStorageGetURLOptionsTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSStorageGetURLOptionsTests: XCTestCase, @unchecked Sendable {
 
     // MARK: - Default initializer (no arguments)
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Service/Storage/AWSS3MultipartUploadRequestCompletedPartTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Service/Storage/AWSS3MultipartUploadRequestCompletedPartTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class AWSS3MultipartUploadRequestCompletedPartTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3MultipartUploadRequestCompletedPartTests: XCTestCase, @unchecked Sendable {
 
     func testSessionWithCompletedParts() throws {
         let completedParts: StorageUploadParts = [

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceDownloadBehaviorTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceDownloadBehaviorTests.swift
@@ -9,7 +9,9 @@
 import XCTest
 @testable import AWSS3StoragePlugin
 
-class AWSS3StorageServiceDownloadBehaviorTests: AWSS3StorageServiceTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StorageServiceDownloadBehaviorTests: AWSS3StorageServiceTestBase, @unchecked Sendable {
 
     let testServiceKey = "TestServiceKey"
     let testFileURL = URL(fileURLWithPath: "path")

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceGetPreSignedURLBehaviorTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceGetPreSignedURLBehaviorTests.swift
@@ -15,7 +15,9 @@ import ClientRuntime
 import XCTest
 
 // swiftlint:disable:next type_name
-class AWSS3StorageServiceGetPreSignedURLBehaviorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StorageServiceGetPreSignedURLBehaviorTests: XCTestCase, @unchecked Sendable {
 
     var systemUnderTest: AWSS3StorageService!
     var authService: MockAWSAuthService!

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceListTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceListTests.swift
@@ -15,7 +15,9 @@ import SmithyHTTPAPI
 @testable import AWSPluginsTestCommon
 @testable import AWSS3StoragePlugin
 
-final class AWSS3StorageServiceListTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AWSS3StorageServiceListTests: XCTestCase, @unchecked Sendable {
 
     var systemUnderTest: AWSS3StorageService!
     var authService: MockAWSAuthService!

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Service/Storage/AWSS3StorageServiceTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSPluginsTestCommon
 @testable import AWSS3StoragePlugin
 
-class AWSS3StorageServiceTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StorageServiceTests: XCTestCase, @unchecked Sendable {
     private var service: AWSS3StorageService!
     private var authService: MockAWSAuthService!
     private var database: StorageTransferDatabaseMock!
@@ -393,7 +395,11 @@ class AWSS3StorageServiceTests: XCTestCase {
     }
 }
 
-private class MockHttpClientEngineProxy: HttpClientEngineProxy {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+private class MockHttpClientEngineProxy: HttpClientEngineProxy, @unchecked Sendable {
     var target: HTTPClient?
 
     var executeCount = 0
@@ -405,7 +411,11 @@ private class MockHttpClientEngineProxy: HttpClientEngineProxy {
     }
 }
 
-private class StorageTransferDatabaseMock: StorageTransferDatabase {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+private class StorageTransferDatabaseMock: StorageTransferDatabase, @unchecked Sendable {
 
     func prepareForBackground(completion: (() -> Void)?) {
         completion?()
@@ -431,7 +441,7 @@ private class StorageTransferDatabaseMock: StorageTransferDatabase {
     var recoverResult: Result<StorageTransferTaskPairs, Error> =  .failure(StorageError.unknown("Result not set", nil))
     func recover(
         urlSession: StorageURLSession,
-        completionHandler: @escaping (Result<StorageTransferTaskPairs, Error>) -> Void
+        completionHandler: @escaping @Sendable (Result<StorageTransferTaskPairs, Error>) -> Void
     ) {
         recoverCount += 1
         completionHandler(recoverResult)

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/AttemptTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/AttemptTests.swift
@@ -11,7 +11,9 @@ import AmplifyTestCommon
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class AttemptTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AttemptTests: XCTestCase, @unchecked Sendable {
     let goodNumber = 42
     let badNumber = 13
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/BytesTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/BytesTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class BytesTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class BytesTests: XCTestCase, @unchecked Sendable {
 
     func testBytes() throws {
         XCTAssertEqual(Bytes.terabytes(1).bytes, Bytes.gigabytes(1).bytes * 1_024)

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/DefaultStorageMultipartUploadClientTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/DefaultStorageMultipartUploadClientTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import func AmplifyTestCommon.XCTAssertThrowFatalError
 @testable import AWSS3StoragePlugin
 
-class DefaultStorageMultipartUploadClientTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DefaultStorageMultipartUploadClientTests: XCTestCase, @unchecked Sendable {
     private var defaultClient: DefaultStorageMultipartUploadClient!
     private var serviceProxy: MockStorageServiceProxy!
     private var session: MockStorageMultipartUploadSession!
@@ -356,7 +358,11 @@ class DefaultStorageMultipartUploadClientTests: XCTestCase {
     }
 }
 
-private class MockStorageServiceProxy: StorageServiceProxy {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+private class MockStorageServiceProxy: StorageServiceProxy, @unchecked Sendable {
     var preSignedURLBuilder: AWSS3PreSignedURLBuilderBehavior! = MockAWSS3PreSignedURLBuilder()
     var awsS3: AWSS3Behavior!
     var urlSession = URLSession.shared

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/DefaultStorageTransferDatabaseTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/DefaultStorageTransferDatabaseTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class DefaultStorageTransferDatabaseTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class DefaultStorageTransferDatabaseTests: XCTestCase, @unchecked Sendable {
     private var database: DefaultStorageTransferDatabase!
     private var uploadFile: UploadFile!
     private var session: MockStorageSessionTask!

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FatalTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FatalTests.swift
@@ -11,7 +11,9 @@ import AmplifyTestCommon
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class FatalTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class FatalTests: XCTestCase, @unchecked Sendable {
 
     func testFatalMustOverride() throws {
         try XCTAssertThrowFatalError { Fatal.mustOverride() }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileHandleTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileHandleTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSS3StoragePlugin
 
-class FileHandleTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class FileHandleTests: XCTestCase, @unchecked Sendable {
 
     /// Given: A FileHandle and a file
     /// When: `read(bytes:bytesReadLimit)` is invoked with `bytesReadLimit` being lower than `bytes`

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileSystemTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/FileSystemTests.swift
@@ -44,7 +44,9 @@ extension Bytes {
     }
 }
 
-class FileSystemTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class FileSystemTests: XCTestCase, @unchecked Sendable {
 
     func testMoveFile_Succeeds_WhenMoveFileExecuted() throws {
         let fs = FileSystem()

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/MockStorageTransferDatabase.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/MockStorageTransferDatabase.swift
@@ -9,7 +9,11 @@ import Foundation
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class MockStorageTransferDatabase: StorageTransferDatabase {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockStorageTransferDatabase: StorageTransferDatabase, @unchecked Sendable {
 
     private let queue = DispatchQueue(
         label: "com.amazon.aws.amplify.storage-tests",
@@ -50,7 +54,7 @@ class MockStorageTransferDatabase: StorageTransferDatabase {
 
     func recover(
         urlSession: StorageURLSession,
-        completionHandler: @escaping (Result<StorageTransferTaskPairs, Error>) -> Void
+        completionHandler: @escaping @Sendable (Result<StorageTransferTaskPairs, Error>) -> Void
     ) {
         // do nothing
     }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageBackgroundEventsRegistryTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageBackgroundEventsRegistryTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class StorageBackgroundEventsRegistryTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageBackgroundEventsRegistryTests: XCTestCase, @unchecked Sendable {
 
     func testRegisteringAndUnregister() async throws {
         let identifier = UUID().uuidString

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageConfigurationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageConfigurationTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSS3StoragePlugin
 
-class StorageConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageConfigurationTests: XCTestCase, @unchecked Sendable {
 
     /// Given: StorageConfiguration with default init
     /// When: progressStallTimeout is read

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageMultipartUploadSessionTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageMultipartUploadSessionTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class StorageMultipartUploadSessionTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageMultipartUploadSessionTests: XCTestCase, @unchecked Sendable {
     enum Failure: Error {
         case unableToCreateData
         case testFailure

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StoragePersistableTransferTaskTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StoragePersistableTransferTaskTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class StoragePersistableTransferTaskTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StoragePersistableTransferTaskTests: XCTestCase, @unchecked Sendable {
     var database: StorageTransferDatabase!
     var fileSystem: FileSystem!
     var logger: Logger!

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageServiceSessionDelegateTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageServiceSessionDelegateTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSPluginsTestCommon
 @testable import AWSS3StoragePlugin
 
-class StorageServiceSessionDelegateTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageServiceSessionDelegateTests: XCTestCase, @unchecked Sendable {
     private var delegate: StorageServiceSessionDelegate!
     private var service: AWSS3StorageServiceMock!
     private var logger: MockLogger!

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageTransferDatabaseTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageTransferDatabaseTests.swift
@@ -17,7 +17,7 @@ import AmplifyTestCommon
 struct MockStorageURLSession: StorageURLSession {
     let sessionTasks: StorageSessionTasks
 
-    func getActiveTasks(resultHandler: @escaping (StorageSessionTasks) -> Void) {
+    func getActiveTasks(resultHandler: @escaping @Sendable (StorageSessionTasks) -> Void) {
         resultHandler(sessionTasks)
     }
 }
@@ -32,7 +32,9 @@ struct MockStorageSessionTask: StorageSessionTask {
     }
 }
 
-class StorageTransferDatabaseTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageTransferDatabaseTests: XCTestCase, @unchecked Sendable {
     var fileSystem: FileSystem!
     var queue: DispatchQueue!
     var temporaryDirectoryURL: URL!
@@ -237,7 +239,8 @@ class StorageTransferDatabaseTests: XCTestCase {
 
         let exp = expectation(description: #function)
 
-        var transferTaskPairs: StorageTransferTaskPairs?
+        // Assigned from the `@Sendable` recovery completion, so it cannot be a captured `var`.
+        let transferTaskPairs = AtomicValue<StorageTransferTaskPairs?>(initialValue: nil)
         let urlSession = MockStorageURLSession(sessionTasks: sessionTasks)
 
         // trigger storing and then load to link tasks with sessions
@@ -246,7 +249,7 @@ class StorageTransferDatabaseTests: XCTestCase {
                 do {
                     let pairs = try result.get()
                     XCTAssertTrue(!pairs.isEmpty)
-                    transferTaskPairs = pairs
+                    transferTaskPairs.set(pairs)
                 } catch {
                     XCTFail("Error: \(error)")
                 }
@@ -256,23 +259,23 @@ class StorageTransferDatabaseTests: XCTestCase {
 
         await fulfillment(of: [exp], timeout: 10.0)
 
-        XCTAssertNotNil(transferTaskPairs)
-        XCTAssertEqual(transferTaskPairs?.count, 3)
+        XCTAssertNotNil(transferTaskPairs.get())
+        XCTAssertEqual(transferTaskPairs.get()?.count, 3)
 
         // the initial task will not have a taskIdentifier
-        guard let multipartUpload = transferTaskPairs?.first(where: { $0.transferTask.uploadId == uploadId && $0.transferTask.partNumber == nil }) else {
+        guard let multipartUpload = transferTaskPairs.get()?.first(where: { $0.transferTask.uploadId == uploadId && $0.transferTask.partNumber == nil }) else {
             XCTFail("Failed to get multipart upload")
             return
         }
 
         // upload part 1 will have a taskIdentifier
-        guard let part1 = transferTaskPairs?.first(where: { $0.transferTask.partNumber == 1 }) else {
+        guard let part1 = transferTaskPairs.get()?.first(where: { $0.transferTask.partNumber == 1 }) else {
             XCTFail("Failed to get part 1")
             return
         }
 
         // upload part 1 will have a taskIdentifier
-        guard let part2 = transferTaskPairs?.first(where: { $0.transferTask.partNumber == 2 }) else {
+        guard let part2 = transferTaskPairs.get()?.first(where: { $0.transferTask.partNumber == 2 }) else {
             XCTFail("Failed to get part 2")
             return
         }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageTransferTaskTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageTransferTaskTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSS3StoragePlugin
 
-class StorageTransferTaskTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageTransferTaskTests: XCTestCase, @unchecked Sendable {
 
     // MARK: - Resume tests
     /// Given: A StorageTransferTask with a sessionTask
@@ -597,7 +599,8 @@ private class MockStorageTask: StorageTask {
     }
 }
 
-private class MockSessionTask: StorageSessionTask {
+// `@unchecked Sendable`: `StorageSessionTask` is `Sendable` now. Counters are read by a single test.
+private final class MockSessionTask: StorageSessionTask, @unchecked Sendable {
     let taskIdentifier: TaskIdentifier
     let state: URLSessionTask.State
 
@@ -625,7 +628,11 @@ private class MockSessionTask: StorageSessionTask {
     }
 }
 
-class MockLogger: Logger {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+
+// by a single test at a time.
+
+class MockLogger: Logger, @unchecked Sendable {
     var logLevel: LogLevel = .verbose
 
     func error(_ message: @autoclosure () -> String) {

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageUploadPartSizeTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageUploadPartSizeTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class StorageUploadPartSizeTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageUploadPartSizeTests: XCTestCase, @unchecked Sendable {
 
     func testUploadPartSizes() throws {
         XCTAssertGreaterThanOrEqual(StorageUploadPartSize.default.size, minimumPartSize)

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageUploadPartTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/StorageUploadPartTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class StorageUploadPartTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageUploadPartTests: XCTestCase, @unchecked Sendable {
 
     func testUploadPartCreation() throws {
         // Creates an array of upload parts with 21 parts

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/UploadFileTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/UploadFileTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class UploadFileTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class UploadFileTests: XCTestCase, @unchecked Sendable {
 
     func testUploadFileCreation() throws {
         let fs = FileSystem()

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/UploadSourceTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Internal/UploadSourceTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class UploadSourceTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class UploadSourceTests: XCTestCase, @unchecked Sendable {
 
     func testDataSource() throws {
         let fs = FileSystem()

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsGetterTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsGetterTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSS3StoragePlugin
 
-class StorageRequestUtilsGetterTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageRequestUtilsGetterTests: XCTestCase, @unchecked Sendable {
 
     let testIdentityId = "TestIdentityId"
     let testTargetIdentityId = "TestTargetIdentityId"

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsTests.swift
@@ -7,7 +7,9 @@
 
 import XCTest
 
-class StorageRequestUtilsTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageRequestUtilsTests: XCTestCase, @unchecked Sendable {
     func testClassMustNotBeEmpty() {
         // Swift format crashes if a test class is empty
     }

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsValidatorTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Support/Utils/StorageRequestUtilsValidatorTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSS3StoragePlugin
 
-class StorageRequestUtilsValidatorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class StorageRequestUtilsValidatorTests: XCTestCase, @unchecked Sendable {
 
     let testIdentityId = "TestIdentityId"
     let testTargetIdentityId = "TestTargetIdentityId"

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageGetURLTaskPropertyTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageGetURLTaskPropertyTests.swift
@@ -18,7 +18,9 @@ import XCTest
 // These tests use randomized inputs to validate universal properties
 // of the method-to-signing-operation mapping in AWSS3StorageGetURLTask.
 
-class AWSS3StorageGetURLTaskPropertyTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StorageGetURLTaskPropertyTests: XCTestCase, @unchecked Sendable {
 
     // MARK: - Helpers
 

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageGetURLTaskTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageGetURLTaskTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSPluginsTestCommon
 @testable import AWSS3StoragePlugin
 
-class AWSS3StorageGetURLTaskTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StorageGetURLTaskTests: XCTestCase, @unchecked Sendable {
 
 
     /// - Given: A configured Storage GetURL Task with mocked service

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageListObjectsTaskTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageListObjectsTaskTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSPluginsTestCommon
 @testable import AWSS3StoragePlugin
 
-class AWSS3StorageListObjectsTaskTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StorageListObjectsTaskTests: XCTestCase, @unchecked Sendable {
 
     /// - Given: A configured Storage List Objects Task with mocked service
     /// - When: AWSS3StorageListObjectsTask value is invoked

--- a/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageRemoveTaskTests.swift
+++ b/AmplifyPlugins/Storage/Tests/AWSS3StoragePluginTests/Tasks/AWSS3StorageRemoveTaskTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSPluginsTestCommon
 @testable import AWSS3StoragePlugin
 
-class AWSS3StorageRemoveTaskTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StorageRemoveTaskTests: XCTestCase, @unchecked Sendable {
 
 
     /// - Given: A configured Storage Remove Task with mocked service

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginAccelerateIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginAccelerateIntegrationTests.swift
@@ -12,7 +12,9 @@ import var CommonCrypto.CC_MD5_DIGEST_LENGTH
 import XCTest
 @testable import Amplify
 
-class AWSS3StoragePluginAccelerateIntegrationTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginAccelerateIntegrationTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
 
     var useAccelerateEndpoint = false
 

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginAccessLevelTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginAccessLevelTests.swift
@@ -10,7 +10,9 @@ import AWSPluginsCore
 import XCTest
 @testable import AWSS3StoragePlugin
 
-class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginAccessLevelTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
 
     struct StorageAccessLevelsTestRun {
         let label: String

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginBasicIntegrationTests.swift
@@ -12,7 +12,9 @@ import CryptoKit
 import SmithyHTTPAPI
 import XCTest
 
-class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginBasicIntegrationTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
 
     var uploadedKeys: [String]!
 

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginConfigurationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginConfigurationTests.swift
@@ -10,7 +10,9 @@ import AWSS3StoragePlugin
 import XCTest
 @testable import Amplify
 
-class AWSS3StoragePluginConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginConfigurationTests: XCTestCase, @unchecked Sendable {
 
     /// Given: awss3StoragePlugin configuration with incorrect DefaultAccessLevel value
     /// When: Configure Amplify

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginDownloadIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginDownloadIntegrationTests.swift
@@ -12,7 +12,9 @@ import ClientRuntime
 import CryptoKit
 import XCTest
 
-class AWSS3StoragePluginDownloadIntegrationTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginDownloadIntegrationTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
     /// Given: An object in storage
     /// When: Call the downloadData API
     /// Then: The operation completes successfully with the data retrieved

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginGetURLIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginGetURLIntegrationTests.swift
@@ -14,7 +14,9 @@ import ClientRuntime
 import CryptoKit
 import XCTest
 
-class AWSS3StoragePluginGetURLIntegrationTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginGetURLIntegrationTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
 
     /// Given: An object in storage
     /// When: Call the getURL API

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginListObjectsIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginListObjectsIntegrationTests.swift
@@ -16,7 +16,9 @@ import AWSS3
 import CryptoKit
 import XCTest
 
-class AWSS3StoragePluginListObjectsIntegrationTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginListObjectsIntegrationTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
 
     /// Given: Multiple data object which is uploaded to a public path
     /// When: `Amplify.Storage.list` is run

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginMultipleBucketTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginMultipleBucketTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-class AWSS3StoragePluginMultipleBucketTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginMultipleBucketTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
     private var customBucket: ResolvedStorageBucket!
 
     override func setUp() async throws {

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginNegativeTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginNegativeTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSS3StoragePlugin
 
-class AWSS3StoragePluginNegativeTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginNegativeTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
 
     /// Given: Object with key `key` does not exist in storage
     /// When: Call the get API

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginOptionsUsabilityTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginOptionsUsabilityTests.swift
@@ -10,7 +10,9 @@ import AWSS3
 import AWSS3StoragePlugin
 import XCTest
 
-class AWSS3StoragePluginOptionsUsabilityTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginOptionsUsabilityTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
 
     override func setUpWithError() throws {
         continueAfterFailure = false

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginPrefixKeyResolverTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginPrefixKeyResolverTests.swift
@@ -11,7 +11,9 @@ import XCTest
 import AWSCognitoAuthPlugin
 @testable import Amplify
 
-class AWSS3StoragePluginKeyResolverTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginKeyResolverTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
 
     override func setUp() async throws {
         do {

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginProgressTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginProgressTests.swift
@@ -22,7 +22,9 @@ import XCTest
 ///
 /// On my laptop, on my network, I only get "progress: 1.0" notifications for payloads
 /// of ~0-1MB. After ~1 MB, I start getting notified more frequently.
-class AWSS3StoragePluginProgressTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginProgressTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
 
     /// - Given: An upload task
     /// - When: A subscription to its progress `resultPublisher` is established **during** upload

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginRemoveIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginRemoveIntegrationTests.swift
@@ -16,7 +16,9 @@ import AWSS3
 import CryptoKit
 import XCTest
 
-class AWSS3StoragePluginRemoveIntegrationTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginRemoveIntegrationTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
 
     /// Given: A data object which is uploaded to a public path
     /// When: `Amplify.Storage.remove` is run

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginTestBase.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginTestBase.swift
@@ -14,7 +14,9 @@ import AWSCognitoAuthPlugin
 import AWSPluginsCore
 @_spi(PluginHTTPClientEngine) import AWSPluginsCore
 
-class AWSS3StoragePluginTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginTestBase: XCTestCase, @unchecked Sendable {
     static let logger = Amplify.Logging.logger(forCategory: "Storage", logLevel: .verbose)
 
     static let smallDataObject = Data(repeating: 0xff, count: 1_024 * 1_024 * ProcessInfo.processInfo.activeProcessorCount)

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginUploadIntegrationTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginUploadIntegrationTests.swift
@@ -12,7 +12,9 @@ import CryptoKit
 import SmithyHTTPAPI
 import XCTest
 
-class AWSS3StoragePluginUploadIntegrationTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginUploadIntegrationTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
 
     var uploadedKeys: [String]!
 

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginUploadMetadataTestCase.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/AWSS3StoragePluginUploadMetadataTestCase.swift
@@ -11,7 +11,9 @@ import AWSS3
 import AWSS3StoragePlugin
 import XCTest
 
-class AWSS3StoragePluginUploadMetadataTestCase: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginUploadMetadataTestCase: AWSS3StoragePluginTestBase, @unchecked Sendable {
     // MARK: - Tests
 
     /// Given: `StorageUploadFileRequest.Options` with `metadata`

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginDownloadFileResumabilityTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginDownloadFileResumabilityTests.swift
@@ -11,5 +11,7 @@ import AWSS3StoragePlugin
 import XCTest
 
 // swiftlint:disable:next type_name
-class AWSS3StoragePluginDownloadFileResumabilityTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginDownloadFileResumabilityTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
 }

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginGetDataResumabilityTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginGetDataResumabilityTests.swift
@@ -12,7 +12,9 @@ import Combine
 import XCTest
 
 // swiftlint:disable:next type_name
-class AWSS3StoragePluginDownloadDataResumabilityTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginDownloadDataResumabilityTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
 
     /// Given: A data object in storage
     /// When: Call the get API then pause

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginPutDataResumabilityTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginPutDataResumabilityTests.swift
@@ -12,7 +12,9 @@ import Combine
 import XCTest
 
 // swiftlint:disable:next type_name
-class AWSS3StoragePluginUploadDataResumabilityTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginUploadDataResumabilityTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
     /// Given: A large data object to upload
     /// When: Call the put API and pause the operation
     /// Then: The operation is stalled (no progress, completed, or failed event)

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginUploadFileResumabilityTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/AWSS3StoragePluginIntegrationTests/ResumabilityTests/AWSS3StoragePluginUploadFileResumabilityTests.swift
@@ -11,5 +11,7 @@ import AWSS3StoragePlugin
 import XCTest
 
 // swiftlint:disable:next type_name
-class AWSS3StoragePluginUploadFileResumabilityTests: AWSS3StoragePluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSS3StoragePluginUploadFileResumabilityTests: AWSS3StoragePluginTestBase, @unchecked Sendable {
 }

--- a/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageStressTests/StorageStressTests.swift
+++ b/AmplifyPlugins/Storage/Tests/StorageHostApp/StorageStressTests/StorageStressTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSS3StoragePlugin
 
-final class StorageStressTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class StorageStressTests: XCTestCase, @unchecked Sendable {
 
     static let logger = Amplify.Logging.logger(forCategory: "Storage", logLevel: .verbose)
 


### PR DESCRIPTION
Slice **35 of 38** in the Swift 6 language-mode migration — 77 file(s).

Stacked on `swift6/34-tests-api`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.