### PR TITLE
test(core): migrate the remaining test targets

### DIFF
--- a/AmplifyClients/AmplifyConnectClient/Tests/ConnectClientHostApp/ConnectClientIntegrationTests/AmplifyConnectClientIntegrationTests.swift
+++ b/AmplifyClients/AmplifyConnectClient/Tests/ConnectClientHostApp/ConnectClientIntegrationTests/AmplifyConnectClientIntegrationTests.swift
@@ -18,7 +18,9 @@ import XCTest
 /// These tests require a deployed backend. See README.md for setup instructions.
 /// Place `amplify_outputs.json` in the test bundle resources.
 @available(iOS 13.0, macOS 12.0, tvOS 13.0, watchOS 9.0, *)
-final class AmplifyConnectClientIntegrationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AmplifyConnectClientIntegrationTests: XCTestCase, @unchecked Sendable {
 
     static let amplifyOutputs = "testconfiguration/AmplifyConnectClientIntegrationTests-amplify_outputs"
     static let credentialsResource = "testconfiguration/AmplifyConnectClientIntegrationTests-credentials"

--- a/AmplifyClients/AmplifyConnectClient/Tests/UnitTests/AmplifyConnectClientTests.swift
+++ b/AmplifyClients/AmplifyConnectClient/Tests/UnitTests/AmplifyConnectClientTests.swift
@@ -11,7 +11,9 @@ import Foundation
 import XCTest
 
 @available(iOS 13.0, macOS 12.0, tvOS 13.0, watchOS 9.0, *)
-final class AmplifyConnectClientTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AmplifyConnectClientTests: XCTestCase, @unchecked Sendable {
 
     /// Test that the identify-user request body contains only the user profile
     ///

--- a/AmplifyClients/AmplifyEventEnrichmentClient/Tests/UnitTests/ActivityTrackerTests.swift
+++ b/AmplifyClients/AmplifyEventEnrichmentClient/Tests/UnitTests/ActivityTrackerTests.swift
@@ -19,7 +19,9 @@ import AppKit
 
 @available(iOS 13.0, macOS 12.0, tvOS 13.0, watchOS 9.0, *)
 @MainActor
-final class ActivityTrackerTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class ActivityTrackerTests: XCTestCase, @unchecked Sendable {
 
     /// Test that ActivityTracker calls onPause when background notification is posted
     ///

--- a/AmplifyClients/AmplifyEventEnrichmentClient/Tests/UnitTests/AmplifyEventEnrichmentClientTests.swift
+++ b/AmplifyClients/AmplifyEventEnrichmentClient/Tests/UnitTests/AmplifyEventEnrichmentClientTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 @available(iOS 13.0, macOS 12.0, tvOS 13.0, watchOS 9.0, *)
 @MainActor
-final class AmplifyEventEnrichmentClientTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AmplifyEventEnrichmentClientTests: XCTestCase, @unchecked Sendable {
 
     /// Test that recording an event returns an enriched event with expected fields
     ///

--- a/AmplifyClients/AmplifyEventEnrichmentClient/Tests/UnitTests/EnrichedEventTests.swift
+++ b/AmplifyClients/AmplifyEventEnrichmentClient/Tests/UnitTests/EnrichedEventTests.swift
@@ -9,7 +9,9 @@
 import Foundation
 import XCTest
 
-final class EnrichedEventTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class EnrichedEventTests: XCTestCase, @unchecked Sendable {
 
     /// Test that toJson produces valid Pinpoint-compatible JSON
     ///

--- a/AmplifyClients/AmplifyEventEnrichmentClient/Tests/UnitTests/EventSinkTests.swift
+++ b/AmplifyClients/AmplifyEventEnrichmentClient/Tests/UnitTests/EventSinkTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 @available(iOS 13.0, macOS 12.0, tvOS 13.0, watchOS 9.0, *)
 @MainActor
-final class EventSinkTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class EventSinkTests: XCTestCase, @unchecked Sendable {
 
     /// Test that the event sink receives events when recording
     ///

--- a/AmplifyClients/AmplifyEventEnrichmentClient/Tests/UnitTests/SessionManagerTests.swift
+++ b/AmplifyClients/AmplifyEventEnrichmentClient/Tests/UnitTests/SessionManagerTests.swift
@@ -9,7 +9,9 @@
 import XCTest
 
 @available(iOS 13.0, macOS 12.0, tvOS 13.0, watchOS 9.0, *)
-final class SessionManagerTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class SessionManagerTests: XCTestCase, @unchecked Sendable {
 
     /// Test that starting a session transitions state to active
     ///

--- a/AmplifyClients/AmplifyFirehoseClient/Tests/UnitTests/AmplifyFirehoseClientConfigureClientTests.swift
+++ b/AmplifyClients/AmplifyFirehoseClient/Tests/UnitTests/AmplifyFirehoseClientConfigureClientTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AmplifyRecordCache
 @testable import AWSFirehose
 
-class AmplifyFirehoseClientConfigureClientTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyFirehoseClientConfigureClientTests: XCTestCase, @unchecked Sendable {
 
     /// Test that the configureClient closure is applied to the SDK configuration.
     ///

--- a/AmplifyClients/AmplifyFirehoseClient/Tests/UnitTests/AmplifyFirehoseClientResourceCleanupTests.swift
+++ b/AmplifyClients/AmplifyFirehoseClient/Tests/UnitTests/AmplifyFirehoseClientResourceCleanupTests.swift
@@ -22,7 +22,9 @@ struct MockFirehoseCredentials: AmplifyFoundation.AWSCredentials {
     var secretAccessKey: String { "mock-secret-key" }
 }
 
-class AmplifyFirehoseClientResourceCleanupTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyFirehoseClientResourceCleanupTests: XCTestCase, @unchecked Sendable {
 
     /// Test that the client is deallocated and the scheduler stops on deinit.
     ///

--- a/AmplifyClients/AmplifyFirehoseClient/Tests/UnitTests/AmplifyFirehoseClientUserAgentTests.swift
+++ b/AmplifyClients/AmplifyFirehoseClient/Tests/UnitTests/AmplifyFirehoseClientUserAgentTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import AmplifyRecordCache
 
 /// Mock HTTP client engine that captures the User-Agent header from outgoing requests.
-private class UserAgentCapturingEngine: HTTPClient {
+/// - Note: `final` and `@unchecked Sendable`: `HTTPClient` is `Sendable`. This test double captures
+///   one header on a single request.
+private final class UserAgentCapturingEngine: HTTPClient, @unchecked Sendable {
     var capturedUserAgent: String?
 
     func send(request: SmithyHTTPAPI.HTTPRequest) async throws -> SmithyHTTPAPI.HTTPResponse {
@@ -24,7 +26,9 @@ private class UserAgentCapturingEngine: HTTPClient {
     }
 }
 
-class AmplifyFirehoseClientUserAgentTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyFirehoseClientUserAgentTests: XCTestCase, @unchecked Sendable {
 
     /// Test that the User-Agent header contains Firehose metadata.
     ///

--- a/AmplifyClients/AmplifyFirehoseClient/Tests/UnitTests/FirehoseErrorConversionTests.swift
+++ b/AmplifyClients/AmplifyFirehoseClient/Tests/UnitTests/FirehoseErrorConversionTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import AmplifyFirehoseClient
 @testable import AmplifyRecordCache
 
-class FirehoseErrorConversionTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class FirehoseErrorConversionTests: XCTestCase, @unchecked Sendable {
 
     /// Test that a FirehoseError passes through unchanged.
     ///

--- a/AmplifyClients/AmplifyFirehoseClient/Tests/UnitTests/FirehoseRecordSenderTests.swift
+++ b/AmplifyClients/AmplifyFirehoseClient/Tests/UnitTests/FirehoseRecordSenderTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AmplifyFirehoseClient
 @testable import AmplifyRecordCache
 
-class FirehoseRecordSenderTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class FirehoseRecordSenderTests: XCTestCase, @unchecked Sendable {
 
     private let testStreamName = "test-delivery-stream"
     private let maxRetries = 3

--- a/AmplifyClients/AmplifyKinesisClient/Tests/RecordValidationTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/RecordValidationTests.swift
@@ -21,7 +21,9 @@ import XCTest
 /// - dataSize should account for both partition key and data blob
 ///
 /// See: https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecordsRequestEntry.html
-class RecordValidationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RecordValidationTests: XCTestCase, @unchecked Sendable {
 
     private let maxRecordSize: Int64 = 1_000
 

--- a/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/AmplifyKinesisClientConfigureClientTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/AmplifyKinesisClientConfigureClientTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AmplifyRecordCache
 @testable import AWSKinesis
 
-class AmplifyKinesisClientConfigureClientTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyKinesisClientConfigureClientTests: XCTestCase, @unchecked Sendable {
 
     /// Verifies that the `configureClient` closure is applied to the underlying
     /// SDK client configuration.

--- a/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/AmplifyKinesisClientResourceCleanupTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/AmplifyKinesisClientResourceCleanupTests.swift
@@ -26,7 +26,9 @@ struct MockCredentials: AmplifyFoundation.AWSCredentials {
     }
 }
 
-class AmplifyKinesisClientResourceCleanupTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyKinesisClientResourceCleanupTests: XCTestCase, @unchecked Sendable {
 
     func testDeinitStopsScheduler() async throws {
         // Create a weak reference to track deallocation

--- a/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/AmplifyKinesisClientUserAgentTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/AmplifyKinesisClientUserAgentTests.swift
@@ -14,7 +14,9 @@ import XCTest
 @testable import AmplifyRecordCache
 
 /// Mock HTTP client engine that captures the User-Agent header from outgoing requests.
-private class UserAgentCapturingEngine: HTTPClient {
+/// - Note: `final` and `@unchecked Sendable`: `HTTPClient` is `Sendable`. This test double captures
+///   one header on a single request.
+private final class UserAgentCapturingEngine: HTTPClient, @unchecked Sendable {
     var capturedUserAgent: String?
 
     func send(request: SmithyHTTPAPI.HTTPRequest) async throws -> SmithyHTTPAPI.HTTPResponse {
@@ -24,7 +26,9 @@ private class UserAgentCapturingEngine: HTTPClient {
     }
 }
 
-class AmplifyKinesisClientUserAgentTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyKinesisClientUserAgentTests: XCTestCase, @unchecked Sendable {
 
     func testUserAgentContainsKinesisMetadata() async throws {
         let capturingEngine = UserAgentCapturingEngine()

--- a/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/KinesisErrorConversionTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/KinesisErrorConversionTests.swift
@@ -9,7 +9,9 @@ import XCTest
 @testable import AmplifyKinesisClient
 @testable import AmplifyRecordCache
 
-class KinesisErrorConversionTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class KinesisErrorConversionTests: XCTestCase, @unchecked Sendable {
 
     func testFromShouldPassThroughKinesisErrorUnchanged() {
         let original = KinesisError.cache("msg", "suggestion")

--- a/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/KinesisRecordSenderTests.swift
+++ b/AmplifyClients/AmplifyKinesisClient/Tests/UnitTests/KinesisRecordSenderTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AmplifyKinesisClient
 @testable import AmplifyRecordCache
 
-class KinesisRecordSenderTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class KinesisRecordSenderTests: XCTestCase, @unchecked Sendable {
 
     private let testStreamName = "test-stream"
     private let maxRetries = 3

--- a/AmplifyClients/AmplifyRecordCache/Tests/AutoFlushSchedulerTests.swift
+++ b/AmplifyClients/AmplifyRecordCache/Tests/AutoFlushSchedulerTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AmplifyRecordCache
 
-class AutoFlushSchedulerTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AutoFlushSchedulerTests: XCTestCase, @unchecked Sendable {
 
     var mockStorage: MockRecordStorage!
     var mockSender: MockRecordSender!

--- a/AmplifyClients/AmplifyRecordCache/Tests/RecordClientConcurrentFlushTests.swift
+++ b/AmplifyClients/AmplifyRecordCache/Tests/RecordClientConcurrentFlushTests.swift
@@ -9,7 +9,9 @@ import SQLite
 import XCTest
 @testable import AmplifyRecordCache
 
-class RecordClientConcurrentFlushTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RecordClientConcurrentFlushTests: XCTestCase, @unchecked Sendable {
 
     private var storage: SQLiteRecordStorage!
     private var sender: SlowMockSender!
@@ -58,6 +60,9 @@ class RecordClientConcurrentFlushTests: XCTestCase {
         )
 
         // When: Two concurrent flushes
+        // Hoisted so the `async let`s capture the client rather than `self`, which is a non-Sendable
+        // `XCTestCase`.
+        let recordClient = recordClient!
         async let flush1 = recordClient.flush()
         // Small delay to ensure flush1 acquires the lock first
         try await Task.sleep(nanoseconds: 50_000_000) // 50ms

--- a/AmplifyClients/AmplifyRecordCache/Tests/RecordClientFlushTests.swift
+++ b/AmplifyClients/AmplifyRecordCache/Tests/RecordClientFlushTests.swift
@@ -11,7 +11,9 @@ import SQLite
 import XCTest
 @testable import AmplifyRecordCache
 
-class RecordClientFlushTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class RecordClientFlushTests: XCTestCase, @unchecked Sendable {
 
     private var storage: SQLiteRecordStorage!
     private var sender: ConfigurableMockSender!

--- a/AmplifyClients/AmplifyRecordCache/Tests/SQLiteRecordStorageCacheAccuracyTests.swift
+++ b/AmplifyClients/AmplifyRecordCache/Tests/SQLiteRecordStorageCacheAccuracyTests.swift
@@ -9,7 +9,9 @@ import SQLite
 import XCTest
 @testable import AmplifyRecordCache
 
-class SQLiteRecordStorageCacheAccuracyTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SQLiteRecordStorageCacheAccuracyTests: XCTestCase, @unchecked Sendable {
 
     var storage: SQLiteRecordStorage!
 
@@ -140,6 +142,9 @@ class SQLiteRecordStorageCacheAccuracyTests: XCTestCase {
         }
 
         let tracker = TestTracker()
+        // Hoisted so the producer/consumer tasks capture the storage rather than `self`, which is a
+        // non-Sendable `XCTestCase`.
+        let storage = storage!
 
         // Create producers - these will hammer the storage concurrently
         let producers = (0 ..< producerCount).map { producerIndex in

--- a/AmplifyFoundation/Tests/AmplifyLoggingTests.swift
+++ b/AmplifyFoundation/Tests/AmplifyLoggingTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @testable import AmplifyFoundation
 
-class AmplifyLoggingTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AmplifyLoggingTests: XCTestCase, @unchecked Sendable {
     var logSink: MockLogSink!
 
     override func setUp() {
@@ -213,7 +215,9 @@ class AmplifyLoggingTests: XCTestCase {
 
 
 /// Mock LogSink for testing which stores the list of log messages in memory
-final class MockLogSink: LogSinkBehavior {
+/// - Note: `@unchecked Sendable`: `LogSinkBehavior` is `Sendable`. This test double is written and
+///   read from a single test.
+final class MockLogSink: LogSinkBehavior, @unchecked Sendable {
     let id: String = UUID().uuidString
     var logLevel: LogLevel = .debug
     var logMessages: [LogMessage] = []

--- a/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginAmplifyVersionableTests.swift
@@ -9,7 +9,9 @@ import AWSPinpointAnalyticsPlugin
 import XCTest
 
 // swiftlint:disable:next type_name
-class AWSPinpointAnalyticsPluginAmplifyVersionableTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSPinpointAnalyticsPluginAmplifyVersionableTests: XCTestCase, @unchecked Sendable {
 
     func testVersionExists() {
         let plugin = AWSPinpointAnalyticsPlugin()

--- a/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginClientBehaviorTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginClientBehaviorTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
 // swiftlint:disable:next type_name
-class AWSPinpointAnalyticsPluginClientBehaviorTests: AWSPinpointAnalyticsPluginTestBase {
+/// - Note: `@unchecked Sendable` so the test body can be captured by the `@Sendable` completion
+///   closures the production API now takes. `XCTestCase` is not `Sendable`, and each test runs alone.
+final class AWSPinpointAnalyticsPluginClientBehaviorTests: AWSPinpointAnalyticsPluginTestBase, @unchecked Sendable {
     let testName = "testName"
     let testIdentityId = "identityId"
     let testEmail = "testEmail"

--- a/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginConfigureTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginConfigureTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSPinpointAnalyticsPlugin
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
-class AWSPinpointAnalyticsPluginConfigureTests: AWSPinpointAnalyticsPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSPinpointAnalyticsPluginConfigureTests: AWSPinpointAnalyticsPluginTestBase, @unchecked Sendable {
 
     override func setUp() async throws {
         AWSPinpointFactory.credentialIdentityResolver = MockCredentialsProvider()

--- a/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginResetTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginResetTests.swift
@@ -10,7 +10,9 @@ import Amplify
 import XCTest
 @testable import AWSPinpointAnalyticsPlugin
 
-class AWSPinpointAnalyticsPluginResetTests: AWSPinpointAnalyticsPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSPinpointAnalyticsPluginResetTests: AWSPinpointAnalyticsPluginTestBase, @unchecked Sendable {
     func testReset() async {
         let resettable = analyticsPlugin as Resettable
         await resettable.reset()

--- a/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginTestBase.swift
+++ b/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/AWSPinpointAnalyticsPluginTestBase.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSPinpointAnalyticsPlugin
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
-class AWSPinpointAnalyticsPluginTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSPinpointAnalyticsPluginTestBase: XCTestCase, @unchecked Sendable {
     var analyticsPlugin: AWSPinpointAnalyticsPlugin!
     var mockPinpoint: MockAWSPinpoint!
     var mockNetworkMonitor: MockNetworkMonitor!

--- a/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/Configuration/AWSPinpointAnalyticsPluginAmplifyOutputsConfigurationTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/Configuration/AWSPinpointAnalyticsPluginAmplifyOutputsConfigurationTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
 // swiftlint:disable:next type_name
-class AWSPinpointAnalyticsPluginAmplifyOutputsConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSPinpointAnalyticsPluginAmplifyOutputsConfigurationTests: XCTestCase, @unchecked Sendable {
     let testAppId = "testAppId"
     let appId = "testAppId"
     let testRegion = "us-east-1"

--- a/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/Configuration/AWSPinpointAnalyticsPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AWSPinpointAnalyticsPluginUnitTests/Configuration/AWSPinpointAnalyticsPluginConfigurationTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
 // swiftlint:disable:next type_name
-class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSPinpointAnalyticsPluginConfigurationTests: XCTestCase, @unchecked Sendable {
     let testAppId = "testAppId"
     let appId: JSONValue = "testAppId"
     let testRegion = "us-east-1"

--- a/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginIntegrationTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AWSPinpointAnalyticsPluginIntegrationTests/AWSPinpointAnalyticsPluginIntegrationTests.swift
@@ -15,7 +15,9 @@ import Network
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
 // swiftlint:disable:next type_name
-class AWSPinpointAnalyticsPluginIntergrationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSPinpointAnalyticsPluginIntergrationTests: XCTestCase, @unchecked Sendable {
 
     static let amplifyConfiguration = "testconfiguration/AWSPinpointAnalyticsPluginIntegrationTests-amplifyconfiguration"
     static let amplifyOutputs = "testconfiguration/AWSPinpointAnalyticsPluginIntegrationTests-amplify_outputs"

--- a/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AnalyticsStressTests/AnalyticsStressTests.swift
+++ b/AmplifyPlugins/Analytics/Tests/AnalyticsHostApp/AnalyticsStressTests/AnalyticsStressTests.swift
@@ -13,7 +13,9 @@ import Network
 @testable import Amplify
 @testable import AWSPinpointAnalyticsPlugin
 
-final class AnalyticsStressTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AnalyticsStressTests: XCTestCase, @unchecked Sendable {
 
     static let amplifyConfiguration = "testconfiguration/AWSAmplifyStressTests-amplifyconfiguration"
     static let analyticsPluginKey = "awsPinpointAnalyticsPlugin"

--- a/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/AWSLocationGeoPluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/AWSLocationGeoPluginAmplifyVersionableTests.swift
@@ -9,7 +9,9 @@ import AWSLocationGeoPlugin
 import XCTest
 
 // swiftlint:disable:next type_name
-class AWSLocationGeoPluginAmplifyVersionableTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSLocationGeoPluginAmplifyVersionableTests: XCTestCase, @unchecked Sendable {
 
     func testVersionExists() {
         let plugin = AWSLocationGeoPlugin()

--- a/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/AWSLocationGeoPluginClientBehaviorTests.swift
+++ b/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/AWSLocationGeoPluginClientBehaviorTests.swift
@@ -10,7 +10,9 @@ import AWSLocation
 import XCTest
 @testable import AWSLocationGeoPlugin
 
-class AWSLocationGeoPluginClientBehaviorTests: AWSLocationGeoPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSLocationGeoPluginClientBehaviorTests: AWSLocationGeoPluginTestBase, @unchecked Sendable {
     let searchText = "coffee shop"
     let coordinates = Geo.Coordinates(latitude: 39.7392, longitude: -104.9903)
 

--- a/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/AWSLocationGeoPluginConfigureTests.swift
+++ b/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/AWSLocationGeoPluginConfigureTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSLocationGeoPlugin
 
-class AWSLocationGeoPluginConfigureTests: AWSLocationGeoPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSLocationGeoPluginConfigureTests: AWSLocationGeoPluginTestBase, @unchecked Sendable {
     // MARK: - Plugin Key test
 
     func testPluginKey() {

--- a/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/AWSLocationGeoPluginResetTests.swift
+++ b/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/AWSLocationGeoPluginResetTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSLocationGeoPlugin
 
-class AWSLocationGeoPluginResetTests: AWSLocationGeoPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSLocationGeoPluginResetTests: AWSLocationGeoPluginTestBase, @unchecked Sendable {
     func testReset() async {
         let resettable = geoPlugin as Resettable
         await resettable.reset()

--- a/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/AWSLocationGeoPluginTestBase.swift
+++ b/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/AWSLocationGeoPluginTestBase.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSLocationGeoPlugin
 @testable import AWSPluginsTestCommon
 
-class AWSLocationGeoPluginTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSLocationGeoPluginTestBase: XCTestCase, @unchecked Sendable {
     var geoPlugin: AWSLocationGeoPlugin!
     var mockLocation: MockAWSLocation!
     var pluginConfig: AWSLocationGeoPluginConfiguration!

--- a/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Configuration/AWSLocationGeoPluginAmplifyOutputsConfigurationTests.swift
+++ b/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Configuration/AWSLocationGeoPluginAmplifyOutputsConfigurationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 @testable import AWSLocationGeoPlugin
 
-class AWSLocationGeoPluginAmplifyOutputsConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSLocationGeoPluginAmplifyOutputsConfigurationTests: XCTestCase, @unchecked Sendable {
 
     func testConfigureSuccessAll() throws {
         do {

--- a/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Configuration/AWSLocationGeoPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Configuration/AWSLocationGeoPluginConfigurationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 @testable import AWSLocationGeoPlugin
 
-class AWSLocationGeoPluginConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSLocationGeoPluginConfigurationTests: XCTestCase, @unchecked Sendable {
 
     func testConfigureSuccessAll() throws {
         do {

--- a/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Mocks/MockAWSClientConfiguration.swift
+++ b/AmplifyPlugins/Geo/Tests/AWSLocationGeoPluginTests/Mocks/MockAWSClientConfiguration.swift
@@ -28,7 +28,9 @@ extension LocationClient.LocationClientConfiguration {
     }
 }
 
-class MockEndPointResolver: EndpointResolver {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+final class MockEndPointResolver: EndpointResolver, @unchecked Sendable {
     func resolve(params: AWSLocation.EndpointParams) throws -> SmithyHTTPAPI.Endpoint {
         return Endpoint(host: "MockHost")
     }

--- a/AmplifyPlugins/Geo/Tests/GeoHostApp/AWSLocationGeoPluginIntegrationTests/AWSLocationGeoPluginIntegrationTests.swift
+++ b/AmplifyPlugins/Geo/Tests/GeoHostApp/AWSLocationGeoPluginIntegrationTests/AWSLocationGeoPluginIntegrationTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSCognitoAuthPlugin
 @testable import AWSLocationGeoPlugin
 
-class AWSLocationGeoPluginIntergrationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSLocationGeoPluginIntergrationTests: XCTestCase, @unchecked Sendable {
     let timeout = 30.0
     let searchText = "coffee shop"
     let coordinates = Geo.Coordinates(latitude: 39.7392, longitude: -104.9903)

--- a/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoStressTests/GeoStressTests.swift
+++ b/AmplifyPlugins/Geo/Tests/GeoHostApp/GeoStressTests/GeoStressTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AWSCognitoAuthPlugin
 @testable import AWSLocationGeoPlugin
 
-final class GeoStressTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class GeoStressTests: XCTestCase, @unchecked Sendable {
     let timeout = 30.0
     let searchText = "coffee shop"
     let coordinates = Geo.Coordinates(latitude: 39.7392, longitude: -104.9903)

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AWSPinpointFactoryTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AWSPinpointFactoryTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @_spi(InternalAWSPinpoint) @testable @preconcurrency import InternalAWSPinpoint
 
-final class AWSPinpointFactoryTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AWSPinpointFactoryTests: XCTestCase, @unchecked Sendable {
     private var appId: String {
         UUID().uuidString
     }

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AnalyticsClientTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AnalyticsClientTests.swift
@@ -10,7 +10,11 @@ import XCTest
 @_spi(InternalAWSPinpoint) @testable @preconcurrency import InternalAWSPinpoint
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
-class AnalyticsClientTests: XCTestCase {
+/// - Note: `@unchecked Sendable` so the test body can be captured by the `@Sendable` completion
+
+///   closures the production API now takes. `XCTestCase` is not `Sendable`, and each test runs alone.
+
+final class AnalyticsClientTests: XCTestCase, @unchecked Sendable {
     private var analyticsClient: AnalyticsClient!
     private var eventRecorder: MockEventRecorder!
     private var session: PinpointSession!

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AnalyticsEventStorageTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AnalyticsEventStorageTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
-class AnalyticsEventStorageTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AnalyticsEventStorageTests: XCTestCase, @unchecked Sendable {
     private let databaseName = "TestDatabase"
     private let eventCountStatement = "SELECT COUNT(*) FROM Event"
     private let dirtyEventCountStatement = "SELECT COUNT(*) FROM DirtyEvent"

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AwsPinpointAnalyticsKeychainMigrationTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/AwsPinpointAnalyticsKeychainMigrationTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import Amplify
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
-class AWSPinpointAnalyticsKeyValueStoreTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSPinpointAnalyticsKeyValueStoreTests: XCTestCase, @unchecked Sendable {
     private let keychain = MockKeychainStore()
     private let archiver = AmplifyArchiver()
     private let userDefaults = UserDefaults.standard

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EndpointClientTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EndpointClientTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @_spi(InternalAWSPinpoint) @testable @preconcurrency import InternalAWSPinpoint
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
-class EndpointClientTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class EndpointClientTests: XCTestCase, @unchecked Sendable {
     private let newTokenHex = "646576696365546f6b656e"
 
     private var endpointClient: EndpointClient!
@@ -225,7 +227,9 @@ class EndpointClientTests: XCTestCase {
     }
 }
 
-class MockEndpointInformationProvider: EndpointInformationProvider {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+class MockEndpointInformationProvider: EndpointInformationProvider, @unchecked Sendable {
     let model = "modelModel"
     let appVersion = "mockAppVersion"
     let platformName = "mockPlatformName"
@@ -235,7 +239,9 @@ class MockEndpointInformationProvider: EndpointInformationProvider {
     }
 }
 
-class MockRemoteNotifications: RemoteNotificationsBehaviour {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+class MockRemoteNotifications: RemoteNotificationsBehaviour, @unchecked Sendable {
     var isRegisteredForRemoteNotifications = true
 
     func requestAuthorization(_ options: UNAuthorizationOptions) async throws -> Bool {

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EndpointInformationProviderTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EndpointInformationProviderTests.swift
@@ -8,7 +8,9 @@
 import XCTest
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
-class EndpointInformationProviderTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class EndpointInformationProviderTests: XCTestCase, @unchecked Sendable {
 
     /// Given: DefaultEndpointInformationProvider
     /// When: endpointInfo() is called

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EventRecorderTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/EventRecorderTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import Amplify
 @_spi(InternalAWSPinpoint) @testable @preconcurrency import InternalAWSPinpoint
 
-class EventRecorderTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class EventRecorderTests: XCTestCase, @unchecked Sendable {
     var recorder: AnalyticsEventRecording!
     var storage: MockAnalyticsEventStorage!
     var pinpointClient: MockPinpointClient!
@@ -41,9 +43,9 @@ class EventRecorderTests: XCTestCase {
     /// - When: instance is constructed
     /// - Then: storage initializatin is called followed by disk size check and dirty event removal
     func testRecorderInitilization() {
-        XCTAssertEqual(storage.initializeStorageCallCount, 1)
-        XCTAssertEqual(storage.deleteDirtyEventCallCount, 1)
-        XCTAssertEqual(storage.checkDiskSizeCallCount, 1)
+        XCTAssertEqual(storage.initializeStorageCallCount.get(), 1)
+        XCTAssertEqual(storage.deleteDirtyEventCallCount.get(), 1)
+        XCTAssertEqual(storage.checkDiskSizeCallCount.get(), 1)
     }
 
     /// - Given: a event recorder
@@ -54,7 +56,7 @@ class EventRecorderTests: XCTestCase {
         let event = PinpointEvent(id: "1", eventType: "eventType", eventDate: Date(), session: session)
 
         XCTAssertEqual(storage.events.count, 0)
-        XCTAssertEqual(storage.checkDiskSizeCallCount, 1)
+        XCTAssertEqual(storage.checkDiskSizeCallCount.get(), 1)
 
         do {
             try await recorder.save(event)
@@ -64,7 +66,7 @@ class EventRecorderTests: XCTestCase {
 
         XCTAssertEqual(storage.events.count, 1)
         XCTAssertEqual(event, storage.events[0])
-        XCTAssertEqual(storage.checkDiskSizeCallCount, 2)
+        XCTAssertEqual(storage.checkDiskSizeCallCount.get(), 2)
     }
 
     /// - Given: a event recorder with events saved in the local storage
@@ -92,7 +94,7 @@ class EventRecorderTests: XCTestCase {
         XCTAssertEqual(events.count, 2)
         XCTAssertEqual(pinpointClient.putEventsCount, 1)
         XCTAssertTrue(storage.events.isEmpty)
-        XCTAssertEqual(storage.deleteEventCallCount, 2)
+        XCTAssertEqual(storage.deleteEventCallCount.get(), 2)
     }
 
     /// - Given: a event recorder with events saved in the local storage with active and stopped sessions
@@ -142,7 +144,7 @@ class EventRecorderTests: XCTestCase {
         } catch {
             XCTAssertEqual(pinpointClient.putEventsCount, 1)
             XCTAssertEqual(storage.events.count, 2)
-            XCTAssertEqual(storage.deleteEventCallCount, 0)
+            XCTAssertEqual(storage.deleteEventCallCount.get(), 0)
             XCTAssertEqual(storage.eventRetryDictionary.count, 0)
             XCTAssertEqual(storage.dirtyEventDictionary.count, 2)
             XCTAssertEqual(storage.dirtyEventDictionary["1"], 1)
@@ -166,7 +168,7 @@ class EventRecorderTests: XCTestCase {
         } catch {
             XCTAssertEqual(pinpointClient.putEventsCount, 1)
             XCTAssertEqual(storage.events.count, 2)
-            XCTAssertEqual(storage.deleteEventCallCount, 0)
+            XCTAssertEqual(storage.deleteEventCallCount.get(), 0)
             XCTAssertEqual(storage.eventRetryDictionary.count, 2)
             XCTAssertEqual(storage.eventRetryDictionary["1"], 1)
             XCTAssertEqual(storage.eventRetryDictionary["2"], 1)
@@ -190,7 +192,7 @@ class EventRecorderTests: XCTestCase {
         } catch {
             XCTAssertEqual(pinpointClient.putEventsCount, 1)
             XCTAssertEqual(storage.events.count, 2)
-            XCTAssertEqual(storage.deleteEventCallCount, 0)
+            XCTAssertEqual(storage.deleteEventCallCount.get(), 0)
             XCTAssertEqual(storage.eventRetryDictionary.count, 0)
             XCTAssertEqual(storage.dirtyEventDictionary.count, 0)
         }
@@ -199,14 +201,16 @@ class EventRecorderTests: XCTestCase {
 
 private struct RetryableError: Error, ModeledError {
     static let typeName = "RetriableError"
-    static let fault = ErrorFault.client
+    // `nonisolated(unsafe)`: `ErrorFault` comes from the AWS SDK and is not declared `Sendable`.
+    nonisolated(unsafe) static let fault = ErrorFault.client
     static let isRetryable = true
     static let isThrottling = false
 }
 
 private struct NonRetryableError: Error, ModeledError {
     static let typeName = "RetriableError"
-    static let fault = ErrorFault.client
+    // `nonisolated(unsafe)`: `ErrorFault` comes from the AWS SDK and is not declared `Sendable`.
+    nonisolated(unsafe) static let fault = ErrorFault.client
     static let isRetryable = false
     static let isThrottling = false
 }

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockActivityTracker.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockActivityTracker.swift
@@ -8,7 +8,9 @@
 import Foundation
 @testable import InternalAWSPinpoint
 
-class MockActivityTracker: ActivityTrackerBehaviour {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+class MockActivityTracker: ActivityTrackerBehaviour, @unchecked Sendable {
     var backgroundTrackingTimeout: TimeInterval = 0
 
     var beginActivityTrackingCount = 0

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockAnalyticsEventStorage.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockAnalyticsEventStorage.swift
@@ -5,49 +5,58 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import Amplify
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
 class MockAnalyticsEventStorage: AnalyticsEventStorage {
     var deletedEvent: String = ""
-    var deleteEventCallCount = 0
-    var deleteDirtyEventCallCount = 0
-    var initializeStorageCallCount = 0
-    var deleteOldestEventCallCount = 0
-    var deleteAllEventsCallCount = 0
-    var updateEventsCallCount = 0
-    var removedFailedEventsCallCount = 0
+    // Boxed: incremented from a `@Sendable` mock closure.
+    let deleteEventCallCount = AtomicValue(initialValue: 0)
+    // Boxed: incremented from a `@Sendable` mock closure.
+    let deleteDirtyEventCallCount = AtomicValue(initialValue: 0)
+    // Boxed: incremented from a `@Sendable` mock closure.
+    let initializeStorageCallCount = AtomicValue(initialValue: 0)
+    // Boxed: incremented from a `@Sendable` mock closure.
+    let deleteOldestEventCallCount = AtomicValue(initialValue: 0)
+    // Boxed: incremented from a `@Sendable` mock closure.
+    let deleteAllEventsCallCount = AtomicValue(initialValue: 0)
+    // Boxed: incremented from a `@Sendable` mock closure.
+    let updateEventsCallCount = AtomicValue(initialValue: 0)
+    // Boxed: incremented from a `@Sendable` mock closure.
+    let removedFailedEventsCallCount = AtomicValue(initialValue: 0)
     var eventRetryDictionary = [String: Int]()
     var dirtyEventDictionary = [String: Int]()
     var events = [PinpointEvent]()
-    var checkDiskSizeCallCount = 0
+    // Boxed: incremented from a `@Sendable` mock closure.
+    let checkDiskSizeCallCount = AtomicValue(initialValue: 0)
 
     func deleteEvent(eventId: String) throws {
         deletedEvent = eventId
-        deleteEventCallCount += 1
+        _ = deleteEventCallCount.increment()
         events.removeAll { $0.id == eventId }
     }
 
     func deleteDirtyEvents() throws {
-        deleteDirtyEventCallCount += 1
+        _ = deleteDirtyEventCallCount.increment()
     }
 
     func initializeStorage() throws {
-        initializeStorageCallCount += 1
+        _ = initializeStorageCallCount.increment()
     }
 
     func deleteOldestEvent() throws {
-        deleteOldestEventCallCount += 1
+        _ = deleteOldestEventCallCount.increment()
     }
 
     func deleteAllEvents() throws {
-        deleteAllEventsCallCount += 1
+        _ = deleteAllEventsCallCount.increment()
     }
     func updateEvents(
         ofType: String,
         withSessionId: PinpointSession.SessionId,
         setAttributes: [String: String]
     ) throws {
-        updateEventsCallCount += 1
+        _ = updateEventsCallCount.increment()
     }
 
     func getEventsWith(limit: Int) throws -> [PinpointEvent] {
@@ -63,7 +72,7 @@ class MockAnalyticsEventStorage: AnalyticsEventStorage {
     }
 
     func removeFailedEvents() throws {
-        removedFailedEventsCallCount += 1
+        _ = removedFailedEventsCallCount.increment()
     }
 
     func saveEvent(_ event: PinpointEvent) throws {
@@ -75,7 +84,7 @@ class MockAnalyticsEventStorage: AnalyticsEventStorage {
     }
 
     func checkDiskSize(limit: Byte) throws {
-        checkDiskSizeCallCount += 1
+        _ = checkDiskSizeCallCount.increment()
     }
 
     var updateSessionCount = 0

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockArchiver.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockArchiver.swift
@@ -8,7 +8,9 @@
 import Foundation
 @testable import InternalAWSPinpoint
 
-class MockArchiver: AmplifyArchiverBehaviour {
+// `@unchecked Sendable`: driven by a single test at a time.
+
+final class MockArchiver: AmplifyArchiverBehaviour, @unchecked Sendable {
     var encoded: Data = .init()
     var decoded: Decodable?
 

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockKeychainStore.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockKeychainStore.swift
@@ -8,7 +8,9 @@
 import AWSPluginsCore
 import Foundation
 
-class MockKeychainStore: KeychainStoreBehavior {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+class MockKeychainStore: KeychainStoreBehavior, @unchecked Sendable {
     var stringValues: [String: String] = [:]
     var dataValues: [String: Data] = [:]
 

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockPinpointClient.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockPinpointClient.swift
@@ -9,7 +9,9 @@ import AWSPinpoint
 import Foundation
 import InternalAWSPinpoint
 
-class MockPinpointClient: PinpointClientProtocol {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+class MockPinpointClient: PinpointClientProtocol, @unchecked Sendable {
 
     func getJourneyRunExecutionActivityMetrics(input: GetJourneyRunExecutionActivityMetricsInput) async throws -> GetJourneyRunExecutionActivityMetricsOutput {
         fatalError("Not supported")

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockUserDefaults.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/Mocks/MockUserDefaults.swift
@@ -8,7 +8,9 @@
 import Foundation
 @testable import InternalAWSPinpoint
 
-class MockUserDefaults: UserDefaultsBehaviour {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+class MockUserDefaults: UserDefaultsBehaviour, @unchecked Sendable {
     var data: [String: UserDefaultsBehaviourValue] = [:]
     var mockedValue: UserDefaultsBehaviourValue?
 

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/PinpointClientTypesCodableTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/PinpointClientTypesCodableTests.swift
@@ -9,7 +9,9 @@ import AWSPinpoint
 import XCTest
 @testable import InternalAWSPinpoint
 
-class PinpointClientTypesCodableTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class PinpointClientTypesCodableTests: XCTestCase, @unchecked Sendable {
     /// Given: Instances of PinpointClient types that conform to Codable
     /// When: They are encoded and decoded
     /// Then: The encoded data can be decoded, and the decoded data is equal to the original one

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/PinpointRequestsRegistryTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/PinpointRequestsRegistryTests.swift
@@ -11,7 +11,9 @@ import SmithyHTTPAPI
 import XCTest
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
-class PinpointRequestsRegistryTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class PinpointRequestsRegistryTests: XCTestCase, @unchecked Sendable {
     private var mockedHttpSdkClient: MockHttpClientEngine!
     private var pinpointConfiguration: PinpointClient.PinpointClientConfiguration!
 
@@ -92,7 +94,9 @@ private extension HTTPClient {
     }
 }
 
-private class MockHttpClientEngine: HTTPClient {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+private class MockHttpClientEngine: HTTPClient, @unchecked Sendable {
     var executeCount = 0
     var request: HTTPRequest?
 

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/SQLiteLocalStorageAdapterTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/SQLiteLocalStorageAdapterTests.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import InternalAWSPinpoint
 
-class SQLiteLocalStorageAdapterTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SQLiteLocalStorageAdapterTests: XCTestCase, @unchecked Sendable {
     private let databaseName = "TestDatabase"
     private var adapter: SQLiteLocalStorageAdapter!
     private var fileManager: MockFileManager!

--- a/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/SessionClientTests.swift
+++ b/AmplifyPlugins/Internal/Tests/InternalAWSPinpointUnitTests/SessionClientTests.swift
@@ -9,7 +9,9 @@ import AmplifyAsyncTesting
 import XCTest
 @_spi(InternalAWSPinpoint) @testable @preconcurrency import InternalAWSPinpoint
 
-class SessionClientTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class SessionClientTests: XCTestCase, @unchecked Sendable {
     private var client: SessionClient!
 
     private var activityTracker: MockActivityTracker!

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginHostApp/AWSCloudWatchLoggingPluginIntegrationTests/AWSCloudWatchLoggingPluginIntegrationTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginHostApp/AWSCloudWatchLoggingPluginIntegrationTests/AWSCloudWatchLoggingPluginIntegrationTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSCloudWatchLoggingPlugin
 @testable import AWSCognitoAuthPlugin
 
-class AWSCloudWatchLoggingPluginIntergrationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSCloudWatchLoggingPluginIntergrationTests: XCTestCase, @unchecked Sendable {
     let amplifyConfigurationFile = "testconfiguration/AWSCloudWatchLoggingPluginIntegrationTests-amplifyconfiguration"
     let amplifyOutputsFile = "testconfiguration/AWSCloudWatchLoggingPluginIntegrationTests-amplify_outputs"
     #if os(tvOS)

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingMonitorTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingMonitorTests.swift
@@ -11,7 +11,9 @@ import XCTest
 
 @testable import AWSCloudWatchLoggingPlugin
 
-final class AWSCloudWatchLoggingMonitorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AWSCloudWatchLoggingMonitorTests: XCTestCase, @unchecked Sendable {
 
     var monitor: AWSCLoudWatchLoggingMonitor!
     var invokedExpectation: XCTestExpectation!

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingPluginConfigurationTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingPluginConfigurationTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSCloudWatchLoggingPlugin
 
-final class AWSCloudWatchLoggingPluginConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AWSCloudWatchLoggingPluginConfigurationTests: XCTestCase, @unchecked Sendable {
 
     /// Given: a json file with the plugin configuration
     /// When: it is read from the bundle and decoded

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingPluginTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingPluginTests.swift
@@ -10,7 +10,9 @@
 import Amplify
 import XCTest
 
-final class AWSCloudWatchLoggingPluginTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AWSCloudWatchLoggingPluginTests: XCTestCase, @unchecked Sendable {
 
     func testDefaultPluginConstructor() throws {
         let plugin = AWSCloudWatchLoggingPlugin()

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingSessionControllerTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchLoggingSessionControllerTests.swift
@@ -12,7 +12,9 @@ import Network
 import XCTest
 @testable import AmplifyTestCommon
 
-final class AWSCloudWatchLoggingSessionControllerTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AWSCloudWatchLoggingSessionControllerTests: XCTestCase, @unchecked Sendable {
     var systemUnderTest: AWSCloudWatchLoggingSessionController!
     let mockCredentialProvider = MockCredentialsProvider()
     let mockAuth = MockAuthCategoryPlugin()

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchingLoggingFilterTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/AWSCloudWatchingLoggingFilterTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 @testable import AWSCloudWatchLoggingPlugin
 
-final class AWSCloudWatchLoggingFilterTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class AWSCloudWatchLoggingFilterTests: XCTestCase, @unchecked Sendable {
     var configuration: AWSCloudWatchLoggingPluginConfiguration!
     var filter: AWSCloudWatchLoggingFilter!
     var remoteLoggingConstraints: LoggingConstraints!

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/BroadcastLoggerTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/BroadcastLoggerTests.swift
@@ -9,7 +9,9 @@ import XCTest
 
 @testable import Amplify
 
-final class BroadcastLoggerTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class BroadcastLoggerTests: XCTestCase, @unchecked Sendable {
 
     var systemUnderTest: BroadcastLogger!
     var mockLogger1: MockLogger!

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/CloudWatchLogConsumerTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/CloudWatchLogConsumerTests.swift
@@ -12,7 +12,9 @@ import XCTest
 
 @testable import AWSCloudWatchLoggingPlugin
 
-final class CloudWatchLogConsumerTests: XCTestCase {
+/// - Note: `@unchecked Sendable` because this test case conforms to `LogBatch` (which is `Sendable`)
+///   in an extension below, and a `Sendable` class cannot inherit from `XCTestCase`.
+final class CloudWatchLogConsumerTests: XCTestCase, @unchecked Sendable {
 
     var systemUnderTest: CloudWatchLoggingConsumer!
     var client: MockCloudWatchLogsClient!

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/DefaultRemoteConfigurationTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/DefaultRemoteConfigurationTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 @testable import AWSCloudWatchLoggingPlugin
 
-final class DefaultRemoteConfigurationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class DefaultRemoteConfigurationTests: XCTestCase, @unchecked Sendable {
 
     /// Given: DefaultRemoteConfiguration
     /// When: it is constructed with parameters

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogActorTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogActorTests.swift
@@ -11,7 +11,9 @@ import XCTest
 
 @testable import AWSCloudWatchLoggingPlugin
 
-final class LogActorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class LogActorTests: XCTestCase, @unchecked Sendable {
 
     let fileCountLimit = 5
     let fileSizeLimitInBytes = 1_024

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogEntryTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogEntryTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 @testable import AWSCloudWatchLoggingPlugin
 
-final class LogEntryTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class LogEntryTests: XCTestCase, @unchecked Sendable {
 
     let levels = [
         LogLevel.error,

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogFileTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogFileTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 @testable import AWSCloudWatchLoggingPlugin
 
-final class LogFileTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class LogFileTests: XCTestCase, @unchecked Sendable {
 
     var systemUnderTest: LogFile!
     var fileURL: URL!

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogRotationTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LogRotationTests.swift
@@ -9,7 +9,9 @@ import XCTest
 
 @testable import AWSCloudWatchLoggingPlugin
 
-final class LogRotationTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class LogRotationTests: XCTestCase, @unchecked Sendable {
 
     var systemUnderTest: LogRotation!
     var directory: URL!

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LoggingConstraintsLocalStoreTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LoggingConstraintsLocalStoreTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 @testable import AWSCloudWatchLoggingPlugin
 
-final class LoggingConstraintsLocalStoreTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class LoggingConstraintsLocalStoreTests: XCTestCase, @unchecked Sendable {
 
     override func setUp() async throws {
         UserDefaults.standard.removeObject(forKey: PluginConstants.awsRemoteLoggingConstraintsKey)

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LoggingNetworkMonitorTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/LoggingNetworkMonitorTests.swift
@@ -13,7 +13,9 @@ import XCTest
 @testable import AmplifyTestCommon
 @testable import AWSCloudWatchLoggingPlugin
 
-final class LoggingNetworkMonitorTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class LoggingNetworkMonitorTests: XCTestCase, @unchecked Sendable {
     func testNetworkMonitorEvent() {
         let onlineExpectation = expectation(description: "Device is online")
         let loggingMonitor: LoggingNetworkMonitor = NWPathMonitor()

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/MockLogger.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/MockLogger.swift
@@ -7,7 +7,8 @@
 
 import Amplify
 
-final class MockLogger {
+// `@unchecked Sendable`: `Logger` is now `Sendable`. Test double driven by a single test at a time.
+final class MockLogger: @unchecked Sendable {
     struct Entry: Equatable {
         var level: LogLevel
         var message: String

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/RotatingLogBatchTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/RotatingLogBatchTests.swift
@@ -11,7 +11,9 @@ import XCTest
 
 @testable import AWSCloudWatchLoggingPlugin
 
-final class RotatingLogBatchTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class RotatingLogBatchTests: XCTestCase, @unchecked Sendable {
     var fileURL: URL!
 
     override func setUp() async throws {

--- a/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/RotatingLoggerTests.swift
+++ b/AmplifyPlugins/Logging/Tests/AWSCloudWatchLoggingPluginTests/RotatingLoggerTests.swift
@@ -11,7 +11,9 @@ import XCTest
 
 @testable import AWSCloudWatchLoggingPlugin
 
-final class RotatingLoggerTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class RotatingLoggerTests: XCTestCase, @unchecked Sendable {
 
     var systemUnderTest: RotatingLogger!
     var directory: URL!

--- a/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginAmplifyVersionableTests.swift
+++ b/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginAmplifyVersionableTests.swift
@@ -8,7 +8,9 @@
 import AWSPinpointPushNotificationsPlugin
 import XCTest
 
-class AWSPinpointPushNotificationsPluginAmplifyVersionableTests: AWSPinpointPushNotificationsPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSPinpointPushNotificationsPluginAmplifyVersionableTests: AWSPinpointPushNotificationsPluginTestBase, @unchecked Sendable {
     func testVersion_shouldReturnNotNil() {
         XCTAssertNotNil(plugin.version)
     }

--- a/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginClientBehaviourTests.swift
+++ b/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginClientBehaviourTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSPinpointPushNotificationsPlugin
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
-class AWSPinpointPushNotificationsPluginClientBehaviourTests: AWSPinpointPushNotificationsPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSPinpointPushNotificationsPluginClientBehaviourTests: AWSPinpointPushNotificationsPluginTestBase, @unchecked Sendable {
     override func setUp() async throws {
         try await super.setUp()
         plugin.configure(

--- a/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginConfigureTests.swift
+++ b/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginConfigureTests.swift
@@ -11,7 +11,9 @@ import XCTest
 @testable import AWSPinpointPushNotificationsPlugin
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
-class AWSPinpointPushNotificationsPluginConfigureTests: AWSPinpointPushNotificationsPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSPinpointPushNotificationsPluginConfigureTests: AWSPinpointPushNotificationsPluginTestBase, @unchecked Sendable {
     private var hubPlugin: HubCategoryPlugin {
         guard let plugin = try? Amplify.Hub.getPlugin(for: "awsHubPlugin"),
             plugin.key == "awsHubPlugin"

--- a/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginResetTests.swift
+++ b/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginResetTests.swift
@@ -9,7 +9,9 @@ import Amplify
 import XCTest
 @testable import AWSPinpointPushNotificationsPlugin
 
-class AWSPinpointPushNotificationsPluginResetTests: AWSPinpointPushNotificationsPluginTestBase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSPinpointPushNotificationsPluginResetTests: AWSPinpointPushNotificationsPluginTestBase, @unchecked Sendable {
     func testReset_shouldResetValues() async {
         let resettable = plugin as Resettable
         await resettable.reset()

--- a/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginTestBase.swift
+++ b/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/AWSPinpointPushNotificationsPluginTestBase.swift
@@ -10,7 +10,9 @@ import XCTest
 @testable import Amplify
 @testable import AWSPinpointPushNotificationsPlugin
 
-class AWSPinpointPushNotificationsPluginTestBase: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class AWSPinpointPushNotificationsPluginTestBase: XCTestCase, @unchecked Sendable {
     var plugin: AWSPinpointPushNotificationsPlugin!
     var mockPinpoint: MockAWSPinpoint!
     var mockRemoteNotifications: MockRemoteNotifications!

--- a/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/ErrorPushNotificationsTests.swift
+++ b/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/ErrorPushNotificationsTests.swift
@@ -12,7 +12,9 @@ import XCTest
 @testable import AWSPinpointPushNotificationsPlugin
 @_spi(UnknownAWSHTTPServiceError) import AWSClientRuntime
 
-class ErrorPushNotificationsTests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+class ErrorPushNotificationsTests: XCTestCase, @unchecked Sendable {
     /// Given: A NSError error
     /// When: pushNotificationsError is invoked
     /// Then: An .unknown error is returned

--- a/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/Mocks/MockRemoteNotifications.swift
+++ b/AmplifyPlugins/Notifications/Push/Tests/AWSPinpointPushNotificationsPluginUnitTests/Mocks/MockRemoteNotifications.swift
@@ -10,7 +10,9 @@ import UserNotifications
 import XCTest
 @_spi(InternalAWSPinpoint) @testable import InternalAWSPinpoint
 
-class MockRemoteNotifications: RemoteNotificationsBehaviour {
+// `@unchecked Sendable`: the protocol it conforms to now requires `Sendable`. Test double driven
+// by a single test at a time.
+class MockRemoteNotifications: RemoteNotificationsBehaviour, @unchecked Sendable {
     var isRegisteredForRemoteNotifications: Bool = true
 
     var mockedRequestAuthorizationResult: Bool = true

--- a/AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp/PushNotificationHostAppUITests/PushNotificationHostAppUITests.swift
+++ b/AmplifyPlugins/Notifications/Push/Tests/PushNotificationHostApp/PushNotificationHostAppUITests/PushNotificationHostAppUITests.swift
@@ -7,7 +7,9 @@
 
 import XCTest
 
-final class PushNotificationHostAppUITests: XCTestCase {
+// `@unchecked Sendable`: `XCTestCase` is not `Sendable`, but the test body is captured by the
+// `@Sendable` closures the API now takes. XCTest runs one test at a time.
+final class PushNotificationHostAppUITests: XCTestCase, @unchecked Sendable {
     private let timeout = TimeInterval(6)
     private let app = XCUIApplication()
 


### PR DESCRIPTION
Slice **37 of 38** in the Swift 6 language-mode migration — 85 file(s).

Stacked on `swift6/36-tests-predictions-pluginscore`. Reference (do not merge): #4283.

Part of the incremental adoption of `swiftLanguageModes: [.v6]`. The mode is flipped only in the final slice, so this change compiles under the current mode and is behaviour-neutral unless its title says otherwise.

CI is intentionally skipped on slices via `[skip ci]`; the full matrix runs on `feat/swift6` after each merge.