### PR TITLE
test(predictions): migrate Predictions and PluginsCore test targets

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/API/AWSAppSyncConfigurationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/API/AWSAppSyncConfigurationTests.swift
@@ -9,7 +9,9 @@ import AWSPluginsCore
 import XCTest
 @testable import Amplify
 
-final class AWSAppSyncConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AWSAppSyncConfigurationTests: XCTestCase, @unchecked Sendable {
 
     func testSuccess() throws {
         let config = AmplifyOutputsData(data: .init(

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/API/AppSyncErrorTypeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/API/AppSyncErrorTypeTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSPluginsCore
 
-class AppSyncErrorTypeTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AppSyncErrorTypeTests: XCTestCase, @unchecked Sendable {
     func testAppSyncErrorTypeFromErrorString() {
         let errorTypes: [String: AppSyncErrorType] = [
             AppSyncErrorType.conflictUnhandled.rawValue: .conflictUnhandled,

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AWSAuthorizationTypeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AWSAuthorizationTypeTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSPluginsCore
 
-class AWSAuthorizationTypeTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAuthorizationTypeTests: XCTestCase, @unchecked Sendable {
 
     func testRequiresAuthPlugin() {
         XCTAssertFalse(AWSAuthorizationType.apiKey.requiresAuthPlugin)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AuthModeStrategyTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Auth/AuthModeStrategyTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable @preconcurrency import Amplify
 @testable import AWSPluginsCore
 
-class AuthModeStrategyTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AuthModeStrategyTests: XCTestCase, @unchecked Sendable {
 
     // Given: default strategy and a model schema
     // When: authTypesFor for .create operation is called

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Keychain/KeychainStoreAttributesTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Keychain/KeychainStoreAttributesTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSPluginsCore
 
-class KeychainStoreAttributesTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class KeychainStoreAttributesTests: XCTestCase, @unchecked Sendable {
 
     var keychainStoreAttribute: KeychainStoreAttributes!
 

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/AnyModel/AnyModelTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/AnyModel/AnyModelTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import AWSPluginsCore
 import XCTest
 
-class AnyModelTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AnyModelTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: AnyModelTester.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelMultipleOwnerAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelMultipleOwnerAuthRuleTests.swift
@@ -65,7 +65,9 @@ public struct ModelMultipleOwner: Model {
  * and uncomment the other tests.
 */
 
-class ModelMultipleOwnerAuthRuleTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ModelMultipleOwnerAuthRuleTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: ModelMultipleOwner.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelReadUpdateAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelReadUpdateAuthRuleTests.swift
@@ -48,7 +48,9 @@ public struct ModelReadUpdateField: Model {
     }
 }
 
-class ModelReadUpdateAuthRuleTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ModelReadUpdateAuthRuleTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: ModelReadUpdateField.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerAuthAndGroupWithGroupClaim.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerAuthAndGroupWithGroupClaim.swift
@@ -79,7 +79,9 @@ public struct OIDCGroupPost: Model {
       }
 }
 
-class ModelWithOwnerAuthAndGroupWithGroupClaim: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ModelWithOwnerAuthAndGroupWithGroupClaim: XCTestCase, @unchecked Sendable {
     override func setUp() {
         ModelRegistry.register(modelType: OIDCGroupPost.self)
     }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerAuthAndMultiGroup.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerAuthAndMultiGroup.swift
@@ -85,7 +85,9 @@ public struct OIDCMultiGroupPost: Model {
     }
 }
 
-class ModelWithOwnerAuthAndMultiGroup: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ModelWithOwnerAuthAndMultiGroup: XCTestCase, @unchecked Sendable {
     override func setUp() {
         ModelRegistry.register(modelType: OIDCMultiGroupPost.self)
     }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerFieldAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/AuthRuleDecorator/ModelWithOwnerFieldAuthRuleTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSPluginsCore
 
 // swiftlint:disable type_body_length
-class ModelWithOwnerFieldAuthRuleTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ModelWithOwnerFieldAuthRuleTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: ModelWithOwnerField.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/IncludeAssociationDecoratorTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Decorator/IncludeAssociationDecoratorTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSPluginsCore
 
 
-class IncludeAssociationDecoratorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class IncludeAssociationDecoratorTests: XCTestCase, @unchecked Sendable {
 
     // MARK: Setup
 

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLCreateMutationTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class GraphQLCreateMutationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLCreateMutationTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: Comment.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDeleteMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLDeleteMutationTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class GraphQLDeleteMutationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLDeleteMutationTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: Comment.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLGetQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLGetQueryTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class GraphQLGetQueryTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLGetQueryTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: Comment.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLListQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLListQueryTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class GraphQLListQueryTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLListQueryTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: Comment.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSubscriptionTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSubscriptionTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSPluginsCore
 
 // swiftlint:disable type_body_length
-class GraphQLSubscriptionTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLSubscriptionTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: Comment.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSyncQueryTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLSyncQueryTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class GraphQLSyncQueryTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLSyncQueryTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: Comment.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLUpdateMutationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLDocument/GraphQLUpdateMutationTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class GraphQLUpdateMutationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLUpdateMutationTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: Comment.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAnyModelWithSyncTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAnyModelWithSyncTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSPluginsCore
 
 // swiftlint:disable type_body_length
-class GraphQLRequestAnyModelWithSyncTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLRequestAnyModelWithSyncTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: Comment.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthIdentityClaimTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthIdentityClaimTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class GraphQLRequestAuthIdentityClaimTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLRequestAuthIdentityClaimTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: ScenarioATest6Post.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthRuleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestAuthRuleTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class GraphQLRequestAuthRuleTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLRequestAuthRuleTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: Article.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestEmbeddableTypeJSONTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestEmbeddableTypeJSONTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class GraphQLRequestEmbeddableTypeJSONTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLRequestEmbeddableTypeJSONTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         let sectionName =  ModelField(name: "name", type: .string, isRequired: true)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestEmbeddableTypeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestEmbeddableTypeTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class GraphQLRequestEmbeddableTypeTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLRequestEmbeddableTypeTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: Todo.self)
@@ -75,7 +77,9 @@ class GraphQLRequestEmbeddableTypeTests: XCTestCase {
     }
 }
 
-class GraphQLRequestJSONNonModelTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLRequestJSONNonModelTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         let sectionName =  ModelField(

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestModelTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestModelTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class GraphQLRequestModelTest: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLRequestModelTest: XCTestCase, @unchecked Sendable {
 
     /// - Given: a `Model` instance
     /// - When:

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestOptionalAssociationTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestOptionalAssociationTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class GraphQLRequestOptionalAssociationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLRequestOptionalAssociationTests: XCTestCase, @unchecked Sendable {
     override func setUp() {
         ModelRegistry.register(modelType: User.self)
         ModelRegistry.register(modelType: UserFollowing.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestOwnerAndGroupTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestOwnerAndGroupTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class GraphQLRequestOwnerAndGroupTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLRequestOwnerAndGroupTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: OGCScenarioBPost.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestSyncCustomPrimaryKeyTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestSyncCustomPrimaryKeyTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class GraphQLRequestSyncCustomPrimaryKeyTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLRequestSyncCustomPrimaryKeyTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: CustomerOrder.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestSyncCustomPrimaryKeyWithMultipleFieldsTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/GraphQLRequest/GraphQLRequestSyncCustomPrimaryKeyWithMultipleFieldsTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSPluginsCore
 
 // swiftlint:disable type_name
-class GraphQLRequestSyncCustomPrimaryKeyWithMultipleFieldsTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class GraphQLRequestSyncCustomPrimaryKeyWithMultipleFieldsTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: CustomerWithMultipleFieldsinPK.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/AuthRuleExtensionTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/AuthRuleExtensionTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import AWSPluginsCore
 import XCTest
 
-class AuthRuleExtensionTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AuthRuleExtensionTests: XCTestCase, @unchecked Sendable {
     func testAuthRuleProviderToAWSAuth() throws {
         let authRuleProviders: [AuthRuleProvider] = [.apiKey, .oidc, .iam, .userPools]
         let expectedAuthTypes: [AWSAuthorizationType] = [

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/ModelGraphQLTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/ModelGraphQLTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class ModelGraphQLTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ModelGraphQLTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: Post.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/ModelSchemaGraphQLTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/ModelSchemaGraphQLTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class ModelSchemaGraphQLTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ModelSchemaGraphQLTests: XCTestCase, @unchecked Sendable {
 
     func testGraphQLNamesForDeprecatedTodo() throws {
         let todo = DeprecatedTodo.schema

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/QueryPredicateGraphQLTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Model/Support/QueryPredicateGraphQLTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSPluginsCore
 
 // swiftlint:disable type_body_length
-class QueryPredicateGraphQLTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class QueryPredicateGraphQLTests: XCTestCase, @unchecked Sendable {
 
     func testPredicateToGraphQLValues() throws {
         let post = Post.keys

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedBoolTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedBoolTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class QueryPredicateEvaluateGeneratedBoolTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class QueryPredicateEvaluateGeneratedBoolTests: XCTestCase, @unchecked Sendable {
     override func setUp() {
         ModelRegistry.register(modelType: QPredGen.self)
     }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTests.swift
@@ -14,7 +14,9 @@ import XCTest
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
 // swiftlint:disable line_length
-class QueryPredicateEvaluateGeneratedDateTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class QueryPredicateEvaluateGeneratedDateTests: XCTestCase, @unchecked Sendable {
     func testTemporalDateTemporal_Date_nownotEqualTemporalDateTemporal_Date_now() throws {
         let predicate = QPredGen.keys.myDate.ne(Temporal.Date.now())
         var instance = QPredGen(name: "test")

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTimeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDateTimeTests.swift
@@ -15,7 +15,9 @@ import XCTest
 // swiftlint:disable file_length
 // swiftlint:disable type_name
 // swiftlint:disable line_length
-class QueryPredicateEvaluateGeneratedDateTimeTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class QueryPredicateEvaluateGeneratedDateTimeTests: XCTestCase, @unchecked Sendable {
     func testTemporalDateTimeTemporal_DateTime_nownotEqualTemporalDateTimeTemporal_DateTime_now() throws {
         let dateTimeNow = Temporal.DateTime.now()
         let predicate = QPredGen.keys.myDateTime.ne(dateTimeNow)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleIntTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleIntTests.swift
@@ -14,7 +14,9 @@ import XCTest
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
 // swiftlint:disable type_name
-class QueryPredicateEvaluateGeneratedDoubleIntTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class QueryPredicateEvaluateGeneratedDoubleIntTests: XCTestCase, @unchecked Sendable {
     func testDouble1_1notEqualInt1() throws {
         let predicate = QPredGen.keys.myDouble.ne(1.1)
         var instance = QPredGen(name: "test")

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedDoubleTests.swift
@@ -14,7 +14,9 @@ import XCTest
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
 // swiftlint:disable type_name
-class QueryPredicateEvaluateGeneratedDoubleTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class QueryPredicateEvaluateGeneratedDoubleTests: XCTestCase, @unchecked Sendable {
     func testDouble1_1notEqualDouble1_1() throws {
         let predicate = QPredGen.keys.myDouble.ne(1.1)
         var instance = QPredGen(name: "test")

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedEnumTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedEnumTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class QueryPredicateEvaluateGeneratedEnumTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class QueryPredicateEvaluateGeneratedEnumTests: XCTestCase, @unchecked Sendable {
     override func setUp() {
         ModelRegistry.register(modelType: Post.self)
     }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntDoubleTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntDoubleTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AmplifyTestCommon
 
 // swiftlint:disable type_name
-class QueryPredicateEvaluateGeneratedIntDoubleTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class QueryPredicateEvaluateGeneratedIntDoubleTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() {
         ModelRegistry.register(modelType: QPredGen.self)

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedIntTests.swift
@@ -14,7 +14,9 @@ import XCTest
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
 // swiftlint:disable type_name
-class QueryPredicateEvaluateGeneratedIntBetweenTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class QueryPredicateEvaluateGeneratedIntBetweenTests: XCTestCase, @unchecked Sendable {
     override func setUp() {
         ModelRegistry.register(modelType: QPredGen.self)
     }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedStringTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedStringTests.swift
@@ -14,7 +14,9 @@ import XCTest
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
 // swiftlint:disable type_name
-class QueryPredicateEvaluateGeneratedStringTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class QueryPredicateEvaluateGeneratedStringTests: XCTestCase, @unchecked Sendable {
     override func setUp() {
         ModelRegistry.register(modelType: QPredGen.self)
     }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedTimeTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGeneratedTimeTests.swift
@@ -14,7 +14,9 @@ import XCTest
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length
 // swiftlint:disable line_length
-class QueryPredicateEvaluateGeneratedTimeTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class QueryPredicateEvaluateGeneratedTimeTests: XCTestCase, @unchecked Sendable {
     override func setUp() {
         ModelRegistry.register(modelType: QPredGen.self)
     }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGenerator.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateGenerator.swift
@@ -30,7 +30,9 @@ let dateNowPlus4day = dateNow.addingTimeInterval(60 * 60 * 4 * 24)
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 // swiftlint:disable function_parameter_count
-class QueryPredicateGenerator: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class QueryPredicateGenerator: XCTestCase, @unchecked Sendable {
     func testBoolBool() throws {
         generate("Bool,Bool")
     }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Query/QueryPredicateEvaluateTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import Amplify
 @testable import AmplifyTestCommon
 
-class QueryPredicateEvaluateTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class QueryPredicateEvaluateTests: XCTestCase, @unchecked Sendable {
     override func setUp() {
         ModelRegistry.register(modelType: QPredGen.self)
     }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/MutationSync/MutationSyncMetadataTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/MutationSync/MutationSyncMetadataTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class MutationSyncMetadataTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class MutationSyncMetadataTests: XCTestCase, @unchecked Sendable {
 
     let postSyncJSON = """
     {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/PaginatedListTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/Sync/PaginatedListTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSPluginsCore
 
-class PaginatedListTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class PaginatedListTests: XCTestCase, @unchecked Sendable {
 
     let syncQueryJSON = """
     {

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/WebSocket/LocalWebSocketServer.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/WebSocket/LocalWebSocketServer.swift
@@ -8,7 +8,9 @@
 import Foundation
 import Network
 
-class LocalWebSocketServer {
+// `@unchecked Sendable`: the connection handler runs on the listener queue and appends to
+// `connections`; this is a single-test helper.
+final class LocalWebSocketServer: @unchecked Sendable {
     let portNumber = UInt16.random(in: 49_152 ..< 65_535)
     var connections = [NWConnection]()
 

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/WebSocket/RetryWithJitterTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/WebSocket/RetryWithJitterTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable @_spi(WebSocket) import AWSPluginsCore
 
-class RetryWithJitterTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RetryWithJitterTests: XCTestCase, @unchecked Sendable {
     struct TestError: Error {
         let message: String
     }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/WebSocket/WebSocketClientTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/WebSocket/WebSocketClientTests.swift
@@ -11,7 +11,9 @@ import XCTest
 
 private let timeout: TimeInterval = 5
 
-class WebSocketClientTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class WebSocketClientTests: XCTestCase, @unchecked Sendable {
     var localWebSocketServer: LocalWebSocketServer?
 
     override func setUp() async throws {
@@ -195,7 +197,9 @@ class WebSocketClientTests: XCTestCase {
 }
 
 
-private class MockNetworkMonitor: WebSocketNetworkMonitorProtocol {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+private final class MockNetworkMonitor: WebSocketNetworkMonitorProtocol, @unchecked Sendable {
     typealias State = AmplifyNetworkMonitor.State
     let subject = PassthroughSubject<State, Never>()
     var publisher: AnyPublisher<(State, State), Never> {

--- a/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
+++ b/AmplifyPlugins/Core/AWSPluginsTestCommon/MockAWSAuthService.swift
@@ -12,7 +12,9 @@ import Foundation
 import InternalAmplifyCredentials
 import SmithyIdentity
 
-public class MockAWSAuthService: AWSAuthCredentialsProviderBehavior {
+/// - Note: `@unchecked Sendable` because `AWSAuthServiceBehavior` now requires `Sendable`. This is a
+///   test double whose mutable fields are set up by a single test before use.
+public class MockAWSAuthService: AWSAuthCredentialsProviderBehavior, @unchecked Sendable {
 
     var interactions: [String] = []
     var getIdentityIdError: AuthError?

--- a/AmplifyPlugins/Core/AmplifyCredentialsTests/Auth/AWSAuthServiceTests.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentialsTests/Auth/AWSAuthServiceTests.swift
@@ -12,7 +12,9 @@ import AWSClientRuntime
 @testable import AWSPluginsCore
 @testable import InternalAmplifyCredentials
 
-class AWSAuthServiceTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSAuthServiceTests: XCTestCase, @unchecked Sendable {
 
     var awsAuthService: AWSAuthServiceBehavior!
 

--- a/AmplifyPlugins/Core/AmplifyCredentialsTests/Utils/FoundationClientEngineTests.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentialsTests/Utils/FoundationClientEngineTests.swift
@@ -9,7 +9,9 @@
 @testable import InternalAmplifyCredentials
 import XCTest
 
-class FoundationClientEngineTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class FoundationClientEngineTests: XCTestCase, @unchecked Sendable {
 
     /// Given: A `FoundationClientEngine`.
     /// When: The engine is initialized.

--- a/AmplifyPlugins/Core/AmplifyCredentialsTests/Utils/UserAgentSettingClientEngineTests.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentialsTests/Utils/UserAgentSettingClientEngineTests.swift
@@ -13,7 +13,9 @@ import InternalAmplifyCredentials
 import SmithyHTTPAPI
 import XCTest
 
-class UserAgentSettingClientEngineTestCase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class UserAgentSettingClientEngineTestCase: XCTestCase, @unchecked Sendable {
     let userAgentKey = "User-Agent"
 
     /// Given: A `UserAgentSettingClientEngine`.
@@ -91,7 +93,9 @@ class UserAgentSettingClientEngineTestCase: XCTestCase {
     }
 }
 
-class MockTargetEngine: HTTPClient {
+/// - Note: `final` and `@unchecked Sendable`: `HTTPClient` is `Sendable`. Test double driven by a
+///   single test.
+final class MockTargetEngine: HTTPClient, @unchecked Sendable {
     var request: HTTPRequest?
 
     func send(

--- a/AmplifyPlugins/Core/AmplifyCredentialsTests/Utils/UserAgentSuffixAppenderTests.swift
+++ b/AmplifyPlugins/Core/AmplifyCredentialsTests/Utils/UserAgentSuffixAppenderTests.swift
@@ -11,7 +11,9 @@ import Smithy
 import SmithyHTTPAPI
 import XCTest
 
-class UserAgentSuffixAppenderTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class UserAgentSuffixAppenderTests: XCTestCase, @unchecked Sendable {
     private let userAgentKey = "User-Agent"
     private let customSuffix = "myCustomSuffix"
     private var appender: UserAgentSuffixAppender!
@@ -83,7 +85,9 @@ class UserAgentSuffixAppenderTests: XCTestCase {
     }
 }
 
-private class MockHttpClientEngine: HTTPClient {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+private class MockHttpClientEngine: HTTPClient, @unchecked Sendable {
     var executeCount = 0
     var executeRequest: HTTPRequest?
     func send(request: HTTPRequest) async throws -> HTTPResponse {

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/ConfigurationTests/AWSPredictionsPluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/ConfigurationTests/AWSPredictionsPluginAmplifyVersionableTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import AWSPredictionsPlugin
 
 // swiftlint:disable:next type_name
-class AWSPredictionsPluginAmplifyVersionableTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSPredictionsPluginAmplifyVersionableTests: XCTestCase, @unchecked Sendable {
     func testVersionExists() {
         let plugin = AWSPredictionsPlugin()
         XCTAssertNotNil(plugin.version)

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/ConfigurationTests/PredictionsPluginConfigurationTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSPredictionsPlugin
 
-class PredictionsPluginConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class PredictionsPluginConfigurationTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         await Amplify.reset()

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/ErrorMapping/PollyErrorMappingTestCase.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/ErrorMapping/PollyErrorMappingTestCase.swift
@@ -10,7 +10,9 @@ import AWSPolly
 import XCTest
 @testable import AWSPredictionsPlugin
 
-final class PollyErrorMappingTestCase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class PollyErrorMappingTestCase: XCTestCase, @unchecked Sendable {
     private func assertCatchVariations(
         for sdkError: Error,
         expecting expectedServiceError: PredictionsError.ServiceError,

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/ErrorMapping/TextractErrorMappingTestCase.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/ErrorMapping/TextractErrorMappingTestCase.swift
@@ -10,7 +10,9 @@ import AWSTextract
 import XCTest
 @testable import AWSPredictionsPlugin
 
-final class TextractErrorMappingTestCase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class TextractErrorMappingTestCase: XCTestCase, @unchecked Sendable {
     private func assertCatchVariations(
         for sdkError: Error,
         expecting expectedServiceError: PredictionsError.ServiceError,

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/EventStreamCodingTests/EventStreamCoderTestCase.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/EventStreamCodingTests/EventStreamCoderTestCase.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSPredictionsPlugin
 
-final class EventStreamCoderTestCase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class EventStreamCoderTestCase: XCTestCase, @unchecked Sendable {
     struct Model: Codable, Equatable {
         let foo: Int
         let bar: String

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/LivenessTests/LivenessChallengeTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/LivenessTests/LivenessChallengeTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AWSPredictionsPlugin
 @_spi(PredictionsFaceLiveness) import AWSPredictionsPlugin
 
-class LivenessChallengeTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class LivenessChallengeTests: XCTestCase, @unchecked Sendable {
 
     func testFaceMovementChallengeQueryParamterString() {
         let challenge: Challenge = .faceMovementChallenge("1.0.0")

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/LivenessTests/LivenessDecodingTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/LivenessTests/LivenessDecodingTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AWSPredictionsPlugin
 @_spi(PredictionsFaceLiveness) import AWSPredictionsPlugin
 
-class LivenessDecodingTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class LivenessDecodingTests: XCTestCase, @unchecked Sendable {
 
     // MARK: - ChallengeEvent
     /// - Given: A valid json payload depicting a FaceMovementChallenge

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceComprehendTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceComprehendTests.swift
@@ -10,7 +10,9 @@ import AWSComprehend
 import XCTest
 @testable import AWSPredictionsPlugin
 
-class PredictionsServiceComprehendTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class PredictionsServiceComprehendTests: XCTestCase, @unchecked Sendable {
     var predictionsService: AWSPredictionsService!
     var mockComprehend: MockComprehendBehavior!
     let inputForTest = "Input text for testing"

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceRekognitionTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceRekognitionTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSPredictionsPlugin
 
 // swiftlint:disable file_length type_body_length
-class PredictionsServiceRekognitionTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class PredictionsServiceRekognitionTests: XCTestCase, @unchecked Sendable {
     var predictionsService: AWSPredictionsService!
     var mockRekognition = MockRekognitionBehavior()
     var mockConfigurationJSON = """

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceTextractTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceTextractTests.swift
@@ -12,7 +12,9 @@ import Foundation
 import XCTest
 @testable import AWSPredictionsPlugin
 
-class PredictionsServiceTextractTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class PredictionsServiceTextractTests: XCTestCase, @unchecked Sendable {
     var predictionsService: AWSPredictionsService!
     let mockTextract = MockTextractBehavior()
 

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceTranscribeTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceTranscribeTests.swift
@@ -10,7 +10,9 @@ import AWSTranscribeStreaming
 import XCTest
 @testable import AWSPredictionsPlugin
 
-class PredictionsServiceTranscribeTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class PredictionsServiceTranscribeTests: XCTestCase, @unchecked Sendable {
     var predictionsService: AWSPredictionsService!
     let mockTranscribe = MockTranscribeBehavior()
     var audioFile: URL!

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceTranslateTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Service/PredictionsTest/PredictionsServiceTranslateTests.swift
@@ -10,7 +10,9 @@ import AWSTranslate
 import XCTest
 @testable import AWSPredictionsPlugin
 
-class PredictionsServiceTranslateTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class PredictionsServiceTranslateTests: XCTestCase, @unchecked Sendable {
     var predictionsService: AWSPredictionsService!
     let mockTranslate = MockTranslateBehavior()
 

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/SigV4SignerTests/SigV4URLSigningTestCase.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/SigV4SignerTests/SigV4URLSigningTestCase.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSPredictionsPlugin
 
-class SigV4URLSigningTestCase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SigV4URLSigningTestCase: XCTestCase, @unchecked Sendable {
     func url() throws -> URL {
         try XCTUnwrap(
             URL(string: "wss://streaming-rekognition.us-east-1.amazon.com/start-face-liveness-session-websocket")

--- a/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Signing+EncodingTests/Signing+EncodingTestCase.swift
+++ b/AmplifyPlugins/Predictions/Tests/AWSPredictionsPluginUnitTests/Signing+EncodingTests/Signing+EncodingTestCase.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AWSPredictionsPlugin
 
-final class SigningEncodingTestCase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class SigningEncodingTestCase: XCTestCase, @unchecked Sendable {
     func url() throws -> URL {
         try XCTUnwrap(
             URL(string: "wss://streaming-rekognition.us-east-1.amazon.com/start-face-liveness-session-websocket")

--- a/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/CoreMLPredictionsPluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/CoreMLPredictionsPluginAmplifyVersionableTests.swift
@@ -10,7 +10,9 @@ import CoreMLPredictionsPlugin
 import XCTest
 
 // swiftlint:disable:next type_name
-class CoreMLPredictionsPluginAmplifyVersionableTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class CoreMLPredictionsPluginAmplifyVersionableTests: XCTestCase, @unchecked Sendable {
 
     func testVersionExists() {
         let plugin = CoreMLPredictionsPlugin()

--- a/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/CoreMLPredictionsPluginClientBehaviorTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/CoreMLPredictionsPluginClientBehaviorTests.swift
@@ -10,7 +10,9 @@ import Amplify
 import XCTest
 @testable import CoreMLPredictionsPlugin
 
-class CoreMLPredictionsPluginTests: CoreMLPredictionsPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class CoreMLPredictionsPluginTests: CoreMLPredictionsPluginTestBase, @unchecked Sendable {
     func testPluginInterpretText() async throws {
         let result = try await coreMLPredictionsPlugin.interpret(
             text: "",

--- a/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/CoreMLPredictionsPluginConfigTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/CoreMLPredictionsPluginConfigTests.swift
@@ -10,7 +10,9 @@ import CoreMLPredictionsPlugin
 import XCTest
 @testable import Amplify
 
-class CoreMLPredictionsPluginConfigTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class CoreMLPredictionsPluginConfigTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         await Amplify.reset()

--- a/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/CoreMLPredictionsPluginTestBase.swift
+++ b/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/CoreMLPredictionsPluginTestBase.swift
@@ -10,7 +10,9 @@ import Amplify
 import XCTest
 @testable import CoreMLPredictionsPlugin
 
-class CoreMLPredictionsPluginTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class CoreMLPredictionsPluginTestBase: XCTestCase, @unchecked Sendable {
     var coreMLPredictionsPlugin: CoreMLPredictionsPlugin!
     var naturalLanguageBehavior: MockCoreMLNaturalLanguageAdapter!
     var visionBehavior: MockCoreMLVisionAdapter!
@@ -21,7 +23,9 @@ class CoreMLPredictionsPluginTestBase: XCTestCase {
         coreMLPredictionsPlugin = CoreMLPredictionsPlugin()
         naturalLanguageBehavior = MockCoreMLNaturalLanguageAdapter()
         visionBehavior = MockCoreMLVisionAdapter()
-        speechBehavior = MockCoreMLSpeechAdapter(response: .init())
+        speechBehavior = MockCoreMLSpeechAdapter(
+            response: .init(formattedString: "", isFinal: true)
+        )
         queue = MockOperationQueue()
         coreMLPredictionsPlugin.configure(
             naturalLanguageBehavior: naturalLanguageBehavior,

--- a/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/DependencyTests/CoreMLNaturalLanguageAdapterTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/DependencyTests/CoreMLNaturalLanguageAdapterTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import CoreMLPredictionsPlugin
 
-class CoreMLNaturalLanguageAdapterTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class CoreMLNaturalLanguageAdapterTests: XCTestCase, @unchecked Sendable {
 
     var coreMLNaturalLanguageAdapter: CoreMLNaturalLanguageAdapter!
 

--- a/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/DependencyTests/CoreMLVisionAdapterTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/DependencyTests/CoreMLVisionAdapterTests.swift
@@ -10,7 +10,9 @@ import Vision
 import XCTest
 @testable import CoreMLPredictionsPlugin
 
-class CoreMLVisionAdapterTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class CoreMLVisionAdapterTests: XCTestCase, @unchecked Sendable {
     var coreMLVisionAdapter: CoreMLVisionAdapter!
 
     override func setUp() {

--- a/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/Mocks/MockCoreMLNaturalLanguageAdapter.swift
+++ b/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/Mocks/MockCoreMLNaturalLanguageAdapter.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import CoreMLPredictionsPlugin
 
-class MockCoreMLNaturalLanguageAdapter: CoreMLNaturalLanguageBehavior {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+final class MockCoreMLNaturalLanguageAdapter: CoreMLNaturalLanguageBehavior, @unchecked Sendable {
 
     func detectDominantLanguage(for text: String) -> Predictions.Language? {
         return .italian

--- a/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/Mocks/MockCoreMLSpeechAdapter.swift
+++ b/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/Mocks/MockCoreMLSpeechAdapter.swift
@@ -12,14 +12,16 @@ import Speech
 import XCTest
 @testable import CoreMLPredictionsPlugin
 
-class MockCoreMLSpeechAdapter: CoreMLSpeechBehavior {
-    var response: SFSpeechRecognitionResult
+/// Returns `CoreMLSpeechTranscription` to match `CoreMLSpeechBehavior`, which no longer hands back a
+/// non-`Sendable` `SFSpeechRecognitionResult`.
+final class MockCoreMLSpeechAdapter: CoreMLSpeechBehavior {
+    let response: CoreMLSpeechTranscription
 
-    init(response: SFSpeechRecognitionResult) {
+    init(response: CoreMLSpeechTranscription) {
         self.response = response
     }
 
-    func getTranscription(_ audioData: URL) async throws -> SFSpeechRecognitionResult {
+    func getTranscription(_ audioData: URL) async throws -> CoreMLSpeechTranscription {
         response
     }
 }

--- a/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/Mocks/MockCoreMLVisionAdapter.swift
+++ b/AmplifyPlugins/Predictions/Tests/CoreMLPredictionsPluginUnitTests/Mocks/MockCoreMLVisionAdapter.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import CoreMLPredictionsPlugin
 
-class MockCoreMLVisionAdapter: CoreMLVisionBehavior {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+final class MockCoreMLVisionAdapter: CoreMLVisionBehavior, @unchecked Sendable {
     func detectLabels(_ imageURL: URL) -> Predictions.Identify.Labels.Result? {
         return nil
     }

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/AWSPredictionsPluginIntegrationTests/AWSPredictionsPluginTestBase.swift
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/AWSPredictionsPluginIntegrationTests/AWSPredictionsPluginTestBase.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSPredictionsPlugin
 
-class AWSPredictionsPluginTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSPredictionsPluginTestBase: XCTestCase, @unchecked Sendable {
 
     // 20 seconds to wait before network timeouts
     let networkTimeout = TimeInterval(20)

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/AWSPredictionsPluginIntegrationTests/ConvertBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/AWSPredictionsPluginIntegrationTests/ConvertBasicIntegrationTests.swift
@@ -12,7 +12,9 @@ import XCTest
 
 import Combine
 
-class ConvertBasicIntegrationTests: AWSPredictionsPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ConvertBasicIntegrationTests: AWSPredictionsPluginTestBase, @unchecked Sendable {
     func testConvertSpeechToText() async throws {
         let testBundle = Bundle(for: type(of: self))
         let url = try XCTUnwrap(testBundle.url(forResource: "audio", withExtension: "wav"))

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/AWSPredictionsPluginIntegrationTests/IdentifyBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/AWSPredictionsPluginIntegrationTests/IdentifyBasicIntegrationTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AWSPredictionsPlugin
 @testable import AWSRekognition
 
-class IdentifyBasicIntegrationTests: AWSPredictionsPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class IdentifyBasicIntegrationTests: AWSPredictionsPluginTestBase, @unchecked Sendable {
 
     private func imageURL(for resource: String) throws -> URL {
         try XCTUnwrap(

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/AWSPredictionsPluginIntegrationTests/InterpretBasicIntegrationTests.swift
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/AWSPredictionsPluginIntegrationTests/InterpretBasicIntegrationTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSPredictionsPlugin
 
-class InterpretBasicIntegrationTests: AWSPredictionsPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class InterpretBasicIntegrationTests: AWSPredictionsPluginTestBase, @unchecked Sendable {
 
     /// Test if we can make successful call to interpret
     ///

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/CoreMLPredictionsPluginIntegrationTests/CoreMLPredictionsPluginIntegrationTest.swift
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/CoreMLPredictionsPluginIntegrationTests/CoreMLPredictionsPluginIntegrationTest.swift
@@ -9,7 +9,9 @@ import Amplify
 import AVFoundation
 import XCTest
 
-class CoreMLPredictionsPluginIntegrationTest: AWSPredictionsPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class CoreMLPredictionsPluginIntegrationTest: AWSPredictionsPluginTestBase, @unchecked Sendable {
 
     func testIdentify() async throws {
         let testBundle = Bundle(for: type(of: self))

--- a/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/CoreMLPredictionsPluginIntegrationTests/CoreMLPredictionsPluginTestBase.swift
+++ b/AmplifyPlugins/Predictions/Tests/PredictionsHostApp/CoreMLPredictionsPluginIntegrationTests/CoreMLPredictionsPluginTestBase.swift
@@ -9,7 +9,9 @@ import CoreMLPredictionsPlugin
 import XCTest
 @testable import Amplify
 
-class AWSPredictionsPluginTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSPredictionsPluginTestBase: XCTestCase, @unchecked Sendable {
     let region: JSONValue = "us-east-1"
     // 180 seconds to wait before network timeouts
     let networkTimeout = TimeInterval(180)


### PR DESCRIPTION
Slice **36 of 38** in the Swift 6 language-mode migration — 84 file(s).

Stacked on `swift6/35-tests-storage`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.