### PR TITLE
fix(api): Detect dead AppSync WebSocket via client-side liveness ping

### DIFF
--- a/AmplifyPlugins/Core/AWSPluginsCore/WebSocket/WebSocketClient.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCore/WebSocket/WebSocketClient.swift
@@ -47,6 +47,21 @@ public final actor WebSocketClient: NSObject {
     private var autoConnectOnNetworkStatusChange: Bool
     /// A flag indicating whether to automatically retry on connection failure
     private var autoRetryOnConnectionFailure: Bool
+
+    /// Interval between client-initiated liveness pings. A ping is sent this often while connected.
+    private let pingInterval: TimeInterval
+    /// How long to wait for a pong before treating the connection as dead.
+    private let pingTimeout: TimeInterval
+    /// Number of consecutive missed pings required before recycling the connection.
+    private let maxMissedPings: Int
+    /// Liveness probe for a connection; overridable in tests. Defaults to a ping/pong within the timeout.
+    private let isConnectionAlive: @Sendable (URLSessionWebSocketTask, TimeInterval) async -> Bool
+    /// Count of consecutive missed pings for the current connection.
+    private var missedPingCount: Int = 0
+    /// The task running the periodic liveness-ping loop for the current connection.
+    private var pingMonitorTask: Task<Void, Never>?
+    /// Guards against overlapping recycles triggered by a failed liveness ping.
+    private var isHandlingDeadConnection: Bool = false
     /// Data stream for downstream subscribers to engage with
     public var publisher: AnyPublisher<WebSocketEvent, Never> {
         subject.eraseToAnyPublisher()
@@ -64,12 +79,20 @@ public final actor WebSocketClient: NSObject {
         - protocols: WebSocket subprotocols, for header `Sec-WebSocket-Protocol`
         - interceptor: An optional interceptor for additional info before establishing the connection
         - networkMonitor: Provides network status notifications
+        - pingInterval: How often to send a client-initiated liveness ping while connected
+        - pingTimeout: How long to wait for a pong before counting the ping as missed
+        - maxMissedPings: Consecutive missed pings that trigger a reconnect
+        - isConnectionAlive: Liveness probe; defaults to a WebSocket ping/pong. Injectable for tests
      */
     public init(
         url: URL,
         handshakeHttpHeaders: [String: String] = [:],
         interceptor: WebSocketInterceptor? = nil,
-        networkMonitor: WebSocketNetworkMonitorProtocol = AmplifyNetworkMonitor()
+        networkMonitor: WebSocketNetworkMonitorProtocol = AmplifyNetworkMonitor(),
+        pingInterval: TimeInterval = 30,
+        pingTimeout: TimeInterval = 5,
+        maxMissedPings: Int = 2,
+        isConnectionAlive: (@Sendable (URLSessionWebSocketTask, TimeInterval) async -> Bool)? = nil
     ) {
         self.url = url
         self.handshakeHttpHeaders = handshakeHttpHeaders
@@ -77,6 +100,10 @@ public final actor WebSocketClient: NSObject {
         self.autoConnectOnNetworkStatusChange = false
         self.autoRetryOnConnectionFailure = false
         self.networkMonitor = networkMonitor
+        self.pingInterval = pingInterval
+        self.pingTimeout = pingTimeout
+        self.maxMissedPings = maxMissedPings
+        self.isConnectionAlive = isConnectionAlive ?? { await WebSocketClient.ping($0, timeout: $1) }
         super.init()
         /**
          The network monitor and retries should have a longer lifespan compared to the connection itself.
@@ -131,6 +158,7 @@ public final actor WebSocketClient: NSObject {
 
         autoConnectOnNetworkStatusChange = false
         autoRetryOnConnectionFailure = false
+        stopPingMonitor()
         connection?.cancel(with: .goingAway, reason: nil)
     }
 
@@ -167,12 +195,17 @@ public final actor WebSocketClient: NSObject {
 
     private func createConnectionAndRead() async {
         log.debug("[WebSocketClient] Creating new connection and starting read")
+        isHandlingDeadConnection = false
+        missedPingCount = 0
         connection = await createWebSocketConnection()
 
         // Perform reading from a WebSocket in a separate task recursively to avoid blocking the execution.
         Task { await self.startReadMessage() }
 
         connection?.resume()
+
+        // Detect a silently-dead socket (e.g. same-network TCP route swap) and recycle it.
+        startPingMonitor()
     }
 
     /**
@@ -354,6 +387,74 @@ extension WebSocketClient {
     }
 }
 
+// MARK: - liveness ping monitor
+extension WebSocketClient {
+    /// Periodically pings the connection and recycles a dead socket via the existing retry path (not via `NWPathMonitor` events).
+    private func startPingMonitor() {
+        pingMonitorTask?.cancel()
+        pingMonitorTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let interval = self?.pingInterval else { return }
+                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+                if Task.isCancelled {
+                    return
+                }
+                await self?.performLivenessCheck()
+            }
+        }
+    }
+
+    private func stopPingMonitor() {
+        pingMonitorTask?.cancel()
+        pingMonitorTask = nil
+    }
+
+    /// Recycles the connection after `maxMissedPings` consecutive missed pongs (one slow pong won't).
+    private func performLivenessCheck() async {
+        guard let connection, connection.state == .running else { return }
+
+        let isAlive = await isConnectionAlive(connection, pingTimeout)
+        if isAlive {
+            missedPingCount = 0
+            return
+        }
+
+        missedPingCount += 1
+        log.debug("[WebSocketClient] Liveness ping missed (\(missedPingCount)/\(maxMissedPings))")
+        guard missedPingCount >= maxMissedPings else { return }
+
+        // Guard against overlapping recycles (reconnect storms).
+        guard !isHandlingDeadConnection else { return }
+        isHandlingDeadConnection = true
+
+        log.debug("[WebSocketClient] \(missedPingCount) consecutive liveness pings failed — recycling dead connection")
+        stopPingMonitor()
+        subject.send(.error(WebSocketClient.Error.connectionLost))
+        // abnormalClosure drives the existing retryOnCloseCode path via didCloseWith.
+        connection.cancel(with: .abnormalClosure, reason: nil)
+    }
+
+    /// Sends one WebSocket ping; returns whether a pong arrived within `timeout` (single-resume race).
+    private nonisolated static func ping(
+        _ task: URLSessionWebSocketTask,
+        timeout: TimeInterval
+    ) async -> Bool {
+        let resumed = AtomicValue(initialValue: false)
+        return await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            task.sendPing { error in
+                if resumed.getAndSet(true) == false {
+                    continuation.resume(returning: error == nil)
+                }
+            }
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
+                if resumed.getAndSet(true) == false {
+                    continuation.resume(returning: false)
+                }
+            }
+        }
+    }
+}
+
 extension WebSocketClient: DefaultLogger {
     public static var log: Logger {
         Amplify.Logging.logger(forNamespace: String(describing: self))
@@ -367,6 +468,7 @@ extension WebSocketClient: Resettable {
         subject.send(completion: .finished)
         autoConnectOnNetworkStatusChange = false
         autoRetryOnConnectionFailure = false
+        stopPingMonitor()
         cancelables = Set()
     }
 }

--- a/AmplifyPlugins/Core/AWSPluginsCoreTests/WebSocket/WebSocketClientTests.swift
+++ b/AmplifyPlugins/Core/AWSPluginsCoreTests/WebSocket/WebSocketClientTests.swift
@@ -169,6 +169,64 @@ class WebSocketClientTests: XCTestCase {
         await fulfillment(of: [disconnectExpectation, reconnectedExpectation], timeout: timeout, enforceOrder: true)
     }
 
+    func testLivenessPing_recyclesConnection_whenServerDoesNotRespondToPing() async throws {
+        var cancellables = Set<AnyCancellable>()
+        guard let endpoint = try localWebSocketServer?.start() else {
+            XCTFail("Local WebSocket server failed to start")
+            return
+        }
+
+        // Inject a dead probe (no pong) so the client detects the zombie socket and recycles it.
+        let webSocketClient = WebSocketClient(
+            url: endpoint,
+            pingInterval: 0.5,
+            pingTimeout: 0.5,
+            isConnectionAlive: { _, _ in false }
+        )
+        await verifyConnected(webSocketClient)
+
+        let recycledExpectation = expectation(description: "Dead ping should recycle the connection")
+        await webSocketClient.publisher.sink { event in
+            if case let .disconnected(closeCode, _) = event, closeCode == .abnormalClosure {
+                recycledExpectation.fulfill()
+            }
+        }
+        .store(in: &cancellables)
+
+        await fulfillment(of: [recycledExpectation], timeout: timeout)
+    }
+
+    func testLivenessPing_doesNotRecycle_onSingleMiss() async throws {
+        guard let endpoint = try localWebSocketServer?.start() else {
+            XCTFail("Local WebSocket server failed to start")
+            return
+        }
+
+        // One miss then healthy: a single (non-consecutive) miss must not recycle.
+        actor MissOnce {
+            private var calls = 0
+            func probe() -> Bool {
+                calls += 1
+                return calls > 1
+            }
+        }
+        let missOnce = MissOnce()
+
+        let webSocketClient = WebSocketClient(
+            url: endpoint,
+            pingInterval: 0.3,
+            pingTimeout: 0.3,
+            isConnectionAlive: { _, _ in await missOnce.probe() }
+        )
+        await verifyConnected(webSocketClient)
+
+        // Allow several ping cycles to run (one miss, then healthy).
+        try await Task.sleep(seconds: 1.5)
+        let stillConnected = await webSocketClient.isConnected
+        XCTAssertTrue(stillConnected, "A single missed ping must not recycle a healthy connection")
+        await webSocketClient.disconnect()
+    }
+
     private func verifyConnected(
         _ webSocketClient: WebSocketClient,
         autoConnectOnNetworkStatusChange: Bool = false,


### PR DESCRIPTION
## Description

An idle AppSync subscription can silently die when iOS moves the TCP route on the same network. The `URLSessionWebSocketTask` still looks `running` (no error, no keep-alive), so the client never notices and live updates stop until an app restart (#3976).

`WebSocketClient` now sends a periodic liveness ping and, after two consecutive missed pongs, it recycles the socket via the existing retry path. It reacts to a real dead ping, not `NWPathMonitor` events, so background/foreground churn can't trigger needless reconnects (avoids the #4220 regression that reverted #4202). The ping interval (30s), pong timeout (5s), and allowed misses (2) are configurable via `init`, so tests can use small values.

## Testing

- Added two tests (both fail on `main` without the fix): one checks a dead socket (no pong) gets detected and reconnected; the other checks one missed ping alone does not reconnect a healthy socket.
- AWSPluginsCore unit suite passing; `swiftformat`/`swiftlint` clean; thread-sanitizer clean; builds on iOS, macOS, tvOS, watchOS.
- Reproduced the bug end-to-end against a live AppSync sandbox, and confirmed the fix keeps a healthy connection alive over a 3.5-minute run (no needless reconnect).
- Could not run the actual silent-zombie recovery end-to-end: a simulator can't create a no-error dead socket, and no physical device was available. That path is covered by the unit test instead.

Refs #4229
